### PR TITLE
Fix setting page ux issue

### DIFF
--- a/pkg/auth/handler/webapp/settings_mfa.go
+++ b/pkg/auth/handler/webapp/settings_mfa.go
@@ -32,11 +32,13 @@ type SettingsMFAViewModel struct {
 	SecondaryTOTPAllowed     bool
 	SecondaryOOBOTPAllowed   bool
 	SecondaryPasswordAllowed bool
+	HasDeviceTokens          bool
 }
 
 type SettingsMFAService interface {
 	ListRecoveryCodes(userID string) ([]*mfa.RecoveryCode, error)
 	InvalidateAllDeviceTokens(userID string) error
+	HasDeviceTokens(userID string) (bool, error)
 }
 
 type SettingsMFAHandler struct {
@@ -86,11 +88,17 @@ func (h *SettingsMFAHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			}
 		}
 
+		hasDeviceTokens, err := h.MFA.HasDeviceTokens(userID)
+		if err != nil {
+			return err
+		}
+
 		viewModel := SettingsMFAViewModel{
 			Authenticators:           authenticators,
 			SecondaryTOTPAllowed:     totp,
 			SecondaryOOBOTPAllowed:   oobotp,
 			SecondaryPasswordAllowed: password,
+			HasDeviceTokens:          hasDeviceTokens,
 		}
 		viewmodels.Embed(data, viewModel)
 

