### PR TITLE
Fix missing validation for login ID form

### DIFF
--- a/pkg/auth/handler/webapp/enter_login_id.go
+++ b/pkg/auth/handler/webapp/enter_login_id.go
@@ -63,10 +63,22 @@ var EnterLoginIDSchema = validation.NewMultipartSchema("").
 				"x_login_id_input_type": { "type": "string" },
 				"x_login_id_key": { "type": "string" },
 				"x_login_id_type": { "type": "string" },
+				"x_calling_code": { "type": "string" },
+				"x_national_number": { "type": "string" },
 				"x_login_id": { "type": "string" }
 			},
 			"required": ["x_login_id_input_type", "x_login_id_key", "x_login_id_type"],
 			"allOf": [
+				{
+					"if": {
+						"properties": {
+							"x_login_id_key": { "type": "string", "const": "phone" }
+						}
+					},
+					"then": {
+						"required": ["x_calling_code", "x_national_number"]
+					}
+				},
 				{
 					"if": {
 						"properties": {


### PR DESCRIPTION
fix https://github.com/authgear/authgear-deploy/issues/40

Add new rule to `enterLoginIDSchema` which requires `x_national_number` if
`login_id_key` is phone

<img width="571" alt="Screenshot 2020-11-02 at 4 31 44 PM" src="https://user-images.githubusercontent.com/54486231/97847885-426a6400-1d2b-11eb-9ac0-74816eb2c38a.png">
