### PR TITLE
Add middleware logs for diagnostic

### DIFF
--- a/pkg/auth/webapp/deps.go
+++ b/pkg/auth/webapp/deps.go
@@ -22,6 +22,8 @@ var DependencySet = wire.NewSet(
 	wire.Struct(new(UILocalesMiddleware), "*"),
 	wire.Struct(new(WeChatRedirectURIMiddleware), "*"),
 	wire.Struct(new(ClientIDMiddleware), "*"),
+
+	NewPublicOriginMiddlewareLogger,
 	wire.Struct(new(PublicOriginMiddleware), "*"),
 
 	NewServiceLogger,

--- a/pkg/auth/webapp/public_origin_middleware.go
+++ b/pkg/auth/webapp/public_origin_middleware.go
@@ -6,17 +6,26 @@ import (
 
 	"github.com/authgear/authgear-server/pkg/lib/config"
 	"github.com/authgear/authgear-server/pkg/util/httputil"
+	"github.com/authgear/authgear-server/pkg/util/log"
 )
+
+type PublicOriginMiddlewareLogger struct{ *log.Logger }
+
+func NewPublicOriginMiddlewareLogger(lf *log.Factory) PublicOriginMiddlewareLogger {
+	return PublicOriginMiddlewareLogger{lf.New("public-origin-middleware")}
+}
 
 type PublicOriginMiddleware struct {
 	Config     *config.HTTPConfig
 	TrustProxy config.TrustProxy
+	Logger     PublicOriginMiddlewareLogger
 }
 
 func (m *PublicOriginMiddleware) Handle(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		publicOrigin, err := url.Parse(m.Config.PublicOrigin)
 		if err != nil {
+			m.Logger.WithError(err).Error("failed to parse public origin")
 			panic(err)
 		}
 
@@ -32,6 +41,7 @@ func (m *PublicOriginMiddleware) Handle(next http.Handler) http.Handler {
 		newURL.Scheme = publicOrigin.Scheme
 		newURL.Host = publicOrigin.Host
 
+		m.Logger.WithField("new_url", newURL).Info("redirect to the configured public origin")
 		http.Redirect(w, r, newURL.String(), http.StatusTemporaryRedirect)
 	})
 }

--- a/pkg/auth/wire_gen.go
+++ b/pkg/auth/wire_gen.go
@@ -22921,6 +22921,7 @@ func newSessionMiddleware(p *deps.RequestProvider) httproute.Middleware {
 		SessionCookie:      cookieDef,
 		Clock:              clockClock,
 	}
+	middlewareLogger := session.NewMiddlewareLogger(factory)
 	sessionMiddleware := &session.Middleware{
 		SessionCookie:              cookieDef,
 		CookieFactory:              cookieFactory,
@@ -22929,6 +22930,7 @@ func newSessionMiddleware(p *deps.RequestProvider) httproute.Middleware {
 		AccessEvents:               eventProvider,
 		Users:                      queries,
 		Database:                   appdbHandle,
+		Logger:                     middlewareLogger,
 	}
 	return sessionMiddleware
 }

--- a/pkg/auth/wire_gen.go
+++ b/pkg/auth/wire_gen.go
@@ -22513,9 +22513,12 @@ func newPublicOriginMiddleware(p *deps.RequestProvider) httproute.Middleware {
 	rootProvider := appProvider.RootProvider
 	environmentConfig := rootProvider.EnvironmentConfig
 	trustProxy := environmentConfig.TrustProxy
+	factory := appProvider.LoggerFactory
+	publicOriginMiddlewareLogger := webapp.NewPublicOriginMiddlewareLogger(factory)
 	publicOriginMiddleware := &webapp.PublicOriginMiddleware{
 		Config:     httpConfig,
 		TrustProxy: trustProxy,
+		Logger:     publicOriginMiddlewareLogger,
 	}
 	return publicOriginMiddleware
 }

--- a/pkg/auth/wire_gen.go
+++ b/pkg/auth/wire_gen.go
@@ -22528,8 +22528,11 @@ func newCORSMiddleware(p *deps.RequestProvider) httproute.Middleware {
 	config := appProvider.Config
 	appConfig := config.AppConfig
 	httpConfig := appConfig.HTTP
+	factory := appProvider.LoggerFactory
+	corsMiddlewareLogger := middleware.NewCORSMiddlewareLogger(factory)
 	corsMiddleware := &middleware.CORSMiddleware{
 		Config: httpConfig,
+		Logger: corsMiddlewareLogger,
 	}
 	return corsMiddleware
 }

