### PR TITLE
Add command to setup db config source for portal

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,12 +55,22 @@ To avoid doing the above every time you open a new shell, you may want to add it
 
 3. Setup `.localhost` domain
 
-For cookie to work properly, you need to use
+   For cookie to work properly, you need to use
 
-- `portal.localhost:8000` to access the portal.
-- `accounts.portal.localhost:3000` to access the main server.
+   - `portal.localhost:8000` to access the portal.
+   - `accounts.portal.localhost:3000` to access the main server.
 
-You can either do this by editing `/etc/hosts` or install `dnsmasq`.
+   You can either do this by editing `/etc/hosts` or install `dnsmasq`.
+
+4. (Optional) To use db as config source.
+
+   - Update `.env` to change `CONFIG_SOURCE_TYPE=database`
+   - Setup config source in db
+      ```
+      go run ./cmd/portal internal setup-portal ./var/
+         --default-domain=accounts.localhost
+         --custom-domain=accounts.portal.localhost
+      ```
 
 ## Database setup
 

--- a/README.md
+++ b/README.md
@@ -43,8 +43,8 @@ To avoid doing the above every time you open a new shell, you may want to add it
    To generate the necessary config and secret yaml file, run
 
    ```sh
-   go run ./cmd/authgear init config --output ./var/authgear.yaml
-   go run ./cmd/authgear init secrets --output ./var/authgear.secrets.yaml
+   go run ./cmd/authgear init authgear.yaml --output ./var/authgear.yaml
+   go run ./cmd/authgear init authgear.secrets.yaml --output ./var/authgear.secrets.yaml
    ```
 
    then follow the instructions. For database URL and schema, use the following,

--- a/README.md
+++ b/README.md
@@ -67,9 +67,9 @@ To avoid doing the above every time you open a new shell, you may want to add it
    - Update `.env` to change `CONFIG_SOURCE_TYPE=database`
    - Setup config source in db
       ```
-      go run ./cmd/portal internal setup-portal ./var/
-         --default-domain=accounts.localhost
-         --custom-domain=accounts.portal.localhost
+      go run ./cmd/portal internal setup-portal ./var/ \
+         --default-authgear-domain=accounts.localhost \
+         --custom-authgear-domain=accounts.portal.localhost \
       ```
 
 ## Database setup

--- a/README.md
+++ b/README.md
@@ -92,13 +92,13 @@ To avoid doing the above every time you open a new shell, you may want to add it
    make sure the db container is running
 
    ```sh
-   go run ./cmd/authgear migrate up --database-url='postgres://postgres@127.0.0.1:5432/postgres?sslmode=disable' --database-schema=app
+   go run ./cmd/authgear database migrate up --database-url='postgres://postgres@127.0.0.1:5432/postgres?sslmode=disable' --database-schema=app
    ```
 
 To create new migration:
 ```sh
-# go run ./cmd/authgear migrate new <migration name>
-go run ./cmd/authgear migrate new add user table
+# go run ./cmd/authgear database migrate new <migration name>
+go run ./cmd/authgear database migrate new add user table
 ```
 
 ## HTTPS setup

