### PR TITLE
Portal access control - Part 2

### DIFF
--- a/migrations/portal/20201015122924-add-unique-to-collaborator-invitation-code.sql
+++ b/migrations/portal/20201015122924-add-unique-to-collaborator-invitation-code.sql
@@ -1,0 +1,5 @@
+-- +migrate Up
+CREATE UNIQUE INDEX _portal_app_collaborator_invitation_code_key ON _portal_app_collaborator_invitation (code);
+
+-- +migrate Down
+DROP INDEX _portal_app_collaborator_invitation_code_key;

--- a/pkg/portal/deps.go
+++ b/pkg/portal/deps.go
@@ -26,13 +26,13 @@ var DependencySet = wire.NewSet(
 	wire.Bind(new(loader.AppService), new(*service.AppService)),
 	wire.Bind(new(loader.DomainService), new(*service.DomainService)),
 	wire.Bind(new(loader.CollaboratorService), new(*service.CollaboratorService)),
+	wire.Bind(new(loader.AuthzService), new(*service.AuthzService)),
 
 	graphql.DependencySet,
 	wire.Bind(new(graphql.ViewerLoader), new(*loader.ViewerLoader)),
 	wire.Bind(new(graphql.AppLoader), new(*loader.AppLoader)),
 	wire.Bind(new(graphql.DomainLoader), new(*loader.DomainLoader)),
 	wire.Bind(new(graphql.CollaboratorLoader), new(*loader.CollaboratorLoader)),
-	wire.Bind(new(graphql.AuthzService), new(*service.AuthzService)),
 
 	transport.DependencySet,
 	wire.Bind(new(transport.AdminAPIConfigResolver), new(*service.AdminAPIService)),

--- a/pkg/portal/deps.go
+++ b/pkg/portal/deps.go
@@ -32,6 +32,7 @@ var DependencySet = wire.NewSet(
 	wire.Bind(new(graphql.AppLoader), new(*loader.AppLoader)),
 	wire.Bind(new(graphql.DomainLoader), new(*loader.DomainLoader)),
 	wire.Bind(new(graphql.CollaboratorLoader), new(*loader.CollaboratorLoader)),
+	wire.Bind(new(graphql.AuthzService), new(*service.AuthzService)),
 
 	transport.DependencySet,
 	wire.Bind(new(transport.AdminAPIConfigResolver), new(*service.AdminAPIService)),

--- a/pkg/portal/graphql/app.go
+++ b/pkg/portal/graphql/app.go
@@ -84,6 +84,14 @@ var nodeApp = node(
 					return ctx.Collaborators.ListCollaborators(app.ID).Value, nil
 				},
 			},
+			"collaboratorInvitations": &graphql.Field{
+				Type: graphql.NewNonNull(graphql.NewList(graphql.NewNonNull(collaboratorInvitation))),
+				Resolve: func(p graphql.ResolveParams) (interface{}, error) {
+					ctx := GQLContext(p.Context)
+					app := p.Source.(*model.App)
+					return ctx.Collaborators.ListInvitations(app.ID).Value, nil
+				},
+			},
 		},
 	}),
 	&model.App{},

