### PR TITLE
Display decoded app id in app list and header

### DIFF
--- a/portal/src/ScreenHeader.tsx
+++ b/portal/src/ScreenHeader.tsx
@@ -30,8 +30,7 @@ const ScreenHeaderAppSection: React.FC<ScreenHeaderAppSectionProps> = function S
     <>
       <Icon className={styles.headerArrow} iconName="ChevronRight" />
       <Text className={styles.headerAppID}>
-        {/* TODO: update app name */}
-        {effectiveAppConfig?.http?.public_origin ?? appID}
+        {effectiveAppConfig?.id ?? appID}
       </Text>
     </>
   );

--- a/portal/src/graphql/portal/AppsScreen.tsx
+++ b/portal/src/graphql/portal/AppsScreen.tsx
@@ -47,10 +47,9 @@ const AppList: React.FC<AppListProps> = function AppList(props: AppListProps) {
 
   const appCardsData: AppCardData[] = useMemo(() => {
     return (apps ?? []).map((app) => {
-      const appID = String(app.id);
+      const appID = app.effectiveAppConfig.id;
       const appOrigin = app.effectiveAppConfig.http?.public_origin;
-      const relPath = "/app/" + encodeURIComponent(appID);
-      // TODO: update app name
+      const relPath = "/app/" + encodeURIComponent(String(app.id));
       return {
         appID,
         appName: appOrigin ?? appID,

--- a/portal/src/types.ts
+++ b/portal/src/types.ts
@@ -256,6 +256,7 @@ export interface HookHandlerConfig {
 
 // PortalAPIAppConfig
 export interface PortalAPIAppConfig {
+  id: string;
   http?: HTTPConfig;
   identity?: IdentityConfig;
   authenticator?: AuthenticatorConfig;


### PR DESCRIPTION
refs #780 

In the issue, the design shows the app id and name, but we don't have the concept of app name. So we showed the encoded app id and the origin. 

I updated to show the decoded app id and kept displaying the app origin, it doesn't look nice actually. Maybe we could consider to show the app id only in the app list?

<img width="386" alt="Screenshot 2020-12-01 at 5 59 15 PM" src="https://user-images.githubusercontent.com/388892/100707638-106a2180-33ff-11eb-805a-a89c8365f1c0.png">
