### PR TITLE
Fix failed to perform action that saves config and templates at the same time in portal

### DIFF
--- a/portal/src/graphql/portal/CustomDomainListScreen.tsx
+++ b/portal/src/graphql/portal/CustomDomainListScreen.tsx
@@ -577,7 +577,7 @@ const CustomDomainListContent: React.FC<CustomDomainListContentProps> = function
 
   const confirmUpdatePublicOrigin = useCallback(() => {
     // save app config form
-    save();
+    save().catch(() => {});
   }, [save]);
 
   const dismissUpdatePublicOriginDialog = useCallback(() => {

--- a/portal/src/graphql/portal/LocalizationConfigurationScreen.tsx
+++ b/portal/src/graphql/portal/LocalizationConfigurationScreen.tsx
@@ -120,7 +120,7 @@ interface FormModel {
   setState: (fn: (state: FormState) => FormState) => void;
   reload: () => void;
   reset: () => void;
-  save: () => void;
+  save: () => Promise<void>;
 }
 
 interface ResourcesConfigurationContentProps {
@@ -508,9 +508,9 @@ const LocalizationConfigurationScreen: React.FC = function LocalizationConfigura
       resources.reset();
       setSelectedLanguage(config.state.fallbackLanguage);
     },
-    save: () => {
-      config.save();
-      resources.save();
+    save: async () => {
+      await config.save();
+      await resources.save();
     },
   };
 

--- a/portal/src/graphql/portal/LoginIDConfigurationScreen.tsx
+++ b/portal/src/graphql/portal/LoginIDConfigurationScreen.tsx
@@ -306,7 +306,7 @@ interface FormModel {
   setState: (fn: (state: FormState) => FormState) => void;
   reload: () => void;
   reset: () => void;
-  save: () => void;
+  save: () => Promise<void>;
 }
 
 function validateForm(
@@ -903,9 +903,9 @@ const LoginIDConfigurationScreen: React.FC = function LoginIDConfigurationScreen
       config.reset();
       resources.reset();
     },
-    save: () => {
-      config.save();
-      resources.save();
+    save: async () => {
+      await config.save();
+      await resources.save();
     },
   };
 

--- a/portal/src/graphql/portal/UISettingsScreen.tsx
+++ b/portal/src/graphql/portal/UISettingsScreen.tsx
@@ -183,7 +183,7 @@ interface FormModel {
   setState: (fn: (state: FormState) => FormState) => void;
   reload: () => void;
   reset: () => void;
-  save: () => void;
+  save: () => Promise<void>;
 }
 
 interface ResourcesConfigurationContentProps {
@@ -829,9 +829,9 @@ const UISettingsScreen: React.FC = function UISettingsScreen() {
       resources.reset();
       setSelectedLanguage(config.state.fallbackLanguage);
     },
-    save: () => {
-      config.save();
-      resources.save();
+    save: async () => {
+      await config.save();
+      await resources.save();
     },
   };
 

--- a/portal/src/hook/useAppConfigForm.ts
+++ b/portal/src/hook/useAppConfigForm.ts
@@ -17,7 +17,7 @@ export interface AppConfigFormModel<State> {
   setState: (fn: (state: State) => State) => void;
   reload: () => void;
   reset: () => void;
-  save: () => void;
+  save: () => Promise<void>;
   setCanSave: (canSave?: boolean) => void;
   effectiveConfig: PortalAPIAppConfig;
 }
@@ -81,7 +81,7 @@ export function useAppConfigForm<State>(
     setIsSubmitted(false);
   }, [isUpdating]);
 
-  const save = useCallback(() => {
+  const save = useCallback(async () => {
     const allowSave = canSave !== undefined ? canSave : isDirty;
     if (!rawConfig || !initialState) {
       return;
@@ -104,7 +104,7 @@ export function useAppConfigForm<State>(
 
     setIsUpdating(true);
     setUpdateError(null);
-    updateConfig(newConfig)
+    await updateConfig(newConfig)
       .then(() => {
         setCurrentState(null);
         setIsSubmitted(true);

--- a/portal/src/hook/useResourceForm.ts
+++ b/portal/src/hook/useResourceForm.ts
@@ -18,7 +18,7 @@ export interface ResourceFormModel<State> {
   setState: (fn: (state: State) => State) => void;
   reload: () => void;
   reset: () => void;
-  save: () => void;
+  save: () => Promise<void>;
 }
 
 export type StateConstructor<State> = (resources: Resource[]) => State;
@@ -78,7 +78,7 @@ export function useResourceForm<State>(
     setCurrentState(null);
   }, [isUpdating, resetError]);
 
-  const save = useCallback(() => {
+  const save = useCallback(async () => {
     if (!diff) {
       return;
     } else if (!diff.needUpdate) {
@@ -87,7 +87,7 @@ export function useResourceForm<State>(
       return;
     }
 
-    updateResources([
+    await updateResources([
       ...diff.newResources,
       ...diff.editedResources,
       ...diff.deletedResources,


### PR DESCRIPTION
Update saving config and templates one by one

Both api will update k8s secret, if we call them at the same time, the
second call may be failed, due to the secret version is updated in the
first call.

ref #1109