### PR TITLE
[Portal] Integrate delete authenticator mutation

### DIFF
--- a/portal/src/graphql/adminapi/UserDetailsAccountSecurity.tsx
+++ b/portal/src/graphql/adminapi/UserDetailsAccountSecurity.tsx
@@ -519,6 +519,11 @@ const UserDetailsAccountSecurity: React.FC<UserDetailsAccountSecurityProps> = fu
   } = useDeleteAuthenticatorMutation();
 
   const [
+    isConfirmationDialogVisible,
+    setIsConfirmationDialogVisible,
+  ] = useState(false);
+  const [isErrorDialogVisible, setIsErrorDialogVisible] = useState(false);
+  const [
     confirmationDialogData,
     setConfirmationDialogData,
   ] = useState<RemoveConfirmationDialogData | null>(null);
@@ -545,12 +550,13 @@ const UserDetailsAccountSecurity: React.FC<UserDetailsAccountSecurityProps> = fu
         authenticatorID,
         authenticatorName,
       });
+      setIsConfirmationDialogVisible(true);
     },
     []
   );
 
   const dismissConfirmationDialog = useCallback(() => {
-    setConfirmationDialogData(null);
+    setIsConfirmationDialogVisible(false);
   }, []);
 
   const onRenderPasswordAuthenticatorDetailCell = useCallback(
@@ -631,15 +637,14 @@ const UserDetailsAccountSecurity: React.FC<UserDetailsAccountSecurityProps> = fu
   }, [deleteAuthenticatorError]);
 
   useEffect(() => {
-    if (errorMessage.errorDialog == null) {
-      setErrorDialogData(null);
-    } else {
+    if (errorMessage.errorDialog != null) {
       setErrorDialogData({ errorMessage: errorMessage.errorDialog });
+      setIsErrorDialogVisible(true);
     }
   }, [errorMessage.errorDialog]);
 
   const dismissErrorDialog = useCallback(() => {
-    setErrorDialogData(null);
+    setIsErrorDialogVisible(false);
   }, []);
 
   return (
@@ -648,7 +653,7 @@ const UserDetailsAccountSecurity: React.FC<UserDetailsAccountSecurityProps> = fu
         <ShowError error={deleteAuthenticatorError} />
       )}
       <RemoveConfirmationDialog
-        visible={confirmationDialogData != null}
+        visible={isConfirmationDialogVisible}
         authenticatorID={confirmationDialogData?.authenticatorID}
         authenticatorName={confirmationDialogData?.authenticatorName}
         onDismiss={dismissConfirmationDialog}
@@ -656,7 +661,7 @@ const UserDetailsAccountSecurity: React.FC<UserDetailsAccountSecurityProps> = fu
         deletingAuthenticator={deletingAuthenticator}
       />
       <ErrorDialog
-        visible={errorDialogData != null}
+        visible={isErrorDialogVisible}
         errorMessage={errorDialogData?.errorMessage}
         onDismiss={dismissErrorDialog}
       />

--- a/portal/src/graphql/adminapi/UserDetailsAccountSecurity.tsx
+++ b/portal/src/graphql/adminapi/UserDetailsAccountSecurity.tsx
@@ -532,10 +532,6 @@ const UserDetailsAccountSecurity: React.FC<UserDetailsAccountSecurityProps> = fu
     setErrorDialogData,
   ] = useState<ErrorDialogData | null>(null);
 
-  const [unhandledViolations, setUnhandledViolations] = useState<Violation[]>(
-    []
-  );
-
   const primaryAuthenticatorLists = useMemo(() => {
     return constructAuthenticatorLists(authenticators, "PRIMARY", locale);
   }, [locale, authenticators]);
@@ -620,28 +616,28 @@ const UserDetailsAccountSecurity: React.FC<UserDetailsAccountSecurityProps> = fu
     [deleteAuthenticator, dismissConfirmationDialog]
   );
 
