### PR TITLE
Update onboarding to disable sms feature with upgrade button

### DIFF
--- a/pkg/lib/config/authentication.go
+++ b/pkg/lib/config/authentication.go
@@ -80,7 +80,6 @@ func (c *AuthenticationConfig) SetDefaults() {
 	if c.SecondaryAuthenticators == nil {
 		c.SecondaryAuthenticators = []authn.AuthenticatorType{
 			authn.AuthenticatorTypeTOTP,
-			authn.AuthenticatorTypeOOBSMS,
 		}
 	}
 	if c.SecondaryAuthenticationMode == "" {

--- a/pkg/lib/config/testdata/default_config.yaml
+++ b/pkg/lib/config/testdata/default_config.yaml
@@ -250,7 +250,6 @@ authentication:
     - password
   secondary_authenticators:
     - totp
-    - oob_otp_sms
   secondary_authentication_mode: if_exists
   device_token:
     expire_in_days: 30

--- a/portal/src/graphql/portal/OnboardingConfigAppScreen.module.scss
+++ b/portal/src/graphql/portal/OnboardingConfigAppScreen.module.scss
@@ -49,15 +49,22 @@
   display: flex;
   flex-direction: row;
   justify-content: space-between;
-  margin: 10px 0;
+  margin-top: 10px;
 }
 
 .identityListItem {
+  display: flex;
+  flex-direction: column;
+  text-align: center;
+}
+
+.identityListItemContent {
   background-color: $neutral-lighter-color;
   position: relative;
   width: 96px;
   height: 106px;
   cursor: pointer;
+  margin-bottom: 10px;
 
   .checkbox {
     position: absolute;
@@ -79,6 +86,26 @@
   }
 }
 
+.upgradeLink {
+  font-size: 14px;
+}
+
+.upgradeTooltip {
+  max-width: 420px;
+  padding: 10px 15px;
+
+  .upgradeTooltipHeader {
+    display: block;
+    font-size: 20px;
+    margin-bottom: 10px;
+  }
+}
+
 .checkboxGroup {
   padding-bottom: 10px;
+}
+
+.readOnly {
+  pointer-events: none;
+  opacity: 0.5;
 }

--- a/portal/src/graphql/portal/OnboardingConfigAppScreen.module.scss
+++ b/portal/src/graphql/portal/OnboardingConfigAppScreen.module.scss
@@ -103,6 +103,12 @@
 
 .checkboxGroup {
   padding-bottom: 10px;
+  display: flex;
+  flex-direction: row;
+
+  .checkbox {
+    padding-right: 10px;
+  }
 }
 
 .readOnly {

--- a/portal/src/locale-data/en.json
+++ b/portal/src/locale-data/en.json
@@ -141,6 +141,10 @@
   "Onboarding.verification.optional" :"Optional",
   "Onboarding.verification.disabled" :"Disabled",
 
+  "Onboarding.upgrade.label": "Upgrade",
+  "Onboarding.upgrade.support-sms.title": "Upgrade plan to use SMS",
+  "Onboarding.upgrade.support-sms.desc": "Add passwordless login and one-time-password via SMS for your app users by upgrading your plan later.",
+  
   "OnboardingCompletion.title": "Done",
   "OnboardingCompletion.desc": "You can always change these configuration in the portal, or configure an even more complicated authentication system.",
   "OnboardingCompletion.completion-message": "You just setup a full feature login, signup and setting page for your next app!",


### PR DESCRIPTION
Update onboarding to disable sms feature with upgrade button

To test this, you will need to add `./vars/authgear.features.yaml` with the following content.

```
identity:
  login_id:
    types:
      phone:
        disabled: true
authentication:
  secondary_authenticators:
    oob_otp_sms:
      disabled: true
```