### PR TITLE
Ensure time.Unix() calls are followed by UTC()

### DIFF
--- a/pkg/lib/ratelimit/storage_redis.go
+++ b/pkg/lib/ratelimit/storage_redis.go
@@ -81,7 +81,7 @@ func (s storageRedisConn) GetResetTime(bucket Bucket, now time.Time) (time.Time,
 		// Invalid reset time, default to now to avoid stuck state
 		return now, nil
 	}
-	return time.Unix(0, nano), nil
+	return time.Unix(0, nano).UTC(), nil
 }
 
 func (s storageRedisConn) Reset(bucket Bucket, now time.Time) error {

--- a/pkg/util/httputil/cookie.go
+++ b/pkg/util/httputil/cookie.go
@@ -133,7 +133,7 @@ func (f *CookieManager) ClearCookie(def *CookieDef) *http.Cookie {
 		Domain:   f.CookieDomain,
 		HttpOnly: !def.AllowScriptAccess,
 		SameSite: def.SameSite,
-		Expires:  time.Unix(0, 0),
+		Expires:  time.Unix(0, 0).UTC(),
 	}
 
 	f.fixupCookie(cookie)


### PR DESCRIPTION
fix #1404