### PR TITLE
Remove extenable widget hover hightlight

### DIFF
--- a/portal/src/ExtendableWidget.module.scss
+++ b/portal/src/ExtendableWidget.module.scss
@@ -12,6 +12,9 @@
 }
 
 .downArrow {
+  &:hover {
+    background-color: transparent;
+  }
   transition: transform 200ms ease;
 }
 


### PR DESCRIPTION
Closes #298 

as it rotates when the arrow rotate