### PR TITLE
Rate limit issue

### DIFF
--- a/pkg/auth/webapp/service2.go
+++ b/pkg/auth/webapp/service2.go
@@ -318,6 +318,9 @@ func (s *Service2) afterPost(
 		// The graph finished. Apply its effect permanently.
 		s.Logger.Debugf("interaction: commit graph")
 		interactionErr = s.Graph.Run(session.ID, graph)
+		// The interaction should not be finished, if there is error when
+		// applying effects.
+		isFinished = interactionErr == nil
 	}
 
 	// Populate cookies.

--- a/pkg/lib/feature/forgotpassword/provider.go
+++ b/pkg/lib/feature/forgotpassword/provider.go
@@ -80,7 +80,7 @@ type Provider struct {
 // The code becomes invalid if it is consumed.
 // Finally the code is sent to the login ID asynchronously.
 func (p *Provider) SendCode(loginID string) error {
-	err := p.RateLimiter.TakeToken(GenerateRateLimitBucket(loginID))
+	err := p.RateLimiter.TakeToken(SendResetPasswordCodeRateLimitBucket(loginID))
 	if err != nil {
 		return err
 	}

--- a/pkg/lib/feature/forgotpassword/ratelimit.go
+++ b/pkg/lib/feature/forgotpassword/ratelimit.go
@@ -9,10 +9,10 @@ import (
 
 // TODO(rate-limit): allow configuration of bucket size & reset period
 
-func GenerateRateLimitBucket(loginID string) ratelimit.Bucket {
+func SendResetPasswordCodeRateLimitBucket(loginID string) ratelimit.Bucket {
 	return ratelimit.Bucket{
-		Key:         fmt.Sprintf("reset-password-generate-code:%s", loginID),
-		Size:        10,
+		Key:         fmt.Sprintf("reset-password-send-code:%s", loginID),
+		Size:        1,
 		ResetPeriod: duration.PerMinute,
 	}
 }

--- a/pkg/lib/feature/verification/ratelimit.go
+++ b/pkg/lib/feature/verification/ratelimit.go
@@ -9,14 +9,6 @@ import (
 
 // TODO(rate-limit): allow configuration of bucket size & reset period
 
-func GenerateRateLimitBucket(userID string) ratelimit.Bucket {
-	return ratelimit.Bucket{
-		Key:         fmt.Sprintf("verification-generate-code:%s", userID),
-		Size:        10,
-		ResetPeriod: duration.PerMinute,
-	}
-}
-
 func VerifyRateLimitBucket(ip string) ratelimit.Bucket {
 	return ratelimit.Bucket{
 		Key:         fmt.Sprintf("verification-verify-code:%s", ip),

--- a/pkg/lib/feature/verification/service.go
+++ b/pkg/lib/feature/verification/service.go
@@ -229,11 +229,6 @@ func (s *Service) IsUserVerified(identities []*identity.Info) (bool, error) {
 }
 
 func (s *Service) CreateNewCode(id string, info *identity.Info, webSessionID string, requestedByUser bool) (*Code, error) {
-	err := s.RateLimiter.TakeToken(GenerateRateLimitBucket(id))
-	if err != nil {
-		return nil, err
-	}
-
 	if info.Type != authn.IdentityTypeLoginID {
 		panic("verification: expect login ID identity")
 	}
@@ -254,7 +249,7 @@ func (s *Service) CreateNewCode(id string, info *identity.Info, webSessionID str
 		RequestedByUser: requestedByUser,
 	}
 
-	err = s.CodeStore.Create(codeModel)
+	err := s.CodeStore.Create(codeModel)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/lib/interaction/context.go
+++ b/pkg/lib/interaction/context.go
@@ -149,6 +149,7 @@ type CookieFactory interface {
 
 type RateLimiter interface {
 	TakeToken(bucket ratelimit.Bucket) error
+	CheckToken(bucket ratelimit.Bucket) (pass bool, resetDuration time.Duration, err error)
 }
 
 type Context struct {

--- a/resources/authgear/templates/en/translation.json
+++ b/resources/authgear/templates/en/translation.json
@@ -41,6 +41,7 @@
   "error-web-ui-invalid-session-return": "<p>This page is no longer active. Please return to the current page.</p>",
   "error-web-ui-invalid-session-action": "Return",
   "error-rate-limited": "Please wait for a moment before retrying.",
+  "error-webhook-disallowed": "Operation is not disallowed.",
   "error-disabled-user": "Administrator has disabled your account.",
   "error-disabled-user-reason": "Reason: {reason}",
   "error-disabled-user-no-reason": "Please contact administrator for details.",

--- a/resources/authgear/templates/en/web/__error.html
+++ b/resources/authgear/templates/en/web/__error.html
@@ -1,8 +1,19 @@
 {{ define "__error.html" }}
-<div class="messages-bar errors-messages-bar errors {{ if not .Error }}display-none{{ end }}" data-network-error="{{ template "error-network" }}" data-server-error="{{ template "error-server" }}">
+{{ $display_error := false }}
+{{ if .Error }}
+    {{ $display_error = true }}
+    {{ if eq .Error.reason "PasswordPolicyViolated" }}
+        <!-- This error is handled differently -->
+        {{ $display_error = false }}
+    {{ else if eq .Error.reason "WebUIInvalidSession" }}
+        <!-- This error is handled as fatal error -->
+        {{ $display_error = false }}
+    {{ end }}
+{{ end }}
+<div class="messages-bar errors-messages-bar errors {{ if not $display_error }}display-none{{ end }}" data-network-error="{{ template "error-network" }}" data-server-error="{{ template "error-server" }}">
     <div class="icon"><i class="far fa-times-circle"></i></div>
     <ul class="messages-txt error-txt">
-        {{ if .Error }}
+        {{ if $display_error }}
             {{ if eq .Error.reason "ValidationFailed" }}
                 {{ range .Error.info.causes }}
                     {{ if (eq .kind "required") }}
@@ -49,8 +60,6 @@
                 {{ end }}
             {{ else if eq .Error.reason "InvalidCredentials" }}
                 <li>{{ template "error-invalid-credentials" }}</li>
-            {{ else if eq .Error.reason "PasswordPolicyViolated" }}
-                <!-- This error is handled differently -->
             {{ else if eq .Error.reason "PasswordResetFailed" }}
                 <li>{{ template "error-password-reset-failed" }}</li>
             {{ else if eq .Error.reason "NewPasswordTypo" }}
@@ -77,8 +86,6 @@
                         {{ template "error-verification-code-invalid-click-to-resend" }}
                     </a>
                 </li>
-            {{ else if eq .Error.reason "WebUIInvalidSession" }}
-                <!-- This error is handled as fatal error -->
             {{ else if eq .Error.reason "RateLimited" }}
                 <li>{{ template "error-rate-limited" }}</li>
             {{ else if eq .Error.reason "WebHookDisallowed" }}

--- a/resources/authgear/templates/en/web/__error.html
+++ b/resources/authgear/templates/en/web/__error.html
@@ -81,6 +81,13 @@
                 <!-- This error is handled as fatal error -->
             {{ else if eq .Error.reason "RateLimited" }}
                 <li>{{ template "error-rate-limited" }}</li>
+            {{ else if eq .Error.reason "WebHookDisallowed" }}
+                <li>
+                    {{ template "error-webhook-disallowed" }}
+                </li>
+                {{ range .Error.info.reasons }}
+                    <li>{{ .reason }}</li>
+                {{ end }}
             {{ else }}
                 <li>{{ .Error.message }}</li>
             {{ end }}


### PR DESCRIPTION
depends on #1027 

fix #1019 

- Fix incorrect timing for signup rate limit
- Remove `verification-generate-code` rate limit which is bounded by `verification-send-code` rate limit
- Rename and update `reset-password-send-code` rate limit