### PR TITLE
Support continue or use another account when triggering authentication

### DIFF
--- a/pkg/auth/deps.go
+++ b/pkg/auth/deps.go
@@ -107,4 +107,5 @@ var DependencySet = wire.NewSet(
 	wire.Bind(new(handlerwebapp.RateLimiter), new(*ratelimit.Limiter)),
 	wire.Bind(new(handlerwebapp.JSONResponseWriter), new(*httputil.JSONResponseWriter)),
 	wire.Bind(new(handlerwebapp.FlashMessage), new(*httputil.FlashMessage)),
+	wire.Bind(new(handlerwebapp.IdentityService), new(*identityservice.Service)),
 )

--- a/pkg/auth/handler/webapp/controller.go
+++ b/pkg/auth/handler/webapp/controller.go
@@ -17,6 +17,7 @@ import (
 
 type PageService interface {
 	UpdateSession(session *webapp.Session) error
+	DeleteSession(id string) error
 	Get(session *webapp.Session) (*interaction.Graph, error)
 	GetSession(id string) (*webapp.Session, error)
 	GetWithIntent(session *webapp.Session, intent interaction.Intent) (*interaction.Graph, error)
@@ -128,6 +129,10 @@ func (c *Controller) UpdateSession(s *webapp.Session) error {
 	}
 
 	return nil
+}
+
+func (c *Controller) DeleteSession(id string) error {
+	return c.Page.DeleteSession(id)
 }
 
 func (c *Controller) Serve() {

--- a/pkg/auth/handler/webapp/deps.go
+++ b/pkg/auth/handler/webapp/deps.go
@@ -21,6 +21,7 @@ var DependencySet = wire.NewSet(
 	wire.Struct(new(LoginHandler), "*"),
 	wire.Struct(new(SignupHandler), "*"),
 	wire.Struct(new(PromoteHandler), "*"),
+	wire.Struct(new(SelectAccountHandler), "*"),
 	wire.Struct(new(SSOCallbackHandler), "*"),
 	wire.Struct(new(EnterLoginIDHandler), "*"),
 	wire.Struct(new(EnterPasswordHandler), "*"),

--- a/pkg/auth/handler/webapp/identity.go
+++ b/pkg/auth/handler/webapp/identity.go
@@ -1,0 +1,50 @@
+package webapp
+
+import (
+	"fmt"
+
+	"github.com/authgear/authgear-server/pkg/lib/authn"
+	"github.com/authgear/authgear-server/pkg/lib/authn/identity"
+)
+
+// identitiesDisplayNamePriorities indicates which identity type will be shown
+// as the identitiesDisplayName
+// Higher level means more willing to be shown
+var identitiesDisplayNamePriorities = map[authn.IdentityType]int{
+	authn.IdentityTypeLoginID: 2,
+	authn.IdentityTypeOAuth:   1,
+}
+
+func IdentitiesDisplayName(identities []*identity.Info) string {
+	level := 0
+	var i *identity.Info
+	for _, perIdentity := range identities {
+		l := identitiesDisplayNamePriorities[perIdentity.Type]
+		if l >= level {
+			level = l
+			i = perIdentity
+		}
+	}
+
+	if i == nil {
+		return ""
+	}
+
+	switch i.Type {
+	case authn.IdentityTypeLoginID:
+		return i.DisplayID()
+	case authn.IdentityTypeOAuth:
+		providerType, _ := i.Claims[identity.IdentityClaimOAuthProviderType].(string)
+		displayID := i.DisplayID()
+		if displayID != "" {
+			return fmt.Sprintf("%s:%s", providerType, i.DisplayID())
+		}
+		return providerType
+	case authn.IdentityTypeAnonymous:
+		return "anonymous"
+	case authn.IdentityTypeBiometric:
+		return "biometric"
+	default:
+		return ""
+	}
+}

--- a/pkg/auth/handler/webapp/identity_test.go
+++ b/pkg/auth/handler/webapp/identity_test.go
@@ -1,0 +1,66 @@
+package webapp_test
+
+import (
+	"testing"
+
+	. "github.com/smartystreets/goconvey/convey"
+
+	"github.com/authgear/authgear-server/pkg/auth/handler/webapp"
+	"github.com/authgear/authgear-server/pkg/lib/authn"
+	"github.com/authgear/authgear-server/pkg/lib/authn/identity"
+)
+
+func TestIdentitiesDisplayName(t *testing.T) {
+	emailIdentity := &identity.Info{
+		Type: authn.IdentityTypeLoginID,
+		Claims: map[string]interface{}{
+			identity.IdentityClaimLoginIDOriginalValue: "user@example.com",
+		},
+	}
+
+	oauthProviderIdentity := &identity.Info{
+		Type: authn.IdentityTypeOAuth,
+		Claims: map[string]interface{}{
+			identity.IdentityClaimOAuthProviderType: "provider",
+			identity.StandardClaimEmail:             "user@oauth-provider.com",
+		},
+	}
+
+	oauthProviderIdentityWithStandardClaims := &identity.Info{
+		Type: authn.IdentityTypeOAuth,
+		Claims: map[string]interface{}{
+			identity.IdentityClaimOAuthProviderType: "provider2",
+		},
+	}
+
+	anonymousIdentity := &identity.Info{
+		Type: authn.IdentityTypeAnonymous,
+	}
+
+	biometricIdentity := &identity.Info{
+		Type: authn.IdentityTypeBiometric,
+	}
+
+	Convey("identitiesDisplayName", t, func() {
+		displayName := webapp.IdentitiesDisplayName([]*identity.Info{
+			anonymousIdentity,
+			oauthProviderIdentity,
+			biometricIdentity,
+			emailIdentity,
+		})
+		So(displayName, ShouldEqual, "user@example.com")
+
+		displayName = webapp.IdentitiesDisplayName([]*identity.Info{
+			anonymousIdentity,
+			oauthProviderIdentity,
+			biometricIdentity,
+		})
+		So(displayName, ShouldEqual, "provider:user@oauth-provider.com")
+
+		displayName = webapp.IdentitiesDisplayName([]*identity.Info{
+			oauthProviderIdentityWithStandardClaims,
+		})
+		So(displayName, ShouldEqual, "provider2")
+
+	})
+}

--- a/pkg/auth/handler/webapp/root.go
+++ b/pkg/auth/handler/webapp/root.go
@@ -3,11 +3,7 @@ package webapp
 import (
 	"net/http"
 
-	"github.com/authgear/authgear-server/pkg/auth/webapp"
-	"github.com/authgear/authgear-server/pkg/lib/config"
-	"github.com/authgear/authgear-server/pkg/lib/session"
 	"github.com/authgear/authgear-server/pkg/util/httproute"
-	"github.com/authgear/authgear-server/pkg/util/slice"
 )
 
 func ConfigureRootRoute(route httproute.Route) httproute.Route {
@@ -17,39 +13,8 @@ func ConfigureRootRoute(route httproute.Route) httproute.Route {
 }
 
 type RootHandler struct {
-	AuthenticationConfig *config.AuthenticationConfig
-	SignedUpCookie       webapp.SignedUpCookieDef
 }
 
 func (h *RootHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	userID := session.GetUserID(r.Context())
-	webSession := webapp.GetSession(r.Context())
-
-	loginPrompt := false
-	fromAuthzEndpoint := false
-	if webSession != nil {
-		// stay in the auth entry point if prompt = login
-		loginPrompt = slice.ContainsString(webSession.Prompt, "login")
-		fromAuthzEndpoint = webSession.ClientID != ""
-	}
-
-	path := ""
-	if fromAuthzEndpoint && userID != nil && !loginPrompt {
-		path = "/select_account"
-	} else {
-		signedUpCookie, err := r.Cookie(h.SignedUpCookie.Def.Name)
-		signedUp := (err == nil && signedUpCookie.Value == "true")
-		path = GetAuthenticationEndpoint(signedUp, h.AuthenticationConfig.PublicSignupDisabled)
-	}
-
-	http.Redirect(w, r, path, http.StatusFound)
-}
-
-func GetAuthenticationEndpoint(signedUp bool, publicSignupDisabled bool) string {
-	path := "/signup"
-	if publicSignupDisabled || signedUp {
-		path = "/login"
-	}
-
-	return path
+	http.Redirect(w, r, "/select_account", http.StatusFound)
 }

--- a/pkg/auth/handler/webapp/select_account.go
+++ b/pkg/auth/handler/webapp/select_account.go
@@ -1,0 +1,69 @@
+package webapp
+
+import (
+	"net/http"
+
+	"github.com/authgear/authgear-server/pkg/auth/handler/webapp/viewmodels"
+	"github.com/authgear/authgear-server/pkg/auth/webapp"
+	"github.com/authgear/authgear-server/pkg/util/httproute"
+	"github.com/authgear/authgear-server/pkg/util/template"
+)
+
+var TemplateWebSelectAccountHTML = template.RegisterHTML(
+	"web/select_account.html",
+	components...,
+)
+
+func ConfigureSelectAccountRoute(route httproute.Route) httproute.Route {
+	return route.
+		WithMethods("OPTIONS", "POST", "GET").
+		WithPathPattern("/select_account")
+}
+
+type SelectAccountHandler struct {
+	ControllerFactory ControllerFactory
+	BaseViewModel     *viewmodels.BaseViewModeler
+	Renderer          Renderer
+}
+
+func (h *SelectAccountHandler) GetData(r *http.Request, rw http.ResponseWriter) (map[string]interface{}, error) {
+	data := make(map[string]interface{})
+	baseViewModel := h.BaseViewModel.ViewModel(r, rw)
+	viewmodels.EmbedForm(data, r.Form)
+	viewmodels.Embed(data, baseViewModel)
+	return data, nil
+}
+
+func (h *SelectAccountHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	ctrl, err := h.ControllerFactory.New(r, w)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+	defer ctrl.Serve()
+
+	redirectURI := "/settings"
+	if s := webapp.GetSession(r.Context()); s != nil {
+		redirectURI = s.RedirectURI
+	}
+
+	ctrl.Get(func() error {
+		data, err := h.GetData(r, w)
+		if err != nil {
+			return err
+		}
+		h.Renderer.RenderHTML(w, r, TemplateWebSelectAccountHTML, data)
+		return nil
+	})
+
+	ctrl.PostAction("continue", func() error {
+		http.Redirect(w, r, redirectURI, http.StatusFound)
+		return nil
+	})
+
+	ctrl.PostAction("login", func() error {
+		http.Redirect(w, r, "/login", http.StatusFound)
+		return nil
+	})
+
+}

--- a/pkg/auth/handler/webapp/select_account.go
+++ b/pkg/auth/handler/webapp/select_account.go
@@ -42,11 +42,6 @@ func (h *SelectAccountHandler) ServeHTTP(w http.ResponseWriter, r *http.Request)
 	}
 	defer ctrl.Serve()
 
-	redirectURI := "/settings"
-	if s := webapp.GetSession(r.Context()); s != nil {
-		redirectURI = s.RedirectURI
-	}
-
 	ctrl.Get(func() error {
 		data, err := h.GetData(r, w)
 		if err != nil {
@@ -57,6 +52,16 @@ func (h *SelectAccountHandler) ServeHTTP(w http.ResponseWriter, r *http.Request)
 	})
 
 	ctrl.PostAction("continue", func() error {
+		redirectURI := "/settings"
+		// continue to use the previous session
+		// complete the web session and redirect to web session's RedirectURI
+		if s := webapp.GetSession(r.Context()); s != nil {
+			redirectURI = s.RedirectURI
+			if err := ctrl.DeleteSession(s.ID); err != nil {
+				return err
+			}
+		}
+
 		http.Redirect(w, r, redirectURI, http.StatusFound)
 		return nil
 	})

--- a/pkg/auth/routes.go
+++ b/pkg/auth/routes.go
@@ -114,6 +114,7 @@ func NewRouter(p *deps.RootProvider, configSource *configsource.ConfigSource) *h
 	router.Add(webapphandler.ConfigureRootRoute(webappAuthEntrypointRoute), p.Handler(newWebAppRootHandler))
 	router.Add(webapphandler.ConfigureLoginRoute(webappAuthEntrypointRoute), p.Handler(newWebAppLoginHandler))
 	router.Add(webapphandler.ConfigureSignupRoute(webappAuthEntrypointRoute), p.Handler(newWebAppSignupHandler))
+	router.Add(webapphandler.ConfigureSelectAccountRoute(webappAuthEntrypointRoute), p.Handler(newWebAppSelectAccountHandler))
 
 	router.Add(webapphandler.ConfigurePromoteRoute(webappPageRoute), p.Handler(newWebAppPromoteHandler))
 	router.Add(webapphandler.ConfigureEnterPasswordRoute(webappPageRoute), p.Handler(newWebAppEnterPasswordHandler))

--- a/pkg/auth/webapp/auth_entry_point_middleware.go
+++ b/pkg/auth/webapp/auth_entry_point_middleware.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/authgear/authgear-server/pkg/lib/config"
 	"github.com/authgear/authgear-server/pkg/lib/session"
-	"github.com/authgear/authgear-server/pkg/util/slice"
 )
 
 type AuthEntryPointMiddleware struct {
@@ -17,13 +16,13 @@ func (m AuthEntryPointMiddleware) Handle(next http.Handler) http.Handler {
 		userID := session.GetUserID(r.Context())
 		webSession := GetSession(r.Context())
 
-		hasPrompt := false
+		fromAuthzEndpoint := false
 		if webSession != nil {
-			// stay in the auth entry point if prompt = login
-			hasPrompt = slice.ContainsString(webSession.Prompt, "login")
+			// stay in the auth entry point if login is triggered by authz endpoint
+			fromAuthzEndpoint = webSession.ClientID != ""
 		}
 
-		if userID != nil && !hasPrompt {
+		if userID != nil && !fromAuthzEndpoint {
 			defaultRedirectURI := "/settings"
 			redirectURI := GetRedirectURI(r, bool(m.TrustProxy), defaultRedirectURI)
 

--- a/pkg/auth/webapp/service2.go
+++ b/pkg/auth/webapp/service2.go
@@ -72,6 +72,10 @@ func (s *Service2) UpdateSession(session *Session) error {
 	return s.Sessions.Update(session)
 }
 
+func (s *Service2) DeleteSession(sessionID string) error {
+	return s.Sessions.Delete(sessionID)
+}
+
 func (s *Service2) Get(session *Session) (*interaction.Graph, error) {
 	graph, err := s.Graph.Get(session.CurrentStep().GraphID)
 	if err != nil {

--- a/pkg/auth/wire_gen.go
+++ b/pkg/auth/wire_gen.go
@@ -3121,16 +3121,7 @@ func newOAuthAppSessionTokenHandler(p *deps.RequestProvider) http.Handler {
 }
 
 func newWebAppRootHandler(p *deps.RequestProvider) http.Handler {
-	appProvider := p.AppProvider
-	config := appProvider.Config
-	appConfig := config.AppConfig
-	authenticationConfig := appConfig.Authentication
-	httpConfig := appConfig.HTTP
-	signedUpCookieDef := webapp.NewSignedUpCookieDef(httpConfig)
-	rootHandler := &webapp2.RootHandler{
-		AuthenticationConfig: authenticationConfig,
-		SignedUpCookie:       signedUpCookieDef,
-	}
+	rootHandler := &webapp2.RootHandler{}
 	return rootHandler
 }
 
@@ -5350,9 +5341,11 @@ func newWebAppSelectAccountHandler(p *deps.RequestProvider) http.Handler {
 		ControllerDeps: controllerDeps,
 	}
 	selectAccountHandler := &webapp2.SelectAccountHandler{
-		ControllerFactory: controllerFactory,
-		BaseViewModel:     baseViewModeler,
-		Renderer:          responseRenderer,
+		ControllerFactory:    controllerFactory,
+		BaseViewModel:        baseViewModeler,
+		Renderer:             responseRenderer,
+		AuthenticationConfig: authenticationConfig,
+		SignedUpCookie:       signedUpCookieDef,
 	}
 	return selectAccountHandler
 }

--- a/pkg/auth/wire_gen.go
+++ b/pkg/auth/wire_gen.go
@@ -5346,6 +5346,7 @@ func newWebAppSelectAccountHandler(p *deps.RequestProvider) http.Handler {
 		Renderer:             responseRenderer,
 		AuthenticationConfig: authenticationConfig,
 		SignedUpCookie:       signedUpCookieDef,
+		Identities:           serviceService,
 	}
 	return selectAccountHandler
 }

--- a/pkg/auth/wire_handler.go
+++ b/pkg/auth/wire_handler.go
@@ -103,6 +103,13 @@ func newWebAppPromoteHandler(p *deps.RequestProvider) http.Handler {
 	))
 }
 
+func newWebAppSelectAccountHandler(p *deps.RequestProvider) http.Handler {
+	panic(wire.Build(
+		DependencySet,
+		wire.Bind(new(http.Handler), new(*handlerwebapp.SelectAccountHandler)),
+	))
+}
+
 func newWebAppSSOCallbackHandler(p *deps.RequestProvider) http.Handler {
 	panic(wire.Build(
 		DependencySet,

--- a/pkg/lib/oauth/handler/handler_authz_test.go
+++ b/pkg/lib/oauth/handler/handler_authz_test.go
@@ -174,6 +174,7 @@ func TestAuthorizationHandler(t *testing.T) {
 						"code_challenge":        "E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM",
 						"nonce":                 "my-nonce",
 						"state":                 "my-state",
+						"prompt":                "none",
 					})
 					So(resp.Result().StatusCode, ShouldEqual, 200)
 
@@ -220,6 +221,7 @@ func TestAuthorizationHandler(t *testing.T) {
 						"scope":                 "openid offline_access",
 						"code_challenge_method": "S256",
 						"code_challenge":        "E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM",
+						"prompt":                "none",
 					})
 					So(resp.Result().StatusCode, ShouldEqual, 200)
 
@@ -303,6 +305,7 @@ func TestAuthorizationHandler(t *testing.T) {
 						"response_type": "none",
 						"scope":         "openid",
 						"state":         "my-state",
+						"prompt":        "none",
 					})
 					So(resp.Result().StatusCode, ShouldEqual, 200)
 

--- a/pkg/lib/oauth/handler/handler_authz_test.go
+++ b/pkg/lib/oauth/handler/handler_authz_test.go
@@ -2,6 +2,7 @@ package handler_test
 
 import (
 	"context"
+	"html/template"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -18,7 +19,33 @@ import (
 	"github.com/authgear/authgear-server/pkg/util/clock"
 )
 
+const htmlRedirectTemplateString = `<!DOCTYPE html>
+<html>
+<head>
+<meta http-equiv="refresh" content="0;url={{ .redirect_uri }}" />
+</head>
+<body>
+<script>
+window.location.href = "{{ .redirect_uri }}"
+</script>
+</body>
+</html>
+`
+
 func TestAuthorizationHandler(t *testing.T) {
+
+	htmlRedirectTemplate, _ := template.New("html_redirect").Parse(htmlRedirectTemplateString)
+	redirectHTML := func(redirectURI string) string {
+		buf := strings.Builder{}
+		_ = htmlRedirectTemplate.Execute(&buf, map[string]string{
+			"redirect_uri": redirectURI,
+		})
+		return buf.String()
+	}
+	redirection := func(resp *httptest.ResponseRecorder) string {
+		return resp.Header().Get("Location")
+	}
+
 	Convey("Authorization handler", t, func() {
 		clock := clock.NewMockClockAt("2020-02-01T00:00:00Z")
 		authzStore := &mockAuthzStore{}
@@ -81,6 +108,9 @@ func TestAuthorizationHandler(t *testing.T) {
 					"redirect_uri": "http://accounts.example.com/settings",
 				})
 				So(resp.Result().StatusCode, ShouldEqual, 200)
+				So(resp.Body.String(), ShouldEqual, redirectHTML(
+					"http://accounts.example.com/settings?error=unauthorized_client&error_description=response+type+is+not+allowed+for+this+client",
+				))
 			})
 		})
 
@@ -94,6 +124,9 @@ func TestAuthorizationHandler(t *testing.T) {
 				"response_type": "code",
 			})
 			So(resp.Result().StatusCode, ShouldEqual, 200)
+			So(resp.Body.String(), ShouldEqual, redirectHTML(
+				"https://example.com/cb?error=invalid_request&error_description=scope+is+required&from=sso",
+			))
 		})
 
 		Convey("authorization code flow", func() {
@@ -108,6 +141,9 @@ func TestAuthorizationHandler(t *testing.T) {
 						"response_type": "code",
 					})
 					So(resp.Result().StatusCode, ShouldEqual, 200)
+					So(resp.Body.String(), ShouldEqual, redirectHTML(
+						"https://example.com/?error=invalid_request&error_description=scope+is+required",
+					))
 				})
 				Convey("missing PKCE code challenge", func() {
 					resp := handle(protocol.AuthorizationRequest{
@@ -116,6 +152,9 @@ func TestAuthorizationHandler(t *testing.T) {
 						"scope":         "openid",
 					})
 					So(resp.Result().StatusCode, ShouldEqual, 200)
+					So(resp.Body.String(), ShouldEqual, redirectHTML(
+						"https://example.com/?error=invalid_request&error_description=PKCE+code+challenge+is+required",
+					))
 				})
 				Convey("unsupported PKCE transform", func() {
 					resp := handle(protocol.AuthorizationRequest{
@@ -126,6 +165,9 @@ func TestAuthorizationHandler(t *testing.T) {
 						"code_challenge":        "code-verifier",
 					})
 					So(resp.Result().StatusCode, ShouldEqual, 200)
+					So(resp.Body.String(), ShouldEqual, redirectHTML(
+						"https://example.com/?error=invalid_request&error_description=only+%27S256%27+PKCE+transform+is+supported",
+					))
 				})
 			})
 			Convey("scope validation", func() {
@@ -147,6 +189,9 @@ func TestAuthorizationHandler(t *testing.T) {
 				})
 				So(validated, ShouldBeTrue)
 				So(resp.Result().StatusCode, ShouldEqual, 200)
+				So(resp.Body.String(), ShouldEqual, redirectHTML(
+					"https://example.com/?error=invalid_scope&error_description=must+request+%27openid%27+scope",
+				))
 			})
 			Convey("request authentication", func() {
 				resp := handle(protocol.AuthorizationRequest{
@@ -158,6 +203,7 @@ func TestAuthorizationHandler(t *testing.T) {
 					"ui_locales":            "ja",
 				})
 				So(resp.Result().StatusCode, ShouldEqual, 302)
+				So(redirection(resp), ShouldEqual, "https://auth/authenticate")
 			})
 			Convey("return authorization code", func() {
 				h.Context = sessiontest.NewMockSession().
@@ -177,6 +223,9 @@ func TestAuthorizationHandler(t *testing.T) {
 						"prompt":                "none",
 					})
 					So(resp.Result().StatusCode, ShouldEqual, 200)
+					So(resp.Body.String(), ShouldEqual, redirectHTML(
+						"https://example.com/?code=authz-code&state=my-state",
+					))
 
 					So(authzStore.authzs, ShouldHaveLength, 1)
 					So(authzStore.authzs[0], ShouldResemble, oauth.Authorization{
@@ -224,6 +273,9 @@ func TestAuthorizationHandler(t *testing.T) {
 						"prompt":                "none",
 					})
 					So(resp.Result().StatusCode, ShouldEqual, 200)
+					So(resp.Body.String(), ShouldEqual, redirectHTML(
+						"https://example.com/?code=authz-code",
+					))
 
 					So(authzStore.authzs, ShouldHaveLength, 1)
 					So(authzStore.authzs[0], ShouldResemble, oauth.Authorization{
@@ -265,6 +317,9 @@ func TestAuthorizationHandler(t *testing.T) {
 						"response_type": "none",
 					})
 					So(resp.Result().StatusCode, ShouldEqual, 200)
+					So(resp.Body.String(), ShouldEqual, redirectHTML(
+						"https://example.com/?error=unauthorized_client&error_description=response+type+is+not+allowed+for+this+client",
+					))
 				})
 			})
 			Convey("scope validation", func() {
@@ -284,6 +339,9 @@ func TestAuthorizationHandler(t *testing.T) {
 				})
 				So(validated, ShouldBeTrue)
 				So(resp.Result().StatusCode, ShouldEqual, 200)
+				So(resp.Body.String(), ShouldEqual, redirectHTML(
+					"https://example.com/?error=invalid_scope&error_description=must+request+%27openid%27+scope",
+				))
 			})
 			Convey("request authentication", func() {
 				resp := handle(protocol.AuthorizationRequest{
@@ -292,6 +350,7 @@ func TestAuthorizationHandler(t *testing.T) {
 					"scope":         "openid",
 				})
 				So(resp.Result().StatusCode, ShouldEqual, 302)
+				So(redirection(resp), ShouldEqual, "https://auth/authenticate")
 			})
 			Convey("redirect to URI", func() {
 				h.Context = sessiontest.NewMockSession().
@@ -308,6 +367,9 @@ func TestAuthorizationHandler(t *testing.T) {
 						"prompt":        "none",
 					})
 					So(resp.Result().StatusCode, ShouldEqual, 200)
+					So(resp.Body.String(), ShouldEqual, redirectHTML(
+						"https://example.com/?state=my-state",
+					))
 
 					So(authzStore.authzs, ShouldHaveLength, 1)
 					So(authzStore.authzs[0], ShouldResemble, oauth.Authorization{

--- a/resources/authgear/static/authgear.css
+++ b/resources/authgear/static/authgear.css
@@ -424,7 +424,7 @@ h1, h2, h3, h4, h5, h6 {
 }
 
 .margin-r-10 {
-  margin-right: 8px;
+  margin-right: 10px;
 }
 
 .padding-0 {
@@ -537,6 +537,11 @@ h1, h2, h3, h4, h5, h6 {
   line-height: 1.75rem;
 }
 
+.text-4xl {
+  font-size: 2.25rem;
+  line-height: 2.5rem;
+}
+
 .font-normal {
   font-weight: 400;
 }
@@ -547,6 +552,10 @@ h1, h2, h3, h4, h5, h6 {
 
 .font-bold {
   font-weight: 700;
+}
+
+.leading-10 {
+  line-height: 2.5rem;
 }
 
 .leading-none {

--- a/resources/authgear/templates/en/translation.json
+++ b/resources/authgear/templates/en/translation.json
@@ -289,5 +289,11 @@
 
   "toc-pp-footer": "By registering, you agree to our <a class=\"link\" target=\"_blank\" href=\"{termsOfService}\">Terms of Service</a> and <a class=\"link\" target=\"_blank\" href=\"{privacyPolicy}\">Privacy Policy</a>",
   "terms-of-service-link": "https://www.authgear.com/terms",
-  "privacy-policy-link": "https://www.authgear.com/data-privacy"
+  "privacy-policy-link": "https://www.authgear.com/data-privacy",
+
+  "select-account-confirm-login": "Confirm Login",
+  "select-account-previously-logged-in-description": "You previously logged in to {AppOrClientName}",
+  "select-account-continue-description": "Would like to continue?",
+  "select-account-continue-label": "Continue",
+  "select-account-use-another-account-label": "Use another account"
 }

--- a/resources/authgear/templates/en/translation.json
+++ b/resources/authgear/templates/en/translation.json
@@ -291,9 +291,8 @@
   "terms-of-service-link": "https://www.authgear.com/terms",
   "privacy-policy-link": "https://www.authgear.com/data-privacy",
 
-  "select-account-confirm-login": "Confirm Login",
-  "select-account-previously-logged-in-description": "You previously logged in to {AppOrClientName}",
-  "select-account-continue-description": "Would like to continue?",
+  "select-account-title": "Continue to {AppOrClientName}",
+  "select-account-you-are-using-description": "You are using",
   "select-account-continue-label": "Continue",
   "select-account-use-another-account-label": "Use another account"
 }

--- a/resources/authgear/templates/en/web/select_account.html
+++ b/resources/authgear/templates/en/web/select_account.html
@@ -6,18 +6,24 @@
 {{ template "__nav_bar.html" true }}
 <div class="flex flex-col width-full margin-v-20">
 
-<h1 class="primary-txt margin-v-20 text-center text-xl font-bold">{{ template "select-account-confirm-login" }}</h1>
-
-<p class="text-sm break-words primary-txt margin-t-0 margin-b-20 text-center">
+<h1 class="primary-txt margin-v-20 text-center text-xl font-bold">
     {{ if $.ClientName }}
-    {{ template "select-account-previously-logged-in-description" (dict "AppOrClientName" $.ClientName) }}
+    {{ template "select-account-title" (dict "AppOrClientName" $.ClientName) }}
     {{ else }}
     {{ $appName := ($.Translations.RenderText "app.name" nil) }}
-    {{ template "select-account-previously-logged-in-description" (dict "AppOrClientName" $appName) }}
+    {{ template "select-account-title" (dict "AppOrClientName" $appName) }}
     {{ end }}
+</h1>
+
+<p class="text-sm primary-txt margin-t-0 margin-b-20 text-center">
+    {{ template "select-account-you-are-using-description" }}
 </p>
 
-<p class="text-sm break-words primary-txt margin-t-0 margin-b-20 text-center">{{ template "select-account-continue-description" }}</p>
+<div class="primary-txt margin-b-20 text-center flex flex-row justify-center justify-center">
+    <i class="ti ti-user text-4xl leading-10"></i>
+    <span class="margin-l-8 truncate text-base leading-10">{{ $.IdentityDisplayName }}</span>
+</div>
+
 
 <form class="flex flex-col width-full margin-b-20" method="post" novalidate>
     {{ $.CSRFField }}

--- a/resources/authgear/templates/en/web/select_account.html
+++ b/resources/authgear/templates/en/web/select_account.html
@@ -1,0 +1,36 @@
+{{ template "__page_frame.html" . }}
+
+{{ define "page-content" }}
+<div class="content">
+<div class="pane flex flex-col">
+{{ template "__nav_bar.html" true }}
+<div class="flex flex-col width-full margin-v-20">
+
+<h1 class="primary-txt margin-v-20 text-center text-xl font-bold">{{ template "select-account-confirm-login" }}</h1>
+
+<p class="text-sm break-words primary-txt margin-t-0 margin-b-20 text-center">
+    {{ if $.ClientName }}
+    {{ template "select-account-previously-logged-in-description" (dict "AppOrClientName" $.ClientName) }}
+    {{ else }}
+    {{ $appName := ($.Translations.RenderText "app.name" nil) }}
+    {{ template "select-account-previously-logged-in-description" (dict "AppOrClientName" $appName) }}
+    {{ end }}
+</p>
+
+<p class="text-sm break-words primary-txt margin-t-0 margin-b-20 text-center">{{ template "select-account-continue-description" }}</p>
+
+<form class="flex flex-col width-full margin-b-20" method="post" novalidate>
+    {{ $.CSRFField }}
+    <button class="btn primary-btn submit-btn" type="submit" name="x_action" value="continue" data-form-xhr="false">{{ template "select-account-continue-label" }}</button>
+</form>
+
+<form class="flex flex-col width-full margin-b-20" method="post" novalidate>
+    {{ $.CSRFField }}
+    <button class="btn light-btn submit-btn" type="submit" name="x_action" value="login" data-form-xhr="false">{{ template "select-account-use-another-account-label" }}</button>
+</form>
+
+</div>
+<div class="footer-watermark margin-v-20"></div>
+</div>
+</div>
+{{ end }}

--- a/resources/authgear/templates/zh-HK/translation.json
+++ b/resources/authgear/templates/zh-HK/translation.json
@@ -291,9 +291,8 @@
   "terms-of-service-link": "https://www.authgear.com/terms-of-services",
   "privacy-policy-link": "https://www.authgear.com/data-privacy",
 
-  "select-account-confirm-login": "確認登錄",
-  "select-account-previously-logged-in-description": "您之前登入過 {AppOrClientName}",
-  "select-account-continue-description": "使用相同帳戶登入?",
+  "select-account-title": "繼續至 {AppOrClientName}",
+  "select-account-you-are-using-description": "您正在使用",
   "select-account-continue-label": "繼續",
   "select-account-use-another-account-label": "使用另一個帳戶"
 }

--- a/resources/authgear/templates/zh-HK/translation.json
+++ b/resources/authgear/templates/zh-HK/translation.json
@@ -289,5 +289,11 @@
 
   "toc-pp-footer": "註冊即表示我已同意 <a target=\"_blank\" href=\"{termsOfService}\">條款和細則</a> 及 <a target=\"_blank\" href=\"{privacyPolicy}\">隱私政策</a>.",
   "terms-of-service-link": "https://www.authgear.com/terms-of-services",
-  "privacy-policy-link": "https://www.authgear.com/data-privacy"
+  "privacy-policy-link": "https://www.authgear.com/data-privacy",
+
+  "select-account-confirm-login": "確認登錄",
+  "select-account-previously-logged-in-description": "您之前登入過 {AppOrClientName}",
+  "select-account-continue-description": "使用相同帳戶登入?",
+  "select-account-continue-label": "繼續",
+  "select-account-use-another-account-label": "使用另一個帳戶"
 }

--- a/resources/authgear/templates/zh-TW/translation.json
+++ b/resources/authgear/templates/zh-TW/translation.json
@@ -291,9 +291,8 @@
   "terms-of-service-link": "https://www.authgear.com/terms-of-services",
   "privacy-policy-link": "https://www.authgear.com/data-privacy",
 
-  "select-account-confirm-login": "確認登錄",
-  "select-account-previously-logged-in-description": "您之前登入過 {AppOrClientName}",
-  "select-account-continue-description": "使用相同帳戶登入?",
+  "select-account-title": "繼續至 {AppOrClientName}",
+  "select-account-you-are-using-description": "您正在使用",
   "select-account-continue-label": "繼續",
   "select-account-use-another-account-label": "使用另一個帳戶"
 }

--- a/resources/authgear/templates/zh-TW/translation.json
+++ b/resources/authgear/templates/zh-TW/translation.json
@@ -289,5 +289,11 @@
 
   "toc-pp-footer": "註冊即表示我已同意 <a target=\"_blank\" href=\"{termsOfService}\">條款和細則</a> 及 <a target=\"_blank\" href=\"{privacyPolicy}\">隱私政策</a>.",
   "terms-of-service-link": "https://www.authgear.com/terms-of-services",
-  "privacy-policy-link": "https://www.authgear.com/data-privacy"
+  "privacy-policy-link": "https://www.authgear.com/data-privacy",
+
+  "select-account-confirm-login": "確認登錄",
+  "select-account-previously-logged-in-description": "您之前登入過 {AppOrClientName}",
+  "select-account-continue-description": "使用相同帳戶登入?",
+  "select-account-continue-label": "繼續",
+  "select-account-use-another-account-label": "使用另一個帳戶"
 }


### PR DESCRIPTION
ref #1258 

WIP:
- [x] Display user email, phone, username or sometime that can identify the user in select account page
- [x] Delete web session after user choose to continue, since the web session should be completed
- [x] Redirect to login when user visit the select account page without idp session
- [x] Refactor to always redirect to `select_account` from `root` and centralize the redirect logic in `select_account` handler