### PR TITLE
Fix DNS screen firing unexpected mutation

### DIFF
--- a/portal/src/graphql/portal/mutations/__generated__/DeleteDomainMutation.ts
+++ b/portal/src/graphql/portal/mutations/__generated__/DeleteDomainMutation.ts
@@ -25,6 +25,8 @@ export interface DeleteDomainMutation_deleteDomain_app {
    */
   id: string;
   domains: DeleteDomainMutation_deleteDomain_app_domains[];
+  rawAppConfig: GQL_AppConfig;
+  effectiveAppConfig: GQL_AppConfig;
 }
 
 export interface DeleteDomainMutation_deleteDomain {

--- a/portal/src/graphql/portal/mutations/deleteDomainMutation.ts
+++ b/portal/src/graphql/portal/mutations/deleteDomainMutation.ts
@@ -18,6 +18,8 @@ const deleteDomainMutation = gql`
           isVerified
           verificationDNSRecord
         }
+        rawAppConfig
+        effectiveAppConfig
       }
     }
   }


### PR DESCRIPTION
fix #538 

Cause:

If domain in config is not included in verified domains (domains in DB with
isVerified = true), it will trigger useEffect on mount, firing mutation. If default domain
(non-custom verified domain) is not found, mutation fails as public
origin is required field

Fix:

Move update config to screen, check if domain in config is included in
verified domain only after delete domain mutation instead of useEffect.

Public origin section only observe public origin in config, will reset
dropdown state if config is changed (after delete domain)