### PR TITLE
Do not redirect if interaction is aborted by webhook 

### DIFF
--- a/pkg/auth/webapp/service2.go
+++ b/pkg/auth/webapp/service2.go
@@ -320,6 +320,8 @@ func (s *Service2) afterPost(
 		interactionErr = s.Graph.Run(session.ID, graph)
 	}
 
+	isFinishedSuccess := isFinished && interactionErr == nil
+
 	// Populate cookies.
 	if interactionErr != nil {
 		if !apierrors.IsAPIError(interactionErr) {
@@ -342,7 +344,7 @@ func (s *Service2) afterPost(
 	}
 
 	// Transition to redirect URI
-	if isFinished {
+	if isFinishedSuccess {
 		result.RedirectURI = deriveFinishRedirectURI(session, graph)
 		switch graph.Intent.(type) {
 		case *intents.IntentAuthenticate:
@@ -382,7 +384,7 @@ func (s *Service2) afterPost(
 	session.Extra = collectExtras(graph.CurrentNode())
 
 	// Persist/discard session
-	if isFinished && !session.KeepAfterFinish {
+	if isFinishedSuccess && !session.KeepAfterFinish {
 		err := s.Sessions.Delete(session.ID)
 		if err != nil {
 			return err

--- a/resources/authgear/templates/en/translation.json
+++ b/resources/authgear/templates/en/translation.json
@@ -41,6 +41,7 @@
   "error-web-ui-invalid-session-return": "<p>This page is no longer active. Please return to the current page.</p>",
   "error-web-ui-invalid-session-action": "Return",
   "error-rate-limited": "Please wait for a moment before retrying.",
+  "error-webhook-disallowed": "Operation is not disallowed.",
   "error-disabled-user": "Administrator has disabled your account.",
   "error-disabled-user-reason": "Reason: {reason}",
   "error-disabled-user-no-reason": "Please contact administrator for details.",

--- a/resources/authgear/templates/en/web/__error.html
+++ b/resources/authgear/templates/en/web/__error.html
@@ -1,8 +1,19 @@
 {{ define "__error.html" }}
-<div class="messages-bar errors-messages-bar errors {{ if not .Error }}display-none{{ end }}" data-network-error="{{ template "error-network" }}" data-server-error="{{ template "error-server" }}">
+{{ $display_error := false }}
+{{ if .Error }}
+    {{ $display_error = true }}
+    {{ if eq .Error.reason "PasswordPolicyViolated" }}
+        <!-- This error is handled differently -->
+        {{ $display_error = false }}
+    {{ else if eq .Error.reason "WebUIInvalidSession" }}
+        <!-- This error is handled as fatal error -->
+        {{ $display_error = false }}
+    {{ end }}
+{{ end }}
+<div class="messages-bar errors-messages-bar errors {{ if not $display_error }}display-none{{ end }}" data-network-error="{{ template "error-network" }}" data-server-error="{{ template "error-server" }}">
     <div class="icon"><i class="far fa-times-circle"></i></div>
     <ul class="messages-txt error-txt">
-        {{ if .Error }}
+        {{ if $display_error }}
             {{ if eq .Error.reason "ValidationFailed" }}
                 {{ range .Error.info.causes }}
                     {{ if (eq .kind "required") }}
@@ -49,8 +60,6 @@
                 {{ end }}
             {{ else if eq .Error.reason "InvalidCredentials" }}
                 <li>{{ template "error-invalid-credentials" }}</li>
-            {{ else if eq .Error.reason "PasswordPolicyViolated" }}
-                <!-- This error is handled differently -->
             {{ else if eq .Error.reason "PasswordResetFailed" }}
                 <li>{{ template "error-password-reset-failed" }}</li>
             {{ else if eq .Error.reason "NewPasswordTypo" }}
@@ -77,8 +86,6 @@
                         {{ template "error-verification-code-invalid-click-to-resend" }}
                     </a>
                 </li>
-            {{ else if eq .Error.reason "WebUIInvalidSession" }}
-                <!-- This error is handled as fatal error -->
             {{ else if eq .Error.reason "RateLimited" }}
                 <li>{{ template "error-rate-limited" }}</li>
             {{ else if eq .Error.reason "WebHookDisallowed" }}

--- a/resources/authgear/templates/en/web/__error.html
+++ b/resources/authgear/templates/en/web/__error.html
@@ -81,6 +81,13 @@
                 <!-- This error is handled as fatal error -->
             {{ else if eq .Error.reason "RateLimited" }}
                 <li>{{ template "error-rate-limited" }}</li>
+            {{ else if eq .Error.reason "WebHookDisallowed" }}
+                <li>
+                    {{ template "error-webhook-disallowed" }}
+                </li>
+                {{ range .Error.info.reasons }}
+                    <li>{{ .reason }}</li>
+                {{ end }}
             {{ else }}
                 <li>{{ .Error.message }}</li>
             {{ end }}


### PR DESCRIPTION
fix authgear/authgear-sdk-js#64

The error will be shown in this way. Only `Operation is not allowed.` can be translated and `Webhook defined error` is the reason returned from the webhook.
<img width="583" alt="Screenshot 2021-03-03 at 1 50 09 PM" src="https://user-images.githubusercontent.com/388892/109745047-69786a00-7c27-11eb-8e85-fb9fbaaa20eb.png">
