### PR TITLE
Fix inconsistent masking of phone number

### DIFF
--- a/pkg/auth/handler/webapp/verify_identity.go
+++ b/pkg/auth/handler/webapp/verify_identity.go
@@ -8,6 +8,7 @@ import (
 	"github.com/authgear/authgear-server/pkg/lib/authn"
 	"github.com/authgear/authgear-server/pkg/lib/authn/identity"
 	"github.com/authgear/authgear-server/pkg/lib/infra/db"
+	"github.com/authgear/authgear-server/pkg/lib/infra/mail"
 	"github.com/authgear/authgear-server/pkg/lib/interaction"
 	"github.com/authgear/authgear-server/pkg/lib/interaction/intents"
 	"github.com/authgear/authgear-server/pkg/util/errorutil"
@@ -87,6 +88,8 @@ func (h *VerifyIdentityHandler) GetData(r *http.Request, state *webapp.State, gr
 		switch authn.AuthenticatorOOBChannel(viewModel.VerificationCodeChannel) {
 		case authn.AuthenticatorOOBChannelSMS:
 			viewModel.IdentityDisplayID = phone.Mask(rawIdentityDisplayID)
+		case authn.AuthenticatorOOBChannelEmail:
+			viewModel.IdentityDisplayID = mail.MaskAddress(rawIdentityDisplayID)
 		default:
 			viewModel.IdentityDisplayID = rawIdentityDisplayID
 		}


### PR DESCRIPTION
fix #643 

Mask phone number for change phone number verification screen
such that it is consistent with screen for verify phone number for
adding secondary sms authenticator

# Screenshot

<img width="517" alt="Screenshot 2020-11-02 at 3 11 17 PM" src="https://user-images.githubusercontent.com/54486231/97840227-9e7abb80-1d1e-11eb-957d-a25576d352a9.png">

<img width="515" alt="Screenshot 2020-11-02 at 4 48 02 PM" src="https://user-images.githubusercontent.com/54486231/97848036-7a71a700-1d2b-11eb-9708-3e1c8d8a503b.png">
