### PR TITLE
Fix edit client form dirty after save

### DIFF
--- a/portal/src/graphql/portal/CreateOAuthClientScreen.tsx
+++ b/portal/src/graphql/portal/CreateOAuthClientScreen.tsx
@@ -185,7 +185,10 @@ const CreateOAuthClientForm: React.FC<CreateOAuthClientFormProps> = function Cre
   );
 
   const isFormModified = useMemo(() => {
-    return !deepEqual(initialState, getReducedClientConfig(clientConfig));
+    return !deepEqual(
+      getReducedClientConfig(initialState),
+      getReducedClientConfig(clientConfig)
+    );
   }, [clientConfig, initialState]);
 
   return (

--- a/portal/src/graphql/portal/ModifyOAuthClientForm.tsx
+++ b/portal/src/graphql/portal/ModifyOAuthClientForm.tsx
@@ -27,7 +27,10 @@ export function getReducedClientConfig(
     ...rest
   } = clientConfig;
 
-  return rest;
+  return {
+    ...rest,
+    post_logout_redirect_uris: rest.post_logout_redirect_uris ?? [],
+  };
 }
 
 function constructClientConfigState(


### PR DESCRIPTION
Object without field post_logout_redirect_uris and having
post_logout_redirect_uris = undefined is not equal, null coalescing to
empty array to fix this