--- a/cmd/authgear/init.go
+++ b/cmd/authgear/init.go
@@ -14,12 +14,12 @@ var InitConfigOutputPath string
 var InitSecretsOutputPath string
 
 var cmdInit = &cobra.Command{
-	Use:   "init [config|secret]",
+	Use:   "init [authgear.yaml|authgear.secrets.yaml]",
 	Short: "Initialize configuration",
 }
 
 var cmdInitConfig = &cobra.Command{
-	Use:   "config",
+	Use:   "authgear.yaml",
 	Short: "Initialize app configuration",
 	Run: func(cmd *cobra.Command, args []string) {
 		opts := config.ReadAppConfigOptionsFromConsole()
@@ -32,7 +32,7 @@ var cmdInitConfig = &cobra.Command{
 }
 
 var cmdInitSecrets = &cobra.Command{
-	Use:   "secrets",
+	Use:   "authgear.secrets.yaml",
 	Short: "Initialize app secrets",
 	Run: func(cmd *cobra.Command, args []string) {
 		opts := config.ReadSecretConfigOptionsFromConsole()

--- a/cmd/authgear/main.go
+++ b/cmd/authgear/main.go
@@ -28,5 +28,5 @@ var cmdRoot = &cobra.Command{
 func init() {
 	cmdRoot.AddCommand(cmdStart)
 	cmdRoot.AddCommand(cmdInit)
-	cmdRoot.AddCommand(cmdMigrate)
+	cmdRoot.AddCommand(cmdDatabase)
 }

--- a/cmd/authgear/migrate.go
+++ b/cmd/authgear/migrate.go
@@ -16,6 +16,8 @@ var DatabaseURL string
 var DatabaseSchema string
 
 func init() {
+	cmdDatabase.AddCommand(cmdMigrate)
+
 	cmdMigrate.AddCommand(cmdMigrateNew)
 	cmdMigrate.AddCommand(cmdMigrateUp)
 	cmdMigrate.AddCommand(cmdMigrateDown)
@@ -35,6 +37,11 @@ func init() {
 			"Database schema name",
 		)
 	}
+}
+
+var cmdDatabase = &cobra.Command{
+	Use:   "database migrate",
+	Short: "Database commands",
 }
 
 var cmdMigrate = &cobra.Command{

--- a/cmd/portal/db.go
+++ b/cmd/portal/db.go
@@ -1,0 +1,26 @@
+package main
+
+import (
+	"errors"
+	"os"
+)
+
+var DatabaseURL string
+var DatabaseSchema string
+
+func loadDBCredentials() (dbURL string, dbSchema string, err error) {
+	if DatabaseURL == "" {
+		DatabaseURL = os.Getenv("DATABASE_URL")
+	}
+	if DatabaseSchema == "" {
+		DatabaseSchema = os.Getenv("DATABASE_SCHEMA")
+	}
+
+	if DatabaseURL == "" {
+		return "", "", errors.New("missing database URL")
+	}
+	if DatabaseSchema == "" {
+		return "", "", errors.New("missing database schema")
+	}
+	return DatabaseURL, DatabaseSchema, nil
+}

--- a/cmd/portal/internal.go
+++ b/cmd/portal/internal.go
@@ -1,0 +1,48 @@
+package main
+
+import (
+	"log"
+
+	"github.com/spf13/cobra"
+
+	"github.com/authgear/authgear-server/cmd/portal/internal"
+)
+
+var defaultDomain string
+var customDomain string
+
+var cmdInternal = &cobra.Command{
+	Use:   "internal [setup-portal]",
+	Short: "Setup portal config source data in db",
+}
+
+var cmdInternalSetupPortal = &cobra.Command{
+	Use:   "setup-portal",
+	Short: "Initialize app configuration",
+	Run: func(cmd *cobra.Command, args []string) {
+		dbURL, dbSchema, err := loadDBCredentials()
+		if err != nil {
+			log.Fatalf("failed to create app: %s", err)
+		}
+
+		internal.SetupPortal(&internal.SetupPortalOptions{
+			DatabaseURL:    dbURL,
+			DatabaseSchema: dbSchema,
+			DefaultDoamin:  defaultDomain,
+			CustomDomain:   customDomain,
+		})
+
+	},
+}
+
+func init() {
+	cmdInternal.AddCommand(cmdInternalSetupPortal)
+
+	cmdInternalSetupPortal.Flags().StringVar(&DatabaseURL, "database-url", "", "Database URL")
+	cmdInternalSetupPortal.Flags().StringVar(&DatabaseSchema, "database-schema", "", "Database schema name")
+	cmdInternalSetupPortal.Flags().StringVar(&defaultDomain, "default-domain", "", "App default domain")
+	cmdInternalSetupPortal.Flags().StringVar(&customDomain, "custom-domain", "", "App custom domain")
+
+	_ = cmdInternalSetupPortal.MarkFlagRequired("default-domain")
+	_ = cmdInternalSetupPortal.MarkFlagRequired("custom-domain")
+}

--- a/cmd/portal/internal.go
+++ b/cmd/portal/internal.go
@@ -8,8 +8,8 @@ import (
 	"github.com/authgear/authgear-server/cmd/portal/internal"
 )
 
-var defaultDomain string
-var customDomain string
+var defaultAuthgearDomain string
+var customAuthgearDomain string
 
 var cmdInternal = &cobra.Command{
 	Use:   "internal [setup-portal]",
@@ -31,11 +31,11 @@ var cmdInternalSetupPortal = &cobra.Command{
 		}
 
 		internal.SetupPortal(&internal.SetupPortalOptions{
-			DatabaseURL:    dbURL,
-			DatabaseSchema: dbSchema,
-			DefaultDoamin:  defaultDomain,
-			CustomDomain:   customDomain,
-			ResourceDir:    resourceDir,
+			DatabaseURL:           dbURL,
+			DatabaseSchema:        dbSchema,
+			DefaultAuthgearDoamin: defaultAuthgearDomain,
+			CustomAuthgearDomain:  customAuthgearDomain,
+			ResourceDir:           resourceDir,
 		})
 
 	},
@@ -46,9 +46,9 @@ func init() {
 
 	cmdInternalSetupPortal.Flags().StringVar(&DatabaseURL, "database-url", "", "Database URL")
 	cmdInternalSetupPortal.Flags().StringVar(&DatabaseSchema, "database-schema", "", "Database schema name")
-	cmdInternalSetupPortal.Flags().StringVar(&defaultDomain, "default-domain", "", "App default domain")
-	cmdInternalSetupPortal.Flags().StringVar(&customDomain, "custom-domain", "", "App custom domain")
+	cmdInternalSetupPortal.Flags().StringVar(&defaultAuthgearDomain, "default-authgear-domain", "", "App default domain")
+	cmdInternalSetupPortal.Flags().StringVar(&customAuthgearDomain, "custom-authgear-domain", "", "App custom domain")
 
-	_ = cmdInternalSetupPortal.MarkFlagRequired("default-domain")
-	_ = cmdInternalSetupPortal.MarkFlagRequired("custom-domain")
+	_ = cmdInternalSetupPortal.MarkFlagRequired("default-authgear-domain")
+	_ = cmdInternalSetupPortal.MarkFlagRequired("custom-authgear-domain")
 }

--- a/cmd/portal/internal.go
+++ b/cmd/portal/internal.go
@@ -25,11 +25,17 @@ var cmdInternalSetupPortal = &cobra.Command{
 			log.Fatalf("failed to create app: %s", err)
 		}
 
+		resourceDir := "./"
+		if len(args) >= 1 {
+			resourceDir = args[0]
+		}
+
 		internal.SetupPortal(&internal.SetupPortalOptions{
 			DatabaseURL:    dbURL,
 			DatabaseSchema: dbSchema,
 			DefaultDoamin:  defaultDomain,
 			CustomDomain:   customDomain,
+			ResourceDir:    resourceDir,
 		})
 
 	},

--- a/cmd/portal/internal/db.go
+++ b/cmd/portal/internal/db.go
@@ -1,0 +1,28 @@
+package internal
+
+import (
+	"database/sql"
+	"fmt"
+	"log"
+
+	sq "github.com/Masterminds/squirrel"
+	"github.com/lib/pq"
+)
+
+func openDB(dbURL string, dbSchema string) *sql.DB {
+	db, err := sql.Open("postgres", dbURL)
+	if err != nil {
+		log.Fatalf("failed to open database: %s", err)
+	}
+
+	_, err = db.Exec(fmt.Sprintf("SET search_path TO %s", pq.QuoteIdentifier(dbSchema)))
+	if err != nil {
+		log.Fatalf("failed to set search_path: %s", err)
+	}
+
+	return db
+}
+
+func newSQLBuilder() sq.StatementBuilderType {
+	return sq.StatementBuilder.PlaceholderFormat(sq.Dollar)
+}

--- a/cmd/portal/internal/setup_portal.go
+++ b/cmd/portal/internal/setup_portal.go
@@ -3,15 +3,23 @@ package internal
 import (
 	"context"
 	"database/sql"
+	"encoding/base64"
 	"encoding/hex"
+	"encoding/json"
 	"fmt"
+	"io/ioutil"
 	"log"
 	"time"
 
 	"github.com/lib/pq"
+	"github.com/spf13/afero"
 	"golang.org/x/net/publicsuffix"
+	"gopkg.in/yaml.v2"
 
+	"github.com/authgear/authgear-server/pkg/lib/config"
+	"github.com/authgear/authgear-server/pkg/lib/config/configsource"
 	corerand "github.com/authgear/authgear-server/pkg/util/rand"
+	"github.com/authgear/authgear-server/pkg/util/resource"
 	"github.com/authgear/authgear-server/pkg/util/uuid"
 )
 
@@ -24,15 +32,33 @@ type SetupPortalOptions struct {
 }
 
 func SetupPortal(opt *SetupPortalOptions) {
-	// parse id from authgear.yaml
-	appID := "accounts"
+	// construct config source
+	data, err := constructConfigSourceData(opt.ResourceDir)
+	if err != nil {
+		log.Fatalf("invalid resource directory: %s", err)
+	}
 
+	err = validateConfigSource(data)
+	if err != nil {
+		log.Fatalf("invalid resource directory: %s", err)
+	}
+
+	appID, err := parseAppID(data["authgear.yaml"])
+	if err != nil {
+		log.Fatalf("failed to parse app id: %s", err)
+	}
+
+	// start store domains and config source to db
 	db := openDB(opt.DatabaseURL, opt.DatabaseSchema)
 
 	ctx := context.Background()
 	tx, err := db.BeginTx(ctx, nil)
 	if err != nil {
 		log.Fatalf("failed to connect db: %s", err)
+	}
+
+	if err := createConfigSource(ctx, tx, appID, data); err != nil {
+		log.Fatalf("failed to create config source record: %s", err)
 	}
 
 	if err := createDomain(ctx, tx, appID, opt.DefaultDoamin, false); err != nil {
@@ -48,8 +74,10 @@ func SetupPortal(opt *SetupPortalOptions) {
 	if err := tx.Commit(); err != nil {
 		log.Fatal(err)
 	}
+
 }
 
+// create domain record in db
 func createDomain(ctx context.Context, tx *sql.Tx, appID string, domain string, isCustom bool) error {
 	apexDomain, err := publicsuffix.EffectiveTLDPlusOne(domain)
 	if err != nil {
@@ -77,7 +105,7 @@ func createDomain(ctx context.Context, tx *sql.Tx, appID string, domain string, 
 			domain,
 			apexDomain,
 			verificationNonce,
-			false,
+			isCustom,
 		)
 
 	q, args, err := builder.ToSql()
@@ -91,4 +119,112 @@ func createDomain(ctx context.Context, tx *sql.Tx, appID string, domain string, 
 	}
 
 	return nil
+}
+
+// create config source record in db
+func createConfigSource(ctx context.Context, tx *sql.Tx, appID string, data map[string]string) error {
+	dataJSON, err := json.Marshal(data)
+	if err != nil {
+		return err
+	}
+
+	builder := newSQLBuilder().
+		Insert(pq.QuoteIdentifier("_portal_config_source")).
+		Columns(
+			"id",
+			"app_id",
+			"data",
+			"created_at",
+			"updated_at",
+		).
+		Values(
+			uuid.New(),
+			appID,
+			dataJSON,
+			time.Now().UTC(),
+			time.Now().UTC(),
+		)
+
+	q, args, err := builder.ToSql()
+	if err != nil {
+		return err
+	}
+
+	_, err = tx.ExecContext(ctx, q, args...)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func constructConfigSourceData(resourceDir string) (map[string]string, error) {
+	fs := afero.NewBasePathFs(afero.NewOsFs(), resourceDir)
+	appFs := &resource.LeveledAferoFs{Fs: fs, FsLevel: resource.FsLevelApp}
+
+	locations, err := resource.EnumerateAllLocations(appFs)
+	if err != nil {
+		return nil, err
+	}
+
+	manager := resource.NewManager(resource.DefaultRegistry, []resource.Fs{appFs})
+	var matches []resource.Location
+	for _, l := range locations {
+		for _, desc := range manager.Registry.Descriptors {
+			if _, ok := desc.MatchResource(l.Path); ok {
+				matches = append(matches, l)
+				break
+			}
+		}
+	}
+
+	// Read the files to construct config source data
+	dbData := make(map[string]string)
+	for _, l := range matches {
+		path := l.Path
+		f, err := fs.Open(l.Path)
+		if err != nil {
+			return nil, err
+		}
+		defer f.Close()
+		data, err := ioutil.ReadAll(f)
+		if err != nil {
+			return nil, err
+		}
+
+		str := base64.StdEncoding.EncodeToString(data)
+		dbData[configsource.EscapePath(path)] = str
+	}
+
+	return dbData, nil
+}
+
+func validateConfigSource(data map[string]string) error {
+	// make sure the resources folder has required files
+	if _, ok := data["authgear.yaml"]; !ok {
+		return fmt.Errorf("missing authgear.yaml")
+	}
+	if _, ok := data["authgear.secrets.yaml"]; !ok {
+		return fmt.Errorf("missing authgear.secrets.yaml")
+	}
+
+	return nil
+}
+
+func parseAppID(base64EncodedAuthgearYAML string) (string, error) {
+	decoded, err := base64.StdEncoding.DecodeString(base64EncodedAuthgearYAML)
+	if err != nil {
+		return "", err
+	}
+
+	cfg := config.AppConfig{}
+	if err := yaml.Unmarshal(decoded, &cfg); err != nil {
+		return "", fmt.Errorf("malformed authgear.yaml: %w", err)
+	}
+
+	if cfg.ID == "" {
+		return "", fmt.Errorf("missing app id")
+	}
+
+	return string(cfg.ID), nil
 }

--- a/cmd/portal/internal/setup_portal.go
+++ b/cmd/portal/internal/setup_portal.go
@@ -24,11 +24,11 @@ import (
 )
 
 type SetupPortalOptions struct {
-	DatabaseURL    string
-	DatabaseSchema string
-	DefaultDoamin  string
-	CustomDomain   string
-	ResourceDir    string
+	DatabaseURL           string
+	DatabaseSchema        string
+	DefaultAuthgearDoamin string
+	CustomAuthgearDomain  string
+	ResourceDir           string
 }
 
 func SetupPortal(opt *SetupPortalOptions) {
@@ -61,12 +61,12 @@ func SetupPortal(opt *SetupPortalOptions) {
 		log.Fatalf("failed to create config source record: %s", err)
 	}
 
-	if err := createDomain(ctx, tx, appID, opt.DefaultDoamin, false); err != nil {
+	if err := createDomain(ctx, tx, appID, opt.DefaultAuthgearDoamin, false); err != nil {
 		_ = tx.Rollback()
 		log.Fatalf("failed to create default domain: %s", err)
 	}
 
-	if err := createDomain(ctx, tx, appID, opt.CustomDomain, true); err != nil {
+	if err := createDomain(ctx, tx, appID, opt.CustomAuthgearDomain, true); err != nil {
 		_ = tx.Rollback()
 		log.Fatalf("failed to create custom domain: %s", err)
 	}

--- a/cmd/portal/internal/setup_portal.go
+++ b/cmd/portal/internal/setup_portal.go
@@ -1,0 +1,94 @@
+package internal
+
+import (
+	"context"
+	"database/sql"
+	"encoding/hex"
+	"fmt"
+	"log"
+	"time"
+
+	"github.com/lib/pq"
+	"golang.org/x/net/publicsuffix"
+
+	corerand "github.com/authgear/authgear-server/pkg/util/rand"
+	"github.com/authgear/authgear-server/pkg/util/uuid"
+)
+
+type SetupPortalOptions struct {
+	DatabaseURL    string
+	DatabaseSchema string
+	DefaultDoamin  string
+	CustomDomain   string
+	ResourceDir    string
+}
+
+func SetupPortal(opt *SetupPortalOptions) {
+	// parse id from authgear.yaml
+	appID := "accounts"
+
+	db := openDB(opt.DatabaseURL, opt.DatabaseSchema)
+
+	ctx := context.Background()
+	tx, err := db.BeginTx(ctx, nil)
+	if err != nil {
+		log.Fatalf("failed to connect db: %s", err)
+	}
+
+	if err := createDomain(ctx, tx, appID, opt.DefaultDoamin, false); err != nil {
+		_ = tx.Rollback()
+		log.Fatalf("failed to create default domain: %s", err)
+	}
+
+	if err := createDomain(ctx, tx, appID, opt.CustomDomain, true); err != nil {
+		_ = tx.Rollback()
+		log.Fatalf("failed to create custom domain: %s", err)
+	}
+
+	if err := tx.Commit(); err != nil {
+		log.Fatal(err)
+	}
+}
+
+func createDomain(ctx context.Context, tx *sql.Tx, appID string, domain string, isCustom bool) error {
+	apexDomain, err := publicsuffix.EffectiveTLDPlusOne(domain)
+	if err != nil {
+		return fmt.Errorf("invalid domain: %w", err)
+	}
+	if !isCustom {
+		// For non-custom domain, assume the domain is always an apex domain,
+		// in case the domain suffix is not yet in PSL.
+		apexDomain = domain
+	}
+
+	nonce := make([]byte, 16)
+	corerand.SecureRand.Read(nonce)
+	verificationNonce := hex.EncodeToString(nonce)
+
+	builder := newSQLBuilder().
+		Insert(pq.QuoteIdentifier("_portal_domain")).
+		Columns(
+			"id", "app_id", "created_at", "domain", "apex_domain", "verification_nonce", "is_custom",
+		).
+		Values(
+			uuid.New(),
+			appID,
+			time.Now().UTC(),
+			domain,
+			apexDomain,
+			verificationNonce,
+			false,
+		)
+
+	q, args, err := builder.ToSql()
+	if err != nil {
+		return err
+	}
+
+	_, err = tx.ExecContext(ctx, q, args...)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/cmd/portal/main.go
+++ b/cmd/portal/main.go
@@ -18,7 +18,7 @@ var cmdRoot = &cobra.Command{
 
 func init() {
 	cmdRoot.AddCommand(cmdStart)
-	cmdRoot.AddCommand(cmdMigrate)
+	cmdRoot.AddCommand(cmdDatabase)
 	cmdRoot.AddCommand(cmdInternal)
 }
 

--- a/cmd/portal/main.go
+++ b/cmd/portal/main.go
@@ -19,6 +19,7 @@ var cmdRoot = &cobra.Command{
 func init() {
 	cmdRoot.AddCommand(cmdStart)
 	cmdRoot.AddCommand(cmdMigrate)
+	cmdRoot.AddCommand(cmdInternal)
 }
 
 func main() {

--- a/cmd/portal/migrate.go
+++ b/cmd/portal/migrate.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"errors"
 	"log"
 	"os"
 	"strconv"
@@ -11,9 +10,6 @@ import (
 
 	"github.com/authgear/authgear-server/cmd/portal/migrate"
 )
-
-var DatabaseURL string
-var DatabaseSchema string
 
 func init() {
 	cmdMigrate.AddCommand(cmdMigrateNew)
@@ -116,21 +112,4 @@ var cmdMigrateStatus = &cobra.Command{
 			os.Exit(1)
 		}
 	},
-}
-
-func loadDBCredentials() (dbURL string, dbSchema string, err error) {
-	if DatabaseURL == "" {
-		DatabaseURL = os.Getenv("DATABASE_URL")
-	}
-	if DatabaseSchema == "" {
-		DatabaseSchema = os.Getenv("DATABASE_SCHEMA")
-	}
-
-	if DatabaseURL == "" {
-		return "", "", errors.New("missing database URL")
-	}
-	if DatabaseSchema == "" {
-		return "", "", errors.New("missing database schema")
-	}
-	return DatabaseURL, DatabaseSchema, nil
 }

--- a/cmd/portal/migrate.go
+++ b/cmd/portal/migrate.go
@@ -12,6 +12,8 @@ import (
 )
 
 func init() {
+	cmdDatabase.AddCommand(cmdMigrate)
+
 	cmdMigrate.AddCommand(cmdMigrateNew)
 	cmdMigrate.AddCommand(cmdMigrateUp)
 	cmdMigrate.AddCommand(cmdMigrateDown)
@@ -31,6 +33,11 @@ func init() {
 			"Database schema name",
 		)
 	}
+}
+
+var cmdDatabase = &cobra.Command{
+	Use:   "database migrate",
+	Short: "Database commands",
 }
 
 var cmdMigrate = &cobra.Command{


### PR DESCRIPTION
require #1140 

refs #1127 

To be discussed:
- I added the command to `./cmd/portal` instead of `./cmd/auth`, seems more appropriate. 
- After implementing it, I found the arguments `default-domain` and `custom-domain` looks like domains of portal, maybe rename to `default-auth-domain` and `custom-auth-domain` are better?