### PR TITLE
Fix back button no response in page with tab

### DIFF
--- a/portal/src/hook/usePivot.ts
+++ b/portal/src/hook/usePivot.ts
@@ -22,7 +22,8 @@ export function usePivotNavigation(
 
   useEffect(() => {
     if (!isHashValid(validItemKeys, hash)) {
-      navigate(`#${initialSelectedKey}`);
+      // NOTE: avoid adding extra entry to history stack
+      navigate(`#${initialSelectedKey}`, { replace: true });
     }
   }, [validItemKeys, hash, initialSelectedKey, navigate]);
 


### PR DESCRIPTION
fix https://github.com/authgear/authgear-deploy/issues/28

Cause:
This is caused by redirection if the fragment (hash) is not valid (each tab has a key, selected tab specified by fragment), as this affects the history, for example:
`previous page` -> `/app/:appID/configuration/authentication` -> `/app/:appID/configuration/authentication#login-id`

So back button has no effect, including the confirm button in navigation blocker dialog.

Fix:

Use `replaceState` to avoid pushing to history stack