### PR TITLE
Add error handling for invalid app ID

### DIFF
--- a/pkg/portal/graphql/app.go
+++ b/pkg/portal/graphql/app.go
@@ -147,9 +147,10 @@ var nodeApp = node(
 	&model.App{},
 	func(ctx context.Context, id string) (interface{}, error) {
 		gqlCtx := GQLContext(ctx)
+		// return nil without error for both inaccessible / not found apps
 		_, err := gqlCtx.AuthzService.CheckAccessOfViewer(id)
 		if err != nil {
-			return nil, err
+			return nil, nil
 		}
 		return gqlCtx.Apps.Load(id).Value, nil
 	},


### PR DESCRIPTION
fix https://github.com/authgear/authgear-deploy/issues/32

Motivation:

- Avoid error like unhandled forbidden error
- App ID which has valid base64 encoding but not valid UTF8 encoding for Postgres

<img width="1338" alt="Screenshot 2020-10-29 at 4 18 31 PM" src="https://user-images.githubusercontent.com/54486231/97556760-d6c78480-1a14-11eb-9226-89e90a386a7a.png">

- App ID with incorrect encoding leads to empty response without error

<img width="1265" alt="Screenshot 2020-10-29 at 4 17 55 PM" src="https://user-images.githubusercontent.com/54486231/97556857-f9f23400-1a14-11eb-82ca-7e5b5d0bde44.png">
