### PR TITLE
Fix horizontal scrollbar appears in country code list on windows browser

### DIFF
--- a/portal/src/graphql/portal/AuthenticationCountryCallingCodeList.module.scss
+++ b/portal/src/graphql/portal/AuthenticationCountryCallingCodeList.module.scss
@@ -25,3 +25,8 @@
 .lastPinnedCallingCode {
   border-bottom: 1px solid #c4c4c4;
 }
+
+// Fix horizontal scrollbar appears on windows browser
+.detailsList {
+  overflow-x: hidden;
+}

--- a/portal/src/graphql/portal/AuthenticationCountryCallingCodeList.tsx
+++ b/portal/src/graphql/portal/AuthenticationCountryCallingCodeList.tsx
@@ -589,6 +589,7 @@ const CountryCallingCodeList: React.FC<CountryCallingCodeListProps> = function C
       <div className={styles.listWrapper}>
         <ScrollablePane>
           <DetailsList
+            className={styles.detailsList}
             columns={countryCodeListColumns}
             items={countryCallingCodeList}
             selectionMode={SelectionMode.none}


### PR DESCRIPTION
fix #646

It seem to be fluent ui bug and not yet fixed (https://github.com/microsoft/fluentui/issues/3608).

The unnecessary horizontal scrollbar appears in DetailsList as it has `overflow-x: auto` style. So I simply added `overflow-x: hidden` to hide horizontal scrollbar. (I have tried setting `overflow-x: visible` to DetailsList, but the horizontal scrollbar would appears in scrollable pane.)

##### Before
![authgear_portal_646-1](https://user-images.githubusercontent.com/25860896/97965066-be7cae80-1df4-11eb-8a1b-a48a75caea94.png)
##### After
![authgear_portal_646-2](https://user-images.githubusercontent.com/25860896/97965075-c0467200-1df4-11eb-8104-8574885d6218.png)
