### PR TITLE
Use URL for Redis connection credentials

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,7 +7,7 @@
 /tls-key.pem
 
 # docker
-docker-compose.override.yml
+docker-compose.override.yaml
 
 # vs code
 .vscode

--- a/cmd/authgear/config/config.go
+++ b/cmd/authgear/config/config.go
@@ -31,9 +31,7 @@ func NewSecretConfigFromOptions(opts *SecretOptions) *config.SecretConfig {
 	items = append(items, config.SecretItem{
 		Key: config.RedisCredentialsKey,
 		Data: &config.RedisCredentials{
-			Host:     opts.RedisHost,
-			Port:     opts.RedisPort,
-			Password: opts.RedisPassword,
+			RedisURL: opts.RedisURL,
 		},
 	})
 

--- a/cmd/authgear/config/options.go
+++ b/cmd/authgear/config/options.go
@@ -24,9 +24,7 @@ func ReadOptionsFromConsole() *Options {
 type SecretOptions struct {
 	DatabaseURL    string
 	DatabaseSchema string
-	RedisHost      string
-	RedisPort      int
-	RedisPassword  string
+	RedisURL       string
 }
 
 func ReadSecretOptionsFromConsole() *SecretOptions {
@@ -42,19 +40,9 @@ func ReadSecretOptionsFromConsole() *SecretOptions {
 		DefaultValue: "public",
 	}.Prompt()
 
-	opts.RedisHost = promptURL{
-		Title:        "Redis host",
-		DefaultValue: "localhost",
-	}.Prompt()
-
-	opts.RedisPort = promptInt{
-		Title:        "Redis port",
-		DefaultValue: 6379,
-	}.Prompt()
-
-	opts.RedisPassword = promptString{
-		Title:        "Redis password",
-		DefaultValue: "",
+	opts.RedisURL = promptURL{
+		Title:        "Redis URL",
+		DefaultValue: "redis://localhost",
 	}.Prompt()
 
 	return opts

--- a/cmd/authgear/config/prompt.go
+++ b/cmd/authgear/config/prompt.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"net/url"
 	"os"
-	"strconv"
 )
 
 type prompt struct {
@@ -61,29 +60,6 @@ func (p promptString) Prompt() string {
 		},
 	}
 	return ps.Prompt().(string)
-}
-
-type promptInt struct {
-	Title        string
-	DefaultValue int
-	Validate     func(value int) error
-}
-
-func (p promptInt) Prompt() int {
-	var ps = prompt{
-		Title:        p.Title,
-		DefaultValue: p.DefaultValue,
-		Coerce: func(value string) (interface{}, error) {
-			return strconv.Atoi(value)
-		},
-		Validate: func(value interface{}) error {
-			if p.Validate != nil {
-				return p.Validate(value.(int))
-			}
-			return nil
-		},
-	}
-	return ps.Prompt().(int)
 }
 
 type promptURL struct {

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -11,7 +11,7 @@ services:
       - "5432:5432"
 
   redis:
-    image: redis:5.0
+    image: redis:6.0
     volumes:
       - redis_data:/data
     ports:

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,6 @@ module github.com/authgear/authgear-server
 go 1.13
 
 require (
-	github.com/FZambia/sentinel v1.1.0
 	github.com/Masterminds/squirrel v1.4.0
 	github.com/getsentry/sentry-go v0.6.1
 	github.com/go-gomail/gomail v0.0.0-20160411212932-81ebce5c23df

--- a/go.sum
+++ b/go.sum
@@ -5,8 +5,6 @@ github.com/BurntSushi/toml v0.3.1 h1:WXkYYl6Yr3qBf1K79EBnL4mak0OimBfB0XUf9Vl28OQ
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/CloudyKit/fastprinter v0.0.0-20170127035650-74b38d55f37a/go.mod h1:EFZQ978U7x8IRnstaskI3IysnWY5Ao3QgZUKOXlsAdw=
 github.com/CloudyKit/jet v2.1.3-0.20180809161101-62edd43e4f88+incompatible/go.mod h1:HPYO+50pSWkPoj9Q/eq0aRGByCL6ScRlUmiEX5Zgm+w=
-github.com/FZambia/sentinel v1.1.0 h1:qrCBfxc8SvJihYNjBWgwUI93ZCvFe/PJIPTHKmlp8a8=
-github.com/FZambia/sentinel v1.1.0/go.mod h1:ytL1Am/RLlAoAXG6Kj5LNuw/TRRQrv2rt2FT26vP5gI=
 github.com/Joker/hpp v1.0.0/go.mod h1:8x5n+M1Hp5hC0g8okX3sR3vFQwynaX/UgSOM9MeBKzY=
 github.com/Joker/jade v1.0.1-0.20190614124447-d475f43051e7/go.mod h1:6E6s8o2AE4KhCrqr6GRJjdC/gNfTdxkIXvuGZZda2VM=
 github.com/Knetic/govaluate v3.0.1-0.20171022003610-9aa49832a739+incompatible/go.mod h1:r7JcOSlj0wfOMncg0iLm8Leh48TZaKVeNIfJntJ2wa0=

--- a/pkg/lib/config/secret_data.go
+++ b/pkg/lib/config/secret_data.go
@@ -1,11 +1,7 @@
 package config
 
 import (
-	"fmt"
-
 	"github.com/lestrrat-go/jwx/jwk"
-
-	"github.com/authgear/authgear-server/pkg/util/validation"
 )
 
 var _ = SecretConfigSchema.Add("DatabaseCredentials", `
@@ -43,45 +39,22 @@ var _ = SecretConfigSchema.Add("RedisCredentials", `
 	"type": "object",
 	"additionalProperties": false,
 	"properties": {
-		"host": { "type": "string" },
-		"port": { "type": "integer" },
-		"password": { "type": "string" },
-		"db": { "type": "integer" }
-	}
+		"redis_url": { "type": "string" }
+	},
+	"required": ["redis_url"]
 }
 `)
 
 type RedisCredentials struct {
-	Host     string `json:"host,omitempty"`
-	Port     int    `json:"port,omitempty"`
-	Password string `json:"password,omitempty"`
-	DB       int    `json:"db,omitempty"`
+	RedisURL string `json:"redis_url,omitempty"`
 }
 
 func (c *RedisCredentials) SensitiveStrings() []string {
-	return []string{
-		c.Host,
-		c.Password,
-	}
-}
-
-func (c *RedisCredentials) SetDefaults() {
-	if c.Port == 0 {
-		c.Port = 6379
-	}
-}
-
-func (c *RedisCredentials) Validate(ctx *validation.Context) {
-	if c.Host == "" {
-		ctx.Child("host").EmitErrorMessage("redis host is not provided")
-	}
+	return []string{c.RedisURL}
 }
 
 func (c *RedisCredentials) ConnKey() string {
-	return fmt.Sprintf("redis/%s:%s/%d",
-		c.Host,
-		c.Password,
-		c.DB)
+	return c.RedisURL
 }
 
 var _ = SecretConfigSchema.Add("SMTPMode", `

--- a/pkg/lib/config/testdata/parse_secret_tests.yaml
+++ b/pkg/lib/config/testdata/parse_secret_tests.yaml
@@ -51,26 +51,14 @@ config:
   secrets:
     - key: redis
       data:
-        host: "127.0.0.1"
-
----
-name: redis/valid-sentinel
-error: null
-config:
-  secrets:
-    - key: redis
-      data:
-        sentinel:
-          enabled: true
-          addrs:
-            - "10.0.10.1"
-            - "10.0.10.2"
+        redis_url: "redis://127.0.0.1"
 
 ---
 name: redis/missing
 error: |-
   invalid secrets:
-  /secrets/0/data/host: redis host is not provided
+  /secrets/0/data: required
+    map[actual:<nil> expected:[redis_url] missing:[redis_url]]
 config:
   secrets:
     - key: redis

--- a/pkg/lib/infra/redis/pool.go
+++ b/pkg/lib/infra/redis/pool.go
@@ -1,7 +1,6 @@
 package redis
 
 import (
-	"fmt"
 	"sync"
 	"time"
 
@@ -64,14 +63,8 @@ func (p *Pool) Close() (err error) {
 }
 
 func (p *Pool) openRedis(cfg *config.RedisConfig, credentials *config.RedisCredentials) *redis.Pool {
-	hostPort := fmt.Sprintf("%s:%d", credentials.Host, credentials.Port)
 	dialFunc := func() (conn redis.Conn, err error) {
-		conn, err = redis.Dial(
-			"tcp",
-			hostPort,
-			redis.DialDatabase(credentials.DB),
-			redis.DialPassword(credentials.Password),
-		)
+		conn, err = redis.DialURL(credentials.RedisURL)
 		return
 	}
 	testOnBorrowFunc := func(conn redis.Conn, t time.Time) (err error) {


### PR DESCRIPTION
TLS can be used using `rediss://localhost`. (note the double s)

fix #193 