--- a/pkg/lib/deps/middleware_request.go
+++ b/pkg/lib/deps/middleware_request.go
@@ -26,6 +26,7 @@ func (m *RequestMiddleware) Handle(next http.Handler) http.Handler {
 		appCtx, err := m.ConfigSource.ProvideContext(r)
 		if err != nil {
 			if errors.Is(err, configsource.ErrAppNotFound) {
+				logger.WithError(err).Error("app not found")
 				http.Error(w, configsource.ErrAppNotFound.Error(), http.StatusNotFound)
 			} else {
 				logger.WithError(err).Error("failed to resolve config")

--- a/pkg/lib/infra/middleware/cors.go
+++ b/pkg/lib/infra/middleware/cors.go
@@ -6,10 +6,18 @@ import (
 	"github.com/iawaknahc/originmatcher"
 
 	"github.com/authgear/authgear-server/pkg/lib/config"
+	"github.com/authgear/authgear-server/pkg/util/log"
 )
+
+type CORSMiddlewareLogger struct{ *log.Logger }
+
+func NewCORSMiddlewareLogger(lf *log.Factory) CORSMiddlewareLogger {
+	return CORSMiddlewareLogger{lf.New("cors-middleware")}
+}
 
 type CORSMiddleware struct {
 	Config *config.HTTPConfig
+	Logger CORSMiddlewareLogger
 }
 
 func (m *CORSMiddleware) Handle(next http.Handler) http.Handler {
@@ -42,6 +50,9 @@ func (m *CORSMiddleware) Handle(next http.Handler) http.Handler {
 
 		requestMethod := r.Method
 		if requestMethod == "OPTIONS" {
+			// FIXME(logging): the log below may cause too many logs to server
+			// should remove the log after diagnostic
+			m.Logger.Info("return 200 for options request")
 			w.WriteHeader(http.StatusOK)
 		} else {
 			next.ServeHTTP(w, r)

--- a/pkg/lib/infra/middleware/cors_test.go
+++ b/pkg/lib/infra/middleware/cors_test.go
@@ -8,6 +8,7 @@ import (
 	. "github.com/smartystreets/goconvey/convey"
 
 	"github.com/authgear/authgear-server/pkg/lib/config"
+	"github.com/authgear/authgear-server/pkg/util/log"
 )
 
 var testBody = []byte{1, 2, 3}
@@ -24,6 +25,7 @@ func TestCORSMiddleware(t *testing.T) {
 			Config: &config.HTTPConfig{
 				AllowedOrigins: specs,
 			},
+			Logger: CORSMiddlewareLogger{log.Null},
 		}
 		h = m.Handle(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			_, _ = w.Write(testBody)

--- a/pkg/lib/infra/middleware/deps.go
+++ b/pkg/lib/infra/middleware/deps.go
@@ -5,6 +5,7 @@ import (
 )
 
 var DependencySet = wire.NewSet(
+	NewCORSMiddlewareLogger,
 	wire.Struct(new(CORSMiddleware), "*"),
 
 	NewPanicLogMiddlewareLogger,

--- a/pkg/lib/session/deps.go
+++ b/pkg/lib/session/deps.go
@@ -5,6 +5,7 @@ import (
 )
 
 var DependencySet = wire.NewSet(
+	NewMiddlewareLogger,
 	wire.Struct(new(Middleware), "*"),
 	wire.Struct(new(Manager), "*"),
 	NewSessionCookieDef,

--- a/pkg/resolver/wire_gen.go
+++ b/pkg/resolver/wire_gen.go
@@ -426,6 +426,7 @@ func newSessionMiddleware(p *deps.RequestProvider) httproute.Middleware {
 		SessionCookie:      cookieDef,
 		Clock:              clock,
 	}
+	middlewareLogger := session.NewMiddlewareLogger(factory)
 	sessionMiddleware := &session.Middleware{
 		SessionCookie:              cookieDef,
 		CookieFactory:              cookieFactory,
@@ -434,6 +435,7 @@ func newSessionMiddleware(p *deps.RequestProvider) httproute.Middleware {
 		AccessEvents:               eventProvider,
 		Users:                      queries,
 		Database:                   appdbHandle,
+		Logger:                     middlewareLogger,
 	}
 	return sessionMiddleware
 }


### PR DESCRIPTION
We encountered a problem in staging server that the server returns http 200 with empty body for all routes, so we suspect the middleware early exit without calling next for some cases. Adding more logs for diagnostic.