### PR TITLE
Remove LegacyPrompt parameter

### DIFF
--- a/pkg/auth/webapp/session.go
+++ b/pkg/auth/webapp/session.go
@@ -65,11 +65,6 @@ type Session struct {
 	// which includes both supported and unsupported prompt
 	Prompt []string `json:"prompt_list,omitempty"`
 
-	// FIXME(webapp): remove LegacyPrompt in the next deployment
-	// LegacyPrompt is legacy prompt parameter
-	// which should restore to prompt list after unmarshal
-	LegacyPrompt string `json:"prompt,omitempty"`
-
 	// UpdatedAt indicate the session last updated time
 	UpdatedAt time.Time `json:"updated_at,omitempty"`
 

--- a/pkg/auth/webapp/session_store.go
+++ b/pkg/auth/webapp/session_store.go
@@ -77,13 +77,6 @@ func (s *SessionStoreRedis) Get(id string) (session *Session, err error) {
 			return err
 		}
 		err = json.Unmarshal(data, &session)
-		// FIXME(webapp): remove LegacyPrompt in the next deployment
-		// translate old LegacyPrompt to Prompt list in web session
-		// since websession only have 20 mins lifetime
-		// the translation logic can be removed in the next deployment
-		if session.LegacyPrompt != "" && len(session.Prompt) == 0 {
-			session.Prompt = []string{session.LegacyPrompt}
-		}
 		// translation logic end
 		if err != nil {
 			return err


### PR DESCRIPTION
fix #1207 

We updated to accept prompt list in the authz endpoint and the legacy
prompt data migration is no longer needed after the prompt list update
is deployed.