### PR TITLE
Publish WeChatLoginStart event for SDK integration

### DIFF
--- a/authui/src/authgear.css
+++ b/authui/src/authgear.css
@@ -553,7 +553,7 @@ a.btn {
   background-color: #07c160;
 }
 
-.sso-loginid-separator {
+.sso-loginid-separator, .wechat-auth-separator {
   text-align: center;
   margin: 6px;
   padding: 6px;

--- a/authui/src/authgear.css
+++ b/authui/src/authgear.css
@@ -1082,3 +1082,9 @@ a.btn {
   border-bottom: 2px solid var(--color-primary);
   color: var(--color-primary);
 }
+
+.wechat-auth-qr-code {
+  width: 200px;
+  height: 200px;
+  align-self: center;
+}

--- a/pkg/admin/web_endpoints.go
+++ b/pkg/admin/web_endpoints.go
@@ -28,7 +28,7 @@ func (WebEndpoints) SSOCallbackURL(providerConfig config.OAuthSSOProviderConfig)
 	panic("not implemented")
 }
 
-func (WebEndpoints) AuthorizeEndpointURL() *url.URL {
+func (WebEndpoints) AuthorizeEndpointURL(config.OAuthSSOProviderConfig) *url.URL {
 	// WechatURLProvider
 	panic("not implemented")
 }

--- a/pkg/auth/deps.go
+++ b/pkg/auth/deps.go
@@ -95,4 +95,5 @@ var DependencySet = wire.NewSet(
 	wire.Bind(new(handlerwebapp.PageService), new(*webapp.Service2)),
 	wire.Bind(new(handlerwebapp.ResourceManager), new(*resource.Manager)),
 	wire.Bind(new(handlerwebapp.VerifyIdentityVerificationService), new(*verification.Service)),
+	wire.Bind(new(handlerwebapp.JSONResponseWriter), new(*httputil.JSONResponseWriter)),
 )

--- a/pkg/auth/handler/webapp/publisher.go
+++ b/pkg/auth/handler/webapp/publisher.go
@@ -33,7 +33,7 @@ func (p *Publisher) Get() *goredis.Client {
 }
 
 func (p *Publisher) Publish(s *webapp.Session, msg *WebsocketMessage) error {
-	channelName := WebsocketChannelName(string(p.AppID), s.ID)
+	channelName := WebsocketChannelName(string(p.AppID), s.WsChannelID)
 
 	b, err := json.Marshal(msg)
 	if err != nil {

--- a/pkg/auth/handler/webapp/viewmodels/base.go
+++ b/pkg/auth/handler/webapp/viewmodels/base.go
@@ -40,6 +40,7 @@ type BaseViewModel struct {
 	ForgotPasswordEnabled bool
 	PublicSignupDisabled  bool
 	PageLoadedAt          int
+	IsNativeSDK           bool
 }
 
 func (m *BaseViewModel) SetError(err error) {
@@ -123,6 +124,7 @@ func (m *BaseViewModeler) ViewModel(r *http.Request, rw http.ResponseWriter) Bas
 		httputil.UpdateCookie(rw, m.ErrorCookie.ResetError())
 	}
 
+	SDK := r.URL.Query().Get("x_sdk")
 	if s := webapp.GetSession(r.Context()); s != nil {
 		for _, step := range s.Steps {
 			if path := step.Kind.Path(); path == "" {
@@ -130,7 +132,14 @@ func (m *BaseViewModeler) ViewModel(r *http.Request, rw http.ResponseWriter) Bas
 			}
 			model.SessionStepURLs = append(model.SessionStepURLs, step.URL().String())
 		}
+		if SDK == "" {
+			SDK = s.SDK
+		}
 	}
+
+	model.IsNativeSDK = (SDK == "ios" ||
+		SDK == "android" ||
+		SDK == "react-native")
 
 	return model
 }

--- a/pkg/auth/handler/webapp/viewmodels/base.go
+++ b/pkg/auth/handler/webapp/viewmodels/base.go
@@ -124,7 +124,7 @@ func (m *BaseViewModeler) ViewModel(r *http.Request, rw http.ResponseWriter) Bas
 		httputil.UpdateCookie(rw, m.ErrorCookie.ResetError())
 	}
 
-	SDK := r.URL.Query().Get("x_sdk")
+	SDK := r.Form.Get("x_sdk")
 	if s := webapp.GetSession(r.Context()); s != nil {
 		for _, step := range s.Steps {
 			if path := step.Kind.Path(); path == "" {

--- a/pkg/auth/handler/webapp/websocket.go
+++ b/pkg/auth/handler/webapp/websocket.go
@@ -94,9 +94,15 @@ type WebsocketMessageKind string
 
 const (
 	// WebsocketMessageKindRefresh means when the client receives this message, they should refresh the page.
-	WebsocketMessageKindRefresh = "refresh"
+	WebsocketMessageKindRefresh          = "refresh"
+	WebsocketMessageKindWeChatLoginStart = "wechat_login_start"
 )
 
 type WebsocketMessage struct {
 	Kind WebsocketMessageKind `json:"kind"`
+	Data interface{}          `json:"data"`
+}
+
+type WebsocketMessageWeChatLoginStartData struct {
+	State string `json:"state"`
 }

--- a/pkg/auth/handler/webapp/websocket.go
+++ b/pkg/auth/handler/webapp/websocket.go
@@ -38,7 +38,7 @@ func (h *WebsocketHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 }
 
 func (h *WebsocketHandler) Accept(r *http.Request) (channelName string, err error) {
-	wsChannelID := r.URL.Query().Get("ws_channel_id")
+	wsChannelID := r.URL.Query().Get("x_ws_channel_id")
 	if wsChannelID == "" {
 		s := webapp.GetSession(r.Context())
 		if s == nil {

--- a/pkg/auth/handler/webapp/websocket.go
+++ b/pkg/auth/handler/webapp/websocket.go
@@ -38,13 +38,17 @@ func (h *WebsocketHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 }
 
 func (h *WebsocketHandler) Accept(r *http.Request) (channelName string, err error) {
-	s := webapp.GetSession(r.Context())
-	if s == nil {
-		err = webapp.ErrSessionNotFound
-		return
+	wsChannelID := r.URL.Query().Get("ws_channel_id")
+	if wsChannelID == "" {
+		s := webapp.GetSession(r.Context())
+		if s == nil {
+			err = webapp.ErrSessionNotFound
+			return
+		}
+		wsChannelID = s.WsChannelID
 	}
 
-	channelName = WebsocketChannelName(string(h.AppID), s.ID)
+	channelName = WebsocketChannelName(string(h.AppID), wsChannelID)
 	return
 }
 

--- a/pkg/auth/handler/webapp/wechat_auth.go
+++ b/pkg/auth/handler/webapp/wechat_auth.go
@@ -25,7 +25,7 @@ var TemplateWebWechatAuthHandlerHTML = template.RegisterHTML(
 func ConfigureWechatAuthRoute(route httproute.Route) httproute.Route {
 	return route.
 		WithMethods("OPTIONS", "GET").
-		WithPathPattern("/sso/wechat/auth")
+		WithPathPattern("/sso/wechat/auth/:alias")
 }
 
 type WeChatAuthViewModel struct {
@@ -99,7 +99,7 @@ func (h *WechatAuthHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 				nonceSource, _ := r.Cookie(h.CSRFCookie.Name)
 
 				data := InputOAuthCallback{
-					ProviderAlias:    step.FormData["x_alias"].(string),
+					ProviderAlias:    httproute.GetParam(r, "alias"),
 					NonceSource:      nonceSource,
 					Code:             step.FormData["x_code"].(string),
 					Scope:            step.FormData["x_scope"].(string),

--- a/pkg/auth/handler/webapp/wechat_auth.go
+++ b/pkg/auth/handler/webapp/wechat_auth.go
@@ -29,7 +29,8 @@ func ConfigureWechatAuthRoute(route httproute.Route) httproute.Route {
 }
 
 type WeChatAuthViewModel struct {
-	ImageURI htmltemplate.URL
+	ImageURI   htmltemplate.URL
+	CurrentURI string
 }
 
 type WechatAuthHandler struct {
@@ -63,7 +64,8 @@ func (h *WechatAuthHandler) GetData(r *http.Request, w http.ResponseWriter, sess
 		// dataURI is generated here and not user generated,
 		// so it is safe to use htmltemplate.URL with it.
 		// nolint:gosec
-		ImageURI: htmltemplate.URL(dataURI),
+		ImageURI:   htmltemplate.URL(dataURI),
+		CurrentURI: r.URL.RequestURI(),
 	}
 
 	viewmodels.Embed(data, baseViewModel)

--- a/pkg/auth/handler/webapp/wechat_callback.go
+++ b/pkg/auth/handler/webapp/wechat_callback.go
@@ -18,7 +18,7 @@ type JSONResponseWriter interface {
 func ConfigureWechatCallbackRoute(route httproute.Route) httproute.Route {
 	return route.
 		WithMethods("OPTIONS", "POST", "GET").
-		WithPathPattern("/sso/wechat/callback/:alias")
+		WithPathPattern("/sso/wechat/callback")
 }
 
 type WechatCallbackHandler struct {
@@ -44,7 +44,6 @@ func (h *WechatCallbackHandler) ServeHTTP(w http.ResponseWriter, r *http.Request
 
 		step := session.CurrentStep()
 		step.FormData["x_action"] = WechatActionCallback
-		step.FormData["x_alias"] = httproute.GetParam(r, "alias")
 		step.FormData["x_code"] = r.Form.Get("code")
 		step.FormData["x_scope"] = r.Form.Get("scope")
 		step.FormData["x_error"] = r.Form.Get("error")

--- a/pkg/auth/handler/webapp/wechat_callback.go
+++ b/pkg/auth/handler/webapp/wechat_callback.go
@@ -4,9 +4,9 @@ import (
 	"net/http"
 
 	"github.com/authgear/authgear-server/pkg/api"
+	"github.com/authgear/authgear-server/pkg/auth/handler/webapp/viewmodels"
 	"github.com/authgear/authgear-server/pkg/auth/webapp"
 	"github.com/authgear/authgear-server/pkg/util/httproute"
-	"github.com/authgear/authgear-server/pkg/util/httputil"
 )
 
 const WechatActionCallback = "callback"
@@ -23,6 +23,7 @@ func ConfigureWechatCallbackRoute(route httproute.Route) httproute.Route {
 
 type WechatCallbackHandler struct {
 	ControllerFactory ControllerFactory
+	BaseViewModel     *viewmodels.BaseViewModeler
 	JSON              JSONResponseWriter
 }
 
@@ -61,7 +62,8 @@ func (h *WechatCallbackHandler) ServeHTTP(w http.ResponseWriter, r *http.Request
 	handler := func() error {
 		err := updateWebSession()
 		// serve api
-		if httputil.IsJSONContentType(r.Header.Get("content-type")) {
+		baseViewModel := h.BaseViewModel.ViewModel(r, w)
+		if baseViewModel.IsNativeSDK {
 			if err == nil {
 				h.JSON.WriteResponse(w, &api.Response{Result: nil})
 			} else {

--- a/pkg/auth/routes.go
+++ b/pkg/auth/routes.go
@@ -127,7 +127,7 @@ func NewRouter(p *deps.RootProvider, configSource *configsource.ConfigSource, st
 	router.Add(webapphandler.ConfigureSSOCallbackRoute(webappSSOCallbackRoute), p.Handler(newWebAppSSOCallbackHandler))
 
 	router.Add(webapphandler.ConfigureWechatAuthRoute(webappPageRoute), p.Handler(newWechatAuthHandler))
-	router.Add(webapphandler.ConfigureWechatCallbackRoute(webappPageRoute), p.Handler(newWechatCallbackHandler))
+	router.Add(webapphandler.ConfigureWechatCallbackRoute(webappSSOCallbackRoute), p.Handler(newWechatCallbackHandler))
 
 	router.Add(oauthhandler.ConfigureOIDCMetadataRoute(oauthAPIRoute), p.Handler(newOAuthMetadataHandler))
 	router.Add(oauthhandler.ConfigureOAuthMetadataRoute(oauthAPIRoute), p.Handler(newOAuthMetadataHandler))

--- a/pkg/auth/webapp/session.go
+++ b/pkg/auth/webapp/session.go
@@ -20,6 +20,7 @@ func WithSession(ctx context.Context, session *Session) context.Context {
 }
 
 type SessionOptions struct {
+	WsChannelID     string
 	RedirectURI     string
 	KeepAfterFinish bool
 	UILocales       string
@@ -30,6 +31,7 @@ type SessionOptions struct {
 
 func NewSessionOptionsFromSession(s *Session) SessionOptions {
 	return SessionOptions{
+		WsChannelID:     s.WsChannelID,
 		RedirectURI:     s.RedirectURI,
 		KeepAfterFinish: s.KeepAfterFinish,
 		UILocales:       s.UILocales,
@@ -40,6 +42,8 @@ func NewSessionOptionsFromSession(s *Session) SessionOptions {
 
 type Session struct {
 	ID string `json:"id"`
+
+	WsChannelID string `json:"ws_channel_id"`
 
 	// Steps is a history stack of steps taken within this session.
 	Steps []SessionStep `json:"steps,omitempty"`
@@ -74,8 +78,13 @@ func newSessionID() string {
 }
 
 func NewSession(options SessionOptions) *Session {
+	id := newSessionID()
+	if options.WsChannelID == "" {
+		options.WsChannelID = id
+	}
 	s := &Session{
-		ID:              newSessionID(),
+		ID:              id,
+		WsChannelID:     options.WsChannelID,
 		RedirectURI:     options.RedirectURI,
 		KeepAfterFinish: options.KeepAfterFinish,
 		Extra:           make(map[string]interface{}),

--- a/pkg/auth/webapp/session.go
+++ b/pkg/auth/webapp/session.go
@@ -25,6 +25,7 @@ type SessionOptions struct {
 	KeepAfterFinish bool
 	UILocales       string
 	Prompt          string
+	SDK             string
 	Extra           map[string]interface{}
 	UpdatedAt       time.Time
 }
@@ -36,6 +37,7 @@ func NewSessionOptionsFromSession(s *Session) SessionOptions {
 		KeepAfterFinish: s.KeepAfterFinish,
 		UILocales:       s.UILocales,
 		Prompt:          s.Prompt,
+		SDK:             s.SDK,
 		Extra:           nil, // Omit extra by default
 	}
 }
@@ -60,6 +62,9 @@ type Session struct {
 
 	// Prompt is used to indicate requested authentication behavior
 	Prompt string `json:"prompt,omitempty"`
+
+	// SDK is used to indicate the request is triggered by sdk
+	SDK string `json:"sdk,omitempty"`
 
 	// UILocales are the locale to be used to render UI, passed in from OAuth
 	// flow or query parameter.
@@ -89,6 +94,7 @@ func NewSession(options SessionOptions) *Session {
 		KeepAfterFinish: options.KeepAfterFinish,
 		Extra:           make(map[string]interface{}),
 		Prompt:          options.Prompt,
+		SDK:             options.SDK,
 		UILocales:       options.UILocales,
 		UpdatedAt:       options.UpdatedAt,
 	}

--- a/pkg/auth/webapp/session_step.go
+++ b/pkg/auth/webapp/session_step.go
@@ -73,15 +73,11 @@ func (k SessionStepKind) Path() string {
 func (k SessionStepKind) MatchPath(path string) bool {
 	switch k {
 	case SessionStepOAuthRedirect:
-		switch path {
-		case "/sso/wechat/auth":
-			// In Wechat authorize flow, instead of redirect user to provider authorization page
-			// redirect user to page that display qr code
-			// https://developers.weixin.qq.com/doc/offiaccount/OA_Web_Apps/Wechat_webpage_authorization.html
-			return true
-		default:
-			return strings.HasPrefix(path, "/sso/oauth2/callback/")
-		}
+		// In Wechat authorize flow, instead of redirect user to provider authorization page
+		// redirect user to page that display qr code
+		// https://developers.weixin.qq.com/doc/offiaccount/OA_Web_Apps/Wechat_webpage_authorization.html
+		return strings.HasPrefix(path, "/sso/wechat/auth/") ||
+			strings.HasPrefix(path, "/sso/oauth2/callback/")
 	case SessionStepAuthenticate:
 		switch path {
 		case "/enter_totp", "/enter_password", "/enter_oob_otp", "/enter_recovery_code", "/send_oob_otp":

--- a/pkg/auth/webapp/url_provider.go
+++ b/pkg/auth/webapp/url_provider.go
@@ -79,6 +79,7 @@ type AuthenticateURLOptions struct {
 	Prompt           string
 	AuthenticateHint interface{}
 	WsChannelID      string
+	SDK              string
 }
 type PageService interface {
 	CreateSession(session *Session, redirectURI string) (*Result, error)
@@ -104,6 +105,7 @@ func (p *AuthenticateURLProvider) AuthenticateURL(options AuthenticateURLOptions
 		Prompt:      options.Prompt,
 		UILocales:   options.UILocales,
 		WsChannelID: options.WsChannelID,
+		SDK:         options.SDK,
 		UpdatedAt:   now,
 	})
 

--- a/pkg/auth/webapp/url_provider.go
+++ b/pkg/auth/webapp/url_provider.go
@@ -78,6 +78,7 @@ type AuthenticateURLOptions struct {
 	UILocales        string
 	Prompt           string
 	AuthenticateHint interface{}
+	WsChannelID      string
 }
 type PageService interface {
 	CreateSession(session *Session, redirectURI string) (*Result, error)
@@ -102,6 +103,7 @@ func (p *AuthenticateURLProvider) AuthenticateURL(options AuthenticateURLOptions
 		RedirectURI: options.RedirectURI,
 		Prompt:      options.Prompt,
 		UILocales:   options.UILocales,
+		WsChannelID: options.WsChannelID,
 		UpdatedAt:   now,
 	})
 

--- a/pkg/auth/webapp/wechat_url_provider.go
+++ b/pkg/auth/webapp/wechat_url_provider.go
@@ -11,12 +11,12 @@ type WechatURLProvider struct {
 	Endpoints EndpointsProvider
 }
 
-func (p *WechatURLProvider) AuthorizeEndpointURL() *url.URL {
-	return p.Endpoints.WeChatAuthorizeEndpointURL()
-}
-
-func (p *WechatURLProvider) SSOCallbackURL(c config.OAuthSSOProviderConfig) *url.URL {
-	u := p.Endpoints.WeChatCallbackEndpointURL()
+func (p *WechatURLProvider) AuthorizeEndpointURL(c config.OAuthSSOProviderConfig) *url.URL {
+	u := p.Endpoints.WeChatAuthorizeEndpointURL()
 	u.Path = path.Join(u.Path, url.PathEscape(c.Alias))
 	return u
+}
+
+func (p *WechatURLProvider) CallbackEndpointURL() *url.URL {
+	return p.Endpoints.WeChatCallbackEndpointURL()
 }

--- a/pkg/auth/wire_gen.go
+++ b/pkg/auth/wire_gen.go
@@ -5344,8 +5344,13 @@ func newWechatCallbackHandler(p *deps.RequestProvider) http.Handler {
 		LoggerFactory:  factory,
 		ControllerDeps: controllerDeps,
 	}
+	jsonResponseWriterLogger := httputil.NewJSONResponseWriterLogger(factory)
+	jsonResponseWriter := &httputil.JSONResponseWriter{
+		Logger: jsonResponseWriterLogger,
+	}
 	wechatCallbackHandler := &webapp2.WechatCallbackHandler{
 		ControllerFactory: controllerFactory,
+		JSON:              jsonResponseWriter,
 	}
 	return wechatCallbackHandler
 }

--- a/pkg/auth/wire_gen.go
+++ b/pkg/auth/wire_gen.go
@@ -5350,6 +5350,7 @@ func newWechatCallbackHandler(p *deps.RequestProvider) http.Handler {
 	}
 	wechatCallbackHandler := &webapp2.WechatCallbackHandler{
 		ControllerFactory: controllerFactory,
+		BaseViewModel:     baseViewModeler,
 		JSON:              jsonResponseWriter,
 	}
 	return wechatCallbackHandler

--- a/pkg/auth/wire_gen.go
+++ b/pkg/auth/wire_gen.go
@@ -4842,6 +4842,7 @@ func newWechatAuthHandler(p *deps.RequestProvider) http.Handler {
 		BaseViewModel:     baseViewModeler,
 		Renderer:          responseRenderer,
 		CSRFCookie:        csrfCookieDef,
+		Publisher:         publisher,
 	}
 	return wechatAuthHandler
 }

--- a/pkg/lib/authn/sso/wechat.go
+++ b/pkg/lib/authn/sso/wechat.go
@@ -11,8 +11,8 @@ const (
 )
 
 type WechatURLProvider interface {
-	AuthorizeEndpointURL() *url.URL
-	SSOCallbackURL(c config.OAuthSSOProviderConfig) *url.URL
+	AuthorizeEndpointURL(c config.OAuthSSOProviderConfig) *url.URL
+	CallbackEndpointURL() *url.URL
 }
 
 type WechatImpl struct {
@@ -34,14 +34,14 @@ func (w *WechatImpl) GetAuthURL(param GetAuthURLParam) (string, error) {
 	v := url.Values{}
 	v.Add("response_type", "code")
 	v.Add("appid", w.ProviderConfig.ClientID)
-	v.Add("redirect_uri", w.URLProvider.SSOCallbackURL(w.ProviderConfig).String())
+	v.Add("redirect_uri", w.URLProvider.CallbackEndpointURL().String())
 	v.Add("scope", w.ProviderConfig.Type.Scope())
 	v.Add("state", param.State)
 
 	authURL := wechatAuthorizationURL + "?" + v.Encode()
 	v = url.Values{}
 	v.Add("x_auth_url", authURL)
-	return w.URLProvider.AuthorizeEndpointURL().String() + "?" + v.Encode(), nil
+	return w.URLProvider.AuthorizeEndpointURL(w.ProviderConfig).String() + "?" + v.Encode(), nil
 }
 
 func (w *WechatImpl) GetAuthInfo(r OAuthAuthorizationResponse, param GetAuthInfoParam) (AuthInfo, error) {

--- a/pkg/lib/oauth/handler/handler_authz.go
+++ b/pkg/lib/oauth/handler/handler_authz.go
@@ -110,6 +110,7 @@ func (h *AuthorizationHandler) doHandle(
 
 	s := session.GetSession(h.Context)
 	authnOptions := webapp.AuthenticateURLOptions{}
+	authnOptions.WsChannelID = r.WsChannelID()
 	if slice.ContainsString(r.Prompt(), "login") {
 		// Request login prompt => force re-authentication and retry
 		r2 := protocol.AuthorizationRequest{}

--- a/pkg/lib/oauth/handler/handler_authz.go
+++ b/pkg/lib/oauth/handler/handler_authz.go
@@ -111,6 +111,7 @@ func (h *AuthorizationHandler) doHandle(
 	s := session.GetSession(h.Context)
 	authnOptions := webapp.AuthenticateURLOptions{}
 	authnOptions.WsChannelID = r.WsChannelID()
+	authnOptions.SDK = r.SDK()
 	if slice.ContainsString(r.Prompt(), "login") {
 		// Request login prompt => force re-authentication and retry
 		r2 := protocol.AuthorizationRequest{}

--- a/pkg/lib/oauth/protocol/authz.go
+++ b/pkg/lib/oauth/protocol/authz.go
@@ -31,3 +31,7 @@ func (r AuthorizationRequest) UILocales() []string { return parseSpaceDelimitedS
 
 func (r AuthorizationRequest) CodeChallenge() string       { return r["code_challenge"] }
 func (r AuthorizationRequest) CodeChallengeMethod() string { return r["code_challenge_method"] }
+
+// Websocket channel
+
+func (r AuthorizationRequest) WsChannelID() string { return r["ws_channel_id"] }

--- a/pkg/lib/oauth/protocol/authz.go
+++ b/pkg/lib/oauth/protocol/authz.go
@@ -35,3 +35,5 @@ func (r AuthorizationRequest) CodeChallengeMethod() string { return r["code_chal
 // Websocket channel
 
 func (r AuthorizationRequest) WsChannelID() string { return r["x_ws_channel_id"] }
+
+func (r AuthorizationRequest) SDK() string { return r["x_sdk"] }

--- a/pkg/lib/oauth/protocol/authz.go
+++ b/pkg/lib/oauth/protocol/authz.go
@@ -34,4 +34,4 @@ func (r AuthorizationRequest) CodeChallengeMethod() string { return r["code_chal
 
 // Websocket channel
 
-func (r AuthorizationRequest) WsChannelID() string { return r["ws_channel_id"] }
+func (r AuthorizationRequest) WsChannelID() string { return r["x_ws_channel_id"] }

--- a/resources/authgear/templates/en/translation.json
+++ b/resources/authgear/templates/en/translation.json
@@ -251,7 +251,11 @@
   "return-page-description": "Please return to where you were to continue. If you were interacting with an mobile app, please switch back to the app. If you were interacting with a website, please switch back to that tab.",
 
   "wechat-auth-title": "Login with WeChat",
-  "wechat-auth-description": "Please scan the QR code in your WeChat app to sign in.",
+  "wechat-auth-with-app-description": "Click the below button to open WeChat app",
+  "wechat-auth-with-qr-code-description": "Scan the QR code in your WeChat app to sign in.",
+  "wechat-open-app": "Open WeChat app to login",
+
+  "wechat-auth-separator": "or",
 
   "toc-pp-footer": "<p class=\"toc-pp-footer\">By registering, you agree to our <a target=\"_blank\" href=\"{termsOfService}\">Terms of Service</a> and <a target=\"_blank\" href=\"{privacyPolicy}\">Privacy Policy</a>.</p>"
 }

--- a/resources/authgear/templates/en/web/wechat_auth.html
+++ b/resources/authgear/templates/en/web/wechat_auth.html
@@ -26,7 +26,7 @@
 
 <p class="description primary-txt">{{ template "wechat-auth-with-qr-code-description" }}</p>
 
-<img src="{{ $.ImageURI }}">
+<img class="wechat-auth-qr-code" src="{{ $.ImageURI }}">
 
 </div>
 </html>

--- a/resources/authgear/templates/en/web/wechat_auth.html
+++ b/resources/authgear/templates/en/web/wechat_auth.html
@@ -14,7 +14,17 @@
 
 {{ template "__error.html" . }}
 
-<p class="description primary-txt">{{ template "wechat-auth-description" }}</p>
+{{ if .IsNativeSDK }}
+
+<p class="description primary-txt">{{ template "wechat-auth-with-app-description" }}</p>
+
+<a class="btn primary-btn" href="{{ $.CurrentURI }}" data-turbolinks-action="replace">{{ template "wechat-open-app" }}</a>
+
+<div class="primary-txt wechat-auth-separator">{{ template "wechat-auth-separator" }}</div>
+
+{{ end }}
+
+<p class="description primary-txt">{{ template "wechat-auth-with-qr-code-description" }}</p>
 
 <img src="{{ $.ImageURI }}">
 


### PR DESCRIPTION
refs #773 

Updates:
- Publish `WeChatLoginStart` evnt in wechat auth endpoint
- Change wechat endpoints to `/sso/wechat/auth/:alias` and `/sso/wechat/callback`
- Support `x_ws_channel_id` parameter in authorize endpoint, allow sdk specify websocket channel id
- Support `x_sdk` in authorize endpoint
- Updated `/sso/wechat/callback` to support api call from sdk