### PR TITLE
Hot-reload local configuration files

### DIFF
--- a/cmd/authgear/server/server.go
+++ b/cmd/authgear/server/server.go
@@ -6,6 +6,7 @@ import (
 	"github.com/authgear/authgear-server/pkg/admin"
 	"github.com/authgear/authgear-server/pkg/auth"
 	"github.com/authgear/authgear-server/pkg/lib/config"
+	configsource "github.com/authgear/authgear-server/pkg/lib/config/source"
 	"github.com/authgear/authgear-server/pkg/lib/deps"
 	"github.com/authgear/authgear-server/pkg/lib/infra/task"
 	"github.com/authgear/authgear-server/pkg/resolver"
@@ -49,12 +50,12 @@ func (c *Controller) Start() {
 		c.logger.Warn("development mode is ON - do not use in production")
 	}
 
-	configSource := newConfigSource(p)
-	err = configSource.Open()
+	configSrcController := newConfigSourceController(p)
+	err = configSrcController.Open()
 	if err != nil {
 		c.logger.WithError(err).Fatal("cannot open configuration")
 	}
-	defer configSource.Close()
+	defer configSrcController.Close()
 
 	var specs []server.Spec
 
@@ -67,7 +68,7 @@ func (c *Controller) Start() {
 		spec := server.Spec{
 			Name:          "Main Server",
 			ListenAddress: u.Host,
-			Handler:       auth.NewRouter(p, configSource),
+			Handler:       auth.NewRouter(p, configSrcController.ForServer(configsource.ServerTypeMain)),
 		}
 
 		if cfg.DevMode && u.Scheme == "https" {
@@ -88,7 +89,7 @@ func (c *Controller) Start() {
 		specs = append(specs, server.Spec{
 			Name:          "Resolver Server",
 			ListenAddress: u.Host,
-			Handler:       resolver.NewRouter(p, configSource),
+			Handler:       resolver.NewRouter(p, configSrcController.ForServer(configsource.ServerTypeResolver)),
 		})
 	}
 
@@ -101,7 +102,7 @@ func (c *Controller) Start() {
 		specs = append(specs, server.Spec{
 			Name:          "Admin API Server",
 			ListenAddress: u.Host,
-			Handler:       admin.NewRouter(p, configSource),
+			Handler:       admin.NewRouter(p, configSrcController.ForServer(configsource.ServerTypeAdminAPI)),
 		})
 	}
 

--- a/cmd/authgear/server/server.go
+++ b/cmd/authgear/server/server.go
@@ -54,6 +54,7 @@ func (c *Controller) Start() {
 	if err != nil {
 		c.logger.WithError(err).Fatal("cannot open configuration")
 	}
+	defer configSource.Close()
 
 	var specs []server.Spec
 

--- a/cmd/authgear/server/wire.go
+++ b/cmd/authgear/server/wire.go
@@ -11,7 +11,7 @@ import (
 	"github.com/authgear/authgear-server/pkg/lib/infra/task/queue"
 )
 
-func newConfigSource(p *deps.RootProvider) configsource.Source {
+func newConfigSourceController(p *deps.RootProvider) *configsource.Controller {
 	panic(wire.Build(deps.RootDependencySet))
 }
 

--- a/cmd/authgear/server/wire_gen.go
+++ b/cmd/authgear/server/wire_gen.go
@@ -17,12 +17,12 @@ import (
 func newConfigSource(p *deps.RootProvider) source.Source {
 	serverConfig := p.ServerConfig
 	factory := p.LoggerFactory
-	localFileLogger := source.NewLocalFileLogger(factory)
-	localFile := &source.LocalFile{
-		Logger:       localFileLogger,
+	localFSLogger := source.NewLocalFSLogger(factory)
+	localFS := &source.LocalFS{
+		Logger:       localFSLogger,
 		ServerConfig: serverConfig,
 	}
-	sourceSource := source.NewSource(serverConfig, localFile)
+	sourceSource := source.NewSource(serverConfig, localFS)
 	return sourceSource
 }
 

--- a/cmd/authgear/server/wire_gen.go
+++ b/cmd/authgear/server/wire_gen.go
@@ -14,7 +14,7 @@ import (
 
 // Injectors from wire.go:
 
-func newConfigSource(p *deps.RootProvider) source.Source {
+func newConfigSourceController(p *deps.RootProvider) *source.Controller {
 	serverConfig := p.ServerConfig
 	factory := p.LoggerFactory
 	localFSLogger := source.NewLocalFSLogger(factory)
@@ -22,8 +22,8 @@ func newConfigSource(p *deps.RootProvider) source.Source {
 		Logger:       localFSLogger,
 		ServerConfig: serverConfig,
 	}
-	sourceSource := source.NewSource(serverConfig, localFS)
-	return sourceSource
+	controller := source.NewController(serverConfig, localFS)
+	return controller
 }
 
 func newInProcessQueue(p *deps.AppProvider, e *executor.InProcessExecutor) *queue.InProcessQueue {

--- a/go.mod
+++ b/go.mod
@@ -42,6 +42,7 @@ require (
 	golang.org/x/net v0.0.0-20200707034311-ab3426394381
 	golang.org/x/text v0.3.3
 	gopkg.in/alexcesaro/quotedprintable.v3 v3.0.0-20150716171945-2caba252f4dc // indirect
+	gopkg.in/fsnotify.v1 v1.4.7
 	gopkg.in/gomail.v2 v2.0.0-20160411212932-81ebce5c23df // indirect
 	gopkg.in/h2non/gock.v1 v1.0.15
 	gopkg.in/yaml.v2 v2.3.0

--- a/go.sum
+++ b/go.sum
@@ -90,6 +90,7 @@ github.com/fatih/structs v1.1.0/go.mod h1:9NiDSp5zOcgEDl+j00MP/WkGVPOlPRLejGD8Ga
 github.com/flosch/pongo2 v0.0.0-20190707114632-bbf5a6c351f4/go.mod h1:T9YF2M40nIgbVgp3rreNmTged+9HrbNTIQf1PsaIiTA=
 github.com/franela/goblin v0.0.0-20200105215937-c9ffbefa60db/go.mod h1:7dvUGVsVBjqR7JHJk0brhHOZYGmfBYOrK0ZhYMEtBr4=
 github.com/franela/goreq v0.0.0-20171204163338-bcd34c9993f8/go.mod h1:ZhphrRTfi2rbfLwlschooIH4+wKKDR4Pdxhh+TRoA20=
+github.com/fsnotify/fsnotify v1.4.7 h1:IXs+QLmnXW2CcXuY+8Mzv/fWEsPGWxqefPtCP5CnV9I=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
 github.com/gavv/httpexpect v2.0.0+incompatible/go.mod h1:x+9tiU1YnrOvnB725RkpoLv1M62hOWzwo5OXotisrKc=
 github.com/getsentry/sentry-go v0.6.1 h1:K84dY1/57OtWhdyr5lbU78Q/+qgzkEyGc/ud+Sipi5k=
@@ -641,6 +642,7 @@ gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127 h1:qIbj1fsPNlZgppZ+VLlY7N33
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/cheggaaa/pb.v1 v1.0.25/go.mod h1:V/YB90LKu/1FcN3WVnfiiE5oMCibMjukxqG/qStrOgw=
 gopkg.in/errgo.v2 v2.1.0/go.mod h1:hNsd1EY+bozCKY1Ytp96fpM3vjJbqLJn88ws8XvfDNI=
+gopkg.in/fsnotify.v1 v1.4.7 h1:xOHLXZwVvI9hhs+cLKq5+I5onOuwQLhQwiu63xxlHs4=
 gopkg.in/fsnotify.v1 v1.4.7/go.mod h1:Tz8NjZHkW78fSQdbUxIjBTcgA1z1m8ZHf0WmKUhAMys=
 gopkg.in/gcfg.v1 v1.2.3/go.mod h1:yesOnuUOFQAhST5vPY4nbZsb/huCgGGXlipJsBn0b3o=
 gopkg.in/go-playground/assert.v1 v1.2.1/go.mod h1:9RXL0bg/zibRAgZUYszZSwO/z8Y/a8bDuhia5mkpMnE=

--- a/pkg/admin/routes.go
+++ b/pkg/admin/routes.go
@@ -10,7 +10,7 @@ import (
 	"github.com/authgear/authgear-server/pkg/util/httputil"
 )
 
-func NewRouter(p *deps.RootProvider, configSource configsource.Source) *httproute.Router {
+func NewRouter(p *deps.RootProvider, configSource *configsource.ConfigSource) *httproute.Router {
 	router := httproute.NewRouter()
 
 	router.Add(httproute.Route{
@@ -24,7 +24,6 @@ func NewRouter(p *deps.RootProvider, configSource configsource.Source) *httprout
 		&deps.RequestMiddleware{
 			RootProvider: p,
 			ConfigSource: configSource,
-			ServerType:   configsource.ServerTypeAdminAPI,
 		},
 		p.Middleware(newRequestRecoverMiddleware),
 		p.Middleware(newAuthorizationMiddleware),

--- a/pkg/auth/routes.go
+++ b/pkg/auth/routes.go
@@ -13,7 +13,7 @@ import (
 	"github.com/authgear/authgear-server/pkg/util/httputil"
 )
 
-func NewRouter(p *deps.RootProvider, configSource configsource.Source) *httproute.Router {
+func NewRouter(p *deps.RootProvider, configSource *configsource.ConfigSource) *httproute.Router {
 	router := httproute.NewRouter()
 
 	router.Add(httproute.Route{
@@ -27,7 +27,6 @@ func NewRouter(p *deps.RootProvider, configSource configsource.Source) *httprout
 		&deps.RequestMiddleware{
 			RootProvider: p,
 			ConfigSource: configSource,
-			ServerType:   configsource.ServerTypeMain,
 		},
 		p.Middleware(newRequestRecoverMiddleware),
 		p.Middleware(newSessionMiddleware),

--- a/pkg/lib/config/config.go
+++ b/pkg/lib/config/config.go
@@ -11,8 +11,9 @@ import (
 )
 
 type Config struct {
-	AppConfig    *AppConfig
-	SecretConfig *SecretConfig
+	BaseDirectory string
+	AppConfig     *AppConfig
+	SecretConfig  *SecretConfig
 }
 
 type AppID string

--- a/pkg/lib/config/server.go
+++ b/pkg/lib/config/server.go
@@ -127,8 +127,6 @@ type ConfigurationSourceConfig struct {
 	// Type sets the type of configuration source
 	Type SourceType `envconfig:"TYPE" default:"local_file"`
 
-	// AppConfigPath sets the path to app configuration YAML file for local file source
-	AppConfigPath string `envconfig:"APP_CONFIG_PATH" default:"authgear.yaml"`
-	// SecretConfigPath sets the path to secret configuration YAML file for local file source
-	SecretConfigPath string `envconfig:"SECRET_CONFIG_PATH" default:"authgear.secrets.yaml"`
+	// ConfigDirectory sets the path to app configuration directory file for local file source
+	ConfigDirectory string `envconfig:"APP_CONFIG_DIR" default:"."`
 }

--- a/pkg/lib/config/server.go
+++ b/pkg/lib/config/server.go
@@ -82,7 +82,7 @@ func (c *ServerConfig) Validate() error {
 	}
 
 	switch c.ConfigSource.Type {
-	case SourceTypeLocalFile:
+	case SourceTypeLocalFS:
 		break
 	default:
 		sourceTypes := make([]string, len(SourceTypes))
@@ -116,19 +116,19 @@ type ServerStaticAssetConfig struct {
 type SourceType string
 
 const (
-	SourceTypeLocalFile SourceType = "local_file"
+	SourceTypeLocalFS SourceType = "local_fs"
 )
 
 var SourceTypes = []SourceType{
-	SourceTypeLocalFile,
+	SourceTypeLocalFS,
 }
 
 type ConfigurationSourceConfig struct {
 	// Type sets the type of configuration source
-	Type SourceType `envconfig:"TYPE" default:"local_file"`
+	Type SourceType `envconfig:"TYPE" default:"local_fs"`
 
 	// Watch indicates whether the configuration source would watch for changes and reload automatically
 	Watch bool `envconfig:"WATCH" default:"true"`
-	// ConfigDirectory sets the path to app configuration directory file for local file source
-	ConfigDirectory string `envconfig:"APP_CONFIG_DIR" default:"."`
+	// Directory sets the path to app configuration directory file for local FS sources
+	Directory string `envconfig:"DIRECTORY" default:"."`
 }

--- a/pkg/lib/config/server.go
+++ b/pkg/lib/config/server.go
@@ -127,6 +127,8 @@ type ConfigurationSourceConfig struct {
 	// Type sets the type of configuration source
 	Type SourceType `envconfig:"TYPE" default:"local_file"`
 
+	// Watch indicates whether the configuration source would watch for changes and reload automatically
+	Watch bool `envconfig:"WATCH" default:"true"`
 	// ConfigDirectory sets the path to app configuration directory file for local file source
 	ConfigDirectory string `envconfig:"APP_CONFIG_DIR" default:"."`
 }

--- a/pkg/lib/config/source/constants.go
+++ b/pkg/lib/config/source/constants.go
@@ -1,0 +1,6 @@
+package source
+
+const (
+	AuthgearYAML       = "authgear.yaml"
+	AuthgearSecretYAML = "authgear.secrets.yaml"
+)

--- a/pkg/lib/config/source/deps.go
+++ b/pkg/lib/config/source/deps.go
@@ -3,8 +3,8 @@ package source
 import "github.com/google/wire"
 
 var DependencySet = wire.NewSet(
-	NewLocalFileLogger,
-	wire.Struct(new(LocalFile), "*"),
+	NewLocalFSLogger,
+	wire.Struct(new(LocalFS), "*"),
 
 	NewSource,
 )

--- a/pkg/lib/config/source/deps.go
+++ b/pkg/lib/config/source/deps.go
@@ -6,5 +6,5 @@ var DependencySet = wire.NewSet(
 	NewLocalFSLogger,
 	wire.Struct(new(LocalFS), "*"),
 
-	NewSource,
+	NewController,
 )

--- a/pkg/lib/config/source/local_file.go
+++ b/pkg/lib/config/source/local_file.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net/http"
+	"path/filepath"
 
 	"github.com/authgear/authgear-server/pkg/lib/config"
 	"github.com/authgear/authgear-server/pkg/util/httputil"
@@ -25,7 +26,9 @@ type LocalFile struct {
 }
 
 func (s *LocalFile) Open() error {
-	appConfigYAML, err := ioutil.ReadFile(s.ServerConfig.ConfigSource.AppConfigPath)
+	dir := s.ServerConfig.ConfigSource.ConfigDirectory
+
+	appConfigYAML, err := ioutil.ReadFile(filepath.Join(dir, AuthgearYAML))
 	if err != nil {
 		return fmt.Errorf("cannot read app config file: %w", err)
 	}
@@ -34,7 +37,7 @@ func (s *LocalFile) Open() error {
 		return fmt.Errorf("cannot parse app config: %w", err)
 	}
 
-	secretConfigYAML, err := ioutil.ReadFile(s.ServerConfig.ConfigSource.SecretConfigPath)
+	secretConfigYAML, err := ioutil.ReadFile(filepath.Join(dir, AuthgearSecretYAML))
 	if err != nil {
 		return fmt.Errorf("cannot read secret config file: %w", err)
 	}

--- a/pkg/lib/config/source/local_file.go
+++ b/pkg/lib/config/source/local_file.go
@@ -6,6 +6,9 @@ import (
 	"io/ioutil"
 	"net/http"
 	"path/filepath"
+	"sync/atomic"
+
+	"gopkg.in/fsnotify.v1"
 
 	"github.com/authgear/authgear-server/pkg/lib/config"
 	"github.com/authgear/authgear-server/pkg/util/httputil"
@@ -22,7 +25,11 @@ type LocalFile struct {
 	Logger       LocalFileLogger
 	ServerConfig *config.ServerConfig
 
-	config *config.Config `wire:"-"`
+	appConfigPath    string            `wire:"-"`
+	secretConfigPath string            `wire:"-"`
+	config           atomic.Value      `wire:"-"`
+	watcher          *fsnotify.Watcher `wire:"-"`
+	done             chan<- struct{}   `wire:"-"`
 }
 
 func (s *LocalFile) Open() error {
@@ -31,7 +38,8 @@ func (s *LocalFile) Open() error {
 		return err
 	}
 
-	appConfigYAML, err := ioutil.ReadFile(filepath.Join(dir, AuthgearYAML))
+	s.appConfigPath = filepath.Join(dir, AuthgearYAML)
+	appConfigYAML, err := ioutil.ReadFile(s.appConfigPath)
 	if err != nil {
 		return fmt.Errorf("cannot read app config file: %w", err)
 	}
@@ -40,7 +48,8 @@ func (s *LocalFile) Open() error {
 		return fmt.Errorf("cannot parse app config: %w", err)
 	}
 
-	secretConfigYAML, err := ioutil.ReadFile(filepath.Join(dir, AuthgearSecretYAML))
+	s.secretConfigPath = filepath.Join(dir, AuthgearSecretYAML)
+	secretConfigYAML, err := ioutil.ReadFile(s.secretConfigPath)
 	if err != nil {
 		return fmt.Errorf("cannot read secret config file: %w", err)
 	}
@@ -53,36 +62,126 @@ func (s *LocalFile) Open() error {
 		return fmt.Errorf("invalid secret config: %w", err)
 	}
 
-	s.config = &config.Config{
+	s.config.Store(&config.Config{
 		BaseDirectory: dir,
 		AppConfig:     appConfig,
 		SecretConfig:  secretConfig,
+	})
+
+	if s.ServerConfig.ConfigSource.Watch {
+		s.watcher, err = fsnotify.NewWatcher()
+		if err != nil {
+			return err
+		}
+
+		done := make(chan struct{})
+		s.done = done
+		go s.watch(done)
+
+		if err = s.watcher.Add(s.appConfigPath); err != nil {
+			return err
+		}
+		if err = s.watcher.Add(s.secretConfigPath); err != nil {
+			return err
+		}
 	}
 	return nil
 }
 
 func (s *LocalFile) Close() error {
+	if s.watcher != nil {
+		close(s.done)
+		return s.watcher.Close()
+	}
+	return nil
+}
+
+func (s *LocalFile) watch(done <-chan struct{}) {
+	for {
+		select {
+		case event, ok := <-s.watcher.Events:
+			if !ok {
+				return
+			}
+			if event.Op&fsnotify.Write != fsnotify.Write {
+				break
+			}
+			s.Logger.
+				WithField("file", event.Name).
+				Info("change detected, reloading...")
+
+			if err := s.reload(event.Name); err != nil {
+				s.Logger.
+					WithError(err).
+					WithField("file", event.Name).
+					Error("reload failed")
+			}
+
+		case err, ok := <-s.watcher.Errors:
+			if !ok {
+				return
+			}
+			s.Logger.WithError(err).Fatal("Watcher failed")
+
+		case <-done:
+			return
+		}
+	}
+}
+
+func (s *LocalFile) reload(filename string) error {
+	newConfig := *s.config.Load().(*config.Config)
+
+	switch filename {
+	case s.appConfigPath:
+		appConfigYAML, err := ioutil.ReadFile(s.appConfigPath)
+		if err != nil {
+			return fmt.Errorf("cannot read app config file: %w", err)
+		}
+		newConfig.AppConfig, err = config.Parse(appConfigYAML)
+		if err != nil {
+			return fmt.Errorf("cannot parse app config: %w", err)
+		}
+
+	case s.secretConfigPath:
+		secretConfigYAML, err := ioutil.ReadFile(s.secretConfigPath)
+		if err != nil {
+			return fmt.Errorf("cannot read secret config file: %w", err)
+		}
+		newConfig.SecretConfig, err = config.ParseSecret(secretConfigYAML)
+		if err != nil {
+			return fmt.Errorf("cannot parse secret config: %w", err)
+		}
+	}
+
+	if err := newConfig.SecretConfig.Validate(newConfig.AppConfig); err != nil {
+		return fmt.Errorf("invalid secret config: %w", err)
+	}
+
+	s.config.Store(&newConfig)
 	return nil
 }
 
 func (s *LocalFile) ProvideConfig(ctx context.Context, r *http.Request, server ServerType) (*config.Config, error) {
+	cfg := s.config.Load().(*config.Config)
+
 	if s.ServerConfig.DevMode {
 		// Accept all hosts under development mode
-		return s.config, nil
+		return cfg, nil
 	}
 
 	var acceptHosts []string
 	switch server {
 	case ServerTypeMain, ServerTypeResolver:
-		acceptHosts = s.config.AppConfig.HTTP.Hosts
+		acceptHosts = cfg.AppConfig.HTTP.Hosts
 	case ServerTypeAdminAPI:
-		acceptHosts = s.config.AppConfig.HTTP.AdminHosts
+		acceptHosts = cfg.AppConfig.HTTP.AdminHosts
 	}
 
 	host := httputil.GetHost(r, s.ServerConfig.TrustProxy)
 	for _, h := range acceptHosts {
 		if h == host {
-			return s.config, nil
+			return cfg, nil
 		}
 	}
 	s.Logger.Debugf("expected host %v, got %s", acceptHosts, host)

--- a/pkg/lib/config/source/local_file.go
+++ b/pkg/lib/config/source/local_file.go
@@ -26,7 +26,10 @@ type LocalFile struct {
 }
 
 func (s *LocalFile) Open() error {
-	dir := s.ServerConfig.ConfigSource.ConfigDirectory
+	dir, err := filepath.Abs(s.ServerConfig.ConfigSource.ConfigDirectory)
+	if err != nil {
+		return err
+	}
 
 	appConfigYAML, err := ioutil.ReadFile(filepath.Join(dir, AuthgearYAML))
 	if err != nil {
@@ -51,8 +54,9 @@ func (s *LocalFile) Open() error {
 	}
 
 	s.config = &config.Config{
-		AppConfig:    appConfig,
-		SecretConfig: secretConfig,
+		BaseDirectory: dir,
+		AppConfig:     appConfig,
+		SecretConfig:  secretConfig,
 	}
 	return nil
 }

--- a/pkg/lib/config/source/local_fs.go
+++ b/pkg/lib/config/source/local_fs.go
@@ -15,14 +15,14 @@ import (
 	"github.com/authgear/authgear-server/pkg/util/log"
 )
 
-type LocalFileLogger struct{ *log.Logger }
+type LocalFSLogger struct{ *log.Logger }
 
-func NewLocalFileLogger(lf *log.Factory) LocalFileLogger {
-	return LocalFileLogger{lf.New("local-file-config")}
+func NewLocalFSLogger(lf *log.Factory) LocalFSLogger {
+	return LocalFSLogger{lf.New("local-fs-config")}
 }
 
-type LocalFile struct {
-	Logger       LocalFileLogger
+type LocalFS struct {
+	Logger       LocalFSLogger
 	ServerConfig *config.ServerConfig
 
 	appConfigPath    string            `wire:"-"`
@@ -32,8 +32,8 @@ type LocalFile struct {
 	done             chan<- struct{}   `wire:"-"`
 }
 
-func (s *LocalFile) Open() error {
-	dir, err := filepath.Abs(s.ServerConfig.ConfigSource.ConfigDirectory)
+func (s *LocalFS) Open() error {
+	dir, err := filepath.Abs(s.ServerConfig.ConfigSource.Directory)
 	if err != nil {
 		return err
 	}
@@ -88,7 +88,7 @@ func (s *LocalFile) Open() error {
 	return nil
 }
 
-func (s *LocalFile) Close() error {
+func (s *LocalFS) Close() error {
 	if s.watcher != nil {
 		close(s.done)
 		return s.watcher.Close()
@@ -96,7 +96,7 @@ func (s *LocalFile) Close() error {
 	return nil
 }
 
-func (s *LocalFile) watch(done <-chan struct{}) {
+func (s *LocalFS) watch(done <-chan struct{}) {
 	for {
 		select {
 		case event, ok := <-s.watcher.Events:
@@ -129,7 +129,7 @@ func (s *LocalFile) watch(done <-chan struct{}) {
 	}
 }
 
-func (s *LocalFile) reload(filename string) error {
+func (s *LocalFS) reload(filename string) error {
 	newConfig := *s.config.Load().(*config.Config)
 
 	switch filename {
@@ -162,7 +162,7 @@ func (s *LocalFile) reload(filename string) error {
 	return nil
 }
 
-func (s *LocalFile) ProvideConfig(ctx context.Context, r *http.Request, server ServerType) (*config.Config, error) {
+func (s *LocalFS) ProvideConfig(ctx context.Context, r *http.Request, server ServerType) (*config.Config, error) {
 	cfg := s.config.Load().(*config.Config)
 
 	if s.ServerConfig.DevMode {

--- a/pkg/lib/config/source/source.go
+++ b/pkg/lib/config/source/source.go
@@ -23,10 +23,10 @@ type Source interface {
 
 func NewSource(
 	cfg *config.ServerConfig,
-	lf *LocalFile,
+	lf *LocalFS,
 ) Source {
 	switch cfg.ConfigSource.Type {
-	case config.SourceTypeLocalFile:
+	case config.SourceTypeLocalFS:
 		return lf
 	default:
 		panic("config_source: invalid config source type")

--- a/pkg/lib/config/source/source.go
+++ b/pkg/lib/config/source/source.go
@@ -15,20 +15,45 @@ const (
 	ServerTypeAdminAPI ServerType = "admin_api"
 )
 
-type Source interface {
+type source interface {
 	Open() error
 	Close() error
 	ProvideConfig(ctx context.Context, r *http.Request, server ServerType) (*config.Config, error)
 }
 
-func NewSource(
+type ConfigSource struct {
+	src        source
+	serverType ServerType
+}
+
+func (s *ConfigSource) ProvideConfig(ctx context.Context, r *http.Request) (*config.Config, error) {
+	return s.src.ProvideConfig(ctx, r, s.serverType)
+}
+
+type Controller struct {
+	src source
+}
+
+func NewController(
 	cfg *config.ServerConfig,
 	lf *LocalFS,
-) Source {
+) *Controller {
 	switch cfg.ConfigSource.Type {
 	case config.SourceTypeLocalFS:
-		return lf
+		return &Controller{src: lf}
 	default:
 		panic("config_source: invalid config source type")
 	}
+}
+
+func (c *Controller) Open() error {
+	return c.src.Open()
+}
+
+func (c *Controller) Close() error {
+	return c.src.Close()
+}
+
+func (c *Controller) ForServer(server ServerType) *ConfigSource {
+	return &ConfigSource{src: c.src, serverType: server}
 }

--- a/pkg/lib/deps/middleware_request.go
+++ b/pkg/lib/deps/middleware_request.go
@@ -10,15 +10,14 @@ import (
 
 type RequestMiddleware struct {
 	RootProvider *RootProvider
-	ConfigSource configsource.Source
-	ServerType   configsource.ServerType
+	ConfigSource *configsource.ConfigSource
 }
 
 func (m *RequestMiddleware) Handle(next http.Handler) http.Handler {
 	logger := m.RootProvider.LoggerFactory.New("request")
 
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		config, err := m.ConfigSource.ProvideConfig(r.Context(), r, m.ServerType)
+		config, err := m.ConfigSource.ProvideConfig(r.Context(), r)
 		if err != nil {
 			if errorutil.Is(err, configsource.ErrAppNotFound) {
 				http.Error(w, configsource.ErrAppNotFound.Error(), http.StatusNotFound)

--- a/pkg/lib/deps/template.go
+++ b/pkg/lib/deps/template.go
@@ -23,6 +23,7 @@ func NewEngineWithConfig(
 	}
 
 	resolver := template.NewResolver(template.NewResolverOptions{
+		BaseDirectory:             c.BaseDirectory,
 		DefaultTemplatesDirectory: serverConfig.DefaultTemplateDirectory,
 		References:                refs,
 		FallbackLanguageTag:       c.AppConfig.Localization.FallbackLanguage,

--- a/pkg/resolver/routes.go
+++ b/pkg/resolver/routes.go
@@ -10,7 +10,7 @@ import (
 	"github.com/authgear/authgear-server/pkg/util/httputil"
 )
 
-func NewRouter(p *deps.RootProvider, configSource configsource.Source) *httproute.Router {
+func NewRouter(p *deps.RootProvider, configSource *configsource.ConfigSource) *httproute.Router {
 	router := httproute.NewRouter()
 
 	router.Add(httproute.Route{
@@ -24,7 +24,6 @@ func NewRouter(p *deps.RootProvider, configSource configsource.Source) *httprout
 		&deps.RequestMiddleware{
 			RootProvider: p,
 			ConfigSource: configSource,
-			ServerType:   configsource.ServerTypeResolver,
 		},
 		p.Middleware(newRequestRecoverMiddleware),
 		p.Middleware(newSessionMiddleware),

--- a/pkg/util/template/file_loader.go
+++ b/pkg/util/template/file_loader.go
@@ -1,18 +1,36 @@
 package template
 
 import (
+	"errors"
 	"fmt"
 	"io/ioutil"
 	"os"
+	"path/filepath"
+	"strings"
 	"unicode/utf8"
 )
 
-type FileLoader struct{}
+type FileLoader struct {
+	BaseDirectory string
+}
 
-func (l *FileLoader) Load(absolutePath string) (templateContent string, err error) {
-	f, err := os.Open(absolutePath)
+func (l *FileLoader) Load(path string) (templateContent string, err error) {
+	if l.BaseDirectory == "" {
+		return "", errors.New("cannot resolve template file without base directory")
+	}
+
+	path = filepath.Join(l.BaseDirectory, path)
+
+	relPath, err := filepath.Rel(l.BaseDirectory, path)
 	if err != nil {
-		err = &errNotFound{name: absolutePath}
+		return "", err
+	} else if strings.HasPrefix(relPath, ".."+string(filepath.Separator)) || relPath == ".." {
+		return "", fmt.Errorf("resolved template file outside base directory: %s", relPath)
+	}
+
+	f, err := os.Open(path)
+	if err != nil {
+		err = &errNotFound{name: path}
 		return
 	}
 	defer f.Close()

--- a/pkg/util/template/resolver.go
+++ b/pkg/util/template/resolver.go
@@ -12,6 +12,7 @@ type Loader interface {
 }
 
 type NewResolverOptions struct {
+	BaseDirectory             string
 	DefaultTemplatesDirectory string
 	References                []Reference
 	FallbackLanguageTag       string
@@ -31,7 +32,7 @@ type Resolver struct {
 }
 
 func NewResolver(opts NewResolverOptions) *Resolver {
-	uriLoader := NewURILoader()
+	uriLoader := NewURILoader(opts.BaseDirectory)
 	defaultLoader := &DefaultLoaderFS{Directory: opts.DefaultTemplatesDirectory}
 	return &Resolver{
 		Loader:              uriLoader,

--- a/pkg/util/template/uri_loader.go
+++ b/pkg/util/template/uri_loader.go
@@ -13,9 +13,11 @@ type URILoader struct {
 	DataLoader *DataLoader
 }
 
-func NewURILoader() *URILoader {
+func NewURILoader(baseDirectory string) *URILoader {
 	return &URILoader{
-		FileLoader: &FileLoader{},
+		FileLoader: &FileLoader{
+			BaseDirectory: baseDirectory,
+		},
 		DataLoader: &DataLoader{},
 	}
 }


### PR DESCRIPTION
@louischan-oursky 
As discussed previously, we would like to refactor `ProvideConfig` into `ResolveAppIDByRequest` and `ResolveConfigByAppID` functions. However, I realized that resolving app ID depends on the host-appID mapping, which is strongly coupled with resolving config logic. Therefore I suppose we should keep it as-is for now.

ref #169 