### PR TITLE
Support database config source

### DIFF
--- a/cmd/authgear/server/server.go
+++ b/cmd/authgear/server/server.go
@@ -1,6 +1,7 @@
 package server
 
 import (
+	"context"
 	golog "log"
 
 	"github.com/authgear/authgear-server/pkg/admin"
@@ -54,7 +55,7 @@ func (c *Controller) Start() {
 		c.logger.Warn("development mode is ON - do not use in production")
 	}
 
-	configSrcController := newConfigSourceController(p)
+	configSrcController := newConfigSourceController(p, context.Background())
 	err = configSrcController.Open()
 	if err != nil {
 		c.logger.WithError(err).Fatal("cannot open configuration")

--- a/cmd/authgear/server/wire.go
+++ b/cmd/authgear/server/wire.go
@@ -3,6 +3,7 @@
 package server
 
 import (
+	"context"
 	"github.com/google/wire"
 
 	"github.com/authgear/authgear-server/pkg/lib/config/configsource"
@@ -11,8 +12,13 @@ import (
 	"github.com/authgear/authgear-server/pkg/lib/infra/task/queue"
 )
 
-func newConfigSourceController(p *deps.RootProvider) *configsource.Controller {
-	panic(wire.Build(deps.RootDependencySet))
+func newConfigSourceController(p *deps.RootProvider, c context.Context) *configsource.Controller {
+	panic(wire.Build(
+		deps.RootDependencySet,
+		wire.FieldsOf(new(*deps.RootProvider),
+			"GlobalDatabasePool",
+		),
+	))
 }
 
 func newInProcessQueue(p *deps.AppProvider, e *executor.InProcessExecutor) *queue.InProcessQueue {

--- a/cmd/authgear/server/wire_gen.go
+++ b/cmd/authgear/server/wire_gen.go
@@ -53,6 +53,7 @@ func newConfigSourceController(p *deps.RootProvider, c context.Context) *configs
 		BaseResources: manager,
 		TrustProxy:    trustProxy,
 		Config:        config,
+		Clock:         clock,
 		Store:         store,
 		Database:      handle,
 	}

--- a/cmd/authgear/server/wire_gen.go
+++ b/cmd/authgear/server/wire_gen.go
@@ -49,13 +49,14 @@ func newConfigSourceController(p *deps.RootProvider, c context.Context) *configs
 		SQLExecutor: sqlExecutor,
 	}
 	database := &configsource.Database{
-		Logger:        databaseLogger,
-		BaseResources: manager,
-		TrustProxy:    trustProxy,
-		Config:        config,
-		Clock:         clock,
-		Store:         store,
-		Database:      handle,
+		Logger:         databaseLogger,
+		BaseResources:  manager,
+		TrustProxy:     trustProxy,
+		Config:         config,
+		Clock:          clock,
+		Store:          store,
+		Database:       handle,
+		DatabaseConfig: databaseEnvironmentConfig,
 	}
 	controller := configsource.NewController(config, localFS, kubernetes, database)
 	return controller

--- a/cmd/portal/server/server.go
+++ b/cmd/portal/server/server.go
@@ -1,6 +1,7 @@
 package server
 
 import (
+	"context"
 	golog "log"
 
 	"github.com/authgear/authgear-server/pkg/portal"
@@ -47,7 +48,7 @@ func (c *Controller) Start() {
 		c.logger.Warn("development mode is ON - do not use in production")
 	}
 
-	configSrcController := newConfigSourceController(p)
+	configSrcController := newConfigSourceController(p, context.Background())
 	err = configSrcController.Open()
 	if err != nil {
 		c.logger.WithError(err).Fatal("cannot open configuration")

--- a/cmd/portal/server/wire.go
+++ b/cmd/portal/server/wire.go
@@ -3,26 +3,31 @@
 package server
 
 import (
+	"context"
 	"github.com/google/wire"
 
 	"github.com/authgear/authgear-server/pkg/lib/config"
 	"github.com/authgear/authgear-server/pkg/lib/config/configsource"
+	globaldb "github.com/authgear/authgear-server/pkg/lib/infra/db/global"
 	"github.com/authgear/authgear-server/pkg/portal/deps"
 	"github.com/authgear/authgear-server/pkg/util/clock"
 )
 
-func newConfigSourceController(p *deps.RootProvider) *configsource.Controller {
+func newConfigSourceController(p *deps.RootProvider, c context.Context) *configsource.Controller {
 	panic(wire.Build(
 		clock.DependencySet,
+		globaldb.DependencySet,
 		configsource.DependencySet,
 		wire.FieldsOf(new(*deps.RootProvider),
 			"EnvironmentConfig",
 			"ConfigSourceConfig",
 			"LoggerFactory",
 			"AppBaseResources",
+			"Database",
 		),
 		wire.FieldsOf(new(*config.EnvironmentConfig),
 			"TrustProxy",
+			"Database",
 		),
 	))
 }

--- a/cmd/portal/server/wire_gen.go
+++ b/cmd/portal/server/wire_gen.go
@@ -47,13 +47,14 @@ func newConfigSourceController(p *deps.RootProvider, c context.Context) *configs
 		SQLExecutor: sqlExecutor,
 	}
 	database := &configsource.Database{
-		Logger:        databaseLogger,
-		BaseResources: manager,
-		TrustProxy:    trustProxy,
-		Config:        config,
-		Clock:         clock,
-		Store:         store,
-		Database:      handle,
+		Logger:         databaseLogger,
+		BaseResources:  manager,
+		TrustProxy:     trustProxy,
+		Config:         config,
+		Clock:          clock,
+		Store:          store,
+		Database:       handle,
+		DatabaseConfig: databaseEnvironmentConfig,
 	}
 	controller := configsource.NewController(config, localFS, kubernetes, database)
 	return controller

--- a/cmd/portal/server/wire_gen.go
+++ b/cmd/portal/server/wire_gen.go
@@ -51,6 +51,7 @@ func newConfigSourceController(p *deps.RootProvider, c context.Context) *configs
 		BaseResources: manager,
 		TrustProxy:    trustProxy,
 		Config:        config,
+		Clock:         clock,
 		Store:         store,
 		Database:      handle,
 	}

--- a/cmd/portal/server/wire_gen.go
+++ b/cmd/portal/server/wire_gen.go
@@ -6,14 +6,16 @@
 package server
 
 import (
+	"context"
 	"github.com/authgear/authgear-server/pkg/lib/config/configsource"
+	"github.com/authgear/authgear-server/pkg/lib/infra/db/global"
 	"github.com/authgear/authgear-server/pkg/portal/deps"
 	"github.com/authgear/authgear-server/pkg/util/clock"
 )
 
 // Injectors from wire.go:
 
-func newConfigSourceController(p *deps.RootProvider) *configsource.Controller {
+func newConfigSourceController(p *deps.RootProvider, c context.Context) *configsource.Controller {
 	config := p.ConfigSourceConfig
 	factory := p.LoggerFactory
 	localFSLogger := configsource.NewLocalFSLogger(factory)
@@ -34,7 +36,25 @@ func newConfigSourceController(p *deps.RootProvider) *configsource.Controller {
 		TrustProxy:    trustProxy,
 		Config:        config,
 	}
-	controller := configsource.NewController(config, localFS, kubernetes)
+	databaseLogger := configsource.NewDatabaseLogger(factory)
+	databaseEnvironmentConfig := &environmentConfig.Database
+	sqlBuilder := global.NewSQLBuilder(databaseEnvironmentConfig)
+	pool := p.Database
+	handle := global.NewHandle(c, pool, factory)
+	sqlExecutor := global.NewSQLExecutor(c, handle)
+	store := &configsource.Store{
+		SQLBuilder:  sqlBuilder,
+		SQLExecutor: sqlExecutor,
+	}
+	database := &configsource.Database{
+		Logger:        databaseLogger,
+		BaseResources: manager,
+		TrustProxy:    trustProxy,
+		Config:        config,
+		Store:         store,
+		Database:      handle,
+	}
+	controller := configsource.NewController(config, localFS, kubernetes, database)
 	return controller
 }
 

--- a/migrations/portal/20210415115311-add_config_source.sql
+++ b/migrations/portal/20210415115311-add_config_source.sql
@@ -1,0 +1,15 @@
+-- +migrate Up
+
+CREATE TABLE _portal_config_source
+(
+    id                 text PRIMARY KEY,
+    app_id             text                        NOT NULL,
+    created_at         timestamp WITHOUT TIME ZONE NOT NULL,
+    updated_at         timestamp WITHOUT TIME ZONE NOT NULL,
+    data               jsonb                       NOT NULL,
+    UNIQUE (app_id)
+);
+
+-- +migrate Down
+
+DROP TABLE _portal_config_source;

--- a/migrations/portal/20210416193011-add_config_source_and_domain_trigger.sql
+++ b/migrations/portal/20210416193011-add_config_source_and_domain_trigger.sql
@@ -1,0 +1,53 @@
+-- +migrate Up
+
+-- +migrate StatementBegin
+CREATE FUNCTION notify_config_source_change() RETURNS TRIGGER AS $$
+DECLARE
+  record RECORD;
+BEGIN
+  IF (TG_OP = 'DELETE') THEN
+    record := OLD;
+  ELSE
+    record := NEW;
+  END IF;
+  PERFORM pg_notify('config_source_change', record.app_id);
+  RETURN NULL;
+END;
+$$ LANGUAGE plpgsql;
+-- +migrate StatementEnd
+
+CREATE TRIGGER notify_config_source_change
+AFTER INSERT OR UPDATE OR DELETE
+ON _portal_config_source
+FOR ROW
+EXECUTE FUNCTION notify_config_source_change();
+
+-- +migrate StatementBegin
+CREATE FUNCTION notify_domain_change() RETURNS TRIGGER AS $$
+  DECLARE
+    record RECORD;
+  BEGIN
+    IF (TG_OP = 'DELETE') THEN
+      record := OLD;
+    ELSE
+      record := NEW;
+    END IF;
+    PERFORM pg_notify('domain_change', record.domain);
+    RETURN NULL;
+  END;
+$$ LANGUAGE plpgsql;
+-- +migrate StatementEnd
+
+CREATE TRIGGER notify_domain_change
+AFTER INSERT OR UPDATE OR DELETE
+ON _portal_domain
+FOR ROW
+EXECUTE FUNCTION notify_domain_change();
+
+-- +migrate Down
+
+DROP TRIGGER notify_config_source_change on _portal_config_source;
+DROP FUNCTION notify_config_source_change;
+
+DROP TRIGGER notify_domain_change on _portal_domain;
+DROP FUNCTION notify_domain_change;

--- a/nginx.conf
+++ b/nginx.conf
@@ -67,6 +67,7 @@ http {
             proxy_pass http://host.docker.internal:3001/resolve;
             proxy_pass_request_body off;
             proxy_set_header Host $http_host;
+            proxy_set_header X-Forwarded-Host "accounts.localhost";
             proxy_set_header Content-Length "";
         }
     }
@@ -109,6 +110,7 @@ http {
             proxy_pass http://host.docker.internal:3001/resolve;
             proxy_pass_request_body off;
             proxy_set_header Host $http_host;
+            proxy_set_header X-Forwarded-Host "accounts.localhost";
             proxy_set_header Content-Length "";
         }
     }

--- a/pkg/lib/config/configsource/config.go
+++ b/pkg/lib/config/configsource/config.go
@@ -5,11 +5,13 @@ type Type string
 const (
 	TypeLocalFS    Type = "local_fs"
 	TypeKubernetes Type = "kubernetes"
+	TypeDatabase   Type = "database"
 )
 
 var Types = []Type{
 	TypeLocalFS,
 	TypeKubernetes,
+	TypeDatabase,
 }
 
 type Config struct {

--- a/pkg/lib/config/configsource/database.go
+++ b/pkg/lib/config/configsource/database.go
@@ -1,0 +1,86 @@
+package configsource
+
+import (
+	"net"
+	"net/http"
+	"time"
+
+	"github.com/spf13/afero"
+
+	"github.com/authgear/authgear-server/pkg/lib/config"
+	globaldb "github.com/authgear/authgear-server/pkg/lib/infra/db/global"
+	"github.com/authgear/authgear-server/pkg/util/httputil"
+	"github.com/authgear/authgear-server/pkg/util/log"
+	"github.com/authgear/authgear-server/pkg/util/resource"
+)
+
+type DatabaseSource struct {
+	ID        string
+	Data      map[string][]byte
+	CreatedAt time.Time
+	UpdatedAt time.Time
+}
+
+type DatabaseLogger struct{ *log.Logger }
+
+func NewDatabaseLogger(lf *log.Factory) DatabaseLogger {
+	return DatabaseLogger{lf.New("configsource-database")}
+}
+
+type Database struct {
+	Logger        DatabaseLogger
+	BaseResources *resource.Manager
+	TrustProxy    config.TrustProxy
+	Config        *Config
+
+	done     chan<- struct{} `wire:"-"`
+	Store    *Store
+	Database *globaldb.Handle
+}
+
+func (d *Database) Open() error {
+	return nil
+}
+
+func (d *Database) Close() error {
+	return nil
+}
+
+func (d *Database) ResolveAppID(r *http.Request) (string, error) {
+	host := httputil.GetHost(r, bool(d.TrustProxy))
+	if h, _, err := net.SplitHostPort(host); err == nil {
+		host = h
+	}
+
+	return "", nil
+}
+
+func (d *Database) ResolveContext(appID string) (*config.AppContext, error) {
+	return nil, nil
+}
+
+func (d *Database) ReloadApp(appID string) {
+}
+
+func MakeAppFSFromDatabaseSource(s *DatabaseSource) (resource.Fs, error) {
+	// Construct a FS that treats `a` and `/a` the same.
+	// The template is loaded by a file URI which is always an absoluted path.
+	appFs := afero.NewBasePathFs(afero.NewMemMapFs(), "/")
+	create := func(name string, data []byte) {
+		file, _ := appFs.Create(name)
+		_, _ = file.Write(data)
+	}
+
+	for key, data := range s.Data {
+		path, err := UnescapePath(key)
+		if err != nil {
+			return nil, err
+		}
+		create(path, data)
+	}
+
+	return &resource.LeveledAferoFs{
+		Fs:      appFs,
+		FsLevel: resource.FsLevelApp,
+	}, nil
+}

--- a/pkg/lib/config/configsource/database.go
+++ b/pkg/lib/config/configsource/database.go
@@ -1,21 +1,27 @@
 package configsource
 
 import (
+	"bytes"
+	"errors"
 	"net"
 	"net/http"
+	"sync/atomic"
 	"time"
 
 	"github.com/spf13/afero"
 
 	"github.com/authgear/authgear-server/pkg/lib/config"
 	globaldb "github.com/authgear/authgear-server/pkg/lib/infra/db/global"
+	"github.com/authgear/authgear-server/pkg/util/clock"
 	"github.com/authgear/authgear-server/pkg/util/httputil"
 	"github.com/authgear/authgear-server/pkg/util/log"
 	"github.com/authgear/authgear-server/pkg/util/resource"
+	"github.com/authgear/authgear-server/pkg/util/uuid"
 )
 
 type DatabaseSource struct {
 	ID        string
+	AppID     string
 	Data      map[string][]byte
 	CreatedAt time.Time
 	UpdatedAt time.Time
@@ -32,6 +38,7 @@ type Database struct {
 	BaseResources *resource.Manager
 	TrustProxy    config.TrustProxy
 	Config        *Config
+	Clock         clock.Clock
 
 	done     chan<- struct{} `wire:"-"`
 	Store    *Store
@@ -69,10 +76,84 @@ func (d *Database) ResolveAppID(r *http.Request) (string, error) {
 }
 
 func (d *Database) ResolveContext(appID string) (*config.AppContext, error) {
-	return nil, nil
+	// fixme(1127) cache
+	app := &dbApp{
+		appID: appID,
+	}
+
+	var appCtx *config.AppContext
+	err := d.Database.WithTx(func() error {
+		a, err := app.Load(d)
+		if err != nil {
+			return err
+		}
+		appCtx = a
+		return nil
+	})
+	return appCtx, err
 }
 
 func (d *Database) ReloadApp(appID string) {
+}
+
+func (d *Database) CreateDatabaseSource(appID string, resources map[string][]byte) error {
+	return d.Database.WithTx(func() error {
+		_, err := d.Store.GetDatabaseSourceByAppID(appID)
+		if err != nil && !errors.Is(err, ErrAppNotFound) {
+			return err
+		} else if err == nil {
+			return ErrDuplicatedAppID
+		}
+
+		dbData := make(map[string][]byte)
+		for path, data := range resources {
+			dbData[EscapePath(path)] = data
+		}
+
+		dbSource := &DatabaseSource{
+			ID:        uuid.New(),
+			AppID:     appID,
+			Data:      dbData,
+			CreatedAt: d.Clock.NowUTC(),
+			UpdatedAt: d.Clock.NowUTC(),
+		}
+		return d.Store.CreateDatabaseSource(dbSource)
+	})
+}
+
+func (d *Database) UpdateDatabaseSource(appID string, updates []*resource.ResourceFile) error {
+	return d.Database.WithTx(func() error {
+		dbs, err := d.Store.GetDatabaseSourceByAppID(appID)
+		if err != nil {
+			return err
+		}
+
+		updated := false
+		for _, u := range updates {
+			key := EscapePath(u.Location.Path)
+			if u.Data == nil {
+				if _, ok := dbs.Data[key]; ok {
+					delete(dbs.Data, key)
+					updated = true
+				}
+			} else {
+				if !bytes.Equal(dbs.Data[key], u.Data) {
+					dbs.Data[key] = u.Data
+					updated = true
+				}
+			}
+		}
+
+		if updated {
+			dbs.UpdatedAt = d.Clock.NowUTC()
+			err = d.Store.UpdateDatabaseSource(dbs)
+			if err != nil {
+				return err
+			}
+		}
+
+		return nil
+	})
 }
 
 func MakeAppFSFromDatabaseSource(s *DatabaseSource) (resource.Fs, error) {
@@ -95,5 +176,42 @@ func MakeAppFSFromDatabaseSource(s *DatabaseSource) (resource.Fs, error) {
 	return &resource.LeveledAferoFs{
 		Fs:      appFs,
 		FsLevel: resource.FsLevelApp,
+	}, nil
+}
+
+type dbApp struct {
+	appID      string
+	appCtx     *config.AppContext
+	err        error
+	lastUsedAt int64
+}
+
+func (a *dbApp) Load(d *Database) (*config.AppContext, error) {
+	a.appCtx, a.err = a.doLoad(d)
+	atomic.StoreInt64(&a.lastUsedAt, d.Clock.NowMonotonic().Unix())
+	return a.appCtx, a.err
+}
+
+func (a *dbApp) doLoad(d *Database) (*config.AppContext, error) {
+	data, err := d.Store.GetDatabaseSourceByAppID(a.appID)
+	if err != nil {
+		return nil, err
+	}
+
+	appFs, err := MakeAppFSFromDatabaseSource(data)
+	if err != nil {
+		return nil, err
+	}
+	resources := d.BaseResources.Overlay(appFs)
+
+	appConfig, err := LoadConfig(resources)
+	if err != nil {
+		return nil, err
+	}
+
+	return &config.AppContext{
+		AppFs:     appFs,
+		Resources: resources,
+		Config:    appConfig,
 	}, nil
 }

--- a/pkg/lib/config/configsource/database.go
+++ b/pkg/lib/config/configsource/database.go
@@ -52,7 +52,20 @@ func (d *Database) ResolveAppID(r *http.Request) (string, error) {
 		host = h
 	}
 
-	return "", nil
+	var appID string
+	err := d.Database.WithTx(func() error {
+		aid, err := d.Store.GetAppIDByDomain(host)
+		if err != nil {
+			return err
+		}
+		appID = aid
+		return nil
+	})
+
+	if err != nil {
+		return "", err
+	}
+	return appID, nil
 }
 
 func (d *Database) ResolveContext(appID string) (*config.AppContext, error) {

--- a/pkg/lib/config/configsource/database.go
+++ b/pkg/lib/config/configsource/database.go
@@ -3,7 +3,6 @@ package configsource
 import (
 	"bytes"
 	"errors"
-	"fmt"
 	"net"
 	"net/http"
 	"sync"
@@ -76,10 +75,11 @@ func (d *Database) Open() error {
 		case PGChannelDomainChange:
 			d.invalidateHost(extra)
 		default:
-			panic(fmt.Sprintf("db_config: unknown notification channel: %s", channel))
+			// unknown notification channel, just skip it
+			d.Logger.WithField("channel", channel).Info("unknown notification channel")
 		}
 	}, func(e error) {
-		panic(fmt.Sprintf("db_config: error on listening pgsql: %s", e))
+		d.Logger.WithError(e).Error("error on listening pgsql")
 	})
 	go d.cleanupCache(done)
 

--- a/pkg/lib/config/configsource/deps.go
+++ b/pkg/lib/config/configsource/deps.go
@@ -7,6 +7,9 @@ var DependencySet = wire.NewSet(
 	wire.Struct(new(LocalFS), "*"),
 	NewKubernetesLogger,
 	wire.Struct(new(Kubernetes), "*"),
+	NewDatabaseLogger,
+	wire.Struct(new(Database), "*"),
+	wire.Struct(new(Store), "*"),
 
 	NewController,
 )

--- a/pkg/lib/config/configsource/errors.go
+++ b/pkg/lib/config/configsource/errors.go
@@ -3,3 +3,4 @@ package configsource
 import "errors"
 
 var ErrAppNotFound = errors.New("app not found")
+var ErrDuplicatedAppID = errors.New("duplicated app ID")

--- a/pkg/lib/config/configsource/source.go
+++ b/pkg/lib/config/configsource/source.go
@@ -43,6 +43,7 @@ func NewController(
 	cfg *Config,
 	lf *LocalFS,
 	k8s *Kubernetes,
+	d *Database,
 ) *Controller {
 	switch cfg.Type {
 	case TypeLocalFS:
@@ -56,6 +57,12 @@ func NewController(
 			Handle:          k8s,
 			AppIDResolver:   k8s,
 			ContextResolver: k8s,
+		}
+	case TypeDatabase:
+		return &Controller{
+			Handle:          d,
+			AppIDResolver:   d,
+			ContextResolver: d,
 		}
 	default:
 		panic("config_source: invalid config source type")

--- a/pkg/lib/config/configsource/store.go
+++ b/pkg/lib/config/configsource/store.go
@@ -2,14 +2,53 @@ package configsource
 
 import (
 	"database/sql"
+	"encoding/json"
 	"errors"
+	"fmt"
 
+	"github.com/authgear/authgear-server/pkg/lib/infra/db"
 	globaldb "github.com/authgear/authgear-server/pkg/lib/infra/db/global"
 )
 
 type Store struct {
 	SQLBuilder  *globaldb.SQLBuilder
 	SQLExecutor *globaldb.SQLExecutor
+}
+
+func (s *Store) selectConfigSourceQuery() db.SelectBuilder {
+	return s.SQLBuilder.Global().
+		Select(
+			"id",
+			"app_id",
+			"created_at",
+			"updated_at",
+			"data",
+		).
+		From(s.SQLBuilder.TableName("_portal_config_source"))
+}
+
+func (s *Store) scanConfigSource(scn db.Scanner) (*DatabaseSource, error) {
+	d := &DatabaseSource{}
+	var dataByte []byte
+
+	err := scn.Scan(
+		&d.ID,
+		&d.AppID,
+		&d.CreatedAt,
+		&d.UpdatedAt,
+		&dataByte,
+	)
+	if errors.Is(err, sql.ErrNoRows) {
+		return nil, ErrAppNotFound
+	} else if err != nil {
+		return nil, err
+	}
+
+	if err = json.Unmarshal(dataByte, &d.Data); err != nil {
+		return nil, err
+	}
+
+	return d, nil
 }
 
 func (s *Store) GetAppIDByDomain(domain string) (string, error) {
@@ -34,4 +73,86 @@ func (s *Store) GetAppIDByDomain(domain string) (string, error) {
 	}
 
 	return appID, nil
+}
+
+func (s *Store) GetDatabaseSourceByAppID(appID string) (*DatabaseSource, error) {
+	builder := s.selectConfigSourceQuery()
+	builder = builder.Where("app_id = ?", appID)
+
+	scanner, err := s.SQLExecutor.QueryRowWith(builder)
+	if err != nil {
+		return nil, err
+	}
+
+	dbs, err := s.scanConfigSource(scanner)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return nil, ErrAppNotFound
+		}
+		return nil, err
+	}
+
+	return dbs, nil
+}
+
+func (s *Store) CreateDatabaseSource(dbs *DatabaseSource) error {
+	data, err := json.Marshal(dbs.Data)
+	if err != nil {
+		return err
+	}
+
+	builder := s.SQLBuilder.Global().
+		Insert(s.SQLBuilder.TableName("_portal_config_source")).
+		Columns(
+			"id",
+			"app_id",
+			"data",
+			"created_at",
+			"updated_at",
+		).
+		Values(
+			dbs.ID,
+			dbs.AppID,
+			data,
+			dbs.CreatedAt,
+			dbs.UpdatedAt,
+		)
+
+	_, err = s.SQLExecutor.ExecWith(builder)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (s *Store) UpdateDatabaseSource(dbs *DatabaseSource) error {
+	data, err := json.Marshal(dbs.Data)
+	if err != nil {
+		return err
+	}
+
+	q := s.SQLBuilder.Global().
+		Update(s.SQLBuilder.TableName("_portal_config_source")).
+		Set("updated_at", dbs.UpdatedAt).
+		Set("data", data).
+		Where("id = ?", dbs.ID)
+
+	result, err := s.SQLExecutor.ExecWith(q)
+	if err != nil {
+		return err
+	}
+
+	rowsAffected, err := result.RowsAffected()
+	if err != nil {
+		return err
+	}
+
+	if rowsAffected == 0 {
+		return ErrAppNotFound
+	} else if rowsAffected > 1 {
+		panic(fmt.Sprintf("config_source_db: want 1 row updated, got %v", rowsAffected))
+	}
+
+	return nil
 }

--- a/pkg/lib/config/configsource/store.go
+++ b/pkg/lib/config/configsource/store.go
@@ -1,0 +1,14 @@
+package configsource
+
+import (
+	globaldb "github.com/authgear/authgear-server/pkg/lib/infra/db/global"
+)
+
+type Store struct {
+	SQLBuilder  *globaldb.SQLBuilder
+	SQLExecutor *globaldb.SQLExecutor
+}
+
+func (s *Store) GetAppIDByDomain(domain string) (string, error) {
+	return "", nil
+}

--- a/pkg/lib/deps/deps_provider.go
+++ b/pkg/lib/deps/deps_provider.go
@@ -10,6 +10,7 @@ import (
 	"github.com/authgear/authgear-server/pkg/lib/config"
 	"github.com/authgear/authgear-server/pkg/lib/config/configsource"
 	"github.com/authgear/authgear-server/pkg/lib/hook"
+	globaldb "github.com/authgear/authgear-server/pkg/lib/infra/db/global"
 	tenantdb "github.com/authgear/authgear-server/pkg/lib/infra/db/tenant"
 	"github.com/authgear/authgear-server/pkg/lib/web"
 	"github.com/authgear/authgear-server/pkg/util/clock"
@@ -27,12 +28,14 @@ var rootDeps = wire.NewSet(
 		"DevMode",
 		"SentryDSN",
 		"StaticAssetURLPrefix",
+		"Database",
 	),
 
 	ProvideCaptureTaskContext,
 	ProvideRestoreTaskContext,
 
 	clock.DependencySet,
+	globaldb.DependencySet,
 	configsource.DependencySet,
 )
 

--- a/pkg/lib/deps/providers.go
+++ b/pkg/lib/deps/providers.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/authgear/authgear-server/pkg/lib/config"
 	"github.com/authgear/authgear-server/pkg/lib/config/configsource"
+	globaldb "github.com/authgear/authgear-server/pkg/lib/infra/db/global"
 	tenantdb "github.com/authgear/authgear-server/pkg/lib/infra/db/tenant"
 	"github.com/authgear/authgear-server/pkg/lib/infra/redis"
 	"github.com/authgear/authgear-server/pkg/lib/infra/task"
@@ -23,6 +24,7 @@ type RootProvider struct {
 	LoggerFactory      *log.Factory
 	SentryHub          *getsentry.Hub
 	DatabasePool       *tenantdb.Pool
+	GlobalDatabasePool *globaldb.Pool
 	RedisPool          *redis.Pool
 	RedisHub           *redis.Hub
 	TaskQueueFactory   TaskQueueFactory
@@ -55,6 +57,7 @@ func NewRootProvider(
 	)
 
 	dbPool := tenantdb.NewPool()
+	globalDBPool := globaldb.NewPool(&cfg.Database)
 	redisPool := redis.NewPool()
 	redisHub := redis.NewHub(redisPool, loggerFactory)
 
@@ -64,6 +67,7 @@ func NewRootProvider(
 		LoggerFactory:      loggerFactory,
 		SentryHub:          sentryHub,
 		DatabasePool:       dbPool,
+		GlobalDatabasePool: globalDBPool,
 		RedisPool:          redisPool,
 		RedisHub:           redisHub,
 		TaskQueueFactory:   taskQueueFactory,

--- a/pkg/lib/infra/db/global/deps.go
+++ b/pkg/lib/infra/db/global/deps.go
@@ -1,0 +1,11 @@
+package global
+
+import (
+	"github.com/google/wire"
+)
+
+var DependencySet = wire.NewSet(
+	NewHandle,
+	NewSQLExecutor,
+	NewSQLBuilder,
+)

--- a/pkg/lib/infra/db/listener.go
+++ b/pkg/lib/infra/db/listener.go
@@ -1,0 +1,51 @@
+package db
+
+import (
+	"errors"
+	"time"
+
+	"github.com/lib/pq"
+)
+
+type PQListener struct {
+	DatabaseURL string
+	Listener    *pq.Listener
+}
+
+func (p *PQListener) Listen(channels []string, done <-chan struct{}, onChange func(channel string, extra string), onError func(error)) {
+	if p.Listener != nil {
+		onError(errors.New("db: PQListener is started already"))
+		return
+	}
+	listener := pq.NewListener(
+		p.DatabaseURL,
+		10*time.Second,
+		1*time.Minute,
+		nil,
+	)
+	for _, channel := range channels {
+		err := listener.Listen(channel)
+		if err != nil {
+			onError(err)
+			return
+		}
+	}
+
+	p.Listener = listener
+	for {
+		select {
+		case <-done:
+			p.Listener = nil
+			return
+		case e := <-listener.Notify:
+			if e != nil {
+				onChange(e.Channel, e.Extra)
+			}
+		case <-time.After(time.Minute):
+			err := listener.Ping()
+			if err != nil {
+				onError(err)
+			}
+		}
+	}
+}


### PR DESCRIPTION
ref #1127 

Initial draft for review only, not fully working

Done
- Basic ResolveAppID from db
- ResolveContext from db
- UpdateResources from db
- CreateResources from db
- Support cache
- Update portal nginx config to have correct host header when calling resolve endpoint

Todo
- TBD: Add `APP_HOST_SUFFIX` config and use it in ResolveAppID
- Command to setup first `accounts` app 