### PR TITLE
Rename email domain blocklist and allowlist in spec

### DIFF
--- a/docs/specs/user-model.md
+++ b/docs/specs/user-model.md
@@ -148,12 +148,12 @@ Login ID type determines the validation, normalization and unique key generation
 
 - [RFC5322](https://tools.ietf.org/html/rfc5322#section-3.4.1)
 - Disallow `+` sign in the local part (Configurable, default OFF)
-- Domain blacklist / whitelist
-  - Block blacklisted domains (Configurable, default OFF, can be ON only if *Allow whitelisted domains* is OFF)
-  - Block email addresses from free email provider domains (Configurable, default OFF, can be ON only if *Block blacklisted domains* is ON)
-  - Allow whitelisted domains only (Configurable, default OFF, can be ON only if *Block blacklisted domains* is OFF)
-  - Domain blacklist / whitelist only affect user signup, users created from portal or via admin API are not affected
-  - Developer will need to provide their blacklist / whitelist in txt file, separated by newline.
+- Domain blocklist / allowlist
+  - Block domains in blocklist (Configurable, default OFF, can be ON only if *Allow domains in allowlist only* is OFF)
+  - Block email addresses from free email provider domains (Configurable, default OFF, can be ON only if *Block domains in blocklist* is ON)
+  - Allow domains in allowlist only (Configurable, default OFF, can be ON only if *Block domains in blocklist* is OFF)
+  - Domain blocklist / allowlist only affect user signup, users created from portal or via admin API are not affected
+  - Developer will need to provide their blocklist / allowlist in txt file, separated by newline.
 
 ###### Normalization of Email Login ID
 

--- a/pkg/lib/config/testdata/default_config.yaml
+++ b/pkg/lib/config/testdata/default_config.yaml
@@ -270,8 +270,8 @@ identity:
         case_sensitive: false
         block_plus_sign: false
         ignore_dot_sign: false
-        domain_blacklist_enabled: false
-        domain_whitelist_enabled: false
+        domain_blocklist_enabled: false
+        domain_allowlist_enabled: false
         block_free_email_provider_domains: false
       username:
         block_reserved_usernames: true


### PR DESCRIPTION
ref #906 

Louis reminded me that we should avoid using the terms blacklist / whitelist, update the spec and config for that.