### PR TITLE
Do not send SameSite=None if Secure attribute is absent

### DIFF
--- a/pkg/auth/dependency/webapp/csrf_middleware.go
+++ b/pkg/auth/dependency/webapp/csrf_middleware.go
@@ -26,7 +26,7 @@ func (m *CSRFMiddleware) Handle(next http.Handler) http.Handler {
 		}
 
 		useragent := r.UserAgent()
-		if samesite.ShouldSendSameSiteNone(useragent) {
+		if samesite.ShouldSendSameSiteNone(useragent, secure) {
 			options = append(options, csrf.SameSite(csrf.SameSiteNoneMode))
 		} else {
 			// http.Cookie SameSiteDefaultMode option will write SameSite

--- a/pkg/core/samesite/incompatible.go
+++ b/pkg/core/samesite/incompatible.go
@@ -25,7 +25,13 @@ var chromiumVersionRegex = regexp.MustCompile(`Chrom[^ \/]+\/(\d+)[\.\d]* `)
 var isUcBrowserRegex = regexp.MustCompile(`UCBrowser\/`)
 var ucBrowserVersionRegex = regexp.MustCompile(`UCBrowser\/(\d+)\.(\d+)\.(\d+)[\.\d]* `)
 
-func ShouldSendSameSiteNone(useragent string) bool {
+func ShouldSendSameSiteNone(useragent string, secure bool) bool {
+	// Any cookie with SameSite=None and not Secure will be rejected.
+	// So without the Secure attribute, the cookie must NOT have SameSite=None.
+	// https://www.chromestatus.com/feature/5633521622188032
+	if !secure {
+		return false
+	}
 	return !isSameSiteNoneIncompatible(useragent)
 }
 

--- a/pkg/core/samesite/incompatible_test.go
+++ b/pkg/core/samesite/incompatible_test.go
@@ -76,15 +76,24 @@ var positiveTestCases = map[string]string{
 
 func TestShouldSendSameSiteNone(t *testing.T) {
 	Convey("TestShouldSendSameSiteNone", t, func() {
+		Convey("do not send SameSite=None if it is not Secure", func() {
+			for _, ua := range positiveTestCases {
+				So(ShouldSendSameSiteNone(ua, false), ShouldBeFalse)
+			}
+			for _, ua := range negativeTestCases {
+				So(ShouldSendSameSiteNone(ua, false), ShouldBeFalse)
+			}
+		})
+
 		Convey("should send same site none", func() {
 			for _, ua := range positiveTestCases {
-				So(ShouldSendSameSiteNone(ua), ShouldBeTrue)
+				So(ShouldSendSameSiteNone(ua, true), ShouldBeTrue)
 			}
 		})
 
 		Convey("should not send same site none", func() {
 			for _, ua := range negativeTestCases {
-				So(ShouldSendSameSiteNone(ua), ShouldBeFalse)
+				So(ShouldSendSameSiteNone(ua, true), ShouldBeFalse)
 			}
 		})
 	})


### PR DESCRIPTION
fix #97 
