### PR TITLE
Support open wechat redirect uri and wechat auth page for mobile integration

### DIFF
--- a/authui/src/authgear.css
+++ b/authui/src/authgear.css
@@ -830,3 +830,11 @@ a.btn {
   border-bottom: 2px solid var(--color-primary);
   color: var(--color-primary);
 }
+
+.switch-link-group .click-to-switch, .switch-link-group.switched .switch-to-item {
+  display: flex;
+}
+
+.switch-link-group.switched .click-to-switch, .switch-link-group .switch-to-item {
+  display: none;
+}

--- a/authui/src/authgear.ts
+++ b/authui/src/authgear.ts
@@ -274,6 +274,31 @@ window.api.onLoad(() => {
   }
 });
 
+// Handle click link switch label and href
+window.api.onLoad(() => {
+  const groups = document.querySelectorAll(".switch-link-group");
+  const disposers: Array<() => void> = [];
+  for (let i = 0; i < groups.length; i++) {
+    const wrapper = groups[i];
+    const clickToSwitchLink = wrapper.querySelector(
+      ".click-to-switch"
+    ) as HTMLAnchorElement;
+    const switchLinks = (e: Event) => {
+      wrapper.classList.add("switched");
+    };
+    clickToSwitchLink.addEventListener("click", switchLinks);
+    disposers.push(() => {
+      clickToSwitchLink.removeEventListener("click", switchLinks);
+    });
+  }
+
+  return () => {
+    for (const disposer of disposers) {
+      disposer();
+    }
+  };
+});
+
 window.api.onLoad(() => {
   const scheme = window.location.protocol === "https:" ? "wss:" : "ws:";
   const host = window.location.host;

--- a/authui/src/authgear.ts
+++ b/authui/src/authgear.ts
@@ -320,6 +320,15 @@ window.api.onLoad(() => {
     ws = null;
   }
 
+  function refreshIfNeeded() {
+    const ele = document.querySelector('[data-is-refresh-link="true"]');
+    if (ele) {
+      // if there is refresh link in the page, don't refresh automatically
+      return;
+    }
+    refreshPage();
+  }
+
   function connect() {
     const url =
       `${scheme}//${host}/ws` +
@@ -352,14 +361,14 @@ window.api.onLoad(() => {
       console.error("ws onerror", e);
     };
 
-    ws.onmessage = function(e) {
+    ws.onmessage = function (e) {
       console.log("ws onmessage", e);
       const message = JSON.parse(e.data);
       switch (message.kind) {
-      case "refresh":
-        refreshPage();
+        case "refresh":
+          refreshIfNeeded();
       }
-    }
+    };
   }
 
   connect();

--- a/pkg/admin/web_endpoints.go
+++ b/pkg/admin/web_endpoints.go
@@ -28,7 +28,7 @@ func (WebEndpoints) SSOCallbackURL(providerConfig config.OAuthSSOProviderConfig)
 	panic("not implemented")
 }
 
-func (WebEndpoints) AuthorizeEndpointURL() *url.URL {
+func (WebEndpoints) AuthorizeEndpointURL(config.OAuthSSOProviderConfig) *url.URL {
 	// WechatURLProvider
 	panic("not implemented")
 }

--- a/pkg/auth/deps.go
+++ b/pkg/auth/deps.go
@@ -95,4 +95,5 @@ var DependencySet = wire.NewSet(
 	wire.Bind(new(handlerwebapp.PageService), new(*webapp.Service2)),
 	wire.Bind(new(handlerwebapp.ResourceManager), new(*resource.Manager)),
 	wire.Bind(new(handlerwebapp.VerifyIdentityVerificationService), new(*verification.Service)),
+	wire.Bind(new(handlerwebapp.JSONResponseWriter), new(*httputil.JSONResponseWriter)),
 )

--- a/pkg/auth/handler/webapp/viewmodels/base.go
+++ b/pkg/auth/handler/webapp/viewmodels/base.go
@@ -40,6 +40,7 @@ type BaseViewModel struct {
 	ForgotPasswordEnabled bool
 	PublicSignupDisabled  bool
 	PageLoadedAt          int
+	IsNativePlatform      bool
 }
 
 func (m *BaseViewModel) SetError(err error) {
@@ -123,6 +124,7 @@ func (m *BaseViewModeler) ViewModel(r *http.Request, rw http.ResponseWriter) Bas
 		httputil.UpdateCookie(rw, m.ErrorCookie.ResetError())
 	}
 
+	platform := r.Form.Get("x_platform")
 	if s := webapp.GetSession(r.Context()); s != nil {
 		for _, step := range s.Steps {
 			if path := step.Kind.Path(); path == "" {
@@ -130,7 +132,13 @@ func (m *BaseViewModeler) ViewModel(r *http.Request, rw http.ResponseWriter) Bas
 			}
 			model.SessionStepURLs = append(model.SessionStepURLs, step.URL().String())
 		}
+		if platform == "" {
+			platform = s.Platform
+		}
 	}
+
+	model.IsNativePlatform = (platform == "ios" ||
+		platform == "android")
 
 	return model
 }

--- a/pkg/auth/handler/webapp/wechat_auth.go
+++ b/pkg/auth/handler/webapp/wechat_auth.go
@@ -25,7 +25,7 @@ var TemplateWebWechatAuthHandlerHTML = template.RegisterHTML(
 func ConfigureWechatAuthRoute(route httproute.Route) httproute.Route {
 	return route.
 		WithMethods("OPTIONS", "GET").
-		WithPathPattern("/sso/wechat/auth")
+		WithPathPattern("/sso/wechat/auth/:alias")
 }
 
 type WeChatAuthViewModel struct {
@@ -96,7 +96,7 @@ func (h *WechatAuthHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 				nonceSource, _ := r.Cookie(h.CSRFCookie.Name)
 
 				data := InputOAuthCallback{
-					ProviderAlias:    step.FormData["x_alias"].(string),
+					ProviderAlias:    httproute.GetParam(r, "alias"),
 					NonceSource:      nonceSource,
 					Code:             step.FormData["x_code"].(string),
 					Scope:            step.FormData["x_scope"].(string),

--- a/pkg/auth/handler/webapp/wechat_callback.go
+++ b/pkg/auth/handler/webapp/wechat_callback.go
@@ -3,11 +3,17 @@ package webapp
 import (
 	"net/http"
 
+	"github.com/authgear/authgear-server/pkg/api"
+	"github.com/authgear/authgear-server/pkg/auth/handler/webapp/viewmodels"
 	"github.com/authgear/authgear-server/pkg/auth/webapp"
 	"github.com/authgear/authgear-server/pkg/util/httproute"
 )
 
 const WechatActionCallback = "callback"
+
+type JSONResponseWriter interface {
+	WriteResponse(rw http.ResponseWriter, resp *api.Response)
+}
 
 func ConfigureWechatCallbackRoute(route httproute.Route) httproute.Route {
 	return route.
@@ -17,6 +23,8 @@ func ConfigureWechatCallbackRoute(route httproute.Route) httproute.Route {
 
 type WechatCallbackHandler struct {
 	ControllerFactory ControllerFactory
+	BaseViewModel     *viewmodels.BaseViewModeler
+	JSON              JSONResponseWriter
 }
 
 func (h *WechatCallbackHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
@@ -29,7 +37,7 @@ func (h *WechatCallbackHandler) ServeHTTP(w http.ResponseWriter, r *http.Request
 
 	sessionID := r.Form.Get("state")
 
-	handler := func() error {
+	updateWebSession := func() error {
 		session, err := ctrl.GetSession(sessionID)
 		if err != nil {
 			return err
@@ -48,6 +56,26 @@ func (h *WechatCallbackHandler) ServeHTTP(w http.ResponseWriter, r *http.Request
 			return err
 		}
 
+		return nil
+	}
+
+	handler := func() error {
+		err := updateWebSession()
+		// serve api
+		baseViewModel := h.BaseViewModel.ViewModel(r, w)
+		if baseViewModel.IsNativePlatform {
+			if err == nil {
+				h.JSON.WriteResponse(w, &api.Response{Result: nil})
+			} else {
+				h.JSON.WriteResponse(w, &api.Response{Error: err})
+			}
+			return nil
+		}
+
+		// serve webapp page
+		if err != nil {
+			return err
+		}
 		result := &webapp.Result{
 			RedirectURI: "/return",
 		}

--- a/pkg/auth/handler/webapp/wechat_callback.go
+++ b/pkg/auth/handler/webapp/wechat_callback.go
@@ -12,7 +12,7 @@ const WechatActionCallback = "callback"
 func ConfigureWechatCallbackRoute(route httproute.Route) httproute.Route {
 	return route.
 		WithMethods("OPTIONS", "POST", "GET").
-		WithPathPattern("/sso/wechat/callback/:alias")
+		WithPathPattern("/sso/wechat/callback")
 }
 
 type WechatCallbackHandler struct {
@@ -37,7 +37,6 @@ func (h *WechatCallbackHandler) ServeHTTP(w http.ResponseWriter, r *http.Request
 
 		step := session.CurrentStep()
 		step.FormData["x_action"] = WechatActionCallback
-		step.FormData["x_alias"] = httproute.GetParam(r, "alias")
 		step.FormData["x_code"] = r.Form.Get("code")
 		step.FormData["x_scope"] = r.Form.Get("scope")
 		step.FormData["x_error"] = r.Form.Get("error")

--- a/pkg/auth/routes.go
+++ b/pkg/auth/routes.go
@@ -129,7 +129,7 @@ func NewRouter(p *deps.RootProvider, configSource *configsource.ConfigSource, st
 	router.Add(webapphandler.ConfigureSSOCallbackRoute(webappSSOCallbackRoute), p.Handler(newWebAppSSOCallbackHandler))
 
 	router.Add(webapphandler.ConfigureWechatAuthRoute(webappPageRoute), p.Handler(newWechatAuthHandler))
-	router.Add(webapphandler.ConfigureWechatCallbackRoute(webappPageRoute), p.Handler(newWechatCallbackHandler))
+	router.Add(webapphandler.ConfigureWechatCallbackRoute(webappSSOCallbackRoute), p.Handler(newWechatCallbackHandler))
 
 	router.Add(oauthhandler.ConfigureOIDCMetadataRoute(oauthAPIRoute), p.Handler(newOAuthMetadataHandler))
 	router.Add(oauthhandler.ConfigureOAuthMetadataRoute(oauthAPIRoute), p.Handler(newOAuthMetadataHandler))

--- a/pkg/auth/webapp/session.go
+++ b/pkg/auth/webapp/session.go
@@ -20,21 +20,23 @@ func WithSession(ctx context.Context, session *Session) context.Context {
 }
 
 type SessionOptions struct {
-	RedirectURI     string
-	KeepAfterFinish bool
-	Prompt          string
-	Platform        string
-	Extra           map[string]interface{}
-	UpdatedAt       time.Time
+	RedirectURI       string
+	KeepAfterFinish   bool
+	Prompt            string
+	Platform          string
+	WeChatRedirectURI string
+	Extra             map[string]interface{}
+	UpdatedAt         time.Time
 }
 
 func NewSessionOptionsFromSession(s *Session) SessionOptions {
 	return SessionOptions{
-		RedirectURI:     s.RedirectURI,
-		KeepAfterFinish: s.KeepAfterFinish,
-		Prompt:          s.Prompt,
-		Platform:        s.Platform,
-		Extra:           nil, // Omit extra by default
+		RedirectURI:       s.RedirectURI,
+		KeepAfterFinish:   s.KeepAfterFinish,
+		Prompt:            s.Prompt,
+		Platform:          s.Platform,
+		WeChatRedirectURI: s.WeChatRedirectURI,
+		Extra:             nil, // Omit extra by default
 	}
 }
 
@@ -62,6 +64,10 @@ type Session struct {
 
 	// UpdatedAt indicate the session last updated time
 	UpdatedAt time.Time `json:"updated_at,omitempty"`
+
+	// WeChatRedirectURI is provided by native mobile platform
+	// which will be redirected to when user click login button in wechat auth page
+	WeChatRedirectURI string `json:"wechat_redirect_uri,omitempty"`
 }
 
 func newSessionID() string {
@@ -74,13 +80,14 @@ func newSessionID() string {
 
 func NewSession(options SessionOptions) *Session {
 	s := &Session{
-		ID:              newSessionID(),
-		RedirectURI:     options.RedirectURI,
-		KeepAfterFinish: options.KeepAfterFinish,
-		Extra:           make(map[string]interface{}),
-		Prompt:          options.Prompt,
-		Platform:        options.Platform,
-		UpdatedAt:       options.UpdatedAt,
+		ID:                newSessionID(),
+		RedirectURI:       options.RedirectURI,
+		KeepAfterFinish:   options.KeepAfterFinish,
+		Extra:             make(map[string]interface{}),
+		Prompt:            options.Prompt,
+		Platform:          options.Platform,
+		WeChatRedirectURI: options.WeChatRedirectURI,
+		UpdatedAt:         options.UpdatedAt,
 	}
 	for k, v := range options.Extra {
 		s.Extra[k] = v

--- a/pkg/auth/webapp/session.go
+++ b/pkg/auth/webapp/session.go
@@ -23,6 +23,7 @@ type SessionOptions struct {
 	RedirectURI     string
 	KeepAfterFinish bool
 	Prompt          string
+	Platform        string
 	Extra           map[string]interface{}
 	UpdatedAt       time.Time
 }
@@ -32,6 +33,7 @@ func NewSessionOptionsFromSession(s *Session) SessionOptions {
 		RedirectURI:     s.RedirectURI,
 		KeepAfterFinish: s.KeepAfterFinish,
 		Prompt:          s.Prompt,
+		Platform:        s.Platform,
 		Extra:           nil, // Omit extra by default
 	}
 }
@@ -55,6 +57,9 @@ type Session struct {
 	// Prompt is used to indicate requested authentication behavior
 	Prompt string `json:"prompt,omitempty"`
 
+	// Platform is used to indicate the request is triggered by which platform
+	Platform string `json:"platform,omitempty"`
+
 	// UpdatedAt indicate the session last updated time
 	UpdatedAt time.Time `json:"updated_at,omitempty"`
 }
@@ -74,6 +79,7 @@ func NewSession(options SessionOptions) *Session {
 		KeepAfterFinish: options.KeepAfterFinish,
 		Extra:           make(map[string]interface{}),
 		Prompt:          options.Prompt,
+		Platform:        options.Platform,
 		UpdatedAt:       options.UpdatedAt,
 	}
 	for k, v := range options.Extra {

--- a/pkg/auth/webapp/session_step.go
+++ b/pkg/auth/webapp/session_step.go
@@ -73,15 +73,11 @@ func (k SessionStepKind) Path() string {
 func (k SessionStepKind) MatchPath(path string) bool {
 	switch k {
 	case SessionStepOAuthRedirect:
-		switch path {
-		case "/sso/wechat/auth":
-			// In Wechat authorize flow, instead of redirect user to provider authorization page
-			// redirect user to page that display qr code
-			// https://developers.weixin.qq.com/doc/offiaccount/OA_Web_Apps/Wechat_webpage_authorization.html
-			return true
-		default:
-			return strings.HasPrefix(path, "/sso/oauth2/callback/")
-		}
+		// In Wechat authorize flow, instead of redirect user to provider authorization page
+		// redirect user to page that display qr code
+		// https://developers.weixin.qq.com/doc/offiaccount/OA_Web_Apps/Wechat_webpage_authorization.html
+		return strings.HasPrefix(path, "/sso/wechat/auth/") ||
+			strings.HasPrefix(path, "/sso/oauth2/callback/")
 	case SessionStepAuthenticate:
 		switch path {
 		case "/enter_totp", "/enter_password", "/enter_oob_otp", "/enter_recovery_code", "/send_oob_otp":

--- a/pkg/auth/webapp/url_provider.go
+++ b/pkg/auth/webapp/url_provider.go
@@ -78,6 +78,7 @@ type AuthenticateURLOptions struct {
 	UILocales        string
 	Prompt           string
 	AuthenticateHint interface{}
+	Platform         string
 }
 type PageService interface {
 	CreateSession(session *Session, redirectURI string) (*Result, error)
@@ -101,6 +102,7 @@ func (p *AuthenticateURLProvider) AuthenticateURL(options AuthenticateURLOptions
 	session := NewSession(SessionOptions{
 		RedirectURI: options.RedirectURI,
 		Prompt:      options.Prompt,
+		Platform:    options.Platform,
 		UpdatedAt:   now,
 	})
 

--- a/pkg/auth/webapp/url_provider.go
+++ b/pkg/auth/webapp/url_provider.go
@@ -73,12 +73,13 @@ type RawSessionCookieRequest struct {
 }
 
 type AuthenticateURLOptions struct {
-	ClientID         string
-	RedirectURI      string
-	UILocales        string
-	Prompt           string
-	AuthenticateHint interface{}
-	Platform         string
+	ClientID          string
+	RedirectURI       string
+	UILocales         string
+	Prompt            string
+	AuthenticateHint  interface{}
+	Platform          string
+	WeChatRedirectURI string
 }
 type PageService interface {
 	CreateSession(session *Session, redirectURI string) (*Result, error)
@@ -100,10 +101,11 @@ type AuthenticateURLProvider struct {
 func (p *AuthenticateURLProvider) AuthenticateURL(options AuthenticateURLOptions) (httputil.Result, error) {
 	now := p.Clock.NowUTC()
 	session := NewSession(SessionOptions{
-		RedirectURI: options.RedirectURI,
-		Prompt:      options.Prompt,
-		Platform:    options.Platform,
-		UpdatedAt:   now,
+		RedirectURI:       options.RedirectURI,
+		Prompt:            options.Prompt,
+		Platform:          options.Platform,
+		WeChatRedirectURI: options.WeChatRedirectURI,
+		UpdatedAt:         now,
 	})
 
 	var result *Result

--- a/pkg/auth/webapp/wechat_url_provider.go
+++ b/pkg/auth/webapp/wechat_url_provider.go
@@ -11,12 +11,12 @@ type WechatURLProvider struct {
 	Endpoints EndpointsProvider
 }
 
-func (p *WechatURLProvider) AuthorizeEndpointURL() *url.URL {
-	return p.Endpoints.WeChatAuthorizeEndpointURL()
-}
-
-func (p *WechatURLProvider) SSOCallbackURL(c config.OAuthSSOProviderConfig) *url.URL {
-	u := p.Endpoints.WeChatCallbackEndpointURL()
+func (p *WechatURLProvider) AuthorizeEndpointURL(c config.OAuthSSOProviderConfig) *url.URL {
+	u := p.Endpoints.WeChatAuthorizeEndpointURL()
 	u.Path = path.Join(u.Path, url.PathEscape(c.Alias))
 	return u
+}
+
+func (p *WechatURLProvider) CallbackEndpointURL() *url.URL {
+	return p.Endpoints.WeChatCallbackEndpointURL()
 }

--- a/pkg/auth/wire_gen.go
+++ b/pkg/auth/wire_gen.go
@@ -5343,8 +5343,14 @@ func newWechatCallbackHandler(p *deps.RequestProvider) http.Handler {
 		LoggerFactory:  factory,
 		ControllerDeps: controllerDeps,
 	}
+	jsonResponseWriterLogger := httputil.NewJSONResponseWriterLogger(factory)
+	jsonResponseWriter := &httputil.JSONResponseWriter{
+		Logger: jsonResponseWriterLogger,
+	}
 	wechatCallbackHandler := &webapp2.WechatCallbackHandler{
 		ControllerFactory: controllerFactory,
+		BaseViewModel:     baseViewModeler,
+		JSON:              jsonResponseWriter,
 	}
 	return wechatCallbackHandler
 }

--- a/pkg/lib/authn/sso/wechat.go
+++ b/pkg/lib/authn/sso/wechat.go
@@ -11,8 +11,8 @@ const (
 )
 
 type WechatURLProvider interface {
-	AuthorizeEndpointURL() *url.URL
-	SSOCallbackURL(c config.OAuthSSOProviderConfig) *url.URL
+	AuthorizeEndpointURL(c config.OAuthSSOProviderConfig) *url.URL
+	CallbackEndpointURL() *url.URL
 }
 
 type WechatImpl struct {
@@ -34,14 +34,14 @@ func (w *WechatImpl) GetAuthURL(param GetAuthURLParam) (string, error) {
 	v := url.Values{}
 	v.Add("response_type", "code")
 	v.Add("appid", w.ProviderConfig.ClientID)
-	v.Add("redirect_uri", w.URLProvider.SSOCallbackURL(w.ProviderConfig).String())
+	v.Add("redirect_uri", w.URLProvider.CallbackEndpointURL().String())
 	v.Add("scope", w.ProviderConfig.Type.Scope())
 	v.Add("state", param.State)
 
 	authURL := wechatAuthorizationURL + "?" + v.Encode()
 	v = url.Values{}
 	v.Add("x_auth_url", authURL)
-	return w.URLProvider.AuthorizeEndpointURL().String() + "?" + v.Encode(), nil
+	return w.URLProvider.AuthorizeEndpointURL(w.ProviderConfig).String() + "?" + v.Encode(), nil
 }
 
 func (w *WechatImpl) GetAuthInfo(r OAuthAuthorizationResponse, param GetAuthInfoParam) (AuthInfo, error) {

--- a/pkg/lib/config/oauth.go
+++ b/pkg/lib/config/oauth.go
@@ -42,7 +42,8 @@ var _ = Schema.Add("OAuthClientConfig", `
 		"access_token_lifetime_seconds": { "$ref": "#/$defs/DurationSeconds", "minimum": 300 },
 		"refresh_token_lifetime_seconds": { "$ref": "#/$defs/DurationSeconds" },
 		"issue_jwt_access_token": { "type": "boolean" },
-		"is_first_party": { "type": "boolean" }
+		"is_first_party": { "type": "boolean" },
+		"wechat_redirect_uris": { "type": "array", "items": { "type": "string", "format": "uri" } }
 	},
 	"required": ["name", "client_id", "redirect_uris"]
 }
@@ -60,6 +61,7 @@ type OAuthClientConfig struct {
 	RefreshTokenLifetime   DurationSeconds `json:"refresh_token_lifetime_seconds,omitempty"`
 	IssueJWTAccessToken    bool            `json:"issue_jwt_access_token,omitempty"`
 	IsFirstParty           bool            `json:"is_first_party,omitempty"`
+	WeChatRedirectURIs     []string        `json:"wechat_redirect_uris,omitempty"`
 }
 
 func (c *OAuthClientConfig) SetDefaults() {

--- a/pkg/lib/oauth/handler/handler_authz.go
+++ b/pkg/lib/oauth/handler/handler_authz.go
@@ -110,6 +110,7 @@ func (h *AuthorizationHandler) doHandle(
 
 	s := session.GetSession(h.Context)
 	authnOptions := webapp.AuthenticateURLOptions{}
+	authnOptions.Platform = r.Platform()
 	if slice.ContainsString(r.Prompt(), "login") {
 		// Request login prompt => force re-authentication and retry
 		r2 := protocol.AuthorizationRequest{}

--- a/pkg/lib/oauth/handler/handler_authz.go
+++ b/pkg/lib/oauth/handler/handler_authz.go
@@ -69,7 +69,15 @@ func (h *AuthorizationHandler) Handle(r protocol.AuthorizationRequest) httputil.
 		}
 	}
 
-	result, err := h.doHandle(redirectURI, client, r)
+	weChatRedirectURI, errResp := parseWeChatRedirectURI(client, r)
+	if errResp != nil {
+		return authorizationResultError{
+			ResponseMode: r.ResponseMode(),
+			Response:     errResp,
+		}
+	}
+
+	result, err := h.doHandle(redirectURI, client, r, weChatRedirectURI)
 	if err != nil {
 		var oauthError *protocol.OAuthProtocolError
 		resultErr := authorizationResultError{
@@ -97,6 +105,7 @@ func (h *AuthorizationHandler) doHandle(
 	redirectURI *url.URL,
 	client *config.OAuthClientConfig,
 	r protocol.AuthorizationRequest,
+	weChatRedirectURI *url.URL,
 ) (httputil.Result, error) {
 	if err := h.validateRequest(client, r); err != nil {
 		return nil, err
@@ -111,6 +120,9 @@ func (h *AuthorizationHandler) doHandle(
 	s := session.GetSession(h.Context)
 	authnOptions := webapp.AuthenticateURLOptions{}
 	authnOptions.Platform = r.Platform()
+	if weChatRedirectURI != nil {
+		authnOptions.WeChatRedirectURI = weChatRedirectURI.String()
+	}
 	if slice.ContainsString(r.Prompt(), "login") {
 		// Request login prompt => force re-authentication and retry
 		r2 := protocol.AuthorizationRequest{}

--- a/pkg/lib/oauth/handler/wechat.go
+++ b/pkg/lib/oauth/handler/wechat.go
@@ -1,0 +1,41 @@
+package handler
+
+import (
+	"net/url"
+
+	"github.com/authgear/authgear-server/pkg/lib/config"
+	"github.com/authgear/authgear-server/pkg/lib/oauth/protocol"
+)
+
+type weChatAuthzRequest interface {
+	WeChatRedirectURI() string
+}
+
+func parseWeChatRedirectURI(client *config.OAuthClientConfig, r weChatAuthzRequest) (*url.URL, protocol.ErrorResponse) {
+	allowedURIs := client.WeChatRedirectURIs
+	redirectURIString := r.WeChatRedirectURI()
+	// wechat redirect uri is optional
+	if redirectURIString == "" {
+		return nil, nil
+	}
+
+	redirectURI, err := url.Parse(redirectURIString)
+	if err != nil {
+		return nil, protocol.NewErrorResponse("invalid_request", "invalid wechat redirect URI")
+	}
+
+	allowed := false
+
+	for _, u := range allowedURIs {
+		if u == redirectURIString {
+			allowed = true
+			break
+		}
+	}
+
+	if !allowed {
+		return nil, protocol.NewErrorResponse("invalid_request", "wechat redirect URI is not allowed")
+	}
+
+	return redirectURI, nil
+}

--- a/pkg/lib/oauth/protocol/authz.go
+++ b/pkg/lib/oauth/protocol/authz.go
@@ -31,3 +31,5 @@ func (r AuthorizationRequest) UILocales() []string { return parseSpaceDelimitedS
 
 func (r AuthorizationRequest) CodeChallenge() string       { return r["code_challenge"] }
 func (r AuthorizationRequest) CodeChallengeMethod() string { return r["code_challenge_method"] }
+
+func (r AuthorizationRequest) Platform() string { return r["x_platform"] }

--- a/pkg/lib/oauth/protocol/authz.go
+++ b/pkg/lib/oauth/protocol/authz.go
@@ -33,3 +33,7 @@ func (r AuthorizationRequest) CodeChallenge() string       { return r["code_chal
 func (r AuthorizationRequest) CodeChallengeMethod() string { return r["code_challenge_method"] }
 
 func (r AuthorizationRequest) Platform() string { return r["x_platform"] }
+
+// wechat mobile support
+
+func (r AuthorizationRequest) WeChatRedirectURI() string { return r["x_wechat_redirect_uri"] }

--- a/resources/authgear/templates/en/translation.json
+++ b/resources/authgear/templates/en/translation.json
@@ -253,7 +253,10 @@
   "return-page-description": "Please return to where you were to continue. If you were interacting with an mobile app, please switch back to the app. If you were interacting with a website, please switch back to that tab.",
 
   "wechat-auth-title": "Login with WeChat",
-  "wechat-auth-description": "Please scan the QR code in your WeChat app to sign in.",
+  "wechat-auth-with-qr-code-description": "Please scan the QR code in your WeChat app to sign in.",
+  "wechat-auth-with-app-description": "Click the below button to continue WeChat Login",
+  "wechat-open-app": "Open WeChat app to login",
+  "wechat-proceed": "Proceed WeChat login",
 
   "toc-pp-footer": "By registering, you agree to our <a target=\"_blank\" href=\"{termsOfService}\">Terms of Service</a> and <a target=\"_blank\" href=\"{privacyPolicy}\">Privacy Policy</a>",
   "terms-of-service-link": "https://www.authgear.com/terms",

--- a/resources/authgear/templates/en/web/wechat_auth.html
+++ b/resources/authgear/templates/en/web/wechat_auth.html
@@ -28,6 +28,7 @@
 <a class="btn primary-btn item switch-to-item"
     href="{{ $.CurrentURI }}"
     data-turbolinks-action="replace"
+    data-is-refresh-link="true"
 >
 {{ template "wechat-proceed" }}
 </a>

--- a/resources/authgear/templates/en/web/wechat_auth.html
+++ b/resources/authgear/templates/en/web/wechat_auth.html
@@ -14,9 +14,30 @@
 
 <h1 class="font-inherit margin-10 primary-txt">{{ template "wechat-auth-title" }}</h1>
 
-<p class="font-smaller overflow-wrap-break-word margin-10 primary-txt">{{ template "wechat-auth-description" }}</p>
+{{ if .IsNativePlatform }}
+{{ if .WeChatRedirectURI }}
+<p class="font-smaller overflow-wrap-break-word margin-10 primary-txt">{{ template "wechat-auth-with-app-description" }}</p>
+
+<div class="switch-link-group flex flex-direction-column margin-10">
+<a class="btn primary-btn item click-to-switch"
+    href="{{ $.WeChatRedirectURI }}"
+    data-turbolinks-action="replace"
+>
+{{ template "wechat-open-app" }}
+</a>
+<a class="btn primary-btn item switch-to-item"
+    href="{{ $.CurrentURI }}"
+    data-turbolinks-action="replace"
+>
+{{ template "wechat-proceed" }}
+</a>
+</div>
+{{ end }}
+{{ else }}
+<p class="font-smaller overflow-wrap-break-word margin-10 primary-txt">{{ template "wechat-auth-with-qr-code-description" }}</p>
 
 <img class="margin-10 qr-code-image" src="{{ $.ImageURI }}">
+{{ end }}
 
 </div>
 </html>


### PR DESCRIPTION
refs #773 

- Add `wechat_redirect_uris` in oauth client config and `wechat_redirect_uri` parameters in authorize endpoint
- Show "open wechat app" link which will go to `wechat_redirect_uri` for mobile integration, after clicking the link, the link will change to refresh page link
- Update wechat endpoints to `/sso/wechat/auth/:alias` and `/sso/wechat/callback`
