### PR TITLE
Logout from setting page directly

### DIFF
--- a/pkg/auth/wire_gen.go
+++ b/pkg/auth/wire_gen.go
@@ -13944,6 +13944,12 @@ func newWebAppSettingsHandler(p *deps.RequestProvider) http.Handler {
 		ControllerDeps: controllerDeps,
 	}
 	csrfCookieDef := webapp.NewCSRFCookieDef(httpConfig)
+	manager2 := &session.Manager{
+		Users:               queries,
+		Hooks:               hookProvider,
+		IDPSessions:         idpsessionManager,
+		AccessTokenSessions: sessionManager,
+	}
 	settingsHandler := &webapp2.SettingsHandler{
 		ControllerFactory: controllerFactory,
 		BaseViewModel:     baseViewModeler,
@@ -13954,6 +13960,8 @@ func newWebAppSettingsHandler(p *deps.RequestProvider) http.Handler {
 		Authenticators:    service3,
 		MFA:               mfaService,
 		CSRFCookie:        csrfCookieDef,
+		TrustProxy:        trustProxy,
+		SessionManager:    manager2,
 	}
 	return settingsHandler
 }

--- a/resources/authgear/templates/en/web/settings.html
+++ b/resources/authgear/templates/en/web/settings.html
@@ -261,9 +261,13 @@
   </section>
 </section>
 
-<p class="align-self-center primary-txt">
-  <a class="link" href="/logout">{{ template "logout-button-label" }}</a>
-</p>
+
+<form class="flex flex-direction-column margin-v-12" method="post">
+{{ $.CSRFField }}
+<button class="btn secondary-btn align-self-center justify-self-end" type="submit" name="x_action" value="logout" data-form-xhr="false">
+  {{ template "logout-button-label" }}
+</button>
+</form>
 
 </main>
 </body>


### PR DESCRIPTION
refs #914 

The logout page is designed for linkable from outside Authgear, so we could
skip the logout page within the Authgear.