### PR TITLE
Update to apply Content Security Policy to web app pages only

### DIFF
--- a/pkg/auth/routes.go
+++ b/pkg/auth/routes.go
@@ -31,7 +31,6 @@ func NewRouter(p *deps.RootProvider, configSource *configsource.ConfigSource) *h
 		},
 		p.Middleware(newPanicLogMiddleware),
 		p.Middleware(newSessionMiddleware),
-		p.Middleware(newSecHeadersMiddleware),
 		p.Middleware(newPublicOriginMiddleware),
 	)
 
@@ -90,6 +89,7 @@ func NewRouter(p *deps.RootProvider, configSource *configsource.ConfigSource) *h
 		webappChain,
 		p.Middleware(newCSRFMiddleware),
 		webapp.TurbolinksMiddleware{},
+		p.Middleware(newSecHeadersMiddleware),
 	)
 	webappAuthEntrypointChain := httproute.Chain(
 		webappPageChain,


### PR DESCRIPTION
To solve the problem of the inline script doesn't work in the authorization
endpoint response.

ref #1203