### PR TITLE
Warn user on change tab with dirty form

### DIFF
--- a/portal/src/graphql/adminapi/UserDetailsScreen.tsx
+++ b/portal/src/graphql/adminapi/UserDetailsScreen.tsx
@@ -33,7 +33,7 @@ const UserDetails: React.FC<UserDetailsProps> = function UserDetails(
 ) {
   const { data, loading, appConfig } = props;
   const { renderToString } = React.useContext(Context);
-  const { hash, onLinkClick } = usePivot();
+  const { selectedKey, onLinkClick } = usePivot();
 
   const availableLoginIdIdentities = useMemo(() => {
     const authenticationIdentities =
@@ -70,7 +70,7 @@ const UserDetails: React.FC<UserDetailsProps> = function UserDetails(
         lastLoginAtISO={data?.lastLoginAt ?? null}
       />
       <div className={styles.userDetailsTab}>
-        <Pivot selectedKey={hash} onLinkClick={onLinkClick}>
+        <Pivot selectedKey={selectedKey} onLinkClick={onLinkClick}>
           <PivotItem
             itemKey="account-security"
             headerText={renderToString("UserDetails.account-security.header")}

--- a/portal/src/graphql/adminapi/UserDetailsScreen.tsx
+++ b/portal/src/graphql/adminapi/UserDetailsScreen.tsx
@@ -1,5 +1,5 @@
 import React, { useMemo } from "react";
-import { useLocation, useParams } from "react-router-dom";
+import { useParams } from "react-router-dom";
 import { Pivot, PivotItem } from "@fluentui/react";
 import { FormattedMessage, Context } from "@oursky/react-messageformat";
 
@@ -15,6 +15,7 @@ import UserDetailsSession from "./UserDetailsSession";
 
 import { useUserQuery } from "./query/userQuery";
 import { UserQuery_node_User } from "./query/__generated__/UserQuery";
+import { usePivot } from "../../hook/usePivot";
 import { nonNullable } from "../../util/types";
 import { extractUserInfoFromIdentities } from "../../util/user";
 import { PortalAPIAppConfig } from "../../types";
@@ -31,9 +32,8 @@ const UserDetails: React.FC<UserDetailsProps> = function UserDetails(
   props: UserDetailsProps
 ) {
   const { data, loading, appConfig } = props;
-  const location = useLocation();
-  const hash = location.hash.slice(1);
   const { renderToString } = React.useContext(Context);
+  const { hash, onLinkClick } = usePivot();
 
   const availableLoginIdIdentities = useMemo(() => {
     const authenticationIdentities =
@@ -70,15 +70,15 @@ const UserDetails: React.FC<UserDetailsProps> = function UserDetails(
         lastLoginAtISO={data?.lastLoginAt ?? null}
       />
       <div className={styles.userDetailsTab}>
-        <Pivot defaultSelectedKey={hash}>
+        <Pivot selectedKey={hash} onLinkClick={onLinkClick}>
           <PivotItem
-            itemKey={"account-security"}
+            itemKey="account-security"
             headerText={renderToString("UserDetails.account-security.header")}
           >
             <UserDetailsAccountSecurity authenticators={authenticators} />
           </PivotItem>
           <PivotItem
-            itemKey={"connected-identities"}
+            itemKey="connected-identities"
             headerText={renderToString(
               "UserDetails.connected-identities.header"
             )}
@@ -89,7 +89,7 @@ const UserDetails: React.FC<UserDetailsProps> = function UserDetails(
             />
           </PivotItem>
           <PivotItem
-            itemKey={"session"}
+            itemKey="session"
             headerText={renderToString("UserDetails.session.header")}
           >
             <UserDetailsSession />

--- a/portal/src/graphql/adminapi/UserDetailsScreen.tsx
+++ b/portal/src/graphql/adminapi/UserDetailsScreen.tsx
@@ -15,7 +15,7 @@ import UserDetailsSession from "./UserDetailsSession";
 
 import { useUserQuery } from "./query/userQuery";
 import { UserQuery_node_User } from "./query/__generated__/UserQuery";
-import { usePivot } from "../../hook/usePivot";
+import { usePivotNavigation } from "../../hook/usePivot";
 import { nonNullable } from "../../util/types";
 import { extractUserInfoFromIdentities } from "../../util/user";
 import { PortalAPIAppConfig } from "../../types";
@@ -33,7 +33,7 @@ const UserDetails: React.FC<UserDetailsProps> = function UserDetails(
 ) {
   const { data, loading, appConfig } = props;
   const { renderToString } = React.useContext(Context);
-  const { selectedKey, onLinkClick } = usePivot();
+  const { selectedKey, onLinkClick } = usePivotNavigation();
 
   const availableLoginIdIdentities = useMemo(() => {
     const authenticationIdentities =

--- a/portal/src/graphql/portal/AuthenticationAuthenticatorSettings.tsx
+++ b/portal/src/graphql/portal/AuthenticationAuthenticatorSettings.tsx
@@ -110,8 +110,10 @@ function useOnActivateClicked<KeyType extends string>(
         return;
       }
       setState((prev: AuthenticatorListItem<KeyType>[]) => {
-        prev[itemIndex].activated = checked;
-        return [...prev];
+        const newState = produce(prev, (draftState) => {
+          draftState[itemIndex].activated = checked;
+        });
+        return newState;
       });
     },
     [state, setState]

--- a/portal/src/graphql/portal/AuthenticationConfigurationScreen.tsx
+++ b/portal/src/graphql/portal/AuthenticationConfigurationScreen.tsx
@@ -12,12 +12,15 @@ import AuthenticationAuthenticatorSettings from "./AuthenticationAuthenticatorSe
 
 import { useAppConfigQuery } from "./query/appConfigQuery";
 import { useUpdateAppConfigMutation } from "./mutations/updateAppConfigMutation";
+import { usePivot } from "../../hook/usePivot";
 
 import styles from "./AuthenticationConfigurationScreen.module.scss";
 
 const AuthenticationScreen: React.FC = function AuthenticationScreen() {
   const { renderToString } = React.useContext(Context);
   const { appID } = useParams();
+  const { hash, onLinkClick } = usePivot();
+
   const {
     updateAppConfig,
     loading: updatingAppConfig,
@@ -55,8 +58,9 @@ const AuthenticationScreen: React.FC = function AuthenticationScreen() {
           <FormattedMessage id="AuthenticationScreen.title" />
         </Text>
         <div className={styles.tabsContainer}>
-          <Pivot>
+          <Pivot selectedKey={hash} onLinkClick={onLinkClick}>
             <PivotItem
+              itemKey="login-id"
               headerText={renderToString("AuthenticationScreen.login-id.title")}
             >
               <AuthenticationLoginIDSettings
@@ -67,6 +71,7 @@ const AuthenticationScreen: React.FC = function AuthenticationScreen() {
               />
             </PivotItem>
             <PivotItem
+              itemKey="authenticator"
               headerText={renderToString(
                 "AuthenticationScreen.authenticator.title"
               )}

--- a/portal/src/graphql/portal/AuthenticationConfigurationScreen.tsx
+++ b/portal/src/graphql/portal/AuthenticationConfigurationScreen.tsx
@@ -19,7 +19,7 @@ import styles from "./AuthenticationConfigurationScreen.module.scss";
 const AuthenticationScreen: React.FC = function AuthenticationScreen() {
   const { renderToString } = React.useContext(Context);
   const { appID } = useParams();
-  const { hash, onLinkClick } = usePivot();
+  const { selectedKey, onLinkClick } = usePivot();
 
   const {
     updateAppConfig,
@@ -58,7 +58,7 @@ const AuthenticationScreen: React.FC = function AuthenticationScreen() {
           <FormattedMessage id="AuthenticationScreen.title" />
         </Text>
         <div className={styles.tabsContainer}>
-          <Pivot selectedKey={hash} onLinkClick={onLinkClick}>
+          <Pivot selectedKey={selectedKey} onLinkClick={onLinkClick}>
             <PivotItem
               itemKey="login-id"
               headerText={renderToString("AuthenticationScreen.login-id.title")}

--- a/portal/src/graphql/portal/AuthenticationConfigurationScreen.tsx
+++ b/portal/src/graphql/portal/AuthenticationConfigurationScreen.tsx
@@ -12,14 +12,14 @@ import AuthenticationAuthenticatorSettings from "./AuthenticationAuthenticatorSe
 
 import { useAppConfigQuery } from "./query/appConfigQuery";
 import { useUpdateAppConfigMutation } from "./mutations/updateAppConfigMutation";
-import { usePivot } from "../../hook/usePivot";
+import { usePivotNavigation } from "../../hook/usePivot";
 
 import styles from "./AuthenticationConfigurationScreen.module.scss";
 
 const AuthenticationScreen: React.FC = function AuthenticationScreen() {
   const { renderToString } = React.useContext(Context);
   const { appID } = useParams();
-  const { selectedKey, onLinkClick } = usePivot();
+  const { selectedKey, onLinkClick } = usePivotNavigation();
 
   const {
     updateAppConfig,

--- a/portal/src/graphql/portal/ForgotPasswordSettings.tsx
+++ b/portal/src/graphql/portal/ForgotPasswordSettings.tsx
@@ -1,11 +1,4 @@
-import React, {
-  useMemo,
-  useContext,
-  useState,
-  useCallback,
-  useEffect,
-  useRef,
-} from "react";
+import React, { useMemo, useContext, useState, useCallback } from "react";
 import { FormattedMessage, Context } from "@oursky/react-messageformat";
 import { TextField, Label } from "@fluentui/react";
 import cn from "classnames";
@@ -14,6 +7,7 @@ import produce from "immer";
 
 import CodeEditor from "../../CodeEditor";
 import ButtonWithLoading from "../../ButtonWithLoading";
+import NavigationBlockerDialog from "../../NavigationBlockerDialog";
 import { setFieldIfChanged, clearEmptyObject } from "../../util/misc";
 import { PortalAPIAppConfig, PortalAPIApp } from "../../types";
 
@@ -27,7 +21,6 @@ interface ForgotPasswordSettingsProps {
     appConfig: PortalAPIAppConfig
   ) => Promise<PortalAPIApp | null>;
   updatingAppConfig: boolean;
-  onIsFormModifiedChange: (modified: boolean) => void;
 }
 
 interface ForgotPasswordSettingsState {
@@ -85,13 +78,9 @@ const ForgotPasswordSettings: React.FC<ForgotPasswordSettingsProps> = function F
     rawAppConfig,
     updateAppConfig,
     updatingAppConfig,
-    onIsFormModifiedChange,
   } = props;
 
   const { renderToString } = useContext(Context);
-
-  const onIsFormModifiedChangeRef = useRef(onIsFormModifiedChange);
-  onIsFormModifiedChangeRef.current = onIsFormModifiedChange;
 
   const initialState = useMemo(() => {
     return constructStateFromAppConfig(effectiveAppConfig);
@@ -167,10 +156,6 @@ const ForgotPasswordSettings: React.FC<ForgotPasswordSettingsProps> = function F
     updateAppConfig(newAppConfig).catch(() => {});
   }, [state, rawAppConfig, updateAppConfig, initialState]);
 
-  useEffect(() => {
-    onIsFormModifiedChangeRef.current(isFormModified);
-  }, [isFormModified]);
-
   return (
     <div className={cn(styles.root, className)}>
       <Label className={styles.boldLabel}>
@@ -232,6 +217,7 @@ const ForgotPasswordSettings: React.FC<ForgotPasswordSettingsProps> = function F
           loadingLabelId="saving"
         />
       </div>
+      <NavigationBlockerDialog blockNavigation={isFormModified} />
     </div>
   );
 };

--- a/portal/src/graphql/portal/PasswordPolicySettings.tsx
+++ b/portal/src/graphql/portal/PasswordPolicySettings.tsx
@@ -1,11 +1,4 @@
-import React, {
-  useMemo,
-  useContext,
-  useState,
-  useCallback,
-  useEffect,
-  useRef,
-} from "react";
+import React, { useMemo, useContext, useState, useCallback } from "react";
 import { FormattedMessage, Context } from "@oursky/react-messageformat";
 import {
   TextField,
@@ -22,6 +15,7 @@ import produce from "immer";
 
 import ToggleWithContent from "../../ToggleWithContent";
 import ButtonWithLoading from "../../ButtonWithLoading";
+import NavigationBlockerDialog from "../../NavigationBlockerDialog";
 import {
   setFieldIfChanged,
   setFieldIfListNonEmpty,
@@ -46,7 +40,6 @@ interface PasswordPolicySettingsProps {
     appConfig: PortalAPIAppConfig
   ) => Promise<PortalAPIApp | null>;
   updatingAppConfig: boolean;
-  onIsFormModifiedChange: (modified: boolean) => void;
 }
 
 interface PasswordPolicySettingsState {
@@ -181,13 +174,9 @@ const PasswordPolicySettings: React.FC<PasswordPolicySettingsProps> = function P
     rawAppConfig,
     updateAppConfig,
     updatingAppConfig,
-    onIsFormModifiedChange,
   } = props;
 
   const { renderToString } = useContext(Context);
-
-  const onIsFormModifiedChangeRef = useRef(onIsFormModifiedChange);
-  onIsFormModifiedChangeRef.current = onIsFormModifiedChange;
 
   const initialState = useMemo(() => {
     return constructStateFromAppConfig(effectiveAppConfig);
@@ -350,10 +339,6 @@ const PasswordPolicySettings: React.FC<PasswordPolicySettingsProps> = function P
     }));
   }, []);
 
-  useEffect(() => {
-    onIsFormModifiedChangeRef.current(isFormModified);
-  }, [isFormModified]);
-
   return (
     <div className={cn(styles.root, className)}>
       <TextField
@@ -468,6 +453,7 @@ const PasswordPolicySettings: React.FC<PasswordPolicySettingsProps> = function P
           loadingLabelId="saving"
         />
       </div>
+      <NavigationBlockerDialog blockNavigation={isFormModified} />
     </div>
   );
 };

--- a/portal/src/graphql/portal/PasswordsScreen.tsx
+++ b/portal/src/graphql/portal/PasswordsScreen.tsx
@@ -10,7 +10,7 @@ import { useAppConfigQuery } from "./query/appConfigQuery";
 import { useUpdateAppConfigMutation } from "./mutations/updateAppConfigMutation";
 import ShowLoading from "../../ShowLoading";
 import ShowError from "../../ShowError";
-import { usePivot } from "../../hook/usePivot";
+import { usePivotNavigation } from "../../hook/usePivot";
 
 import styles from "./PasswordsScreen.module.scss";
 
@@ -20,7 +20,7 @@ const FORGOT_PASSWORD_POLICY_KEY = "forgot_password";
 const PasswordsScreen: React.FC = function PasswordsScreen() {
   const { renderToString } = useContext(Context);
   const { appID } = useParams();
-  const { selectedKey, onLinkClick } = usePivot();
+  const { selectedKey, onLinkClick } = usePivotNavigation();
 
   const {
     updateAppConfig,

--- a/portal/src/graphql/portal/PasswordsScreen.tsx
+++ b/portal/src/graphql/portal/PasswordsScreen.tsx
@@ -1,10 +1,4 @@
-import React, {
-  useMemo,
-  useContext,
-  useState,
-  useCallback,
-  useRef,
-} from "react";
+import React, { useMemo, useContext } from "react";
 import { useParams } from "react-router-dom";
 import { FormattedMessage, Context } from "@oursky/react-messageformat";
 import { Pivot, PivotItem, Text } from "@fluentui/react";
@@ -16,20 +10,17 @@ import { useAppConfigQuery } from "./query/appConfigQuery";
 import { useUpdateAppConfigMutation } from "./mutations/updateAppConfigMutation";
 import ShowLoading from "../../ShowLoading";
 import ShowError from "../../ShowError";
-import BlockerDialog from "../../BlockerDialog";
+import { usePivot } from "../../hook/usePivot";
 
 import styles from "./PasswordsScreen.module.scss";
 
 const PASSWORD_POLICY_PIVOT_KEY = "password_policy";
 const FORGOT_PASSWORD_POLICY_KEY = "forgot_password";
 
-type PivotKey =
-  | typeof PASSWORD_POLICY_PIVOT_KEY
-  | typeof FORGOT_PASSWORD_POLICY_KEY;
-
 const PasswordsScreen: React.FC = function PasswordsScreen() {
   const { renderToString } = useContext(Context);
   const { appID } = useParams();
+  const { hash, onLinkClick } = usePivot();
 
   const {
     updateAppConfig,
@@ -37,6 +28,7 @@ const PasswordsScreen: React.FC = function PasswordsScreen() {
     error: updateAppConfigError,
   } = useUpdateAppConfigMutation(appID);
   const { loading, error, data, refetch } = useAppConfigQuery(appID);
+
   const { effectiveAppConfig, rawAppConfig } = useMemo(() => {
     const node = data?.node;
     return node?.__typename === "App"
@@ -49,87 +41,6 @@ const PasswordsScreen: React.FC = function PasswordsScreen() {
           rawAppConfig: null,
         };
   }, [data]);
-
-  const [currentPivotKey, setCurrentPivotKey] = useState<PivotKey>(
-    PASSWORD_POLICY_PIVOT_KEY
-  );
-  const selectedPivotKeyRef = useRef<PivotKey>(PASSWORD_POLICY_PIVOT_KEY);
-  const [
-    isPasswordPolicyFormModified,
-    setIsPasswordPolicyFormModified,
-  ] = useState(false);
-  const [
-    isForgotPasswordFormModified,
-    setIsForgotPasswordFormModified,
-  ] = useState(false);
-  const [
-    shouldDisplayDiscardChangesDialog,
-    setShouldDisplayDiscardChangesDialog,
-  ] = useState(false);
-
-  const onPivotLinkClick = useCallback(
-    (item?: PivotItem) => {
-      if (!item || !item.props.itemKey) {
-        return;
-      }
-
-      const newPivotKey = item.props.itemKey as PivotKey;
-      selectedPivotKeyRef.current = newPivotKey;
-
-      if (newPivotKey !== currentPivotKey) {
-        switch (currentPivotKey) {
-          case PASSWORD_POLICY_PIVOT_KEY:
-            if (isPasswordPolicyFormModified) {
-              setShouldDisplayDiscardChangesDialog(true);
-            } else {
-              setCurrentPivotKey(newPivotKey);
-            }
-            break;
-          case FORGOT_PASSWORD_POLICY_KEY:
-            if (isForgotPasswordFormModified) {
-              setShouldDisplayDiscardChangesDialog(true);
-            } else {
-              setCurrentPivotKey(newPivotKey);
-            }
-            break;
-          default:
-            break;
-        }
-      }
-    },
-    [
-      setCurrentPivotKey,
-      setShouldDisplayDiscardChangesDialog,
-      currentPivotKey,
-      isPasswordPolicyFormModified,
-      isForgotPasswordFormModified,
-    ]
-  );
-
-  const onIsPasswordPolicyFormModifiedChange = useCallback(
-    (modified: boolean) => {
-      setIsPasswordPolicyFormModified(modified);
-    },
-    [setIsPasswordPolicyFormModified]
-  );
-
-  const onIsForgotPasswordFormModifiedChange = useCallback(
-    (modified: boolean) => {
-      setIsForgotPasswordFormModified(modified);
-    },
-    [setIsForgotPasswordFormModified]
-  );
-
-  const onDialogDismiss = useCallback(() => {
-    setShouldDisplayDiscardChangesDialog(false);
-  }, [setShouldDisplayDiscardChangesDialog]);
-
-  const onDialogConfirm = useCallback(() => {
-    setShouldDisplayDiscardChangesDialog(false);
-    // The pivot item would be unmounted and reset to initial state when switching back.
-    // So don't need to reset form data.
-    setCurrentPivotKey(selectedPivotKeyRef.current);
-  }, [setShouldDisplayDiscardChangesDialog, setCurrentPivotKey]);
 
   if (loading) {
     return <ShowLoading />;
@@ -147,7 +58,7 @@ const PasswordsScreen: React.FC = function PasswordsScreen() {
           <FormattedMessage id="PasswordsScreen.title" />
         </Text>
         <div className={styles.tabsContainer}>
-          <Pivot onLinkClick={onPivotLinkClick} selectedKey={currentPivotKey}>
+          <Pivot onLinkClick={onLinkClick} selectedKey={hash}>
             <PivotItem
               headerText={renderToString(
                 "PasswordsScreen.password-policy.title"
@@ -159,7 +70,6 @@ const PasswordsScreen: React.FC = function PasswordsScreen() {
                 rawAppConfig={rawAppConfig}
                 updateAppConfig={updateAppConfig}
                 updatingAppConfig={updatingAppConfig}
-                onIsFormModifiedChange={onIsPasswordPolicyFormModifiedChange}
               />
             </PivotItem>
             <PivotItem
@@ -173,19 +83,11 @@ const PasswordsScreen: React.FC = function PasswordsScreen() {
                 rawAppConfig={rawAppConfig}
                 updateAppConfig={updateAppConfig}
                 updatingAppConfig={updatingAppConfig}
-                onIsFormModifiedChange={onIsForgotPasswordFormModifiedChange}
               />
             </PivotItem>
           </Pivot>
         </div>
       </div>
-      <BlockerDialog
-        hidden={!shouldDisplayDiscardChangesDialog}
-        contentTitleId="SwitchTabBlockerDialog.title"
-        contentSubTextId="SwitchTabBlockerDialog.content"
-        onDialogConfirm={onDialogConfirm}
-        onDialogDismiss={onDialogDismiss}
-      />
     </main>
   );
 };

--- a/portal/src/graphql/portal/PasswordsScreen.tsx
+++ b/portal/src/graphql/portal/PasswordsScreen.tsx
@@ -20,7 +20,7 @@ const FORGOT_PASSWORD_POLICY_KEY = "forgot_password";
 const PasswordsScreen: React.FC = function PasswordsScreen() {
   const { renderToString } = useContext(Context);
   const { appID } = useParams();
-  const { hash, onLinkClick } = usePivot();
+  const { selectedKey, onLinkClick } = usePivot();
 
   const {
     updateAppConfig,
@@ -58,7 +58,7 @@ const PasswordsScreen: React.FC = function PasswordsScreen() {
           <FormattedMessage id="PasswordsScreen.title" />
         </Text>
         <div className={styles.tabsContainer}>
-          <Pivot onLinkClick={onLinkClick} selectedKey={hash}>
+          <Pivot onLinkClick={onLinkClick} selectedKey={selectedKey}>
             <PivotItem
               headerText={renderToString(
                 "PasswordsScreen.password-policy.title"

--- a/portal/src/hook/usePivot.ts
+++ b/portal/src/hook/usePivot.ts
@@ -1,0 +1,24 @@
+import { useCallback } from "react";
+import { useLocation, useNavigate } from "react-router-dom";
+import { IPivotItemProps } from "@fluentui/react";
+
+export function usePivot(): {
+  hash: string;
+  onLinkClick: (item?: { props: IPivotItemProps }) => void;
+} {
+  const navigate = useNavigate();
+  const location = useLocation();
+  const hash = location.hash.slice(1);
+
+  const onLinkClick = useCallback(
+    (item) => {
+      const itemKey = item?.props.itemKey;
+      if (typeof itemKey === "string") {
+        navigate(`./#${itemKey}`);
+      }
+    },
+    [navigate]
+  );
+
+  return { hash, onLinkClick };
+}

--- a/portal/src/hook/usePivot.ts
+++ b/portal/src/hook/usePivot.ts
@@ -3,7 +3,7 @@ import { useLocation, useNavigate } from "react-router-dom";
 import { IPivotItemProps } from "@fluentui/react";
 
 export function usePivot(): {
-  hash: string;
+  selectedKey: string;
   onLinkClick: (item?: { props: IPivotItemProps }) => void;
 } {
   const navigate = useNavigate();
@@ -20,5 +20,5 @@ export function usePivot(): {
     [navigate]
   );
 
-  return { hash, onLinkClick };
+  return { selectedKey: hash, onLinkClick };
 }

--- a/portal/src/hook/usePivot.ts
+++ b/portal/src/hook/usePivot.ts
@@ -2,7 +2,7 @@ import { useCallback } from "react";
 import { useLocation, useNavigate } from "react-router-dom";
 import { IPivotItemProps } from "@fluentui/react";
 
-export function usePivot(): {
+export function usePivotNavigation(): {
   selectedKey: string;
   onLinkClick: (item?: { props: IPivotItemProps }) => void;
 } {

--- a/portal/src/hook/usePivot.ts
+++ b/portal/src/hook/usePivot.ts
@@ -14,7 +14,7 @@ export function usePivot(): {
     (item) => {
       const itemKey = item?.props.itemKey;
       if (typeof itemKey === "string") {
-        navigate(`./#${itemKey}`);
+        navigate(`./#${encodeURIComponent(itemKey)}`);
       }
     },
     [navigate]


### PR DESCRIPTION
fix #333 

- use url fragment (hash) to control pivot
- change tab => navigation => can use NavigationBlockerDialog to block
- avoid unnecessary useRef, useEffect to handle warn user on change tab
- fix password screen not warning user when leaving page with dirty form