### PR TITLE
Treat plaintext blocklist entry as anchored pattern

### DIFF
--- a/pkg/util/blocklist/blocklist.go
+++ b/pkg/util/blocklist/blocklist.go
@@ -50,7 +50,7 @@ func New(data string) (*Blocklist, error) {
 			e.pattern = pattern
 		} else {
 			// Plain text pattern
-			e.pattern = regexp.MustCompile(regexp.QuoteMeta(line))
+			e.pattern = regexp.MustCompile("^" + regexp.QuoteMeta(line) + "$")
 		}
 
 		entries = append(entries, e)

--- a/pkg/util/blocklist/blocklist_test.go
+++ b/pkg/util/blocklist/blocklist_test.go
@@ -32,6 +32,7 @@ func TestBlocklist(t *testing.T) {
 			So(list.IsBlocked("test"), ShouldBeFalse)
 			So(list.IsBlocked("admin"), ShouldBeFalse)
 			So(list.IsBlocked("adm1n"), ShouldBeTrue)
+			So(list.IsBlocked("adm1n1"), ShouldBeFalse)
 			So(list.IsBlocked("www"), ShouldBeTrue)
 			So(list.IsBlocked("www01"), ShouldBeFalse)
 			So(list.IsBlocked("www02"), ShouldBeTrue)


### PR DESCRIPTION
fix #675 