### PR TITLE
Handle verification email being opened in another user agent

### DIFF
--- a/pkg/auth/deps.go
+++ b/pkg/auth/deps.go
@@ -94,4 +94,5 @@ var DependencySet = wire.NewSet(
 	wire.Bind(new(handlerwebapp.LogoutSessionManager), new(*session.Manager)),
 	wire.Bind(new(handlerwebapp.PageService), new(*webapp.Service2)),
 	wire.Bind(new(handlerwebapp.ResourceManager), new(*resource.Manager)),
+	wire.Bind(new(handlerwebapp.VerifyIdentityVerificationService), new(*verification.Service)),
 )

--- a/pkg/auth/handler/webapp/alternatives.go
+++ b/pkg/auth/handler/webapp/alternatives.go
@@ -80,10 +80,10 @@ func handleAlternativeSteps(ctrl *Controller) {
 
 		var result *webapp.Result
 		if inputFn == nil {
-			session.Steps = append(session.Steps, webapp.SessionStep{
-				Kind:    stepKind,
-				GraphID: session.CurrentStep().GraphID,
-			})
+			session.Steps = append(session.Steps, webapp.NewSessionStep(
+				stepKind,
+				session.CurrentStep().GraphID,
+			))
 			if err = ctrl.Page.UpdateSession(session); err != nil {
 				return err
 			}

--- a/pkg/auth/handler/webapp/controller.go
+++ b/pkg/auth/handler/webapp/controller.go
@@ -16,6 +16,7 @@ import (
 type PageService interface {
 	UpdateSession(session *webapp.Session) error
 	Get(session *webapp.Session) (*interaction.Graph, error)
+	GetSession(id string) (*webapp.Session, error)
 	GetWithIntent(session *webapp.Session, intent interaction.Intent) (*interaction.Graph, error)
 	PostWithIntent(
 		session *webapp.Session,
@@ -96,6 +97,14 @@ func (c *Controller) Get(fn func() error) {
 
 func (c *Controller) PostAction(action string, fn func() error) {
 	c.postHandlers[action] = fn
+}
+
+func (c *Controller) GetSession(id string) (*webapp.Session, error) {
+	return c.Page.GetSession(id)
+}
+
+func (c *Controller) UpdateSession(s *webapp.Session) error {
+	return c.Page.UpdateSession(s)
 }
 
 func (c *Controller) Serve() {
@@ -202,6 +211,14 @@ func (c *Controller) InteractionGet() (*interaction.Graph, error) {
 		return nil, err
 	}
 
+	if err := c.rewindSessionHistory(s); err != nil {
+		return nil, err
+	}
+
+	return c.Page.Get(s)
+}
+
+func (c *Controller) InteractionGetWithSession(s *webapp.Session) (*interaction.Graph, error) {
 	if err := c.rewindSessionHistory(s); err != nil {
 		return nil, err
 	}

--- a/pkg/auth/handler/webapp/deps.go
+++ b/pkg/auth/handler/webapp/deps.go
@@ -46,4 +46,5 @@ var DependencySet = wire.NewSet(
 	wire.Struct(new(ChangeSecondaryPasswordHandler), "*"),
 	wire.Struct(new(UserDisabledHandler), "*"),
 	wire.Struct(new(LogoutHandler), "*"),
+	wire.Struct(new(ReturnHandler), "*"),
 )

--- a/pkg/auth/handler/webapp/return.go
+++ b/pkg/auth/handler/webapp/return.go
@@ -1,0 +1,52 @@
+package webapp
+
+import (
+	"net/http"
+
+	"github.com/authgear/authgear-server/pkg/auth/handler/webapp/viewmodels"
+	"github.com/authgear/authgear-server/pkg/util/httproute"
+	"github.com/authgear/authgear-server/pkg/util/template"
+)
+
+var TemplateWebReturnHTML = template.RegisterHTML(
+	"web/return.html",
+	components...,
+)
+
+func ConfigureReturnRoute(route httproute.Route) httproute.Route {
+	return route.
+		WithMethods("OPTIONS", "GET").
+		WithPathPattern("/return")
+}
+
+type ReturnHandler struct {
+	ControllerFactory ControllerFactory
+	BaseViewModel     *viewmodels.BaseViewModeler
+	Renderer          Renderer
+}
+
+func (h *ReturnHandler) GetData(r *http.Request, w http.ResponseWriter) (map[string]interface{}, error) {
+	data := make(map[string]interface{})
+	baseViewModel := h.BaseViewModel.ViewModel(r, w)
+	viewmodels.Embed(data, baseViewModel)
+	return data, nil
+}
+
+func (h *ReturnHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	ctrl, err := h.ControllerFactory.New(r, w)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+	defer ctrl.Serve()
+
+	ctrl.Get(func() error {
+		data, err := h.GetData(r, w)
+		if err != nil {
+			return err
+		}
+
+		h.Renderer.RenderHTML(w, r, TemplateWebReturnHTML, data)
+		return nil
+	})
+}

--- a/pkg/auth/handler/webapp/verify_identity.go
+++ b/pkg/auth/handler/webapp/verify_identity.go
@@ -8,6 +8,7 @@ import (
 	"github.com/authgear/authgear-server/pkg/auth/webapp"
 	"github.com/authgear/authgear-server/pkg/lib/authn"
 	"github.com/authgear/authgear-server/pkg/lib/authn/identity"
+	"github.com/authgear/authgear-server/pkg/lib/feature/verification"
 	"github.com/authgear/authgear-server/pkg/lib/infra/mail"
 	"github.com/authgear/authgear-server/pkg/lib/interaction"
 	"github.com/authgear/authgear-server/pkg/lib/interaction/intents"
@@ -41,18 +42,30 @@ func ConfigureVerifyIdentityRoute(route httproute.Route) httproute.Route {
 		WithPathPattern("/verify_identity")
 }
 
+const (
+	VerifyIdentityActionSubmit            = "submit"
+	VerifyIdentityActionResume            = "resume"
+	VerifyIdentityActionUpdateSessionStep = "update_session_step"
+)
+
 type VerifyIdentityViewModel struct {
 	VerificationCode             string
 	VerificationCodeSendCooldown int
 	VerificationCodeLength       int
 	VerificationCodeChannel      string
 	IdentityDisplayID            string
+	Action                       string
+}
+
+type VerifyIdentityVerificationService interface {
+	GetCode(id string) (*verification.Code, error)
 }
 
 type VerifyIdentityHandler struct {
 	ControllerFactory ControllerFactory
 	BaseViewModel     *viewmodels.BaseViewModeler
 	Renderer          Renderer
+	Verifications     VerifyIdentityVerificationService
 }
 
 type VerifyIdentityNode interface {
@@ -60,15 +73,28 @@ type VerifyIdentityNode interface {
 	GetVerificationCodeChannel() string
 	GetVerificationCodeSendCooldown() int
 	GetVerificationCodeLength() int
+	GetRequestedByUser() bool
 }
 
-func (h *VerifyIdentityHandler) GetData(r *http.Request, rw http.ResponseWriter, graph *interaction.Graph) (map[string]interface{}, error) {
+func (h *VerifyIdentityHandler) GetData(r *http.Request, rw http.ResponseWriter, action string, maybeSession *webapp.Session, graph *interaction.Graph) (map[string]interface{}, error) {
 	data := map[string]interface{}{}
 
 	baseViewModel := h.BaseViewModel.ViewModel(r, rw)
-	viewModel := VerifyIdentityViewModel{
-		VerificationCode: r.Form.Get("code"),
+
+	code := r.Form.Get("code")
+
+	if code == "" && maybeSession != nil {
+		step := maybeSession.CurrentStep()
+		if c, ok := step.FormData["x_code"].(string); ok {
+			code = c
+		}
 	}
+
+	viewModel := VerifyIdentityViewModel{
+		VerificationCode: code,
+		Action:           action,
+	}
+
 	var n VerifyIdentityNode
 	if graph.FindLastNode(&n) {
 		rawIdentityDisplayID := n.GetVerificationIdentity().DisplayID()
@@ -116,34 +142,105 @@ func (h *VerifyIdentityHandler) ServeHTTP(w http.ResponseWriter, r *http.Request
 		RedirectURI:     "/verify_identity/success",
 		KeepAfterFinish: true,
 	}
-	intent := intents.NewIntentVerifyIdentityResume(r.Form.Get("id"))
 
-	ctrl.Get(func() error {
-		session, err := ctrl.InteractionSession()
-		if errors.Is(err, webapp.ErrSessionNotFound) ||
-			errors.Is(err, webapp.ErrInvalidSession) {
-			session = nil
+	verificationCodeID := r.Form.Get("id")
+	intent := intents.NewIntentVerifyIdentityResume(verificationCodeID)
+
+	inputFn := func() (input interface{}, err error) {
+		err = VerifyIdentitySchema.PartValidator(VerifyIdentityRequestSchema).ValidateValue(FormToJSON(r.Form))
+		if err != nil {
+			return
 		}
 
-		if session != nil {
+		code := r.Form.Get("x_code")
+
+		input = &InputVerificationCode{
+			Code: code,
+		}
+		return
+	}
+
+	ctrl.Get(func() error {
+		if verificationCodeID != "" {
+			// The verification code ID is non-empty.
+			// So this page was opened by verification link.
+			// We have two outcomes.
+			// If the verification is requested by the user, we want to start IntentVerifyIdentityResume.
+			// Otherwise, we want to update the current SessionStep FormData.
+
+			code, err := h.Verifications.GetCode(verificationCodeID)
+			if err != nil {
+				return err
+			}
+
+			var graph *interaction.Graph
+			session, err := ctrl.GetSession(code.WebSessionID)
+			if errors.Is(err, webapp.ErrSessionNotFound) || errors.Is(err, webapp.ErrInvalidSession) {
+				session = nil
+			} else if err != nil {
+				return err
+			}
+
+			var action string
+			if session == nil {
+				// The web session is invalid.
+				// Here we assume the verification is requested by the user.
+				// This is because if verification is NOT requested by the user, the interaction can never continue.
+				action = VerifyIdentityActionResume
+			} else {
+				graph, err = ctrl.InteractionGetWithSession(session)
+				if err != nil {
+					return err
+				}
+				var n VerifyIdentityNode
+				if graph.FindLastNode(&n) {
+					requestedByUser := n.GetRequestedByUser()
+					if requestedByUser {
+						action = VerifyIdentityActionResume
+					} else {
+						action = VerifyIdentityActionUpdateSessionStep
+					}
+				}
+			}
+
+			switch action {
+			case VerifyIdentityActionResume:
+				graph, err := ctrl.EntryPointGet(opts, intent)
+				if err != nil {
+					return err
+				}
+
+				data, err := h.GetData(r, w, action, session, graph)
+				if err != nil {
+					return err
+				}
+
+				h.Renderer.RenderHTML(w, r, TemplateWebVerifyIdentityHTML, data)
+			case VerifyIdentityActionUpdateSessionStep:
+				data, err := h.GetData(r, w, action, session, graph)
+				if err != nil {
+					return err
+				}
+
+				h.Renderer.RenderHTML(w, r, TemplateWebVerifyIdentityHTML, data)
+			}
+		} else {
+			// The verification code ID is empty.
+			// So this page should be opened by the original user agent.
+			// We assume this user agent has web session cookie.
+			session, err := ctrl.InteractionSession()
+			if errors.Is(err, webapp.ErrSessionNotFound) || errors.Is(err, webapp.ErrInvalidSession) {
+				session = nil
+			} else if err != nil {
+				return err
+			}
+
 			graph, err := ctrl.InteractionGet()
 			if err != nil {
 				return err
 			}
 
-			data, err := h.GetData(r, w, graph)
-			if err != nil {
-				return err
-			}
-
-			h.Renderer.RenderHTML(w, r, TemplateWebVerifyIdentityHTML, data)
-		} else {
-			graph, err := ctrl.EntryPointGet(opts, intent)
-			if err != nil {
-				return err
-			}
-
-			data, err := h.GetData(r, w, graph)
+			data, err := h.GetData(r, w, VerifyIdentityActionSubmit, session, graph)
 			if err != nil {
 				return err
 			}
@@ -166,36 +263,50 @@ func (h *VerifyIdentityHandler) ServeHTTP(w http.ResponseWriter, r *http.Request
 		return nil
 	})
 
-	ctrl.PostAction("submit", func() error {
-		inputFn := func() (input interface{}, err error) {
-			err = VerifyIdentitySchema.PartValidator(VerifyIdentityRequestSchema).ValidateValue(FormToJSON(r.Form))
-			if err != nil {
-				return
-			}
-
-			code := r.Form.Get("x_code")
-
-			input = &InputVerificationCode{
-				Code: code,
-			}
-			return
+	ctrl.PostAction(VerifyIdentityActionSubmit, func() error {
+		result, err := ctrl.InteractionPost(inputFn)
+		if err != nil {
+			return err
 		}
+		result.WriteResponse(w, r)
+		return nil
+	})
 
-		session, err := ctrl.InteractionSession()
-		if errors.Is(err, webapp.ErrSessionNotFound) {
-			session = nil
+	ctrl.PostAction(VerifyIdentityActionResume, func() error {
+		result, err := ctrl.EntryPointPost(opts, intent, inputFn)
+		if err != nil {
+			return err
 		}
+		result.WriteResponse(w, r)
+		return nil
+	})
 
-		var result *webapp.Result
-		if session != nil {
-			result, err = ctrl.InteractionPost(inputFn)
-		} else {
-			result, err = ctrl.EntryPointPost(opts, intent, inputFn)
-		}
+	ctrl.PostAction(VerifyIdentityActionUpdateSessionStep, func() error {
+		code, err := h.Verifications.GetCode(verificationCodeID)
 		if err != nil {
 			return err
 		}
 
+		session, err := ctrl.GetSession(code.WebSessionID)
+		if err != nil {
+			return err
+		}
+
+		step := session.CurrentStep()
+		if step.FormData == nil {
+			step.FormData = make(map[string]interface{})
+		}
+		step.FormData["x_code"] = r.Form.Get("x_code")
+		session.Steps[len(session.Steps)-1] = step
+
+		err = ctrl.UpdateSession(session)
+		if err != nil {
+			return err
+		}
+
+		result := &webapp.Result{
+			RedirectURI: "/return",
+		}
 		result.WriteResponse(w, r)
 		return nil
 	})

--- a/pkg/auth/handler/webapp/verify_identity.go
+++ b/pkg/auth/handler/webapp/verify_identity.go
@@ -293,9 +293,6 @@ func (h *VerifyIdentityHandler) ServeHTTP(w http.ResponseWriter, r *http.Request
 		}
 
 		step := session.CurrentStep()
-		if step.FormData == nil {
-			step.FormData = make(map[string]interface{})
-		}
 		step.FormData["x_code"] = r.Form.Get("x_code")
 		session.Steps[len(session.Steps)-1] = step
 

--- a/pkg/auth/routes.go
+++ b/pkg/auth/routes.go
@@ -107,6 +107,7 @@ func NewRouter(p *deps.RootProvider, configSource *configsource.ConfigSource, st
 	router.Add(webapphandler.ConfigureResetPasswordRoute(webappPageRoute), p.Handler(newWebAppResetPasswordHandler))
 	router.Add(webapphandler.ConfigureResetPasswordSuccessRoute(webappPageRoute), p.Handler(newWebAppResetPasswordSuccessHandler))
 	router.Add(webapphandler.ConfigureUserDisabledRoute(webappPageRoute), p.Handler(newWebAppUserDisabledHandler))
+	router.Add(webapphandler.ConfigureReturnRoute(webappPageRoute), p.Handler(newWebAppReturnHandler))
 
 	router.Add(webapphandler.ConfigureLogoutRoute(webappAuthenticatedRoute), p.Handler(newWebAppLogoutHandler))
 	router.Add(webapphandler.ConfigureEnterLoginIDRoute(webappAuthenticatedRoute), p.Handler(newWebAppEnterLoginIDHandler))

--- a/pkg/auth/webapp/service2.go
+++ b/pkg/auth/webapp/service2.go
@@ -15,6 +15,7 @@ import (
 )
 
 type SessionStore interface {
+	Get(id string) (*Session, error)
 	Create(session *Session) (err error)
 	Update(session *Session) (err error)
 	Delete(id string) (err error)
@@ -59,6 +60,10 @@ func (s *Service2) CreateSession(session *Session, redirectURI string) (*Result,
 		Cookies:     []*http.Cookie{s.CookieFactory.ValueCookie(s.SessionCookie.Def, session.ID)},
 	}
 	return result, nil
+}
+
+func (s *Service2) GetSession(id string) (*Session, error) {
+	return s.Sessions.Get(id)
 }
 
 func (s *Service2) UpdateSession(session *Session) error {

--- a/pkg/auth/webapp/service2.go
+++ b/pkg/auth/webapp/service2.go
@@ -143,10 +143,10 @@ func (s *Service2) doPost(
 		}
 
 		kind := deriveSessionStepKind(graph)
-		session.Steps = append(session.Steps, SessionStep{
-			Kind:    deriveSessionStepKind(graph),
-			GraphID: graph.InstanceID,
-		})
+		session.Steps = append(
+			session.Steps,
+			NewSessionStep(deriveSessionStepKind(graph), graph.InstanceID),
+		)
 
 		inputFn = nil
 		// Select default for steps with choice
@@ -173,25 +173,25 @@ func (s *Service2) doPost(
 
 			switch defaultEdge := edges[0].(type) {
 			case *nodes.EdgeConsumeRecoveryCode:
-				session.Steps = append(session.Steps, SessionStep{
-					Kind:    SessionStepEnterRecoveryCode,
-					GraphID: graph.InstanceID,
-				})
+				session.Steps = append(session.Steps, NewSessionStep(
+					SessionStepEnterRecoveryCode,
+					graph.InstanceID,
+				))
 			case *nodes.EdgeAuthenticationPassword:
-				session.Steps = append(session.Steps, SessionStep{
-					Kind:    SessionStepEnterPassword,
-					GraphID: graph.InstanceID,
-				})
+				session.Steps = append(session.Steps, NewSessionStep(
+					SessionStepEnterPassword,
+					graph.InstanceID,
+				))
 			case *nodes.EdgeAuthenticationTOTP:
-				session.Steps = append(session.Steps, SessionStep{
-					Kind:    SessionStepEnterTOTP,
-					GraphID: graph.InstanceID,
-				})
+				session.Steps = append(session.Steps, NewSessionStep(
+					SessionStepEnterTOTP,
+					graph.InstanceID,
+				))
 			case *nodes.EdgeAuthenticationOOBTrigger:
-				session.Steps = append(session.Steps, SessionStep{
-					Kind:    SessionStepSendOOBOTPAuthn,
-					GraphID: graph.InstanceID,
-				})
+				session.Steps = append(session.Steps, NewSessionStep(
+					SessionStepSendOOBOTPAuthn,
+					graph.InstanceID,
+				))
 			default:
 				panic(fmt.Errorf("webapp: unexpected edge: %T", defaultEdge))
 			}
@@ -199,15 +199,15 @@ func (s *Service2) doPost(
 		case SessionStepCreateAuthenticator:
 			switch defaultEdge := edges[0].(type) {
 			case *nodes.EdgeCreateAuthenticatorPassword:
-				session.Steps = append(session.Steps, SessionStep{
-					Kind:    SessionStepCreatePassword,
-					GraphID: graph.InstanceID,
-				})
+				session.Steps = append(session.Steps, NewSessionStep(
+					SessionStepCreatePassword,
+					graph.InstanceID,
+				))
 			case *nodes.EdgeCreateAuthenticatorOOBSetup:
-				session.Steps = append(session.Steps, SessionStep{
-					Kind:    SessionStepSetupOOBOTP,
-					GraphID: graph.InstanceID,
-				})
+				session.Steps = append(session.Steps, NewSessionStep(
+					SessionStepSetupOOBOTP,
+					graph.InstanceID,
+				))
 			case *nodes.EdgeCreateAuthenticatorTOTPSetup:
 				inputFn = func() (interface{}, error) {
 					return &inputSelectTOTP{}, nil

--- a/pkg/auth/webapp/service2.go
+++ b/pkg/auth/webapp/service2.go
@@ -136,7 +136,7 @@ func (s *Service2) doPost(
 	var err error
 	for {
 		var edges []interaction.Edge
-		graph, edges, err = s.runGraph(result, inputFn, graphFn)
+		graph, edges, err = s.runGraph(session, result, inputFn, graphFn)
 		isFinished = len(edges) == 0 && err == nil
 		if err != nil || isFinished {
 			break
@@ -235,13 +235,14 @@ func (s *Service2) doPost(
 }
 
 func (s *Service2) runGraph(
+	session *Session,
 	result *Result,
 	inputFn func() (interface{}, error),
 	graphFn func(ctx *interaction.Context) (*interaction.Graph, error),
 ) (*interaction.Graph, []interaction.Edge, error) {
 	var graph *interaction.Graph
 	var edges []interaction.Edge
-	interactionErr := s.Graph.DryRun("", func(ctx *interaction.Context) (*interaction.Graph, error) {
+	interactionErr := s.Graph.DryRun(session.ID, func(ctx *interaction.Context) (*interaction.Graph, error) {
 		var err error
 		graph, err = graphFn(ctx)
 		if err != nil {

--- a/pkg/auth/webapp/session_step.go
+++ b/pkg/auth/webapp/session_step.go
@@ -26,6 +26,14 @@ const (
 	SessionStepUserDisabled        SessionStepKind = "user-disabled"
 )
 
+func NewSessionStep(kind SessionStepKind, graphID string) SessionStep {
+	return SessionStep{
+		Kind:     kind,
+		GraphID:  graphID,
+		FormData: make(map[string]interface{}),
+	}
+}
+
 func (k SessionStepKind) Path() string {
 	switch k {
 	case SessionStepPromoteUser:
@@ -86,8 +94,9 @@ func (k SessionStepKind) MatchPath(path string) bool {
 }
 
 type SessionStep struct {
-	Kind    SessionStepKind `json:"kind"`
-	GraphID string          `json:"graph_id"`
+	Kind     SessionStepKind        `json:"kind"`
+	GraphID  string                 `json:"graph_id"`
+	FormData map[string]interface{} `json:"form_data"`
 }
 
 func (s SessionStep) URL() *url.URL {

--- a/pkg/auth/webapp/session_step.go
+++ b/pkg/auth/webapp/session_step.go
@@ -94,8 +94,14 @@ func (k SessionStepKind) MatchPath(path string) bool {
 }
 
 type SessionStep struct {
-	Kind     SessionStepKind        `json:"kind"`
-	GraphID  string                 `json:"graph_id"`
+	// Kind is the kind of the step.
+	Kind SessionStepKind `json:"kind"`
+	// GraphID is the graph ID of the step.
+	GraphID string `json:"graph_id"`
+	// FormData is the place to store shared form data across different user agents.
+	// The only use case currently is verification email being opened in another user agent.
+	// In that case, the form submitted by the other user agent will update FormData.
+	// The original user agent will then read from it to fill in its form.
 	FormData map[string]interface{} `json:"form_data"`
 }
 

--- a/pkg/auth/wire_gen.go
+++ b/pkg/auth/wire_gen.go
@@ -9232,6 +9232,7 @@ func newWebAppVerifyIdentityHandler(p *deps.RequestProvider) http.Handler {
 		ControllerFactory: controllerFactory,
 		BaseViewModel:     baseViewModeler,
 		Renderer:          responseRenderer,
+		Verifications:     verificationService,
 	}
 	return verifyIdentityHandler
 }

--- a/pkg/auth/wire_gen.go
+++ b/pkg/auth/wire_gen.go
@@ -16560,6 +16560,501 @@ func newWebAppStaticAssetsHandler(p *deps.RequestProvider) http.Handler {
 	return staticAssetsHandler
 }
 
+func newWebAppReturnHandler(p *deps.RequestProvider) http.Handler {
+	appProvider := p.AppProvider
+	factory := appProvider.LoggerFactory
+	handle := appProvider.Database
+	serviceLogger := webapp.NewServiceLogger(factory)
+	request := p.Request
+	config := appProvider.Config
+	appConfig := config.AppConfig
+	appID := appConfig.ID
+	redisHandle := appProvider.Redis
+	sessionStoreRedis := &webapp.SessionStoreRedis{
+		AppID: appID,
+		Redis: redisHandle,
+	}
+	httpConfig := appConfig.HTTP
+	sessionCookieDef := webapp.NewSessionCookieDef(httpConfig)
+	authenticationConfig := appConfig.Authentication
+	cookieDef := mfa.NewDeviceTokenCookieDef(httpConfig, authenticationConfig)
+	errorCookieDef := webapp.NewErrorCookieDef(httpConfig)
+	rootProvider := appProvider.RootProvider
+	environmentConfig := rootProvider.EnvironmentConfig
+	trustProxy := environmentConfig.TrustProxy
+	cookieFactory := deps.NewCookieFactory(request, trustProxy)
+	errorCookie := &webapp.ErrorCookie{
+		Cookie:        errorCookieDef,
+		CookieFactory: cookieFactory,
+	}
+	logger := interaction.NewLogger(factory)
+	context := deps.ProvideRequestContext(request)
+	sqlExecutor := db.SQLExecutor{
+		Context:  context,
+		Database: handle,
+	}
+	clockClock := _wireSystemClockValue
+	identityConfig := appConfig.Identity
+	secretConfig := config.SecretConfig
+	databaseCredentials := deps.ProvideDatabaseCredentials(secretConfig)
+	sqlBuilder := db.ProvideSQLBuilder(databaseCredentials, appID)
+	store := &service.Store{
+		SQLBuilder:  sqlBuilder,
+		SQLExecutor: sqlExecutor,
+	}
+	loginidStore := &loginid.Store{
+		SQLBuilder:  sqlBuilder,
+		SQLExecutor: sqlExecutor,
+	}
+	loginIDConfig := identityConfig.LoginID
+	manager := appProvider.Resources
+	typeCheckerFactory := &loginid.TypeCheckerFactory{
+		Config:    loginIDConfig,
+		Resources: manager,
+	}
+	checker := &loginid.Checker{
+		Config:             loginIDConfig,
+		TypeCheckerFactory: typeCheckerFactory,
+	}
+	normalizerFactory := &loginid.NormalizerFactory{
+		Config: loginIDConfig,
+	}
+	provider := &loginid.Provider{
+		Store:             loginidStore,
+		Config:            loginIDConfig,
+		Checker:           checker,
+		NormalizerFactory: normalizerFactory,
+		Clock:             clockClock,
+	}
+	oauthStore := &oauth3.Store{
+		SQLBuilder:  sqlBuilder,
+		SQLExecutor: sqlExecutor,
+	}
+	oauthProvider := &oauth3.Provider{
+		Store: oauthStore,
+		Clock: clockClock,
+	}
+	anonymousStore := &anonymous.Store{
+		SQLBuilder:  sqlBuilder,
+		SQLExecutor: sqlExecutor,
+	}
+	anonymousProvider := &anonymous.Provider{
+		Store: anonymousStore,
+		Clock: clockClock,
+	}
+	serviceService := &service.Service{
+		Authentication: authenticationConfig,
+		Identity:       identityConfig,
+		Store:          store,
+		LoginID:        provider,
+		OAuth:          oauthProvider,
+		Anonymous:      anonymousProvider,
+	}
+	serviceStore := &service2.Store{
+		SQLBuilder:  sqlBuilder,
+		SQLExecutor: sqlExecutor,
+	}
+	passwordStore := &password.Store{
+		SQLBuilder:  sqlBuilder,
+		SQLExecutor: sqlExecutor,
+	}
+	authenticatorConfig := appConfig.Authenticator
+	authenticatorPasswordConfig := authenticatorConfig.Password
+	passwordLogger := password.NewLogger(factory)
+	historyStore := &password.HistoryStore{
+		Clock:       clockClock,
+		SQLBuilder:  sqlBuilder,
+		SQLExecutor: sqlExecutor,
+	}
+	passwordChecker := password.ProvideChecker(authenticatorPasswordConfig, historyStore)
+	housekeeperLogger := password.NewHousekeeperLogger(factory)
+	housekeeper := &password.Housekeeper{
+		Store:  historyStore,
+		Logger: housekeeperLogger,
+		Config: authenticatorPasswordConfig,
+	}
+	passwordProvider := &password.Provider{
+		Store:           passwordStore,
+		Config:          authenticatorPasswordConfig,
+		Clock:           clockClock,
+		Logger:          passwordLogger,
+		PasswordHistory: historyStore,
+		PasswordChecker: passwordChecker,
+		Housekeeper:     housekeeper,
+	}
+	totpStore := &totp.Store{
+		SQLBuilder:  sqlBuilder,
+		SQLExecutor: sqlExecutor,
+	}
+	authenticatorTOTPConfig := authenticatorConfig.TOTP
+	totpProvider := &totp.Provider{
+		Store:  totpStore,
+		Config: authenticatorTOTPConfig,
+		Clock:  clockClock,
+	}
+	authenticatorOOBConfig := authenticatorConfig.OOB
+	oobStore := &oob.Store{
+		SQLBuilder:  sqlBuilder,
+		SQLExecutor: sqlExecutor,
+	}
+	storeRedis := &oob.StoreRedis{
+		Redis: redisHandle,
+		AppID: appID,
+		Clock: clockClock,
+	}
+	oobLogger := oob.NewLogger(factory)
+	oobProvider := &oob.Provider{
+		Config:    authenticatorOOBConfig,
+		Store:     oobStore,
+		CodeStore: storeRedis,
+		Clock:     clockClock,
+		Logger:    oobLogger,
+	}
+	ratelimitLogger := ratelimit.NewLogger(factory)
+	storageRedis := &ratelimit.StorageRedis{
+		AppID: appID,
+		Redis: redisHandle,
+	}
+	limiter := &ratelimit.Limiter{
+		Logger:  ratelimitLogger,
+		Storage: storageRedis,
+		Clock:   clockClock,
+	}
+	service3 := &service2.Service{
+		Store:       serviceStore,
+		Password:    passwordProvider,
+		TOTP:        totpProvider,
+		OOBOTP:      oobProvider,
+		RateLimiter: limiter,
+	}
+	verificationLogger := verification.NewLogger(factory)
+	verificationConfig := appConfig.Verification
+	verificationStoreRedis := &verification.StoreRedis{
+		Redis: redisHandle,
+		AppID: appID,
+		Clock: clockClock,
+	}
+	storePQ := &verification.StorePQ{
+		SQLBuilder:  sqlBuilder,
+		SQLExecutor: sqlExecutor,
+	}
+	verificationService := &verification.Service{
+		Request:     request,
+		Logger:      verificationLogger,
+		Config:      verificationConfig,
+		TrustProxy:  trustProxy,
+		Clock:       clockClock,
+		CodeStore:   verificationStoreRedis,
+		ClaimStore:  storePQ,
+		RateLimiter: limiter,
+	}
+	storeDeviceTokenRedis := &mfa.StoreDeviceTokenRedis{
+		Redis: redisHandle,
+		AppID: appID,
+		Clock: clockClock,
+	}
+	storeRecoveryCodePQ := &mfa.StoreRecoveryCodePQ{
+		SQLBuilder:  sqlBuilder,
+		SQLExecutor: sqlExecutor,
+	}
+	mfaService := &mfa.Service{
+		DeviceTokens:  storeDeviceTokenRedis,
+		RecoveryCodes: storeRecoveryCodePQ,
+		Clock:         clockClock,
+		Config:        authenticationConfig,
+		RateLimiter:   limiter,
+	}
+	userStore := &user.Store{
+		SQLBuilder:  sqlBuilder,
+		SQLExecutor: sqlExecutor,
+	}
+	defaultTemplateLanguage := deps.ProvideDefaultTemplateLanguage(config)
+	resolver := &template.Resolver{
+		Resources:          manager,
+		DefaultLanguageTag: defaultTemplateLanguage,
+	}
+	engine := &template.Engine{
+		Resolver: resolver,
+	}
+	localizationConfig := appConfig.Localization
+	staticAssetURLPrefix := environmentConfig.StaticAssetURLPrefix
+	staticAssetResolver := &web.StaticAssetResolver{
+		Context:            context,
+		Config:             httpConfig,
+		Localization:       localizationConfig,
+		StaticAssetsPrefix: staticAssetURLPrefix,
+		Resources:          manager,
+	}
+	translationService := &translation.Service{
+		Context:           context,
+		EnvironmentConfig: environmentConfig,
+		TemplateEngine:    engine,
+		StaticAssets:      staticAssetResolver,
+	}
+	welcomeMessageConfig := appConfig.WelcomeMessage
+	queue := appProvider.TaskQueue
+	welcomemessageProvider := &welcomemessage.Provider{
+		Translation:          translationService,
+		RateLimiter:          limiter,
+		WelcomeMessageConfig: welcomeMessageConfig,
+		TaskQueue:            queue,
+	}
+	rawCommands := &user.RawCommands{
+		Store:                  userStore,
+		Clock:                  clockClock,
+		WelcomeMessageProvider: welcomemessageProvider,
+	}
+	authorizationStore := &pq.AuthorizationStore{
+		SQLBuilder:  sqlBuilder,
+		SQLExecutor: sqlExecutor,
+	}
+	storeRedisLogger := idpsession.NewStoreRedisLogger(factory)
+	idpsessionStoreRedis := &idpsession.StoreRedis{
+		Redis:  redisHandle,
+		AppID:  appID,
+		Clock:  clockClock,
+		Logger: storeRedisLogger,
+	}
+	sessionConfig := appConfig.Session
+	idpsessionCookieDef := idpsession.NewSessionCookieDef(httpConfig, sessionConfig)
+	idpsessionManager := &idpsession.Manager{
+		Store:         idpsessionStoreRedis,
+		Clock:         clockClock,
+		Config:        sessionConfig,
+		CookieFactory: cookieFactory,
+		CookieDef:     idpsessionCookieDef,
+	}
+	redisLogger := redis.NewLogger(factory)
+	grantStore := &redis.GrantStore{
+		Redis:       redisHandle,
+		AppID:       appID,
+		Logger:      redisLogger,
+		SQLBuilder:  sqlBuilder,
+		SQLExecutor: sqlExecutor,
+		Clock:       clockClock,
+	}
+	sessionManager := &oauth2.SessionManager{
+		Store: grantStore,
+		Clock: clockClock,
+	}
+	coordinator := &facade.Coordinator{
+		Identities:      serviceService,
+		Authenticators:  service3,
+		Verification:    verificationService,
+		MFA:             mfaService,
+		Users:           rawCommands,
+		PasswordHistory: historyStore,
+		OAuth:           authorizationStore,
+		IDPSessions:     idpsessionManager,
+		OAuthSessions:   sessionManager,
+		IdentityConfig:  identityConfig,
+	}
+	identityFacade := facade.IdentityFacade{
+		Coordinator: coordinator,
+	}
+	authenticatorFacade := facade.AuthenticatorFacade{
+		Coordinator: coordinator,
+	}
+	mainOriginProvider := &MainOriginProvider{
+		Request:    request,
+		TrustProxy: trustProxy,
+	}
+	endpointsProvider := &EndpointsProvider{
+		OriginProvider: mainOriginProvider,
+	}
+	messageSender := &otp.MessageSender{
+		Translation: translationService,
+		Endpoints:   endpointsProvider,
+		RateLimiter: limiter,
+		TaskQueue:   queue,
+	}
+	codeSender := &oob.CodeSender{
+		OTPMessageSender: messageSender,
+	}
+	oAuthClientCredentials := deps.ProvideOAuthClientCredentials(secretConfig)
+	urlProvider := &webapp.URLProvider{
+		Endpoints: endpointsProvider,
+	}
+	userInfoDecoder := sso.UserInfoDecoder{
+		LoginIDNormalizerFactory: normalizerFactory,
+	}
+	oAuthProviderFactory := &sso.OAuthProviderFactory{
+		Endpoints:                endpointsProvider,
+		IdentityConfig:           identityConfig,
+		Credentials:              oAuthClientCredentials,
+		RedirectURL:              urlProvider,
+		Clock:                    clockClock,
+		UserInfoDecoder:          userInfoDecoder,
+		LoginIDNormalizerFactory: normalizerFactory,
+	}
+	forgotPasswordConfig := appConfig.ForgotPassword
+	forgotpasswordStore := &forgotpassword.Store{
+		AppID: appID,
+		Redis: redisHandle,
+	}
+	providerLogger := forgotpassword.NewProviderLogger(factory)
+	forgotpasswordProvider := &forgotpassword.Provider{
+		Request:        request,
+		Translation:    translationService,
+		Config:         forgotPasswordConfig,
+		TrustProxy:     trustProxy,
+		Store:          forgotpasswordStore,
+		Clock:          clockClock,
+		URLs:           urlProvider,
+		TaskQueue:      queue,
+		Logger:         providerLogger,
+		Identities:     identityFacade,
+		Authenticators: authenticatorFacade,
+		RateLimiter:    limiter,
+	}
+	verificationCodeSender := &verification.CodeSender{
+		OTPMessageSender: messageSender,
+		WebAppURLs:       urlProvider,
+	}
+	challengeProvider := &challenge.Provider{
+		Redis: redisHandle,
+		AppID: appID,
+		Clock: clockClock,
+	}
+	hookLogger := hook.NewLogger(factory)
+	queries := &user.Queries{
+		Store:        userStore,
+		Identities:   identityFacade,
+		Verification: verificationService,
+	}
+	rawProvider := &user.RawProvider{
+		RawCommands: rawCommands,
+		Queries:     queries,
+	}
+	hookStore := &hook.Store{
+		SQLBuilder:  sqlBuilder,
+		SQLExecutor: sqlExecutor,
+	}
+	hookConfig := appConfig.Hook
+	webhookKeyMaterials := deps.ProvideWebhookKeyMaterials(secretConfig)
+	syncHTTPClient := hook.NewSyncHTTPClient(hookConfig)
+	asyncHTTPClient := hook.NewAsyncHTTPClient()
+	deliverer := &hook.Deliverer{
+		Config:    hookConfig,
+		Secret:    webhookKeyMaterials,
+		Clock:     clockClock,
+		SyncHTTP:  syncHTTPClient,
+		AsyncHTTP: asyncHTTPClient,
+	}
+	hookProvider := &hook.Provider{
+		Context:   context,
+		Logger:    hookLogger,
+		Database:  handle,
+		Clock:     clockClock,
+		Users:     rawProvider,
+		Store:     hookStore,
+		Deliverer: deliverer,
+	}
+	commands := &user.Commands{
+		Raw:          rawCommands,
+		Hooks:        hookProvider,
+		Verification: verificationService,
+	}
+	userProvider := &user.Provider{
+		Commands: commands,
+		Queries:  queries,
+	}
+	eventStoreRedis := &access.EventStoreRedis{
+		Redis: redisHandle,
+		AppID: appID,
+	}
+	eventProvider := &access.EventProvider{
+		Store: eventStoreRedis,
+	}
+	idpsessionRand := _wireRandValue
+	idpsessionProvider := &idpsession.Provider{
+		Request:      request,
+		Store:        idpsessionStoreRedis,
+		AccessEvents: eventProvider,
+		TrustProxy:   trustProxy,
+		Config:       sessionConfig,
+		Clock:        clockClock,
+		Random:       idpsessionRand,
+	}
+	interactionContext := &interaction.Context{
+		Request:                  request,
+		Database:                 sqlExecutor,
+		Clock:                    clockClock,
+		Config:                   appConfig,
+		TrustProxy:               trustProxy,
+		Identities:               identityFacade,
+		Authenticators:           authenticatorFacade,
+		AnonymousIdentities:      anonymousProvider,
+		OOBAuthenticators:        oobProvider,
+		OOBCodeSender:            codeSender,
+		OAuthProviderFactory:     oAuthProviderFactory,
+		MFA:                      mfaService,
+		ForgotPassword:           forgotpasswordProvider,
+		ResetPassword:            forgotpasswordProvider,
+		LoginIDNormalizerFactory: normalizerFactory,
+		Verification:             verificationService,
+		VerificationCodeSender:   verificationCodeSender,
+		RateLimiter:              limiter,
+		Challenges:               challengeProvider,
+		Users:                    userProvider,
+		Hooks:                    hookProvider,
+		CookieFactory:            cookieFactory,
+		Sessions:                 idpsessionProvider,
+		SessionCookie:            idpsessionCookieDef,
+		MFADeviceTokenCookie:     cookieDef,
+	}
+	interactionStoreRedis := &interaction.StoreRedis{
+		Redis: redisHandle,
+		AppID: appID,
+	}
+	interactionService := &interaction.Service{
+		Logger:  logger,
+		Context: interactionContext,
+		Store:   interactionStoreRedis,
+	}
+	webappService2 := &webapp.Service2{
+		Logger:               serviceLogger,
+		Request:              request,
+		Sessions:             sessionStoreRedis,
+		SessionCookie:        sessionCookieDef,
+		MFADeviceTokenCookie: cookieDef,
+		ErrorCookie:          errorCookie,
+		CookieFactory:        cookieFactory,
+		Graph:                interactionService,
+	}
+	uiConfig := appConfig.UI
+	baseViewModeler := &viewmodels.BaseViewModeler{
+		AuthUI:         uiConfig,
+		StaticAssets:   staticAssetResolver,
+		ForgotPassword: forgotPasswordConfig,
+		Authentication: authenticationConfig,
+		ErrorCookie:    errorCookie,
+		Translations:   translationService,
+	}
+	responseRendererLogger := webapp2.NewResponseRendererLogger(factory)
+	responseRenderer := &webapp2.ResponseRenderer{
+		TemplateEngine: engine,
+		Logger:         responseRendererLogger,
+	}
+	controllerDeps := webapp2.ControllerDeps{
+		Database:      handle,
+		Page:          webappService2,
+		BaseViewModel: baseViewModeler,
+		Renderer:      responseRenderer,
+		TrustProxy:    trustProxy,
+	}
+	controllerFactory := webapp2.ControllerFactory{
+		LoggerFactory:  factory,
+		ControllerDeps: controllerDeps,
+	}
+	returnHandler := &webapp2.ReturnHandler{
+		ControllerFactory: controllerFactory,
+		BaseViewModel:     baseViewModeler,
+		Renderer:          responseRenderer,
+	}
+	return returnHandler
+}
+
 // Injectors from wire_middleware.go:
 
 func newSentryMiddleware(p *deps.RootProvider) httproute.Middleware {

--- a/pkg/auth/wire_handler.go
+++ b/pkg/auth/wire_handler.go
@@ -291,3 +291,10 @@ func newWebAppStaticAssetsHandler(p *deps.RequestProvider) http.Handler {
 		wire.Bind(new(http.Handler), new(*handlerwebapp.StaticAssetsHandler)),
 	))
 }
+
+func newWebAppReturnHandler(p *deps.RequestProvider) http.Handler {
+	panic(wire.Build(
+		DependencySet,
+		wire.Bind(new(http.Handler), new(*handlerwebapp.ReturnHandler)),
+	))
+}

--- a/pkg/lib/feature/verification/code.go
+++ b/pkg/lib/feature/verification/code.go
@@ -25,6 +25,8 @@ type Code struct {
 	LoginID     string    `json:"login_id"`
 	Code        string    `json:"code"`
 	ExpireAt    time.Time `json:"expire_at"`
+
+	WebSessionID string `json:"web_session_id"`
 }
 
 func (c *Code) SendResult() *otp.CodeSendResult {

--- a/pkg/lib/feature/verification/code.go
+++ b/pkg/lib/feature/verification/code.go
@@ -27,6 +27,8 @@ type Code struct {
 	ExpireAt    time.Time `json:"expire_at"`
 
 	WebSessionID string `json:"web_session_id"`
+
+	RequestedByUser bool `json:"requested_by_user"`
 }
 
 func (c *Code) SendResult() *otp.CodeSendResult {

--- a/pkg/lib/feature/verification/service.go
+++ b/pkg/lib/feature/verification/service.go
@@ -232,7 +232,7 @@ func (s *Service) IsUserVerified(identities []*identity.Info) (bool, error) {
 	}
 }
 
-func (s *Service) CreateNewCode(id string, info *identity.Info) (*Code, error) {
+func (s *Service) CreateNewCode(id string, info *identity.Info, webSessionID string) (*Code, error) {
 	err := s.RateLimiter.TakeToken(GenerateRateLimitBucket(id))
 	if err != nil {
 		return nil, err
@@ -254,6 +254,7 @@ func (s *Service) CreateNewCode(id string, info *identity.Info) (*Code, error) {
 		LoginID:      info.Claims[identity.IdentityClaimLoginIDValue].(string),
 		Code:         code,
 		ExpireAt:     s.Clock.NowUTC().Add(s.Config.CodeExpiry.Duration()),
+		WebSessionID: webSessionID,
 	}
 
 	err = s.CodeStore.Create(codeModel)

--- a/pkg/lib/feature/verification/service.go
+++ b/pkg/lib/feature/verification/service.go
@@ -232,7 +232,7 @@ func (s *Service) IsUserVerified(identities []*identity.Info) (bool, error) {
 	}
 }
 
-func (s *Service) CreateNewCode(id string, info *identity.Info, webSessionID string) (*Code, error) {
+func (s *Service) CreateNewCode(id string, info *identity.Info, webSessionID string, requestedByUser bool) (*Code, error) {
 	err := s.RateLimiter.TakeToken(GenerateRateLimitBucket(id))
 	if err != nil {
 		return nil, err
@@ -246,15 +246,16 @@ func (s *Service) CreateNewCode(id string, info *identity.Info, webSessionID str
 
 	code := otp.FormatNumeric.Generate()
 	codeModel := &Code{
-		ID:           id,
-		UserID:       info.UserID,
-		IdentityID:   info.ID,
-		IdentityType: string(info.Type),
-		LoginIDType:  string(loginIDType),
-		LoginID:      info.Claims[identity.IdentityClaimLoginIDValue].(string),
-		Code:         code,
-		ExpireAt:     s.Clock.NowUTC().Add(s.Config.CodeExpiry.Duration()),
-		WebSessionID: webSessionID,
+		ID:              id,
+		UserID:          info.UserID,
+		IdentityID:      info.ID,
+		IdentityType:    string(info.Type),
+		LoginIDType:     string(loginIDType),
+		LoginID:         info.Claims[identity.IdentityClaimLoginIDValue].(string),
+		Code:            code,
+		ExpireAt:        s.Clock.NowUTC().Add(s.Config.CodeExpiry.Duration()),
+		WebSessionID:    webSessionID,
+		RequestedByUser: requestedByUser,
 	}
 
 	err = s.CodeStore.Create(codeModel)

--- a/pkg/lib/interaction/context.go
+++ b/pkg/lib/interaction/context.go
@@ -126,7 +126,7 @@ type LoginIDNormalizerFactory interface {
 type VerificationService interface {
 	GetIdentityVerificationStatus(i *identity.Info) ([]verification.ClaimStatus, error)
 	GetAuthenticatorVerificationStatus(a *authenticator.Info) (verification.AuthenticatorStatus, error)
-	CreateNewCode(id string, info *identity.Info) (*verification.Code, error)
+	CreateNewCode(id string, info *identity.Info, webSessionID string) (*verification.Code, error)
 	GetCode(id string) (*verification.Code, error)
 	VerifyCode(id string, code string) (*verification.Code, error)
 	NewVerifiedClaim(userID string, claimName string, claimValue string) *verification.Claim

--- a/pkg/lib/interaction/context.go
+++ b/pkg/lib/interaction/context.go
@@ -126,7 +126,12 @@ type LoginIDNormalizerFactory interface {
 type VerificationService interface {
 	GetIdentityVerificationStatus(i *identity.Info) ([]verification.ClaimStatus, error)
 	GetAuthenticatorVerificationStatus(a *authenticator.Info) (verification.AuthenticatorStatus, error)
-	CreateNewCode(id string, info *identity.Info, webSessionID string) (*verification.Code, error)
+	CreateNewCode(
+		id string,
+		info *identity.Info,
+		webSessionID string,
+		requestedByUser bool,
+	) (*verification.Code, error)
 	GetCode(id string) (*verification.Code, error)
 	VerifyCode(id string, code string) (*verification.Code, error)
 	NewVerifiedClaim(userID string, claimName string, claimValue string) *verification.Claim

--- a/pkg/lib/interaction/context.go
+++ b/pkg/lib/interaction/context.go
@@ -148,7 +148,7 @@ type RateLimiter interface {
 
 type Context struct {
 	IsCommitting bool   `wire:"-"`
-	WebStateID   string `wire:"-"`
+	WebSessionID string `wire:"-"`
 
 	Request    *http.Request
 	Database   db.SQLExecutor

--- a/pkg/lib/interaction/nodes/ensure_verification.go
+++ b/pkg/lib/interaction/nodes/ensure_verification.go
@@ -62,11 +62,21 @@ func (n *NodeEnsureVerificationBegin) DeriveEdges(graph *interaction.Graph) ([]i
 		break
 	case verification.StatusPending:
 		if n.RequestedByUser && !n.SkipVerification {
-			return []interaction.Edge{&EdgeVerifyIdentity{Identity: n.Identity}}, nil
+			return []interaction.Edge{
+				&EdgeVerifyIdentity{
+					Identity:        n.Identity,
+					RequestedByUser: n.RequestedByUser,
+				},
+			}, nil
 		}
 	case verification.StatusRequired:
 		if !n.SkipVerification {
-			return []interaction.Edge{&EdgeVerifyIdentity{Identity: n.Identity}}, nil
+			return []interaction.Edge{
+				&EdgeVerifyIdentity{
+					Identity:        n.Identity,
+					RequestedByUser: n.RequestedByUser,
+				},
+			}, nil
 		}
 	}
 

--- a/pkg/lib/interaction/nodes/use_identity_oauth_provider.go
+++ b/pkg/lib/interaction/nodes/use_identity_oauth_provider.go
@@ -55,7 +55,7 @@ func (e *EdgeUseIdentityOAuthProvider) Instantiate(ctx *interaction.Context, gra
 
 	nonceSource := input.GetNonceSource()
 	errorRedirectURI := input.GetErrorRedirectURI()
-	state := ctx.WebStateID
+	state := ctx.WebSessionID
 
 	oauthProvider := ctx.OAuthProviderFactory.NewOAuthProvider(alias)
 	if oauthProvider == nil {

--- a/pkg/lib/interaction/nodes/use_identity_oauth_user_info.go
+++ b/pkg/lib/interaction/nodes/use_identity_oauth_user_info.go
@@ -42,7 +42,7 @@ func (e *EdgeUseIdentityOAuthUserInfo) Instantiate(ctx *interaction.Context, gra
 	alias := input.GetProviderAlias()
 	nonceSource := input.GetNonceSource()
 	code := input.GetCode()
-	state := ctx.WebStateID
+	state := ctx.WebSessionID
 	scope := input.GetScope()
 	oauthError := input.GetError()
 	errorDescription := input.GetErrorDescription()

--- a/pkg/lib/interaction/nodes/verify_identity.go
+++ b/pkg/lib/interaction/nodes/verify_identity.go
@@ -84,6 +84,11 @@ func (n *NodeVerifyIdentity) GetVerificationCodeLength() int {
 	return n.CodeLength
 }
 
+// GetVerificationCodeChannel implements VerifyIdentityNode.
+func (n *NodeVerifyIdentity) GetRequestedByUser() bool {
+	return n.RequestedByUser
+}
+
 func (n *NodeVerifyIdentity) Prepare(ctx *interaction.Context, graph *interaction.Graph) error {
 	return nil
 }

--- a/pkg/lib/interaction/nodes/verify_identity.go
+++ b/pkg/lib/interaction/nodes/verify_identity.go
@@ -113,7 +113,12 @@ func (n *NodeVerifyIdentity) SendCode(ctx *interaction.Context) (*otp.CodeSendRe
 	}
 
 	if code == nil || ctx.Clock.NowUTC().After(code.ExpireAt) {
-		code, err = ctx.Verification.CreateNewCode(n.CodeID, n.Identity, ctx.WebSessionID)
+		code, err = ctx.Verification.CreateNewCode(
+			n.CodeID,
+			n.Identity,
+			ctx.WebSessionID,
+			n.RequestedByUser,
+		)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/lib/interaction/nodes/verify_identity.go
+++ b/pkg/lib/interaction/nodes/verify_identity.go
@@ -15,13 +15,15 @@ func init() {
 }
 
 type EdgeVerifyIdentity struct {
-	Identity *identity.Info
+	Identity        *identity.Info
+	RequestedByUser bool
 }
 
 func (e *EdgeVerifyIdentity) Instantiate(ctx *interaction.Context, graph *interaction.Graph, rawInput interface{}) (interaction.Node, error) {
 	node := &NodeVerifyIdentity{
-		Identity: e.Identity,
-		CodeID:   verification.NewCodeID(),
+		Identity:        e.Identity,
+		CodeID:          verification.NewCodeID(),
+		RequestedByUser: e.RequestedByUser,
 	}
 	result, err := node.SendCode(ctx)
 	if err != nil {
@@ -47,15 +49,19 @@ func (e *EdgeVerifyIdentityResume) Instantiate(ctx *interaction.Context, graph *
 		Channel:      r.Channel,
 		CodeLength:   r.CodeLength,
 		SendCooldown: r.SendCooldown,
+		// VerifyIdentityResume is always requested by user.
+		RequestedByUser: true,
 	}, nil
 }
 
 type NodeVerifyIdentity struct {
-	Identity     *identity.Info `json:"identity"`
-	CodeID       string         `json:"code_id"`
-	Channel      string         `json:"channel"`
-	CodeLength   int            `json:"code_length"`
-	SendCooldown int            `json:"send_cooldown"`
+	Identity        *identity.Info `json:"identity"`
+	CodeID          string         `json:"code_id"`
+	RequestedByUser bool           `json:"requested_by_user"`
+
+	Channel      string `json:"channel"`
+	CodeLength   int    `json:"code_length"`
+	SendCooldown int    `json:"send_cooldown"`
 }
 
 // GetVerificationIdentity implements VerifyIdentityNode.

--- a/pkg/lib/interaction/nodes/verify_identity.go
+++ b/pkg/lib/interaction/nodes/verify_identity.go
@@ -102,7 +102,7 @@ func (n *NodeVerifyIdentity) SendCode(ctx *interaction.Context) (*otp.CodeSendRe
 	}
 
 	if code == nil || ctx.Clock.NowUTC().After(code.ExpireAt) {
-		code, err = ctx.Verification.CreateNewCode(n.CodeID, n.Identity)
+		code, err = ctx.Verification.CreateNewCode(n.CodeID, n.Identity, ctx.WebSessionID)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/lib/interaction/service.go
+++ b/pkg/lib/interaction/service.go
@@ -70,7 +70,7 @@ func (s *Service) Get(instanceID string) (*Graph, error) {
 	return s.Store.GetGraphInstance(instanceID)
 }
 
-func (s *Service) DryRun(webStateID string, fn func(*Context) (*Graph, error)) (err error) {
+func (s *Service) DryRun(webSessionID string, fn func(*Context) (*Graph, error)) (err error) {
 	ctx, err := s.Context.initialize()
 	if err != nil {
 		return
@@ -85,7 +85,7 @@ func (s *Service) DryRun(webStateID string, fn func(*Context) (*Graph, error)) (
 	}()
 
 	ctx.IsCommitting = false
-	ctx.WebStateID = webStateID
+	ctx.WebSessionID = webSessionID
 	graph, err := fn(ctx)
 	if err != nil {
 		return
@@ -99,7 +99,7 @@ func (s *Service) DryRun(webStateID string, fn func(*Context) (*Graph, error)) (
 	return
 }
 
-func (s *Service) Run(webStateID string, graph *Graph) (err error) {
+func (s *Service) Run(webSessionID string, graph *Graph) (err error) {
 	ctx, err := s.Context.initialize()
 	if err != nil {
 		return
@@ -124,7 +124,7 @@ func (s *Service) Run(webStateID string, graph *Graph) (err error) {
 	}()
 
 	ctx.IsCommitting = false
-	ctx.WebStateID = webStateID
+	ctx.WebSessionID = webSessionID
 	err = graph.Apply(ctx)
 	if err != nil {
 		return

--- a/resources/authgear/templates/en/translation.json
+++ b/resources/authgear/templates/en/translation.json
@@ -246,5 +246,8 @@
   "show-password-label": "Show password",
   "hide-password-label": "Hide password",
 
+  "return-page-title": "Return to where you were",
+  "return-page-description": "Please return to where you were to continue. If you were interacting with an mobile app, please switch back to the app. If you were interacting with a website, please switch back to that tab.",
+
   "toc-pp-footer": "<p class=\"toc-pp-footer\">By registering, you agree to our <a target=\"_blank\" href=\"{termsOfService}\">Terms of Service</a> and <a target=\"_blank\" href=\"{privacyPolicy}\">Privacy Policy</a>.</p>"
 }

--- a/resources/authgear/templates/en/translation.json
+++ b/resources/authgear/templates/en/translation.json
@@ -111,6 +111,9 @@
   "verify-user-resend-button-label": "Resend",
   "verify-user-resend-button-label--unit": "Resend (%ds)",
 
+  "verify-user-return-page-title": "Continue verification",
+  "verify-user-return-page-description": "Please click the button and then return to where you were.",
+
   "verify-user-success-page-title": "Account verification",
   "verify-user-success-description": "You have successfully verified your account.",
 

--- a/resources/authgear/templates/en/web/return.html
+++ b/resources/authgear/templates/en/web/return.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html>
+{{ template "__html_head.html" . }}
+<body class="page">
+<div class="content">
+
+{{ template "__header.html" . }}
+
+{{ template "__nav_bar.html" true }}
+
+<div class="simple-form vertical-form form-fields-container pane">
+
+<h1 class="title primary-txt">{{ template "return-page-title" }}</h1>
+
+{{ template "__error.html" . }}
+
+<p class="description primary-txt">{{ template "return-page-description" }}</p>
+
+</div>
+</html>

--- a/resources/authgear/templates/en/web/verify_identity.html
+++ b/resources/authgear/templates/en/web/verify_identity.html
@@ -6,6 +6,23 @@
 
 {{ template "__header.html" . }}
 
+{{ if eq $.Action "update_session_step" }}
+
+<form class="simple-form vertical-form form-fields-container pane" method="post" novalidate>
+
+<h1 class="title primary-txt">{{ template "verify-user-return-page-title" }}</h1>
+<div class="description primary-txt">{{ template "verify-user-return-page-description" }}</div>
+
+{{ $.CSRFField }}
+
+{{ template "__error.html" . }}
+
+<input type="hidden" name="x_code" value="{{ $.VerificationCode }}">
+<button class="btn primary-btn align-self-flex-end" type="submit" name="x_action" value="{{ $.Action }}">{{ template "next-button-label" }}</button>
+</form>
+
+{{ else }}
+
 {{ if $.IdentityDisplayID }}
 {{ template "__nav_bar.html" }}
 {{ else }}
@@ -55,7 +72,7 @@
 		value="{{ $.VerificationCode }}"
 	>
 {{ end }}
-<button class="btn primary-btn align-self-flex-end" type="submit" name="x_action" value="submit">{{ template "next-button-label" }}</button>
+<button class="btn primary-btn align-self-flex-end" type="submit" name="x_action" value="{{ $.Action }}">{{ template "next-button-label" }}</button>
 </form>
 
 <form class="link verify-user-trigger-form" method="post" novalidate>
@@ -71,6 +88,8 @@
 {{ end }}
 
 </div>
+
+{{ end }}
 
 </div>
 </body>


### PR DESCRIPTION
This is the first part of #763. The user has to refresh the page manually to have the code filled in in the original user agent. The next PR will implement a websocket protocol between the server and the client to avoid manual refreshing.