### PR TITLE
Fix leaving min length field empty in password policy page unhandled error

### DIFF
--- a/portal/src/graphql/portal/PasswordPolicySettings.tsx
+++ b/portal/src/graphql/portal/PasswordPolicySettings.tsx
@@ -17,6 +17,7 @@ import ToggleWithContent from "../../ToggleWithContent";
 import ButtonWithLoading from "../../ButtonWithLoading";
 import NavigationBlockerDialog from "../../NavigationBlockerDialog";
 import {
+  setNumericFieldIfChanged,
   setFieldIfChanged,
   setFieldIfListNonEmpty,
   isArrayEqualInOrder,
@@ -43,15 +44,15 @@ interface PasswordPolicySettingsProps {
 }
 
 interface PasswordPolicySettingsState {
-  minLength: number;
+  minLength: string;
   isDigitRequired: boolean;
   isLowercaseRequired: boolean;
   isUppercaseRequired: boolean;
   isSymbolRequired: boolean;
   minGuessableLevel: PasswordPolicyGuessableLevel;
   preventReuse: boolean;
-  historyDays: number;
-  historySize: number;
+  historyDays: string;
+  historySize: string;
   excludedKeywords: string[];
 }
 
@@ -59,19 +60,19 @@ function constructStateFromAppConfig(
   appConfig: PortalAPIAppConfig | null
 ): PasswordPolicySettingsState {
   const passwordPolicy = appConfig?.authenticator?.password?.policy;
-  const historyDays = passwordPolicy?.history_days ?? 0;
-  const historySize = passwordPolicy?.history_size ?? 0;
+  const historyDaysConfig = passwordPolicy?.history_days;
+  const historySizeConfig = passwordPolicy?.history_size;
 
   return {
-    minLength: passwordPolicy?.min_length ?? NaN,
+    minLength: passwordPolicy?.min_length?.toString() ?? "",
     isDigitRequired: !!passwordPolicy?.digit_required,
     isLowercaseRequired: !!passwordPolicy?.lowercase_required,
     isUppercaseRequired: !!passwordPolicy?.uppercase_required,
     isSymbolRequired: !!passwordPolicy?.symbol_required,
     minGuessableLevel: passwordPolicy?.minimum_guessable_level ?? 0,
-    preventReuse: historyDays !== 0 || historySize !== 0,
-    historyDays,
-    historySize,
+    preventReuse: historyDaysConfig != null || historySizeConfig != null,
+    historyDays: historyDaysConfig?.toString() ?? "",
+    historySize: historySizeConfig?.toString() ?? "",
     excludedKeywords: passwordPolicy?.excluded_keywords ?? [],
   };
 }
@@ -90,13 +91,12 @@ function constructAppConfigFromState(
 
     const passwordPolicy = draftConfig.authenticator.password.policy;
 
-    if (initialScreenState.minLength !== screenState.minLength) {
-      if (Number.isNaN(screenState.minLength) || screenState.minLength === 0) {
-        passwordPolicy.min_length = undefined;
-      } else {
-        passwordPolicy.min_length = screenState.minLength;
-      }
-    }
+    setNumericFieldIfChanged(
+      passwordPolicy,
+      "min_length",
+      Number(initialScreenState.minLength),
+      Number(screenState.minLength)
+    );
 
     setFieldIfChanged(
       passwordPolicy,
@@ -133,18 +133,18 @@ function constructAppConfigFromState(
       screenState.minGuessableLevel
     );
 
-    setFieldIfChanged(
+    setNumericFieldIfChanged(
       passwordPolicy,
       "history_days",
-      initialScreenState.historyDays,
-      screenState.historyDays
+      Number(initialScreenState.historyDays),
+      Number(screenState.historyDays)
     );
 
-    setFieldIfChanged(
+    setNumericFieldIfChanged(
       passwordPolicy,
       "history_size",
-      initialScreenState.historySize,
-      screenState.historySize
+      Number(initialScreenState.historySize),
+      Number(screenState.historySize)
     );
 
     if (
@@ -218,7 +218,7 @@ const PasswordPolicySettings: React.FC<PasswordPolicySettingsProps> = function P
     // empty string parse to NaN
     setState((state) => ({
       ...state,
-      minLength: parseInt(value, 10),
+      minLength: value,
     }));
   }, []);
 
@@ -276,15 +276,15 @@ const PasswordPolicySettings: React.FC<PasswordPolicySettingsProps> = function P
       setState((state) => ({
         ...state,
         preventReuse: true,
-        historyDays: 90,
-        historySize: 3,
+        historyDays: "90",
+        historySize: "3",
       }));
     } else {
       setState((state) => ({
         ...state,
         preventReuse: false,
-        historyDays: 0,
-        historySize: 0,
+        historyDays: "",
+        historySize: "",
       }));
     }
   }, []);
@@ -295,7 +295,7 @@ const PasswordPolicySettings: React.FC<PasswordPolicySettingsProps> = function P
     }
     setState((state) => ({
       ...state,
-      historyDays: parseInt(value, 10),
+      historyDays: value,
     }));
   }, []);
 
