### PR TITLE
Fix old_identity and new_identity payload are swapped in login id update event

### DIFF
--- a/pkg/lib/interaction/nodes/do_update_identity.go
+++ b/pkg/lib/interaction/nodes/do_update_identity.go
@@ -70,8 +70,8 @@ func (n *NodeDoUpdateIdentity) GetEffects() ([]interaction.Effect, error) {
 				loginIDType := n.IdentityAfterUpdate.Claims[identity.IdentityClaimLoginIDType].(string)
 				e = nonblocking.NewIdentityLoginIDUpdatedEventPayload(
 					*user,
-					n.IdentityBeforeUpdate.ToModel(),
 					n.IdentityAfterUpdate.ToModel(),
+					n.IdentityBeforeUpdate.ToModel(),
 					loginIDType,
 					n.IsAdminAPI,
 				)


### PR DESCRIPTION
fix #1197 