--- a/pkg/lib/authn/mfa/service.go
+++ b/pkg/lib/authn/mfa/service.go
@@ -11,6 +11,7 @@ type StoreDeviceToken interface {
 	Get(userID string, token string) (*DeviceToken, error)
 	Create(token *DeviceToken) error
 	DeleteAll(userID string) error
+	HasTokens(userID string) (bool, error)
 }
 
 type StoreRecoveryCode interface {
@@ -64,6 +65,10 @@ func (s *Service) VerifyDeviceToken(userID string, token string) error {
 
 func (s *Service) InvalidateAllDeviceTokens(userID string) error {
 	return s.DeviceTokens.DeleteAll(userID)
+}
+
+func (s *Service) HasDeviceTokens(userID string) (bool, error) {
+	return s.DeviceTokens.HasTokens(userID)
 }
 
 func (s *Service) GenerateRecoveryCodes() []string {

--- a/pkg/lib/authn/mfa/store_device_token_redis.go
+++ b/pkg/lib/authn/mfa/store_device_token_redis.go
@@ -106,6 +106,27 @@ func (s *StoreDeviceTokenRedis) DeleteAll(userID string) error {
 	return err
 }
 
+func (s *StoreDeviceTokenRedis) HasTokens(userID string) (bool, error) {
+	hasTokens := false
+
+	err := s.Redis.WithConn(func(conn *goredis.Conn) error {
+		ctx := context.Background()
+		key := redisDeviceTokensKey(s.AppID, userID)
+		_, err := conn.Get(ctx, key).Bytes()
+		if err != nil {
+			if errors.Is(err, goredis.Nil) {
+				hasTokens = false
+				return nil
+			}
+			return err
+		}
+		hasTokens = true
+		return nil
+	})
+
+	return hasTokens, err
+}
+
 func (s *StoreDeviceTokenRedis) saveTokens(conn *goredis.Conn, key string, tokens map[string]*DeviceToken, ttl time.Duration) error {
 	ctx := context.Background()
 

--- a/pkg/lib/interaction/nodes/authn_begin.go
+++ b/pkg/lib/interaction/nodes/authn_begin.go
@@ -134,7 +134,7 @@ func (n *NodeAuthenticationBegin) GetAuthenticationEdges() ([]interaction.Edge, 
 	)
 	interaction.SortAuthenticators(
 		nil,
-		totps,
+		oobs,
 		func(i int) interaction.SortableAuthenticator {
 			a := interaction.SortableAuthenticatorInfo(*oobs[i])
 			return &a

--- a/resources/authgear/static/authgear-dark-theme.css
+++ b/resources/authgear/static/authgear-dark-theme.css
@@ -74,7 +74,7 @@
     color: var(--color-primary-shaded-7);
   }
   .secondary-btn:disabled {
-    color: var(--color-primary-shaded-1);
+    color: var(--color-black-shaded-2);
   }
 }
 

--- a/resources/authgear/static/authgear-light-theme.css
+++ b/resources/authgear/static/authgear-light-theme.css
@@ -168,7 +168,7 @@
   color: var(--color-primary-shaded-7);
 }
 .secondary-btn:disabled {
-  color: var(--color-primary-shaded-1);
+  color: var(--color-white-shaded-2);
 }
 
 /* <a> does not have disabled attribute */

--- a/resources/authgear/templates/en/translation.json
+++ b/resources/authgear/templates/en/translation.json
@@ -162,8 +162,8 @@
   "change-secondary-password-page-title": "Change Additional Password",
   "change-secondary-password-page-description": "Please enter your new password below.",
 
-  "logout-button-hint": "Click the button to sign out",
-  "logout-button-label": "Sign out",
+  "logout-button-hint": "Click the button to log out",
+  "logout-button-label": "Log out",
 
   "settings-page-security-section-title": "Security",
   "settings-page-security-section-description": "These can be used to make sure that it''s really you signing in.",

--- a/resources/authgear/templates/en/translation.json
+++ b/resources/authgear/templates/en/translation.json
@@ -183,7 +183,9 @@
   "settings-page-session-section-title": "Signed in Sessions",
   "settings-page-session-section-description": "Manage your signed in sessions on your autenticated devices.",
   "show-recovery-code-button-label": "Show Codes",
-  "revoke-all-device-tokens-button-label": "Forget all trusted devices",
+  "settings-page-trusted-devices-title": "Trusted Devices",
+  "revoke-all-device-tokens-button-label": "Forget all trusted devices that could skip MFA",
+  "no-device-tokens-description": "No trusted devices that could skip MFA",
 
   "settings-identity-title": "Login Info",
   "settings-identity-description": "There are the methods to sign in your account",

--- a/resources/authgear/templates/en/translation.json
+++ b/resources/authgear/templates/en/translation.json
@@ -61,6 +61,7 @@
   "add-button-label": "Add",
   "remove-button-label": "Remove",
   "details-button-label": "Details",
+  "configure-button-label": "Configure",
   "more-button-label": "More",
   "setup-password-button-label": "Setup Password",
   "change-password-button-label": "Change Password",

--- a/resources/authgear/templates/en/web/enter_oob_otp.html
+++ b/resources/authgear/templates/en/web/enter_oob_otp.html
@@ -57,8 +57,8 @@
 <form class="link margin-10" method="post" novalidate>
 {{ $.CSRFField }}
 
-<span class="primary-txt">{{ template "oob-otp-resend-button-hint" }}</span>
-<button id="resend-button" class="btn secondary-btn" type="submit" name="x_action" value="resend"
+<span class="primary-txt font-smaller">{{ template "oob-otp-resend-button-hint" }}</span>
+<button id="resend-button" class="btn secondary-btn font-smaller" type="submit" name="x_action" value="resend"
 	data-cooldown="{{ $.OOBOTPCodeSendCooldown }}"
 	data-label="{{ template "oob-otp-resend-button-label" }}"
 	data-label-unit="{{ template "oob-otp-resend-button-label--unit" }}">{{ template "oob-otp-resend-button-label" }}</button>

--- a/resources/authgear/templates/en/web/logout.html
+++ b/resources/authgear/templates/en/web/logout.html
@@ -14,7 +14,7 @@
       {{ template "logout-button-hint" }}
     </h2>
     <!-- We need to disable XHR for this request because after logout it could possibly redirect to external website with post_logout_uri -->
-    <form class="grid-area-action" method="post" novalidate>
+    <form class="grid-area-action flex align-items-center" method="post" novalidate>
       {{ $.CSRFField }}
       <button class="btn secondary-btn" type="submit" name="x_action" value="logout" data-form-xhr="false">{{ template "logout-button-label" }}</button>
     </form>

--- a/resources/authgear/templates/en/web/settings.html
+++ b/resources/authgear/templates/en/web/settings.html
@@ -10,10 +10,6 @@
 
 {{ template "__error.html" . }}
 
-<p class="align-self-center primary-txt">
-  Click <a class="link" href="/logout">here</a> to sign out.
-</p>
-
 {{/* Identity */}}
 <section class="pane">
   <section class="margin-h-14 padding-v-10 gap-8 row-sep grid grid-title-desc">
@@ -264,6 +260,10 @@
     </a>
   </section>
 </section>
+
+<p class="align-self-center primary-txt">
+  <a class="link" href="/logout">{{ template "logout-button-label" }}</a>
+</p>
 
 </main>
 </body>

--- a/resources/authgear/templates/en/web/settings_mfa.html
+++ b/resources/authgear/templates/en/web/settings_mfa.html
@@ -53,7 +53,11 @@
     </p>
     {{ end }}
     <a class="link grid-area-action1 justify-self-end" href="/settings/mfa/totp">
+      {{ if $has_secondary_totp }}
       {{ template "details-button-label" }}
+      {{ else }}
+      {{ template "configure-button-label" }}
+      {{ end }}
     </a>
   </section>
   {{ end }}
@@ -69,12 +73,16 @@
       {{ template "activated-label" }}
     </p>
     {{ else }}
-    <p class="grid-area-desc margin-0 font-smaller good-txt">
+    <p class="grid-area-desc margin-0 font-smaller warn-txt">
       {{ template "inactive-label" }}
     </p>
     {{ end }}
     <a class="link grid-area-action1 justify-self-end" href="/settings/mfa/oob_otp">
+      {{ if $has_secondary_oob_otp }}
       {{ template "details-button-label" }}
+      {{ else }}
+      {{ template "configure-button-label" }}
+      {{ end }}
     </a>
   </section>
   {{ end }}

--- a/resources/authgear/templates/en/web/settings_mfa.html
+++ b/resources/authgear/templates/en/web/settings_mfa.html
@@ -128,13 +128,24 @@
 
   <!-- Revoke all device tokens -->
   {{ if $has_mfa }}
-  <form class="margin-h-14 padding-v-10 row-sep gap-8 grid grid-action" method="post" novalidate>
+  <section class="margin-h-14 padding-v-10 row-sep gap-8 grid grid-title-desc-action1-action2">
+    <h3 class="grid-area-title margin-0 font-inherit primary-txt">
+      {{ template "settings-page-trusted-devices-title" }}
+    </h3>
+  {{ if $.HasDeviceTokens }}
+  <form class="grid-area-desc margin-0" method="post" novalidate>
     {{ $.CSRFField }}
-    <button class="grid-area-action justify-self-start btn destructive-btn" type="submit" name="x_action" value="revoke_devices">
+    <button class="justify-self-start btn destructive-btn" type="submit" name="x_action" value="revoke_devices">
       {{ template "revoke-all-device-tokens-button-label" }}
     </button>
   </form>
+  {{ else }}
+  <p class="grid-area-desc margin-0 font-smaller secondary-txt">
+    {{ template "no-device-tokens-description" }}
+  </p>
   {{ end }}
+  {{ end }}
+  </section>
 </section>
 
 </main>

--- a/resources/authgear/templates/en/web/settings_recovery_code.html
+++ b/resources/authgear/templates/en/web/settings_recovery_code.html
@@ -10,32 +10,29 @@
 
 	{{ template "__error.html" . }}
 
-	<section class="pane">
-		<section class="recovery-code-row recovery-code-title-section">
-			<h1 class="title primary-txt">
-				{{ template "recovery-code-title" }}
-			</h1>
-		</section>
+	<section class="pane padding-6">
+		<h1 class="font-inherit margin-10 primary-txt">
+			{{ template "recovery-code-title" }}
+		</h1>
 
-		<section class="recovery-code-row recovery-code-list-section">
+		<section class="margin-10 recovery-code-list-section">
 			{{ if $.AllowListRecoveryCodes }}
-				<p class="description primary-txt">{{ template "recovery-code-storage-description" }}</p>
-
-				<div class="code-list-container">
-					<ol class="code-list">
+				<p class="margin-v-10 primary-txt">{{ template "recovery-code-storage-description" }}</p>
+				<div class="margin-10 code-list-container">
+					<ol class="margin-0 padding-0 code-list">
 						{{ range $.RecoveryCodes }}
 							<li class="code-item">{{ . }}</li>
 						{{ end }}
 					</ol>
 				</div>
 
-				<p class="description primary-txt">{{ template "recovery-code-consumption-description" }}</p>
+				<p class="margin-v-10 primary-txt">{{ template "recovery-code-consumption-description" }}</p>
 			{{ else }}
-				<p class="description primary-txt">{{ template "recovery-code-list-disabled" }}</p>
+				<p class="margin-v-10 primary-txt">{{ template "recovery-code-list-disabled" }}</p>
 			{{ end }}
 		</section>
 
-		<section class="recovery-code-row recovery-code-action-section">
+		<section class="margin-10 recovery-code-action-section">
 			<form method="post" novalidate>
 				{{ $.CSRFField }}
 				<button class="action btn primary-btn" type="submit" name="x_action" value="regenerate">

--- a/resources/authgear/templates/en/web/verify_identity.html
+++ b/resources/authgear/templates/en/web/verify_identity.html
@@ -60,8 +60,8 @@
 {{ $.CSRFField }}
 
 {{ if not (eq $.Action "update_session_step") }}
-<span class="primary-txt">{{ template "verify-user-resend-button-hint" }}</span>
-<button id="resend-button" class="btn secondary-btn" type="submit" name="x_action" value="resend"
+<span class="primary-txt font-smaller">{{ template "verify-user-resend-button-hint" }}</span>
+<button id="resend-button" class="btn secondary-btn font-smaller" type="submit" name="x_action" value="resend"
 	data-cooldown="{{ $.VerificationCodeSendCooldown }}"
 	data-label="{{ template "verify-user-resend-button-label" }}"
 	data-label-unit="{{ template "verify-user-resend-button-label--unit" }}">{{ template "verify-user-resend-button-label" }}</button>


### PR DESCRIPTION
refs #914 
- At `/settings`
    - Move "Click here to sign up" from the top to bottom with "Log out"
- At `/settings/mfa`
    - "Forget all trusted devices" => "Forgot all trusted devices that could skip MFA", and give a feedback when this button is clicked.
    - When there are no MFA configured, change "Details" to "Configure"
- At `enter_oob_otp `
    - The "Didn't receive the code?" text size is abnormal (should be same or smaller then content font size)
    - The "Resend" text countdown is grey and impossible to read.