@@ -305,7 +305,7 @@ const PasswordPolicySettings: React.FC<PasswordPolicySettingsProps> = function P
     }
     setState((state) => ({
       ...state,
-      historySize: parseInt(value, 10),
+      historySize: value,
     }));
   }, []);
 

--- a/portal/src/graphql/portal/PasswordPolicySettings.tsx
+++ b/portal/src/graphql/portal/PasswordPolicySettings.tsx
@@ -94,8 +94,8 @@ function constructAppConfigFromState(
     setNumericFieldIfChanged(
       passwordPolicy,
       "min_length",
-      Number(initialScreenState.minLength),
-      Number(screenState.minLength)
+      initialScreenState.minLength,
+      screenState.minLength
     );
 
     setFieldIfChanged(
@@ -136,15 +136,15 @@ function constructAppConfigFromState(
     setNumericFieldIfChanged(
       passwordPolicy,
       "history_days",
-      Number(initialScreenState.historyDays),
-      Number(screenState.historyDays)
+      initialScreenState.historyDays,
+      screenState.historyDays
     );
 
     setNumericFieldIfChanged(
       passwordPolicy,
       "history_size",
-      Number(initialScreenState.historySize),
-      Number(screenState.historySize)
+      initialScreenState.historySize,
+      screenState.historySize
     );
 
     if (

--- a/portal/src/graphql/portal/PasswordPolicySettings.tsx
+++ b/portal/src/graphql/portal/PasswordPolicySettings.tsx
@@ -63,7 +63,7 @@ function constructStateFromAppConfig(
   const historySize = passwordPolicy?.history_size ?? 0;
 
   return {
-    minLength: passwordPolicy?.min_length ?? 0,
+    minLength: passwordPolicy?.min_length ?? NaN,
     isDigitRequired: !!passwordPolicy?.digit_required,
     isLowercaseRequired: !!passwordPolicy?.lowercase_required,
     isUppercaseRequired: !!passwordPolicy?.uppercase_required,
@@ -90,12 +90,13 @@ function constructAppConfigFromState(
 
     const passwordPolicy = draftConfig.authenticator.password.policy;
 
-    setFieldIfChanged(
-      passwordPolicy,
-      "min_length",
-      initialScreenState.minLength,
-      screenState.minLength
-    );
+    if (initialScreenState.minLength !== screenState.minLength) {
+      if (Number.isNaN(screenState.minLength) || screenState.minLength === 0) {
+        passwordPolicy.min_length = undefined;
+      } else {
+        passwordPolicy.min_length = screenState.minLength;
+      }
+    }
 
     setFieldIfChanged(
       passwordPolicy,
@@ -214,6 +215,7 @@ const PasswordPolicySettings: React.FC<PasswordPolicySettingsProps> = function P
     if (value === undefined) {
       return;
     }
+    // empty string parse to NaN
     setState((state) => ({
       ...state,
       minLength: parseInt(value, 10),

--- a/portal/src/util/misc.ts
+++ b/portal/src/util/misc.ts
@@ -14,6 +14,21 @@ export function setFieldIfChanged<
   }
 }
 
+export function setNumericFieldIfChanged<M, K extends keyof M>(
+  map: Partial<M>,
+  key: K,
+  initialValue: M[K] extends number ? M[K] : never,
+  value: M[K] extends number ? M[K] : never
+): void {
+  if (initialValue !== value) {
+    if (value === 0) {
+      map[key] = undefined;
+    } else {
+      map[key] = value;
+    }
+  }
+}
+
 export function setFieldIfListNonEmpty<T, K extends keyof T>(
   map: T,
   field: K,

--- a/portal/src/util/misc.ts
+++ b/portal/src/util/misc.ts
@@ -16,15 +16,16 @@ export function setFieldIfChanged<
 
 export function setNumericFieldIfChanged<M, K extends keyof M>(
   map: Partial<M>,
-  key: K,
-  initialValue: M[K] extends number ? M[K] : never,
-  value: M[K] extends number ? M[K] : never
+  key: M[K] extends number ? K : never,
+  initialValue: string | undefined,
+  value: string | undefined
 ): void {
   if (initialValue !== value) {
-    if (value === 0) {
+    const numberValue = Number(value);
+    if (value === "" || Number.isNaN(numberValue)) {
       map[key] = undefined;
     } else {
-      map[key] = value;
+      map[key] = numberValue as any;
     }
   }
 }


### PR DESCRIPTION
# Error screenshot

<img width="1048" alt="Screenshot 2020-10-07 at 5 24 12 PM" src="https://user-images.githubusercontent.com/54486231/95313494-c6633480-08c2-11eb-9793-67df84359905.png">

## Cause 
parseInt("", 10) = NaN, NaN is not valid number in authgear config, leads to unhandled error