--- a/pkg/portal/graphql/app_mutation.go
+++ b/pkg/portal/graphql/app_mutation.go
@@ -64,6 +64,12 @@ var _ = registerMutationField(
 			appID := resolvedNodeID.ID
 
 			gqlCtx := GQLContext(p.Context)
+
+			err := gqlCtx.AuthzService.CheckAccessOfViewer(appID)
+			if err != nil {
+				return nil, err
+			}
+
 			lazy := gqlCtx.Apps.Get(appID)
 			return lazy.
 				Map(func(value interface{}) (interface{}, error) {

--- a/pkg/portal/graphql/app_mutation.go
+++ b/pkg/portal/graphql/app_mutation.go
@@ -65,11 +65,6 @@ var _ = registerMutationField(
 
 			gqlCtx := GQLContext(p.Context)
 
-			err := gqlCtx.AuthzService.CheckAccessOfViewer(appID)
-			if err != nil {
-				return nil, err
-			}
-
 			lazy := gqlCtx.Apps.Get(appID)
 			return lazy.
 				Map(func(value interface{}) (interface{}, error) {

--- a/pkg/portal/graphql/collaborator.go
+++ b/pkg/portal/graphql/collaborator.go
@@ -8,8 +8,36 @@ var collaborator = graphql.NewObject(graphql.ObjectConfig{
 	Name:        "Collaborator",
 	Description: "Collaborator of an app",
 	Fields: graphql.Fields{
-		"id":        &graphql.Field{Type: graphql.NewNonNull(graphql.String)},
-		"userID":    &graphql.Field{Type: graphql.NewNonNull(graphql.String)},
+		"id": &graphql.Field{Type: graphql.NewNonNull(graphql.String)},
+
+		// AppID is intentionally excluded because
+		// if we wanted to reference back the app, we would add "app"
+		// But adding it would result in a circular schema.
+
+		// The value is a plain user ID.
+		// Is there any better way to handle this field?
+		"userID": &graphql.Field{Type: graphql.NewNonNull(graphql.String)},
+
 		"createdAt": &graphql.Field{Type: graphql.NewNonNull(graphql.DateTime)},
+	},
+})
+
+var collaboratorInvitation = graphql.NewObject(graphql.ObjectConfig{
+	Name:        "CollaboratorInvitation",
+	Description: "Collaborator invitation of an app",
+	Fields: graphql.Fields{
+		"id": &graphql.Field{Type: graphql.NewNonNull(graphql.String)},
+
+		// AppID is intentionally excluded because
+		// if we wanted to reference back the app, we would add "app"
+		// But adding it would result in a circular schema.
+
+		// The value is a plain user ID.
+		// Is there any better way to handle this field?
+		"invitedBy": &graphql.Field{Type: graphql.NewNonNull(graphql.String)},
+
+		"inviteeEmail": &graphql.Field{Type: graphql.NewNonNull(graphql.String)},
+		"createdAt":    &graphql.Field{Type: graphql.NewNonNull(graphql.DateTime)},
+		"expireAt":     &graphql.Field{Type: graphql.NewNonNull(graphql.DateTime)},
 	},
 })

--- a/pkg/portal/graphql/collaborator_mutation.go
+++ b/pkg/portal/graphql/collaborator_mutation.go
@@ -2,7 +2,9 @@ package graphql
 
 import (
 	"github.com/graphql-go/graphql"
+	"github.com/graphql-go/relay"
 
+	"github.com/authgear/authgear-server/pkg/api/apierrors"
 	"github.com/authgear/authgear-server/pkg/portal/model"
 )
 
@@ -26,7 +28,7 @@ var deleteCollaboratorPayload = graphql.NewObject(graphql.ObjectConfig{
 var _ = registerMutationField(
 	"deleteCollaborator",
 	&graphql.Field{
-		Description: "Delete collaborator of target app",
+		Description: "Delete collaborator of target app.",
 		Type:        graphql.NewNonNull(deleteCollaboratorPayload),
 		Args: graphql.FieldConfigArgument{
 			"input": &graphql.ArgumentConfig{
@@ -39,6 +41,150 @@ var _ = registerMutationField(
 
 			gqlCtx := GQLContext(p.Context)
 			return gqlCtx.Collaborators.DeleteCollaborator(collaboratorID).
+				Map(func(value interface{}) (interface{}, error) {
+					c := value.(*model.Collaborator)
+					app := gqlCtx.Apps.Get(c.AppID)
+					return map[string]interface{}{
+						"app": app,
+					}, nil
+				}).Value, nil
+		},
+	},
+)
+
+var deleteCollaboratorInvitationInput = graphql.NewInputObject(graphql.InputObjectConfig{
+	Name: "DeleteCollaboratorInvitationInput",
+	Fields: graphql.InputObjectConfigFieldMap{
+		"collaboratorInvitationID": &graphql.InputObjectFieldConfig{
+			Type:        graphql.NewNonNull(graphql.String),
+			Description: "Collaborator invitation ID.",
+		},
+	},
+})
+
+var deleteCollaboratorInvitationPayload = graphql.NewObject(graphql.ObjectConfig{
+	Name: "DeleteCollaboratorInvitationPayload",
+	Fields: graphql.Fields{
+		"app": &graphql.Field{Type: graphql.NewNonNull(nodeApp)},
+	},
+})
+
+var _ = registerMutationField(
+	"deleteCollaboratorInvitation",
+	&graphql.Field{
+		Description: "Delete collaborator invitation of target app.",
+		Type:        graphql.NewNonNull(deleteCollaboratorInvitationPayload),
+		Args: graphql.FieldConfigArgument{
+			"input": &graphql.ArgumentConfig{
+				Type: graphql.NewNonNull(deleteCollaboratorInvitationInput),
+			},
+		},
+		Resolve: func(p graphql.ResolveParams) (interface{}, error) {
+			input := p.Args["input"].(map[string]interface{})
+			collaboratorInvitationID := input["collaboratorInvitationID"].(string)
+
+			gqlCtx := GQLContext(p.Context)
+			return gqlCtx.Collaborators.DeleteInvitation(collaboratorInvitationID).
+				Map(func(value interface{}) (interface{}, error) {
+					i := value.(*model.CollaboratorInvitation)
+					app := gqlCtx.Apps.Get(i.AppID)
+					return map[string]interface{}{
+						"app": app,
+					}, nil
+				}).Value, nil
+		},
+	},
+)
+
+var createCollaboratorInvitationInput = graphql.NewInputObject(graphql.InputObjectConfig{
+	Name: "CreateCollaboratorInvitationInput",
+	Fields: graphql.InputObjectConfigFieldMap{
+		"appID": &graphql.InputObjectFieldConfig{
+			Type:        graphql.NewNonNull(graphql.ID),
+			Description: "Target app ID.",
+		},
+		"inviteeEmail": &graphql.InputObjectFieldConfig{
+			Type:        graphql.NewNonNull(graphql.String),
+			Description: "Invitee email address.",
+		},
+	},
+})
+
+var createCollaboratorInvitationPayload = graphql.NewObject(graphql.ObjectConfig{
+	Name: "CreateCollaboratorInvitationPayload",
+	Fields: graphql.Fields{
+		"app": &graphql.Field{Type: graphql.NewNonNull(nodeApp)},
+	},
+})
+
+var _ = registerMutationField(
+	"createCollaboratorInvitation",
+	&graphql.Field{
+		Description: "Invite a collaborator to the target app.",
+		Type:        graphql.NewNonNull(createCollaboratorInvitationPayload),
+		Args: graphql.FieldConfigArgument{
+			"input": &graphql.ArgumentConfig{
+				Type: graphql.NewNonNull(createCollaboratorInvitationInput),
+			},
+		},
+		Resolve: func(p graphql.ResolveParams) (interface{}, error) {
+			input := p.Args["input"].(map[string]interface{})
+			appNodeID := input["appID"].(string)
+			inviteeEmail := input["inviteeEmail"].(string)
+
+			resolvedNodeID := relay.FromGlobalID(appNodeID)
+			if resolvedNodeID.Type != typeApp {
+				return nil, apierrors.NewInvalid("invalid app ID")
+			}
+			appID := resolvedNodeID.ID
+
+			// FIXME(collaborator): Use JSON schema to validate input.
+
+			gqlCtx := GQLContext(p.Context)
+			return gqlCtx.Collaborators.SendInvitation(appID, inviteeEmail).
+				Map(func(value interface{}) (interface{}, error) {
+					app := gqlCtx.Apps.Get(appID)
+					return map[string]interface{}{
+						"app": app,
+					}, nil
+				}).Value, nil
+		},
+	},
+)
+
+var acceptCollaboratorInvitationInput = graphql.NewInputObject(graphql.InputObjectConfig{
+	Name: "AcceptCollaboratorInvitationInput",
+	Fields: graphql.InputObjectConfigFieldMap{
+		"code": &graphql.InputObjectFieldConfig{
+			Type:        graphql.NewNonNull(graphql.String),
+			Description: "Invitation code.",
+		},
+	},
+})
+
+var acceptCollaboratorInvitationPayload = graphql.NewObject(graphql.ObjectConfig{
+	Name: "AcceptCollaboratorInvitationPayload",
+	Fields: graphql.Fields{
+		"app": &graphql.Field{Type: graphql.NewNonNull(nodeApp)},
+	},
+})
+
+var _ = registerMutationField(
+	"acceptCollaboratorInvitation",
+	&graphql.Field{
+		Description: "Accept collaborator invitation to the target app.",
+		Type:        graphql.NewNonNull(acceptCollaboratorInvitationPayload),
+		Args: graphql.FieldConfigArgument{
+			"input": &graphql.ArgumentConfig{
+				Type: graphql.NewNonNull(acceptCollaboratorInvitationInput),
+			},
+		},
+		Resolve: func(p graphql.ResolveParams) (interface{}, error) {
+			input := p.Args["input"].(map[string]interface{})
+			code := input["code"].(string)
+
+			gqlCtx := GQLContext(p.Context)
+			return gqlCtx.Collaborators.AcceptInvitation(code).
 				Map(func(value interface{}) (interface{}, error) {
 					c := value.(*model.Collaborator)
 					app := gqlCtx.Apps.Get(c.AppID)

--- a/pkg/portal/graphql/collaborator_mutation.go
+++ b/pkg/portal/graphql/collaborator_mutation.go
@@ -164,7 +164,8 @@ var createCollaboratorInvitationInputSchema = validation.NewMultipartSchema("").
 var createCollaboratorInvitationPayload = graphql.NewObject(graphql.ObjectConfig{
 	Name: "CreateCollaboratorInvitationPayload",
 	Fields: graphql.Fields{
-		"app": &graphql.Field{Type: graphql.NewNonNull(nodeApp)},
+		"app":                    &graphql.Field{Type: graphql.NewNonNull(nodeApp)},
+		"collaboratorInvitation": &graphql.Field{Type: graphql.NewNonNull(collaboratorInvitation)},
 	},
 })
 
@@ -207,7 +208,8 @@ var _ = registerMutationField(
 				Map(func(value interface{}) (interface{}, error) {
 					app := gqlCtx.Apps.Get(appID)
 					return map[string]interface{}{
-						"app": app,
+						"app":                    app,
+						"collaboratorInvitation": value,
 					}, nil
 				}).Value, nil
 		},

--- a/pkg/portal/graphql/collaborator_mutation.go
+++ b/pkg/portal/graphql/collaborator_mutation.go
@@ -12,10 +12,6 @@ import (
 var deleteCollaboratorInput = graphql.NewInputObject(graphql.InputObjectConfig{
 	Name: "DeleteCollaboratorInput",
 	Fields: graphql.InputObjectConfigFieldMap{
-		"appID": &graphql.InputObjectFieldConfig{
-			Type:        graphql.NewNonNull(graphql.ID),
-			Description: "Target app ID.",
-		},
 		"collaboratorID": &graphql.InputObjectFieldConfig{
 			Type:        graphql.NewNonNull(graphql.String),
 			Description: "Collaborator ID.",
@@ -43,19 +39,8 @@ var _ = registerMutationField(
 		Resolve: func(p graphql.ResolveParams) (interface{}, error) {
 			input := p.Args["input"].(map[string]interface{})
 			collaboratorID := input["collaboratorID"].(string)
-			appNodeID := input["appID"].(string)
-			resolvedNodeID := relay.FromGlobalID(appNodeID)
-			if resolvedNodeID.Type != typeApp {
-				return nil, apierrors.NewInvalid("invalid app ID")
-			}
-			appID := resolvedNodeID.ID
 
 			gqlCtx := GQLContext(p.Context)
-
-			err := gqlCtx.AuthzService.CheckAccessOfViewer(appID)
-			if err != nil {
-				return nil, err
-			}
 
 			return gqlCtx.Collaborators.DeleteCollaborator(collaboratorID).
 				Map(func(value interface{}) (interface{}, error) {
@@ -72,10 +57,6 @@ var _ = registerMutationField(
 var deleteCollaboratorInvitationInput = graphql.NewInputObject(graphql.InputObjectConfig{
 	Name: "DeleteCollaboratorInvitationInput",
 	Fields: graphql.InputObjectConfigFieldMap{
-		"appID": &graphql.InputObjectFieldConfig{
-			Type:        graphql.NewNonNull(graphql.ID),
-			Description: "Target app ID.",
-		},
 		"collaboratorInvitationID": &graphql.InputObjectFieldConfig{
 			Type:        graphql.NewNonNull(graphql.String),
 			Description: "Collaborator invitation ID.",
@@ -102,21 +83,9 @@ var _ = registerMutationField(
 		},
 		Resolve: func(p graphql.ResolveParams) (interface{}, error) {
 			input := p.Args["input"].(map[string]interface{})
-			appNodeID := input["appID"].(string)
 			collaboratorInvitationID := input["collaboratorInvitationID"].(string)
 
-			resolvedNodeID := relay.FromGlobalID(appNodeID)
-			if resolvedNodeID.Type != typeApp {
-				return nil, apierrors.NewInvalid("invalid app ID")
-			}
-			appID := resolvedNodeID.ID
-
 			gqlCtx := GQLContext(p.Context)
-
-			err := gqlCtx.AuthzService.CheckAccessOfViewer(appID)
-			if err != nil {
-				return nil, err
-			}
 
 			return gqlCtx.Collaborators.DeleteInvitation(collaboratorInvitationID).
 				Map(func(value interface{}) (interface{}, error) {
@@ -198,11 +167,6 @@ var _ = registerMutationField(
 			appID := resolvedNodeID.ID
 
 			gqlCtx := GQLContext(p.Context)
-
-			err = gqlCtx.AuthzService.CheckAccessOfViewer(appID)
-			if err != nil {
-				return nil, err
-			}
 
 			return gqlCtx.Collaborators.SendInvitation(appID, inviteeEmail).
 				Map(func(value interface{}) (interface{}, error) {

--- a/pkg/portal/graphql/context.go
+++ b/pkg/portal/graphql/context.go
@@ -37,10 +37,6 @@ type CollaboratorLoader interface {
 	AcceptInvitation(code string) *graphqlutil.Lazy
 }
 
-type AuthzService interface {
-	CheckAccessOfViewer(appID string) error
-}
-
 type Logger struct{ *log.Logger }
 
 func NewLogger(lf *log.Factory) Logger { return Logger{lf.New("portal-graphql")} }
@@ -51,7 +47,6 @@ type Context struct {
 	Apps          AppLoader
 	Domains       DomainLoader
 	Collaborators CollaboratorLoader
-	AuthzService  AuthzService
 }
 
 func (c *Context) Logger() *log.Logger {

--- a/pkg/portal/graphql/context.go
+++ b/pkg/portal/graphql/context.go
@@ -30,6 +30,11 @@ type DomainLoader interface {
 type CollaboratorLoader interface {
 	ListCollaborators(appID string) *graphqlutil.Lazy
 	DeleteCollaborator(id string) *graphqlutil.Lazy
+
+	ListInvitations(appID string) *graphqlutil.Lazy
+	DeleteInvitation(id string) *graphqlutil.Lazy
+	SendInvitation(appID string, inviteeEmail string) *graphqlutil.Lazy
+	AcceptInvitation(code string) *graphqlutil.Lazy
 }
 
 type Logger struct{ *log.Logger }

--- a/pkg/portal/graphql/context.go
+++ b/pkg/portal/graphql/context.go
@@ -37,6 +37,10 @@ type CollaboratorLoader interface {
 	AcceptInvitation(code string) *graphqlutil.Lazy
 }
 
+type AuthzService interface {
+	CheckAccessOfViewer(appID string) error
+}
+
 type Logger struct{ *log.Logger }
 
 func NewLogger(lf *log.Factory) Logger { return Logger{lf.New("portal-graphql")} }
@@ -47,6 +51,7 @@ type Context struct {
 	Apps          AppLoader
 	Domains       DomainLoader
 	Collaborators CollaboratorLoader
+	AuthzService  AuthzService
 }
 
 func (c *Context) Logger() *log.Logger {

--- a/pkg/portal/graphql/domain_mutation.go
+++ b/pkg/portal/graphql/domain_mutation.go
@@ -52,6 +52,12 @@ var _ = registerMutationField(
 			appID := resolvedNodeID.ID
 
 			gqlCtx := GQLContext(p.Context)
+
+			err := gqlCtx.AuthzService.CheckAccessOfViewer(appID)
+			if err != nil {
+				return nil, err
+			}
+
 			lazy := gqlCtx.Apps.Get(appID)
 			return lazy.
 				Map(func(value interface{}) (interface{}, error) {
@@ -111,6 +117,12 @@ var _ = registerMutationField(
 			appID := resolvedNodeID.ID
 
 			gqlCtx := GQLContext(p.Context)
+
+			err := gqlCtx.AuthzService.CheckAccessOfViewer(appID)
+			if err != nil {
+				return nil, err
+			}
+
 			lazy := gqlCtx.Apps.Get(appID)
 			return lazy.
 				Map(func(value interface{}) (interface{}, error) {
@@ -170,6 +182,12 @@ var _ = registerMutationField(
 			appID := resolvedNodeID.ID
 
 			gqlCtx := GQLContext(p.Context)
+
+			err := gqlCtx.AuthzService.CheckAccessOfViewer(appID)
+			if err != nil {
+				return nil, err
+			}
+
 			lazy := gqlCtx.Apps.Get(appID)
 			return lazy.
 				Map(func(value interface{}) (interface{}, error) {
@@ -178,7 +196,7 @@ var _ = registerMutationField(
 						Map(func(domain interface{}) (interface{}, error) {
 							return map[string]interface{}{
 								"domain": domain,
-								"app":          app,
+								"app":    app,
 							}, nil
 						}), nil
 				}).Value, nil

--- a/pkg/portal/graphql/domain_mutation.go
+++ b/pkg/portal/graphql/domain_mutation.go
@@ -53,11 +53,6 @@ var _ = registerMutationField(
 
 			gqlCtx := GQLContext(p.Context)
 
-			err := gqlCtx.AuthzService.CheckAccessOfViewer(appID)
-			if err != nil {
-				return nil, err
-			}
-
 			lazy := gqlCtx.Apps.Get(appID)
 			return lazy.
 				Map(func(value interface{}) (interface{}, error) {
@@ -118,11 +113,6 @@ var _ = registerMutationField(
 
 			gqlCtx := GQLContext(p.Context)
 
-			err := gqlCtx.AuthzService.CheckAccessOfViewer(appID)
-			if err != nil {
-				return nil, err
-			}
-
 			lazy := gqlCtx.Apps.Get(appID)
 			return lazy.
 				Map(func(value interface{}) (interface{}, error) {
@@ -182,11 +172,6 @@ var _ = registerMutationField(
 			appID := resolvedNodeID.ID
 
 			gqlCtx := GQLContext(p.Context)
-
-			err := gqlCtx.AuthzService.CheckAccessOfViewer(appID)
-			if err != nil {
-				return nil, err
-			}
 
 			lazy := gqlCtx.Apps.Get(appID)
 			return lazy.

--- a/pkg/portal/loader/authz.go
+++ b/pkg/portal/loader/authz.go
@@ -1,0 +1,5 @@
+package loader
+
+type AuthzService interface {
+	CheckAccessOfViewer(appID string) error
+}

--- a/pkg/portal/loader/collaborator.go
+++ b/pkg/portal/loader/collaborator.go
@@ -19,9 +19,15 @@ type CollaboratorService interface {
 
 type CollaboratorLoader struct {
 	Collaborators CollaboratorService
+	Authz         AuthzService
 }
 
 func (l *CollaboratorLoader) ListCollaborators(appID string) *graphqlutil.Lazy {
+	err := l.Authz.CheckAccessOfViewer(appID)
+	if err != nil {
+		return graphqlutil.NewLazyError(err)
+	}
+
 	return graphqlutil.NewLazy(func() (interface{}, error) {
 		return l.Collaborators.ListCollaborators(appID)
 	})
@@ -30,6 +36,11 @@ func (l *CollaboratorLoader) ListCollaborators(appID string) *graphqlutil.Lazy {
 func (l *CollaboratorLoader) DeleteCollaborator(id string) *graphqlutil.Lazy {
 	return graphqlutil.NewLazy(func() (interface{}, error) {
 		c, err := l.Collaborators.GetCollaborator(id)
+		if err != nil {
+			return nil, err
+		}
+
+		err = l.Authz.CheckAccessOfViewer(c.AppID)
 		if err != nil {
 			return nil, err
 		}
@@ -44,6 +55,11 @@ func (l *CollaboratorLoader) DeleteCollaborator(id string) *graphqlutil.Lazy {
 }
 
 func (l *CollaboratorLoader) ListInvitations(appID string) *graphqlutil.Lazy {
+	err := l.Authz.CheckAccessOfViewer(appID)
+	if err != nil {
+		return graphqlutil.NewLazyError(err)
+	}
+
 	return graphqlutil.NewLazy(func() (interface{}, error) {
 		return l.Collaborators.ListInvitations(appID)
 	})
@@ -52,6 +68,11 @@ func (l *CollaboratorLoader) ListInvitations(appID string) *graphqlutil.Lazy {
 func (l *CollaboratorLoader) DeleteInvitation(id string) *graphqlutil.Lazy {
 	return graphqlutil.NewLazy(func() (interface{}, error) {
 		i, err := l.Collaborators.GetInvitation(id)
+		if err != nil {
+			return nil, err
+		}
+
+		err = l.Authz.CheckAccessOfViewer(i.AppID)
 		if err != nil {
 			return nil, err
 		}
@@ -66,6 +87,11 @@ func (l *CollaboratorLoader) DeleteInvitation(id string) *graphqlutil.Lazy {
 }
 
 func (l *CollaboratorLoader) SendInvitation(appID string, inviteeEmail string) *graphqlutil.Lazy {
+	err := l.Authz.CheckAccessOfViewer(appID)
+	if err != nil {
+		return graphqlutil.NewLazyError(err)
+	}
+
 	return graphqlutil.NewLazy(func() (interface{}, error) {
 		i, err := l.Collaborators.SendInvitation(appID, inviteeEmail)
 		if err != nil {

--- a/pkg/portal/loader/collaborator.go
+++ b/pkg/portal/loader/collaborator.go
@@ -9,6 +9,12 @@ type CollaboratorService interface {
 	ListCollaborators(appID string) ([]*model.Collaborator, error)
 	GetCollaborator(id string) (*model.Collaborator, error)
 	DeleteCollaborator(c *model.Collaborator) error
+
+	ListInvitations(appID string) ([]*model.CollaboratorInvitation, error)
+	GetInvitation(id string) (*model.CollaboratorInvitation, error)
+	DeleteInvitation(i *model.CollaboratorInvitation) error
+	SendInvitation(appID string, inviteeEmail string) (*model.CollaboratorInvitation, error)
+	AcceptInvitation(code string) (*model.Collaborator, error)
 }
 
 type CollaboratorLoader struct {
@@ -33,6 +39,48 @@ func (l *CollaboratorLoader) DeleteCollaborator(id string) *graphqlutil.Lazy {
 			return nil, err
 		}
 
+		return c, nil
+	})
+}
+
+func (l *CollaboratorLoader) ListInvitations(appID string) *graphqlutil.Lazy {
+	return graphqlutil.NewLazy(func() (interface{}, error) {
+		return l.Collaborators.ListInvitations(appID)
+	})
+}
+
+func (l *CollaboratorLoader) DeleteInvitation(id string) *graphqlutil.Lazy {
+	return graphqlutil.NewLazy(func() (interface{}, error) {
+		i, err := l.Collaborators.GetInvitation(id)
+		if err != nil {
+			return nil, err
+		}
+
+		err = l.Collaborators.DeleteInvitation(i)
+		if err != nil {
+			return nil, err
+		}
+
+		return i, nil
+	})
+}
+
+func (l *CollaboratorLoader) SendInvitation(appID string, inviteeEmail string) *graphqlutil.Lazy {
+	return graphqlutil.NewLazy(func() (interface{}, error) {
+		i, err := l.Collaborators.SendInvitation(appID, inviteeEmail)
+		if err != nil {
+			return nil, err
+		}
+		return i, nil
+	})
+}
+
+func (l *CollaboratorLoader) AcceptInvitation(code string) *graphqlutil.Lazy {
+	return graphqlutil.NewLazy(func() (interface{}, error) {
+		c, err := l.Collaborators.AcceptInvitation(code)
+		if err != nil {
+			return nil, err
+		}
 		return c, nil
 	})
 }

--- a/pkg/portal/loader/domain.go
+++ b/pkg/portal/loader/domain.go
@@ -14,27 +14,48 @@ type DomainService interface {
 
 type DomainLoader struct {
 	Domains DomainService
+	Authz   AuthzService
 }
 
 func (l *DomainLoader) ListDomains(appID string) *graphqlutil.Lazy {
+	err := l.Authz.CheckAccessOfViewer(appID)
+	if err != nil {
+		return graphqlutil.NewLazyError(err)
+	}
+
 	return graphqlutil.NewLazy(func() (interface{}, error) {
 		return l.Domains.ListDomains(appID)
 	})
 }
 
 func (l *DomainLoader) CreateDomain(appID string, domain string) *graphqlutil.Lazy {
+	err := l.Authz.CheckAccessOfViewer(appID)
+	if err != nil {
+		return graphqlutil.NewLazyError(err)
+	}
+
 	return graphqlutil.NewLazy(func() (interface{}, error) {
 		return l.Domains.CreateDomain(appID, domain, false, true)
 	})
 }
 
 func (l *DomainLoader) DeleteDomain(appID string, id string) *graphqlutil.Lazy {
+	err := l.Authz.CheckAccessOfViewer(appID)
+	if err != nil {
+		return graphqlutil.NewLazyError(err)
+	}
+
 	return graphqlutil.NewLazy(func() (interface{}, error) {
 		return nil, l.Domains.DeleteDomain(appID, id)
 	})
 }
 
 func (l *DomainLoader) VerifyDomain(appID string, id string) *graphqlutil.Lazy {
+	err := l.Authz.CheckAccessOfViewer(appID)
+	if err != nil {
+		return graphqlutil.NewLazyError(err)
+	}
+
 	return graphqlutil.NewLazy(func() (interface{}, error) {
 		return l.Domains.VerifyDomain(appID, id)
 	})

--- a/pkg/portal/model/collaborator.go
+++ b/pkg/portal/model/collaborator.go
@@ -10,3 +10,13 @@ type Collaborator struct {
 	UserID    string    `json:"userID"`
 	CreatedAt time.Time `json:"createdAt"`
 }
+
+type CollaboratorInvitation struct {
+	ID           string    `json:"id"`
+	AppID        string    `json:"appID"`
+	InvitedBy    string    `json:"invitedBy"`
+	InviteeEmail string    `json:"inviteeEmail"`
+	Code         string    `json:"-"`
+	CreatedAt    time.Time `json:"createdAt"`
+	ExpireAt     time.Time `json:"expireAt"`
+}

--- a/pkg/portal/service/authz.go
+++ b/pkg/portal/service/authz.go
@@ -1,10 +1,15 @@
 package service
 
 import (
+	"context"
 	"errors"
 
+	"github.com/authgear/authgear-server/pkg/api/apierrors"
 	"github.com/authgear/authgear-server/pkg/portal/model"
+	"github.com/authgear/authgear-server/pkg/portal/session"
 )
+
+var ErrForbidden = apierrors.Forbidden.WithReason("Forbidden").New("forbidden")
 
 type AuthzConfigService interface {
 	GetStaticAppIDs() ([]string, error)
@@ -14,9 +19,11 @@ type AuthzCollaboratorService interface {
 	NewCollaborator(appID string, userID string) *model.Collaborator
 	CreateCollaborator(c *model.Collaborator) error
 	ListCollaboratorsByUser(userID string) ([]*model.Collaborator, error)
+	GetCollaboratorByAppAndUser(appID string, userID string) (*model.Collaborator, error)
 }
 
 type AuthzService struct {
+	Context       context.Context
 	Configs       AuthzConfigService
 	Collaborators AuthzCollaboratorService
 }
@@ -45,4 +52,20 @@ func (s *AuthzService) ListAuthorizedApps(userID string) ([]string, error) {
 func (s *AuthzService) AddAuthorizedUser(appID string, userID string) error {
 	c := s.Collaborators.NewCollaborator(appID, userID)
 	return s.Collaborators.CreateCollaborator(c)
+}
+
+func (s *AuthzService) CheckAccessOfViewer(appID string) error {
+	sessionInfo := session.GetValidSessionInfo(s.Context)
+	if sessionInfo == nil {
+		return ErrForbidden
+	}
+
+	userID := sessionInfo.UserID
+	_, err := s.Collaborators.GetCollaboratorByAppAndUser(appID, userID)
+	if errors.Is(err, ErrCollaboratorNotFound) {
+		return ErrForbidden
+	} else if err != nil {
+		return err
+	}
+	return nil
 }

--- a/pkg/portal/service/collaborator.go
+++ b/pkg/portal/service/collaborator.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"errors"
+	"time"
 
 	sq "github.com/Masterminds/squirrel"
 
@@ -11,13 +12,20 @@ import (
 	"github.com/authgear/authgear-server/pkg/portal/db"
 	"github.com/authgear/authgear-server/pkg/portal/model"
 	"github.com/authgear/authgear-server/pkg/portal/session"
+	"github.com/authgear/authgear-server/pkg/util/base32"
 	"github.com/authgear/authgear-server/pkg/util/clock"
+	"github.com/authgear/authgear-server/pkg/util/rand"
 	"github.com/authgear/authgear-server/pkg/util/uuid"
 )
 
 var ErrCollaboratorNotFound = apierrors.NotFound.WithReason("CollaboratorNotFound").New("collaborator not found")
 var ErrCollaboratorUnauthorized = apierrors.Unauthorized.WithReason("CollaboratorUnauthorized").New("collaborator unauthorized")
 var ErrCollaboratorSelfDeletion = apierrors.Forbidden.WithReason("CollaboratorSelfDeletion").New("cannot remove self from collaborator")
+
+var ErrCollaboratorInvitationNotFound = apierrors.NotFound.WithReason("CollaboratorInvitationNotFound").New("collaborator invitation not found")
+var ErrCollaboratorInvitationDuplicate = apierrors.AlreadyExists.WithReason("CollaboratorInvitationDuplicate").New("collaborator invitation duplicate")
+var ErrCollaboratorInvitationInvalidCode = apierrors.Invalid.WithReason("CollaboratorInvitationInvalidCode").New("collaborator invitation invalid code")
+var ErrCollaboratorInvitationDuplicateCode = apierrors.InternalError.WithReason("CollaboratorInvitationDuplicateCode").New("collaborator invitation duplicate code")
 
 type CollaboratorService struct {
 	Context     context.Context
@@ -33,6 +41,18 @@ func (s *CollaboratorService) selectCollaborator() sq.SelectBuilder {
 		"user_id",
 		"created_at",
 	).From(s.SQLBuilder.FullTableName("app_collaborator"))
+}
+
+func (s *CollaboratorService) selectCollaboratorInvitation() sq.SelectBuilder {
+	return s.SQLBuilder.Select(
+		"id",
+		"app_id",
+		"invited_by",
+		"invitee_email",
+		"code",
+		"created_at",
+		"expire_at",
+	).From(s.SQLBuilder.FullTableName("app_collaborator_invitation"))
 }
 
 func (s *CollaboratorService) ListCollaborators(appID string) ([]*model.Collaborator, error) {
@@ -138,6 +158,178 @@ func (s *CollaboratorService) DeleteCollaborator(c *model.Collaborator) error {
 	return nil
 }
 
+func (s *CollaboratorService) ListInvitations(appID string) ([]*model.CollaboratorInvitation, error) {
+	now := s.Clock.NowUTC()
+	q := s.selectCollaboratorInvitation().Where("app_id = ? AND expire_at > ?", appID, now)
+	rows, err := s.SQLExecutor.QueryWith(q)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var is []*model.CollaboratorInvitation
+	for rows.Next() {
+		i, err := scanCollaboratorInvitation(rows)
+		if err != nil {
+			return nil, err
+		}
+		is = append(is, i)
+	}
+
+	return is, nil
+}
+
+func (s *CollaboratorService) SendInvitation(
+	appID string,
+	inviteeEmail string,
+) (*model.CollaboratorInvitation, error) {
+	sessionInfo := session.GetValidSessionInfo(s.Context)
+	if sessionInfo == nil {
+		return nil, ErrCollaboratorUnauthorized
+	}
+	invitedBy := sessionInfo.UserID
+
+	// FIXME(collaborator): Check if the invitee is collaborator
+	// It is impossible now because Admin API does not have getUserByClaim
+
+	// FIXME(collaborator): Check if the actor is a collaborator
+	// We should do this for all querys and mutations.
+
+	// Check if the invitee has a pending invitation already.
+	invitations, err := s.ListInvitations(appID)
+	if err != nil {
+		return nil, err
+	}
+	for _, i := range invitations {
+		if i.InviteeEmail == inviteeEmail {
+			return nil, ErrCollaboratorInvitationDuplicate
+		}
+	}
+
+	code := generateCollaboratorInvitationCode()
+	now := s.Clock.NowUTC()
+	// Expire in 3 days.
+	expireAt := now.Add(3 * 24 * time.Hour)
+
+	i := &model.CollaboratorInvitation{
+		ID:           uuid.New(),
+		AppID:        appID,
+		InvitedBy:    invitedBy,
+		InviteeEmail: inviteeEmail,
+		Code:         code,
+		CreatedAt:    now,
+		ExpireAt:     expireAt,
+	}
+
+	err = s.createCollaboratorInvitation(i)
+	if err != nil {
+		return nil, err
+	}
+
+	// FIXME(collaborator): Send the invitation email
+
+	return i, nil
+}
+
+func (s *CollaboratorService) GetInvitation(id string) (*model.CollaboratorInvitation, error) {
+	q := s.selectCollaboratorInvitation().Where("id = ?", id)
+	row, err := s.SQLExecutor.QueryRowWith(q)
+	if err != nil {
+		return nil, err
+	}
+	return scanCollaboratorInvitation(row)
+}
+
+func (s *CollaboratorService) DeleteInvitation(i *model.CollaboratorInvitation) error {
+	_, err := s.SQLExecutor.ExecWith(s.SQLBuilder.
+		Delete(s.SQLBuilder.FullTableName("app_collaborator_invitation")).
+		Where("id = ?", i.ID),
+	)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (s *CollaboratorService) AcceptInvitation(code string) (*model.Collaborator, error) {
+	sessionInfo := session.GetValidSessionInfo(s.Context)
+	if sessionInfo == nil {
+		return nil, ErrCollaboratorUnauthorized
+	}
+	actorID := sessionInfo.UserID
+
+	now := s.Clock.NowUTC()
+	q := s.selectCollaboratorInvitation().Where("code = ? AND expire_at > ?", code, now)
+	rows, err := s.SQLExecutor.QueryWith(q)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var is []*model.CollaboratorInvitation
+	for rows.Next() {
+		i, err := scanCollaboratorInvitation(rows)
+		if err != nil {
+			return nil, err
+		}
+		is = append(is, i)
+	}
+
+	if len(is) <= 0 {
+		return nil, ErrCollaboratorInvitationInvalidCode
+	}
+
+	if len(is) > 1 {
+		return nil, ErrCollaboratorInvitationDuplicateCode
+	}
+
+	invitation := is[0]
+
+	// FIXME(collaborator): Check if the inviteeEmail matches actor.
+	err = s.DeleteInvitation(invitation)
+	if err != nil {
+		return nil, err
+	}
+
+	collaborator := s.NewCollaborator(invitation.AppID, actorID)
+	err = s.CreateCollaborator(collaborator)
+	if err != nil {
+		return nil, err
+	}
+
+	return collaborator, nil
+}
+
+func (s *CollaboratorService) createCollaboratorInvitation(i *model.CollaboratorInvitation) error {
+	_, err := s.SQLExecutor.ExecWith(s.SQLBuilder.
+		Insert(s.SQLBuilder.FullTableName("app_collaborator_invitation")).
+		Columns(
+			"id",
+			"app_id",
+			"invited_by",
+			"invitee_email",
+			"code",
+			"created_at",
+			"expire_at",
+		).
+		Values(
+			i.ID,
+			i.AppID,
+			i.InvitedBy,
+			i.InviteeEmail,
+			i.Code,
+			i.CreatedAt,
+			i.ExpireAt,
+		),
+	)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
 func scanCollaborator(scan db.Scanner) (*model.Collaborator, error) {
 	c := &model.Collaborator{}
 
@@ -154,4 +346,30 @@ func scanCollaborator(scan db.Scanner) (*model.Collaborator, error) {
 	}
 
 	return c, nil
+}
+
+func scanCollaboratorInvitation(scan db.Scanner) (*model.CollaboratorInvitation, error) {
+	i := &model.CollaboratorInvitation{}
+
+	err := scan.Scan(
+		&i.ID,
+		&i.AppID,
+		&i.InvitedBy,
+		&i.InviteeEmail,
+		&i.Code,
+		&i.CreatedAt,
+		&i.ExpireAt,
+	)
+	if errors.Is(err, sql.ErrNoRows) {
+		return nil, ErrCollaboratorInvitationNotFound
+	} else if err != nil {
+		return nil, err
+	}
+
+	return i, nil
+}
+
+func generateCollaboratorInvitationCode() string {
+	code := rand.StringWithAlphabet(32, base32.Alphabet, rand.SecureRand)
+	return code
 }

--- a/pkg/portal/service/collaborator.go
+++ b/pkg/portal/service/collaborator.go
@@ -25,7 +25,6 @@ var ErrCollaboratorDuplicate = apierrors.AlreadyExists.WithReason("CollaboratorD
 var ErrCollaboratorInvitationNotFound = apierrors.NotFound.WithReason("CollaboratorInvitationNotFound").New("collaborator invitation not found")
 var ErrCollaboratorInvitationDuplicate = apierrors.AlreadyExists.WithReason("CollaboratorInvitationDuplicate").New("collaborator invitation duplicate")
 var ErrCollaboratorInvitationInvalidCode = apierrors.Invalid.WithReason("CollaboratorInvitationInvalidCode").New("collaborator invitation invalid code")
-var ErrCollaboratorInvitationDuplicateCode = apierrors.InternalError.WithReason("CollaboratorInvitationDuplicateCode").New("collaborator invitation duplicate code")
 
 type CollaboratorService struct {
 	Context     context.Context
@@ -277,10 +276,6 @@ func (s *CollaboratorService) AcceptInvitation(code string) (*model.Collaborator
 
 	if len(is) <= 0 {
 		return nil, ErrCollaboratorInvitationInvalidCode
-	}
-
-	if len(is) > 1 {
-		return nil, ErrCollaboratorInvitationDuplicateCode
 	}
 
 	invitation := is[0]

--- a/pkg/portal/wire_gen.go
+++ b/pkg/portal/wire_gen.go
@@ -141,13 +141,16 @@ func newGraphQLHandler(p *deps.RequestProvider) http.Handler {
 		AppDomains:  domainService,
 	}
 	appLoader := &loader.AppLoader{
-		Apps: appService,
+		Apps:  appService,
+		Authz: authzService,
 	}
 	domainLoader := &loader.DomainLoader{
 		Domains: domainService,
+		Authz:   authzService,
 	}
 	collaboratorLoader := &loader.CollaboratorLoader{
 		Collaborators: collaboratorService,
+		Authz:         authzService,
 	}
 	graphqlContext := &graphql.Context{
 		GQLLogger:     logger,
@@ -155,7 +158,6 @@ func newGraphQLHandler(p *deps.RequestProvider) http.Handler {
 		Apps:          appLoader,
 		Domains:       domainLoader,
 		Collaborators: collaboratorLoader,
-		AuthzService:  authzService,
 	}
 	graphQLHandler := &transport.GraphQLHandler{
 		DevMode:        devMode,

--- a/pkg/portal/wire_gen.go
+++ b/pkg/portal/wire_gen.go
@@ -112,6 +112,7 @@ func newGraphQLHandler(p *deps.RequestProvider) http.Handler {
 		SQLExecutor: sqlExecutor,
 	}
 	authzService := &service.AuthzService{
+		Context:       context,
 		Configs:       configService,
 		Collaborators: collaboratorService,
 	}
@@ -154,6 +155,7 @@ func newGraphQLHandler(p *deps.RequestProvider) http.Handler {
 		Apps:          appLoader,
 		Domains:       domainLoader,
 		Collaborators: collaboratorLoader,
+		AuthzService:  authzService,
 	}
 	graphQLHandler := &transport.GraphQLHandler{
 		DevMode:        devMode,
@@ -212,6 +214,7 @@ func newAdminAPIHandler(p *deps.RequestProvider) http.Handler {
 		SQLExecutor: sqlExecutor,
 	}
 	authzService := &service.AuthzService{
+		Context:       context,
 		Configs:       configService,
 		Collaborators: collaboratorService,
 	}

--- a/pkg/util/graphqlutil/lazy.go
+++ b/pkg/util/graphqlutil/lazy.go
@@ -21,6 +21,10 @@ func NewLazyValue(value interface{}) *Lazy {
 	}
 }
 
+func NewLazyError(err error) *Lazy {
+	return &Lazy{err: err}
+}
+
 func (l *Lazy) Value() (interface{}, error) {
 	if l.init != nil {
 		l.value, l.err = l.init()

--- a/portal/src/graphql/portal/schema.graphql
+++ b/portal/src/graphql/portal/schema.graphql
@@ -1,5 +1,20 @@
+""""""
+input AcceptCollaboratorInvitationInput {
+  """Invitation code."""
+  code: String!
+}
+
+""""""
+type AcceptCollaboratorInvitationPayload {
+  """"""
+  app: App!
+}
+
 """Authgear app"""
 type App implements Node {
+  """"""
+  collaboratorInvitations: [CollaboratorInvitation!]!
+
   """"""
   collaborators: [Collaborator!]!
 
@@ -67,6 +82,24 @@ type Collaborator {
   userID: String!
 }
 
+"""Collaborator invitation of an app"""
+type CollaboratorInvitation {
+  """"""
+  createdAt: DateTime!
+
+  """"""
+  expireAt: DateTime!
+
+  """"""
+  id: String!
+
+  """"""
+  invitedBy: String!
+
+  """"""
+  inviteeEmail: String!
+}
+
 """"""
 input CreateAppInput {
   """ID of the new app."""
@@ -75,6 +108,21 @@ input CreateAppInput {
 
 """"""
 type CreateAppPayload {
+  """"""
+  app: App!
+}
+
+""""""
+input CreateCollaboratorInvitationInput {
+  """Target app ID."""
+  appID: ID!
+
+  """Invitee email address."""
+  inviteeEmail: String!
+}
+
+""""""
+type CreateCollaboratorInvitationPayload {
   """"""
   app: App!
 }
@@ -104,8 +152,26 @@ scalar DateTime
 
 """"""
 input DeleteCollaboratorInput {
+  """Target app ID."""
+  appID: ID!
+
   """Collaborator ID."""
   collaboratorID: String!
+}
+
+""""""
+input DeleteCollaboratorInvitationInput {
+  """Target app ID."""
+  appID: ID!
+
+  """Collaborator invitation ID."""
+  collaboratorInvitationID: String!
+}
+
+""""""
+type DeleteCollaboratorInvitationPayload {
+  """"""
+  app: App!
 }
 
 """"""
@@ -155,14 +221,23 @@ type Domain {
 
 """"""
 type Mutation {
+  """Accept collaborator invitation to the target app."""
+  acceptCollaboratorInvitation(input: AcceptCollaboratorInvitationInput!): AcceptCollaboratorInvitationPayload!
+
   """Create new app"""
   createApp(input: CreateAppInput!): CreateAppPayload!
+
+  """Invite a collaborator to the target app."""
+  createCollaboratorInvitation(input: CreateCollaboratorInvitationInput!): CreateCollaboratorInvitationPayload!
 
   """Create domain for target app"""
   createDomain(input: CreateDomainInput!): CreateDomainPayload!
 
-  """Delete collaborator of target app"""
+  """Delete collaborator of target app."""
   deleteCollaborator(input: DeleteCollaboratorInput!): DeleteCollaboratorPayload!
+
+  """Delete collaborator invitation of target app."""
+  deleteCollaboratorInvitation(input: DeleteCollaboratorInvitationInput!): DeleteCollaboratorInvitationPayload!
 
   """Delete domain of target app"""
   deleteDomain(input: DeleteDomainInput!): DeleteDomainPayload!

--- a/portal/src/graphql/portal/schema.graphql
+++ b/portal/src/graphql/portal/schema.graphql
@@ -125,6 +125,9 @@ input CreateCollaboratorInvitationInput {
 type CreateCollaboratorInvitationPayload {
   """"""
   app: App!
+
+  """"""
+  collaboratorInvitation: CollaboratorInvitation!
 }
 
 """"""
@@ -152,18 +155,12 @@ scalar DateTime
 
 """"""
 input DeleteCollaboratorInput {
-  """Target app ID."""
-  appID: ID!
-
   """Collaborator ID."""
   collaboratorID: String!
 }
 
 """"""
 input DeleteCollaboratorInvitationInput {
-  """Target app ID."""
-  appID: ID!
-
   """Collaborator invitation ID."""
   collaboratorInvitationID: String!
 }


### PR DESCRIPTION
fix #433 

There are two remaining FIXMEs

- Send the invitation email. I am going to reuse the template mechanism from pkg/lib. The problem is where to store the default template. Storing it in templates/ seems a bit inappropriate because it is a place for authgear.
- Able to call Admin API of `accounts`. 