-  const errorMessage = useMemo(() => {
+  const { errorMessages, unhandledViolations } = useMemo(() => {
     const violations = parseError(deleteAuthenticatorError);
     const errorDialogErrorMessages: string[] = [];
-    const unknownViolations: Violation[] = [];
+    const unhandledViolations: Violation[] = [];
 
     for (const violation of violations) {
-      unknownViolations.push(violation);
+      unhandledViolations.push(violation);
     }
 
-    setUnhandledViolations(unknownViolations);
-
-    return {
+    const errorMessages = {
       errorDialog: defaultFormatErrorMessageList(errorDialogErrorMessages),
     };
+
+    return { errorMessages, unhandledViolations };
   }, [deleteAuthenticatorError]);
 
   useEffect(() => {
-    if (errorMessage.errorDialog != null) {
-      setErrorDialogData({ errorMessage: errorMessage.errorDialog });
+    if (errorMessages.errorDialog != null) {
+      setErrorDialogData({ errorMessage: errorMessages.errorDialog });
       setIsErrorDialogVisible(true);
     }
-  }, [errorMessage.errorDialog]);
+  }, [errorMessages.errorDialog]);
 
   const dismissErrorDialog = useCallback(() => {
     setIsErrorDialogVisible(false);

--- a/portal/src/graphql/adminapi/UserDetailsAccountSecurity.tsx
+++ b/portal/src/graphql/adminapi/UserDetailsAccountSecurity.tsx
@@ -527,7 +527,6 @@ const UserDetailsAccountSecurity: React.FC<UserDetailsAccountSecurityProps> = fu
     setErrorDialogData,
   ] = useState<ErrorDialogData | null>(null);
 
-  const [violations, setViolations] = useState<Violation[]>([]);
   const [unhandledViolations, setUnhandledViolations] = useState<Violation[]>(
     []
   );
@@ -607,10 +606,7 @@ const UserDetailsAccountSecurity: React.FC<UserDetailsAccountSecurityProps> = fu
             throw new Error();
           }
         })
-        .catch((err) => {
-          const newViolations = parseError(err);
-          setViolations(newViolations);
-        })
+        .catch(() => {})
         .finally(() => {
           dismissConfirmationDialog();
         });
