### PR TITLE
Skip running image job in forked repo

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -31,14 +31,15 @@ jobs:
   image:
     runs-on: ubuntu-18.04
     needs: test
-    if: ${{ github.event_name == 'push' }}
     steps:
     - uses: actions/checkout@v2
     - run: make build-image
     - run: make tag-image
     - name: docker login
+      if: ${{ github.repository == 'authgear/authgear-server' }}
       env:
         QUAY_IO_USERNAME: ${{ secrets.QUAY_IO_USERNAME }}
         QUAY_IO_PASSWORD: ${{ secrets.QUAY_IO_PASSWORD }}
       run: docker login -u "$QUAY_IO_USERNAME" -p "$QUAY_IO_PASSWORD" quay.io
     - run: make push-image
+      if: ${{ github.repository == 'authgear/authgear-server' }}


### PR DESCRIPTION
This job requires credentials which are not available in forked repo.