@@ -619,6 +615,7 @@ const UserDetailsAccountSecurity: React.FC<UserDetailsAccountSecurityProps> = fu
   );
 
   const errorMessage = useMemo(() => {
+    const violations = parseError(deleteAuthenticatorError);
     const errorDialogErrorMessages: string[] = [];
     const unknownViolations: Violation[] = [];
 
@@ -631,7 +628,7 @@ const UserDetailsAccountSecurity: React.FC<UserDetailsAccountSecurityProps> = fu
     return {
       errorDialog: defaultFormatErrorMessageList(errorDialogErrorMessages),
     };
-  }, [violations]);
+  }, [deleteAuthenticatorError]);
 
   useEffect(() => {
     if (errorMessage.errorDialog == null) {

--- a/portal/src/graphql/adminapi/mutations/__generated__/DeleteAuthenticatorMutation.ts
+++ b/portal/src/graphql/adminapi/mutations/__generated__/DeleteAuthenticatorMutation.ts
@@ -1,0 +1,24 @@
+/* tslint:disable */
+/* eslint-disable */
+// @generated
+// This file was automatically generated and should not be edited.
+
+// ====================================================
+// GraphQL mutation operation: DeleteAuthenticatorMutation
+// ====================================================
+
+export interface DeleteAuthenticatorMutation_deleteAuthenticator {
+  __typename: "DeleteAuthenticatorPayload";
+  success: boolean;
+}
+
+export interface DeleteAuthenticatorMutation {
+  /**
+   * Delete authenticator of user
+   */
+  deleteAuthenticator: DeleteAuthenticatorMutation_deleteAuthenticator;
+}
+
+export interface DeleteAuthenticatorMutationVariables {
+  authenticatorID: string;
+}

--- a/portal/src/graphql/adminapi/mutations/deleteAuthenticatorMutation.ts
+++ b/portal/src/graphql/adminapi/mutations/deleteAuthenticatorMutation.ts
@@ -1,0 +1,39 @@
+import { gql, useMutation } from "@apollo/client";
+import { useCallback } from "react";
+import { DeleteAuthenticatorMutation } from "./__generated__/DeleteAuthenticatorMutation";
+
+const deleteAuthenticatorMutation = gql`
+  mutation DeleteAuthenticatorMutation($authenticatorID: ID!) {
+    deleteAuthenticator(input: { authenticatorID: $authenticatorID }) {
+      success
+    }
+  }
+`;
+
+export function useDeleteAuthenticatorMutation(): {
+  deleteAuthenticator: (authenticatorID: string) => Promise<boolean>;
+  loading: boolean;
+  error: unknown;
+} {
+  const [mutationFunction, { error, loading }] = useMutation<
+    DeleteAuthenticatorMutation
+  >(deleteAuthenticatorMutation);
+  const deleteAuthenticator = useCallback(
+    async (authenticatorID: string) => {
+      const result = await mutationFunction({
+        variables: {
+          authenticatorID,
+        },
+      });
+
+      return result.data?.deleteAuthenticator.success ?? false;
+    },
+    [mutationFunction]
+  );
+
+  return {
+    deleteAuthenticator,
+    loading,
+    error,
+  };
+}

--- a/portal/src/locale-data/en.json
+++ b/portal/src/locale-data/en.json
@@ -98,6 +98,8 @@
   "UserDetails.account-security.secondary.totp": "Authenticator Apps / Devices",
   "UserDetails.account-security.secondary.oob-otp": "Verification code via SMS / Email",
   "UserDetails.account-security.secondary.password": "Additional Password",
+  "UserDetails.account-security.remove-confirm-dialog.title": "Remove Authenticator",
+  "UserDetails.account-security.remove-confirm-dialog.message": "Are you sure you want to remove authenticator {authenticatorName}",
 
   "ResetPasswordScreen.title": "Reset Password",
   "ResetPasswordScreen.new-password": "New Password",

--- a/portal/src/util/error.ts
+++ b/portal/src/util/error.ts
@@ -130,8 +130,9 @@ function extractViolationFromErrorCause(cause: ErrorCause): Violation | null {
 }
 
 export function handleUpdateAppConfigError(error: GraphQLError): Violation[] {
+  const unknownViolation: Violation[] = [{ kind: "Unknown" }];
   if (!isAPIError(error.extensions)) {
-    return [];
+    return unknownViolation;
   }
   const { extensions } = error;
   switch (extensions.reason) {
@@ -155,11 +156,14 @@ export function handleUpdateAppConfigError(error: GraphQLError): Violation[] {
       return [{ kind: "PasswordPolicyViolated", causes: causeNames }];
     }
     default:
-      return [];
+      return unknownViolation;
   }
 }
 
 export function parseError(error: unknown): Violation[] {
+  if (error == null) {
+    return [];
+  }
   if (error instanceof ApolloError) {
     const violations: Violation[] = [];
     for (const graphQLError of error.graphQLErrors) {
@@ -172,5 +176,5 @@ export function parseError(error: unknown): Violation[] {
   }
 
   // unrecognized error
-  return [];
+  return [{ kind: "Unknown" }];
 }

--- a/portal/src/util/validation.ts
+++ b/portal/src/util/validation.ts
@@ -11,7 +11,8 @@ export type Violation =
   | DuplicatedIdentityViolation
   | InvalidViolation
   | CustomViolation
-  | PasswordPolicyViolatedViolation;
+  | PasswordPolicyViolatedViolation
+  | UnknownViolation;
 
 interface RequiredViolation {
   kind: "required";
@@ -49,6 +50,10 @@ interface InvalidViolation {
 export interface PasswordPolicyViolatedViolation {
   kind: "PasswordPolicyViolated";
   causes: string[];
+}
+
+interface UnknownViolation {
+  kind: "Unknown";
 }
 
 // used for local validation


### PR DESCRIPTION
Closes #370 

TODO: 
- handle error from backend
  - get unknown error from backend
  - can only add 1 secondary authenticator during setup, cannot test for error

get following error from backend
```json
{
	"data": null,
	"errors": [
		{
			"message": "reflect: call of reflect.Value.Type on zero Value",
			"locations": [
				{
					"line": 2,
					"column": 3
				}
			],
			"path": [
				"deleteAuthenticator"
			]
		}
	]
}
```