### PR TITLE
Refactor sql builder

### DIFF
--- a/cmd/authgear/elasticsearch/wire_gen.go
+++ b/cmd/authgear/elasticsearch/wire_gen.go
@@ -41,18 +41,18 @@ func NewReindexer(ctx context.Context, pool *db.Pool, databaseCredentials *confi
 	databaseConfig := NewDatabaseConfig()
 	factory := NewLoggerFactory()
 	handle := appdb.NewHandle(ctx, pool, databaseConfig, databaseCredentials, factory)
-	sqlBuilder := appdb.NewSQLBuilder(databaseCredentials, appID)
+	sqlBuilderApp := appdb.NewSQLBuilderApp(databaseCredentials, appID)
 	sqlExecutor := appdb.NewSQLExecutor(ctx, handle)
 	store := &user.Store{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	oauthStore := &oauth.Store{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	loginidStore := &loginid.Store{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	reindexer := &Reindexer{

--- a/cmd/portal/analytic/wire.go
+++ b/cmd/portal/analytic/wire.go
@@ -14,21 +14,12 @@ import (
 	"github.com/google/wire"
 )
 
-func NewEmptyAppID() config.AppID {
-	// Analytic reports need to run query based on different app ids
-	// To simplify the implementation, we assume all apps run with the same
-	// database, and the appID will be provided during the runtime
-	// so the app id injected through wire will not be used
-	return config.AppID("")
-}
-
 func NewUserWeeklyReport(
 	ctx context.Context,
 	pool *db.Pool,
 	databaseCredentials *config.DatabaseCredentials,
 ) *analytic.UserWeeklyReport {
 	panic(wire.Build(
-		NewEmptyAppID,
 		DependencySet,
 	))
 }
@@ -40,7 +31,6 @@ func NewProjectWeeklyReport(
 	auditDatabaseCredentials *config.AuditDatabaseCredentials,
 ) *analytic.ProjectWeeklyReport {
 	panic(wire.Build(
-		NewEmptyAppID,
 		DependencySet,
 	))
 }
@@ -54,7 +44,6 @@ func NewCountCollector(
 	credentials *config.AnalyticRedisCredentials,
 ) *analytic.CountCollector {
 	panic(wire.Build(
-		NewEmptyAppID,
 		DependencySet,
 	))
 }

--- a/cmd/portal/analytic/wire_gen.go
+++ b/cmd/portal/analytic/wire_gen.go
@@ -33,8 +33,7 @@ func NewUserWeeklyReport(ctx context.Context, pool *db.Pool, databaseCredentials
 		SQLExecutor: sqlExecutor,
 	}
 	appdbHandle := appdb.NewHandle(ctx, pool, databaseConfig, databaseCredentials, factory)
-	appID := NewEmptyAppID()
-	appdbSQLBuilder := appdb.NewSQLBuilder(databaseCredentials, appID)
+	appdbSQLBuilder := appdb.NewSQLBuilder(databaseCredentials)
 	appdbSQLExecutor := appdb.NewSQLExecutor(ctx, appdbHandle)
 	appDBStore := &analytic.AppDBStore{
 		SQLBuilder:  appdbSQLBuilder,
@@ -61,15 +60,14 @@ func NewProjectWeeklyReport(ctx context.Context, pool *db.Pool, databaseCredenti
 		SQLExecutor: sqlExecutor,
 	}
 	appdbHandle := appdb.NewHandle(ctx, pool, databaseConfig, databaseCredentials, factory)
-	appID := NewEmptyAppID()
-	appdbSQLBuilder := appdb.NewSQLBuilder(databaseCredentials, appID)
+	appdbSQLBuilder := appdb.NewSQLBuilder(databaseCredentials)
 	appdbSQLExecutor := appdb.NewSQLExecutor(ctx, appdbHandle)
 	appDBStore := &analytic.AppDBStore{
 		SQLBuilder:  appdbSQLBuilder,
 		SQLExecutor: appdbSQLExecutor,
 	}
 	readHandle := auditdb.NewReadHandle(ctx, pool, databaseConfig, auditDatabaseCredentials, factory)
-	auditdbSQLBuilder := auditdb.NewSQLBuilder(auditDatabaseCredentials, appID)
+	auditdbSQLBuilder := auditdb.NewSQLBuilder(auditDatabaseCredentials)
 	writeHandle := auditdb.NewWriteHandle(ctx, pool, databaseConfig, auditDatabaseCredentials, factory)
 	writeSQLExecutor := auditdb.NewWriteSQLExecutor(ctx, writeHandle)
 	auditDBStore := &analytic.AuditDBStore{
@@ -99,15 +97,14 @@ func NewCountCollector(ctx context.Context, pool *db.Pool, databaseCredentials *
 		SQLExecutor: sqlExecutor,
 	}
 	appdbHandle := appdb.NewHandle(ctx, pool, databaseConfig, databaseCredentials, factory)
-	appID := NewEmptyAppID()
-	appdbSQLBuilder := appdb.NewSQLBuilder(databaseCredentials, appID)
+	appdbSQLBuilder := appdb.NewSQLBuilder(databaseCredentials)
 	appdbSQLExecutor := appdb.NewSQLExecutor(ctx, appdbHandle)
 	appDBStore := &analytic.AppDBStore{
 		SQLBuilder:  appdbSQLBuilder,
 		SQLExecutor: appdbSQLExecutor,
 	}
 	writeHandle := auditdb.NewWriteHandle(ctx, pool, databaseConfig, auditDatabaseCredentials, factory)
-	auditdbSQLBuilder := auditdb.NewSQLBuilder(auditDatabaseCredentials, appID)
+	auditdbSQLBuilder := auditdb.NewSQLBuilder(auditDatabaseCredentials)
 	writeSQLExecutor := auditdb.NewWriteSQLExecutor(ctx, writeHandle)
 	auditDBStore := &analytic.AuditDBStore{
 		SQLBuilder:  auditdbSQLBuilder,
@@ -142,10 +139,3 @@ func NewPeriodicalArgumentParser() *periodical.ArgumentParser {
 var (
 	_wireSystemClockValue = clock.NewSystemClock()
 )
-
-// wire.go:
-
-func NewEmptyAppID() config.AppID {
-
-	return config.AppID("")
-}

--- a/pkg/admin/wire_gen.go
+++ b/pkg/admin/wire_gen.go
@@ -371,8 +371,9 @@ func newGraphQLHandler(p *deps.RequestProvider) http.Handler {
 	welcomeMessageConfig := appConfig.WelcomeMessage
 	queue := appProvider.TaskQueue
 	eventLogger := event.NewLogger(factory)
+	sqlBuilder := appdb.NewSQLBuilder(databaseCredentials)
 	storeImpl := &event.StoreImpl{
-		SQLBuilder:  sqlBuilderApp,
+		SQLBuilder:  sqlBuilder,
 		SQLExecutor: sqlExecutor,
 	}
 	hookLogger := hook.NewLogger(factory)

--- a/pkg/admin/wire_gen.go
+++ b/pkg/admin/wire_gen.go
@@ -149,13 +149,13 @@ func newGraphQLHandler(p *deps.RequestProvider) http.Handler {
 	databaseCredentials := deps.ProvideDatabaseCredentials(secretConfig)
 	appConfig := configConfig.AppConfig
 	appID := appConfig.ID
-	sqlBuilder := appdb.NewSQLBuilder(databaseCredentials, appID)
+	sqlBuilderApp := appdb.NewSQLBuilderApp(databaseCredentials, appID)
 	request := p.Request
 	contextContext := deps.ProvideRequestContext(request)
 	handle := appProvider.AppDatabase
 	sqlExecutor := appdb.NewSQLExecutor(contextContext, handle)
 	store := &user.Store{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	authenticationConfig := appConfig.Authentication
@@ -163,11 +163,11 @@ func newGraphQLHandler(p *deps.RequestProvider) http.Handler {
 	featureConfig := configConfig.FeatureConfig
 	identityFeatureConfig := featureConfig.Identity
 	serviceStore := &service.Store{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	loginidStore := &loginid.Store{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	loginIDConfig := identityConfig.LoginID
@@ -192,7 +192,7 @@ func newGraphQLHandler(p *deps.RequestProvider) http.Handler {
 		Clock:             clockClock,
 	}
 	oauthStore := &oauth.Store{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	oauthProvider := &oauth.Provider{
@@ -200,7 +200,7 @@ func newGraphQLHandler(p *deps.RequestProvider) http.Handler {
 		Clock: clockClock,
 	}
 	anonymousStore := &anonymous.Store{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	anonymousProvider := &anonymous.Provider{
@@ -208,7 +208,7 @@ func newGraphQLHandler(p *deps.RequestProvider) http.Handler {
 		Clock: clockClock,
 	}
 	biometricStore := &biometric.Store{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	biometricProvider := &biometric.Provider{
@@ -226,11 +226,11 @@ func newGraphQLHandler(p *deps.RequestProvider) http.Handler {
 		Biometric:             biometricProvider,
 	}
 	store2 := &service2.Store{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	passwordStore := &password.Store{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	authenticatorConfig := appConfig.Authenticator
@@ -238,7 +238,7 @@ func newGraphQLHandler(p *deps.RequestProvider) http.Handler {
 	passwordLogger := password.NewLogger(factory)
 	historyStore := &password.HistoryStore{
 		Clock:       clockClock,
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	passwordChecker := password.ProvideChecker(authenticatorPasswordConfig, historyStore)
@@ -258,7 +258,7 @@ func newGraphQLHandler(p *deps.RequestProvider) http.Handler {
 		Housekeeper:     housekeeper,
 	}
 	totpStore := &totp.Store{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	authenticatorTOTPConfig := authenticatorConfig.TOTP
@@ -269,7 +269,7 @@ func newGraphQLHandler(p *deps.RequestProvider) http.Handler {
 	}
 	authenticatorOOBConfig := authenticatorConfig.OOB
 	oobStore := &oob.Store{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	appredisHandle := appProvider.Redis
@@ -314,7 +314,7 @@ func newGraphQLHandler(p *deps.RequestProvider) http.Handler {
 		Clock: clockClock,
 	}
 	storePQ := &verification.StorePQ{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	verificationService := &verification.Service{
@@ -333,7 +333,7 @@ func newGraphQLHandler(p *deps.RequestProvider) http.Handler {
 		Clock: clockClock,
 	}
 	storeRecoveryCodePQ := &mfa.StoreRecoveryCodePQ{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	mfaService := &mfa.Service{
@@ -372,7 +372,7 @@ func newGraphQLHandler(p *deps.RequestProvider) http.Handler {
 	queue := appProvider.TaskQueue
 	eventLogger := event.NewLogger(factory)
 	storeImpl := &event.StoreImpl{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	hookLogger := hook.NewLogger(factory)
@@ -394,10 +394,10 @@ func newGraphQLHandler(p *deps.RequestProvider) http.Handler {
 	auditLogger := audit.NewLogger(factory)
 	writeHandle := appProvider.AuditWriteDatabase
 	auditDatabaseCredentials := deps.ProvideAuditDatabaseCredentials(secretConfig)
-	auditdbSQLBuilder := auditdb.NewSQLBuilder(auditDatabaseCredentials, appID)
+	auditdbSQLBuilderApp := auditdb.NewSQLBuilderApp(auditDatabaseCredentials, appID)
 	writeSQLExecutor := auditdb.NewWriteSQLExecutor(contextContext, writeHandle)
 	writeStore := &audit.WriteStore{
-		SQLBuilder:  auditdbSQLBuilder,
+		SQLBuilder:  auditdbSQLBuilderApp,
 		SQLExecutor: writeSQLExecutor,
 	}
 	auditSink := &audit.Sink{
@@ -419,7 +419,7 @@ func newGraphQLHandler(p *deps.RequestProvider) http.Handler {
 		WelcomeMessageProvider: welcomemessageProvider,
 	}
 	authorizationStore := &pq.AuthorizationStore{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	storeRedisLogger := idpsession.NewStoreRedisLogger(factory)
@@ -445,7 +445,7 @@ func newGraphQLHandler(p *deps.RequestProvider) http.Handler {
 		Redis:       appredisHandle,
 		AppID:       appID,
 		Logger:      redisLogger,
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 		Clock:       clockClock,
 	}
@@ -485,7 +485,7 @@ func newGraphQLHandler(p *deps.RequestProvider) http.Handler {
 	readHandle := appProvider.AuditReadDatabase
 	readSQLExecutor := auditdb.NewReadSQLExecutor(contextContext, readHandle)
 	readStore := &audit.ReadStore{
-		SQLBuilder:  auditdbSQLBuilder,
+		SQLBuilder:  auditdbSQLBuilderApp,
 		SQLExecutor: readSQLExecutor,
 	}
 	query := &audit.Query{

--- a/pkg/auth/wire_gen.go
+++ b/pkg/auth/wire_gen.go
@@ -131,10 +131,10 @@ func newOAuthAuthorizeHandler(p *deps.RequestProvider) http.Handler {
 	}
 	secretConfig := config.SecretConfig
 	databaseCredentials := deps.ProvideDatabaseCredentials(secretConfig)
-	sqlBuilder := appdb.NewSQLBuilder(databaseCredentials, appID)
+	sqlBuilderApp := appdb.NewSQLBuilderApp(databaseCredentials, appID)
 	sqlExecutor := appdb.NewSQLExecutor(contextContext, handle)
 	authorizationStore := &pq.AuthorizationStore{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	logger := redis.NewLogger(factory)
@@ -143,7 +143,7 @@ func newOAuthAuthorizeHandler(p *deps.RequestProvider) http.Handler {
 		Redis:       appredisHandle,
 		AppID:       appID,
 		Logger:      logger,
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 		Clock:       clock,
 	}
@@ -177,11 +177,11 @@ func newOAuthAuthorizeHandler(p *deps.RequestProvider) http.Handler {
 	identityConfig := appConfig.Identity
 	identityFeatureConfig := featureConfig.Identity
 	serviceStore := &service.Store{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	loginidStore := &loginid.Store{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	loginIDConfig := identityConfig.LoginID
@@ -205,7 +205,7 @@ func newOAuthAuthorizeHandler(p *deps.RequestProvider) http.Handler {
 		Clock:             clock,
 	}
 	oauthStore := &oauth3.Store{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	oauthProvider := &oauth3.Provider{
@@ -213,7 +213,7 @@ func newOAuthAuthorizeHandler(p *deps.RequestProvider) http.Handler {
 		Clock: clock,
 	}
 	anonymousStore := &anonymous.Store{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	anonymousProvider := &anonymous.Provider{
@@ -221,7 +221,7 @@ func newOAuthAuthorizeHandler(p *deps.RequestProvider) http.Handler {
 		Clock: clock,
 	}
 	biometricStore := &biometric.Store{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	biometricProvider := &biometric.Provider{
@@ -239,11 +239,11 @@ func newOAuthAuthorizeHandler(p *deps.RequestProvider) http.Handler {
 		Biometric:             biometricProvider,
 	}
 	store2 := &service2.Store{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	passwordStore := &password.Store{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	authenticatorConfig := appConfig.Authenticator
@@ -251,7 +251,7 @@ func newOAuthAuthorizeHandler(p *deps.RequestProvider) http.Handler {
 	passwordLogger := password.NewLogger(factory)
 	historyStore := &password.HistoryStore{
 		Clock:       clock,
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	passwordChecker := password.ProvideChecker(authenticatorPasswordConfig, historyStore)
@@ -271,7 +271,7 @@ func newOAuthAuthorizeHandler(p *deps.RequestProvider) http.Handler {
 		Housekeeper:     housekeeper,
 	}
 	totpStore := &totp.Store{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	authenticatorTOTPConfig := authenticatorConfig.TOTP
@@ -282,7 +282,7 @@ func newOAuthAuthorizeHandler(p *deps.RequestProvider) http.Handler {
 	}
 	authenticatorOOBConfig := authenticatorConfig.OOB
 	oobStore := &oob.Store{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	oobStoreRedis := &oob.StoreRedis{
@@ -323,7 +323,7 @@ func newOAuthAuthorizeHandler(p *deps.RequestProvider) http.Handler {
 		Clock: clock,
 	}
 	storePQ := &verification.StorePQ{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	verificationService := &verification.Service{
@@ -342,7 +342,7 @@ func newOAuthAuthorizeHandler(p *deps.RequestProvider) http.Handler {
 		Clock: clock,
 	}
 	storeRecoveryCodePQ := &mfa.StoreRecoveryCodePQ{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	mfaService := &mfa.Service{
@@ -353,7 +353,7 @@ func newOAuthAuthorizeHandler(p *deps.RequestProvider) http.Handler {
 		RateLimiter:   limiter,
 	}
 	userStore := &user.Store{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	defaultLanguageTag := deps.ProvideDefaultLanguageTag(config)
@@ -384,7 +384,7 @@ func newOAuthAuthorizeHandler(p *deps.RequestProvider) http.Handler {
 	queue := appProvider.TaskQueue
 	eventLogger := event.NewLogger(factory)
 	storeImpl := &event.StoreImpl{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	hookLogger := hook.NewLogger(factory)
@@ -406,10 +406,10 @@ func newOAuthAuthorizeHandler(p *deps.RequestProvider) http.Handler {
 	auditLogger := audit.NewLogger(factory)
 	writeHandle := appProvider.AuditWriteDatabase
 	auditDatabaseCredentials := deps.ProvideAuditDatabaseCredentials(secretConfig)
-	auditdbSQLBuilder := auditdb.NewSQLBuilder(auditDatabaseCredentials, appID)
+	auditdbSQLBuilderApp := auditdb.NewSQLBuilderApp(auditDatabaseCredentials, appID)
 	writeSQLExecutor := auditdb.NewWriteSQLExecutor(contextContext, writeHandle)
 	writeStore := &audit.WriteStore{
-		SQLBuilder:  auditdbSQLBuilder,
+		SQLBuilder:  auditdbSQLBuilderApp,
 		SQLExecutor: writeSQLExecutor,
 	}
 	auditSink := &audit.Sink{
@@ -715,10 +715,10 @@ func newOAuthFromWebAppHandler(p *deps.RequestProvider) http.Handler {
 	}
 	secretConfig := config.SecretConfig
 	databaseCredentials := deps.ProvideDatabaseCredentials(secretConfig)
-	sqlBuilder := appdb.NewSQLBuilder(databaseCredentials, appID)
+	sqlBuilderApp := appdb.NewSQLBuilderApp(databaseCredentials, appID)
 	sqlExecutor := appdb.NewSQLExecutor(contextContext, handle)
 	authorizationStore := &pq.AuthorizationStore{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	logger := redis.NewLogger(factory)
@@ -727,7 +727,7 @@ func newOAuthFromWebAppHandler(p *deps.RequestProvider) http.Handler {
 		Redis:       appredisHandle,
 		AppID:       appID,
 		Logger:      logger,
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 		Clock:       clockClock,
 	}
@@ -761,11 +761,11 @@ func newOAuthFromWebAppHandler(p *deps.RequestProvider) http.Handler {
 	identityConfig := appConfig.Identity
 	identityFeatureConfig := featureConfig.Identity
 	serviceStore := &service.Store{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	loginidStore := &loginid.Store{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	loginIDConfig := identityConfig.LoginID
@@ -789,7 +789,7 @@ func newOAuthFromWebAppHandler(p *deps.RequestProvider) http.Handler {
 		Clock:             clockClock,
 	}
 	oauthStore := &oauth3.Store{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	oauthProvider := &oauth3.Provider{
@@ -797,7 +797,7 @@ func newOAuthFromWebAppHandler(p *deps.RequestProvider) http.Handler {
 		Clock: clockClock,
 	}
 	anonymousStore := &anonymous.Store{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	anonymousProvider := &anonymous.Provider{
@@ -805,7 +805,7 @@ func newOAuthFromWebAppHandler(p *deps.RequestProvider) http.Handler {
 		Clock: clockClock,
 	}
 	biometricStore := &biometric.Store{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	biometricProvider := &biometric.Provider{
@@ -823,11 +823,11 @@ func newOAuthFromWebAppHandler(p *deps.RequestProvider) http.Handler {
 		Biometric:             biometricProvider,
 	}
 	store2 := &service2.Store{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	passwordStore := &password.Store{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	authenticatorConfig := appConfig.Authenticator
@@ -835,7 +835,7 @@ func newOAuthFromWebAppHandler(p *deps.RequestProvider) http.Handler {
 	passwordLogger := password.NewLogger(factory)
 	historyStore := &password.HistoryStore{
 		Clock:       clockClock,
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	passwordChecker := password.ProvideChecker(authenticatorPasswordConfig, historyStore)
@@ -855,7 +855,7 @@ func newOAuthFromWebAppHandler(p *deps.RequestProvider) http.Handler {
 		Housekeeper:     housekeeper,
 	}
 	totpStore := &totp.Store{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	authenticatorTOTPConfig := authenticatorConfig.TOTP
@@ -866,7 +866,7 @@ func newOAuthFromWebAppHandler(p *deps.RequestProvider) http.Handler {
 	}
 	authenticatorOOBConfig := authenticatorConfig.OOB
 	oobStore := &oob.Store{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	oobStoreRedis := &oob.StoreRedis{
@@ -907,7 +907,7 @@ func newOAuthFromWebAppHandler(p *deps.RequestProvider) http.Handler {
 		Clock: clockClock,
 	}
 	storePQ := &verification.StorePQ{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	verificationService := &verification.Service{
@@ -926,7 +926,7 @@ func newOAuthFromWebAppHandler(p *deps.RequestProvider) http.Handler {
 		Clock: clockClock,
 	}
 	storeRecoveryCodePQ := &mfa.StoreRecoveryCodePQ{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	mfaService := &mfa.Service{
@@ -937,7 +937,7 @@ func newOAuthFromWebAppHandler(p *deps.RequestProvider) http.Handler {
 		RateLimiter:   limiter,
 	}
 	userStore := &user.Store{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	defaultLanguageTag := deps.ProvideDefaultLanguageTag(config)
@@ -968,7 +968,7 @@ func newOAuthFromWebAppHandler(p *deps.RequestProvider) http.Handler {
 	queue := appProvider.TaskQueue
 	eventLogger := event.NewLogger(factory)
 	storeImpl := &event.StoreImpl{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	hookLogger := hook.NewLogger(factory)
@@ -990,10 +990,10 @@ func newOAuthFromWebAppHandler(p *deps.RequestProvider) http.Handler {
 	auditLogger := audit.NewLogger(factory)
 	writeHandle := appProvider.AuditWriteDatabase
 	auditDatabaseCredentials := deps.ProvideAuditDatabaseCredentials(secretConfig)
-	auditdbSQLBuilder := auditdb.NewSQLBuilder(auditDatabaseCredentials, appID)
+	auditdbSQLBuilderApp := auditdb.NewSQLBuilderApp(auditDatabaseCredentials, appID)
 	writeSQLExecutor := auditdb.NewWriteSQLExecutor(contextContext, writeHandle)
 	writeStore := &audit.WriteStore{
-		SQLBuilder:  auditdbSQLBuilder,
+		SQLBuilder:  auditdbSQLBuilderApp,
 		SQLExecutor: writeSQLExecutor,
 	}
 	auditSink := &audit.Sink{
@@ -1260,11 +1260,11 @@ func newOAuthTokenHandler(p *deps.RequestProvider) http.Handler {
 	handlerTokenHandlerLogger := handler.NewTokenHandlerLogger(factory)
 	secretConfig := config.SecretConfig
 	databaseCredentials := deps.ProvideDatabaseCredentials(secretConfig)
-	sqlBuilder := appdb.NewSQLBuilder(databaseCredentials, appID)
+	sqlBuilderApp := appdb.NewSQLBuilderApp(databaseCredentials, appID)
 	contextContext := deps.ProvideRequestContext(request)
 	sqlExecutor := appdb.NewSQLExecutor(contextContext, handle)
 	authorizationStore := &pq.AuthorizationStore{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	appredisHandle := appProvider.Redis
@@ -1275,7 +1275,7 @@ func newOAuthTokenHandler(p *deps.RequestProvider) http.Handler {
 		Redis:       appredisHandle,
 		AppID:       appID,
 		Logger:      logger,
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 		Clock:       clockClock,
 	}
@@ -1292,11 +1292,11 @@ func newOAuthTokenHandler(p *deps.RequestProvider) http.Handler {
 	identityConfig := appConfig.Identity
 	identityFeatureConfig := featureConfig.Identity
 	serviceStore := &service.Store{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	loginidStore := &loginid.Store{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	loginIDConfig := identityConfig.LoginID
@@ -1320,7 +1320,7 @@ func newOAuthTokenHandler(p *deps.RequestProvider) http.Handler {
 		Clock:             clockClock,
 	}
 	oauthStore := &oauth3.Store{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	oauthProvider := &oauth3.Provider{
@@ -1328,7 +1328,7 @@ func newOAuthTokenHandler(p *deps.RequestProvider) http.Handler {
 		Clock: clockClock,
 	}
 	anonymousStore := &anonymous.Store{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	anonymousProvider := &anonymous.Provider{
@@ -1336,7 +1336,7 @@ func newOAuthTokenHandler(p *deps.RequestProvider) http.Handler {
 		Clock: clockClock,
 	}
 	biometricStore := &biometric.Store{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	biometricProvider := &biometric.Provider{
@@ -1354,11 +1354,11 @@ func newOAuthTokenHandler(p *deps.RequestProvider) http.Handler {
 		Biometric:             biometricProvider,
 	}
 	store2 := &service2.Store{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	passwordStore := &password.Store{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	authenticatorConfig := appConfig.Authenticator
@@ -1366,7 +1366,7 @@ func newOAuthTokenHandler(p *deps.RequestProvider) http.Handler {
 	passwordLogger := password.NewLogger(factory)
 	historyStore := &password.HistoryStore{
 		Clock:       clockClock,
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	passwordChecker := password.ProvideChecker(authenticatorPasswordConfig, historyStore)
@@ -1386,7 +1386,7 @@ func newOAuthTokenHandler(p *deps.RequestProvider) http.Handler {
 		Housekeeper:     housekeeper,
 	}
 	totpStore := &totp.Store{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	authenticatorTOTPConfig := authenticatorConfig.TOTP
@@ -1397,7 +1397,7 @@ func newOAuthTokenHandler(p *deps.RequestProvider) http.Handler {
 	}
 	authenticatorOOBConfig := authenticatorConfig.OOB
 	oobStore := &oob.Store{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	storeRedis := &oob.StoreRedis{
@@ -1438,7 +1438,7 @@ func newOAuthTokenHandler(p *deps.RequestProvider) http.Handler {
 		Clock: clockClock,
 	}
 	storePQ := &verification.StorePQ{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	verificationService := &verification.Service{
@@ -1457,7 +1457,7 @@ func newOAuthTokenHandler(p *deps.RequestProvider) http.Handler {
 		Clock: clockClock,
 	}
 	storeRecoveryCodePQ := &mfa.StoreRecoveryCodePQ{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	mfaService := &mfa.Service{
@@ -1468,7 +1468,7 @@ func newOAuthTokenHandler(p *deps.RequestProvider) http.Handler {
 		RateLimiter:   limiter,
 	}
 	userStore := &user.Store{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	defaultLanguageTag := deps.ProvideDefaultLanguageTag(config)
@@ -1500,7 +1500,7 @@ func newOAuthTokenHandler(p *deps.RequestProvider) http.Handler {
 	queue := appProvider.TaskQueue
 	eventLogger := event.NewLogger(factory)
 	storeImpl := &event.StoreImpl{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	hookLogger := hook.NewLogger(factory)
@@ -1522,10 +1522,10 @@ func newOAuthTokenHandler(p *deps.RequestProvider) http.Handler {
 	auditLogger := audit.NewLogger(factory)
 	writeHandle := appProvider.AuditWriteDatabase
 	auditDatabaseCredentials := deps.ProvideAuditDatabaseCredentials(secretConfig)
-	auditdbSQLBuilder := auditdb.NewSQLBuilder(auditDatabaseCredentials, appID)
+	auditdbSQLBuilderApp := auditdb.NewSQLBuilderApp(auditDatabaseCredentials, appID)
 	writeSQLExecutor := auditdb.NewWriteSQLExecutor(contextContext, writeHandle)
 	writeStore := &audit.WriteStore{
-		SQLBuilder:  auditdbSQLBuilder,
+		SQLBuilder:  auditdbSQLBuilderApp,
 		SQLExecutor: writeSQLExecutor,
 	}
 	auditSink := &audit.Sink{
@@ -1794,12 +1794,12 @@ func newOAuthRevokeHandler(p *deps.RequestProvider) http.Handler {
 	databaseCredentials := deps.ProvideDatabaseCredentials(secretConfig)
 	appConfig := config.AppConfig
 	appID := appConfig.ID
-	sqlBuilder := appdb.NewSQLBuilder(databaseCredentials, appID)
+	sqlBuilderApp := appdb.NewSQLBuilderApp(databaseCredentials, appID)
 	request := p.Request
 	contextContext := deps.ProvideRequestContext(request)
 	sqlExecutor := appdb.NewSQLExecutor(contextContext, handle)
 	store := &user.Store{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	authenticationConfig := appConfig.Authentication
@@ -1807,11 +1807,11 @@ func newOAuthRevokeHandler(p *deps.RequestProvider) http.Handler {
 	featureConfig := config.FeatureConfig
 	identityFeatureConfig := featureConfig.Identity
 	serviceStore := &service.Store{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	loginidStore := &loginid.Store{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	loginIDConfig := identityConfig.LoginID
@@ -1836,7 +1836,7 @@ func newOAuthRevokeHandler(p *deps.RequestProvider) http.Handler {
 		Clock:             clockClock,
 	}
 	oauthStore := &oauth3.Store{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	oauthProvider := &oauth3.Provider{
@@ -1844,7 +1844,7 @@ func newOAuthRevokeHandler(p *deps.RequestProvider) http.Handler {
 		Clock: clockClock,
 	}
 	anonymousStore := &anonymous.Store{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	anonymousProvider := &anonymous.Provider{
@@ -1852,7 +1852,7 @@ func newOAuthRevokeHandler(p *deps.RequestProvider) http.Handler {
 		Clock: clockClock,
 	}
 	biometricStore := &biometric.Store{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	biometricProvider := &biometric.Provider{
@@ -1870,11 +1870,11 @@ func newOAuthRevokeHandler(p *deps.RequestProvider) http.Handler {
 		Biometric:             biometricProvider,
 	}
 	store2 := &service2.Store{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	passwordStore := &password.Store{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	authenticatorConfig := appConfig.Authenticator
@@ -1882,7 +1882,7 @@ func newOAuthRevokeHandler(p *deps.RequestProvider) http.Handler {
 	logger := password.NewLogger(factory)
 	historyStore := &password.HistoryStore{
 		Clock:       clockClock,
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	passwordChecker := password.ProvideChecker(authenticatorPasswordConfig, historyStore)
@@ -1902,7 +1902,7 @@ func newOAuthRevokeHandler(p *deps.RequestProvider) http.Handler {
 		Housekeeper:     housekeeper,
 	}
 	totpStore := &totp.Store{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	authenticatorTOTPConfig := authenticatorConfig.TOTP
@@ -1913,7 +1913,7 @@ func newOAuthRevokeHandler(p *deps.RequestProvider) http.Handler {
 	}
 	authenticatorOOBConfig := authenticatorConfig.OOB
 	oobStore := &oob.Store{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	appredisHandle := appProvider.Redis
@@ -1958,7 +1958,7 @@ func newOAuthRevokeHandler(p *deps.RequestProvider) http.Handler {
 		Clock: clockClock,
 	}
 	storePQ := &verification.StorePQ{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	verificationService := &verification.Service{
@@ -1977,7 +1977,7 @@ func newOAuthRevokeHandler(p *deps.RequestProvider) http.Handler {
 		Clock: clockClock,
 	}
 	storeRecoveryCodePQ := &mfa.StoreRecoveryCodePQ{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	mfaService := &mfa.Service{
@@ -2016,7 +2016,7 @@ func newOAuthRevokeHandler(p *deps.RequestProvider) http.Handler {
 	queue := appProvider.TaskQueue
 	eventLogger := event.NewLogger(factory)
 	storeImpl := &event.StoreImpl{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	hookLogger := hook.NewLogger(factory)
@@ -2038,10 +2038,10 @@ func newOAuthRevokeHandler(p *deps.RequestProvider) http.Handler {
 	auditLogger := audit.NewLogger(factory)
 	writeHandle := appProvider.AuditWriteDatabase
 	auditDatabaseCredentials := deps.ProvideAuditDatabaseCredentials(secretConfig)
-	auditdbSQLBuilder := auditdb.NewSQLBuilder(auditDatabaseCredentials, appID)
+	auditdbSQLBuilderApp := auditdb.NewSQLBuilderApp(auditDatabaseCredentials, appID)
 	writeSQLExecutor := auditdb.NewWriteSQLExecutor(contextContext, writeHandle)
 	writeStore := &audit.WriteStore{
-		SQLBuilder:  auditdbSQLBuilder,
+		SQLBuilder:  auditdbSQLBuilderApp,
 		SQLExecutor: writeSQLExecutor,
 	}
 	auditSink := &audit.Sink{
@@ -2063,7 +2063,7 @@ func newOAuthRevokeHandler(p *deps.RequestProvider) http.Handler {
 		WelcomeMessageProvider: welcomemessageProvider,
 	}
 	authorizationStore := &pq.AuthorizationStore{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	storeRedisLogger := idpsession.NewStoreRedisLogger(factory)
@@ -2089,7 +2089,7 @@ func newOAuthRevokeHandler(p *deps.RequestProvider) http.Handler {
 		Redis:       appredisHandle,
 		AppID:       appID,
 		Logger:      redisLogger,
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 		Clock:       clockClock,
 	}
@@ -2189,12 +2189,12 @@ func newOAuthJWKSHandler(p *deps.RequestProvider) http.Handler {
 	databaseCredentials := deps.ProvideDatabaseCredentials(secretConfig)
 	appConfig := config.AppConfig
 	appID := appConfig.ID
-	sqlBuilder := appdb.NewSQLBuilder(databaseCredentials, appID)
+	sqlBuilderApp := appdb.NewSQLBuilderApp(databaseCredentials, appID)
 	contextContext := deps.ProvideRequestContext(request)
 	handle := appProvider.AppDatabase
 	sqlExecutor := appdb.NewSQLExecutor(contextContext, handle)
 	store := &user.Store{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	authenticationConfig := appConfig.Authentication
@@ -2202,11 +2202,11 @@ func newOAuthJWKSHandler(p *deps.RequestProvider) http.Handler {
 	featureConfig := config.FeatureConfig
 	identityFeatureConfig := featureConfig.Identity
 	serviceStore := &service.Store{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	loginidStore := &loginid.Store{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	loginIDConfig := identityConfig.LoginID
@@ -2231,7 +2231,7 @@ func newOAuthJWKSHandler(p *deps.RequestProvider) http.Handler {
 		Clock:             clockClock,
 	}
 	oauthStore := &oauth3.Store{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	oauthProvider := &oauth3.Provider{
@@ -2239,7 +2239,7 @@ func newOAuthJWKSHandler(p *deps.RequestProvider) http.Handler {
 		Clock: clockClock,
 	}
 	anonymousStore := &anonymous.Store{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	anonymousProvider := &anonymous.Provider{
@@ -2247,7 +2247,7 @@ func newOAuthJWKSHandler(p *deps.RequestProvider) http.Handler {
 		Clock: clockClock,
 	}
 	biometricStore := &biometric.Store{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	biometricProvider := &biometric.Provider{
@@ -2265,11 +2265,11 @@ func newOAuthJWKSHandler(p *deps.RequestProvider) http.Handler {
 		Biometric:             biometricProvider,
 	}
 	store2 := &service2.Store{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	passwordStore := &password.Store{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	authenticatorConfig := appConfig.Authenticator
@@ -2277,7 +2277,7 @@ func newOAuthJWKSHandler(p *deps.RequestProvider) http.Handler {
 	logger := password.NewLogger(factory)
 	historyStore := &password.HistoryStore{
 		Clock:       clockClock,
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	passwordChecker := password.ProvideChecker(authenticatorPasswordConfig, historyStore)
@@ -2297,7 +2297,7 @@ func newOAuthJWKSHandler(p *deps.RequestProvider) http.Handler {
 		Housekeeper:     housekeeper,
 	}
 	totpStore := &totp.Store{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	authenticatorTOTPConfig := authenticatorConfig.TOTP
@@ -2308,7 +2308,7 @@ func newOAuthJWKSHandler(p *deps.RequestProvider) http.Handler {
 	}
 	authenticatorOOBConfig := authenticatorConfig.OOB
 	oobStore := &oob.Store{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	appredisHandle := appProvider.Redis
@@ -2350,7 +2350,7 @@ func newOAuthJWKSHandler(p *deps.RequestProvider) http.Handler {
 		Clock: clockClock,
 	}
 	storePQ := &verification.StorePQ{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	verificationService := &verification.Service{
@@ -2369,7 +2369,7 @@ func newOAuthJWKSHandler(p *deps.RequestProvider) http.Handler {
 		Clock: clockClock,
 	}
 	storeRecoveryCodePQ := &mfa.StoreRecoveryCodePQ{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	mfaService := &mfa.Service{
@@ -2408,7 +2408,7 @@ func newOAuthJWKSHandler(p *deps.RequestProvider) http.Handler {
 	queue := appProvider.TaskQueue
 	eventLogger := event.NewLogger(factory)
 	storeImpl := &event.StoreImpl{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	hookLogger := hook.NewLogger(factory)
@@ -2430,10 +2430,10 @@ func newOAuthJWKSHandler(p *deps.RequestProvider) http.Handler {
 	auditLogger := audit.NewLogger(factory)
 	writeHandle := appProvider.AuditWriteDatabase
 	auditDatabaseCredentials := deps.ProvideAuditDatabaseCredentials(secretConfig)
-	auditdbSQLBuilder := auditdb.NewSQLBuilder(auditDatabaseCredentials, appID)
+	auditdbSQLBuilderApp := auditdb.NewSQLBuilderApp(auditDatabaseCredentials, appID)
 	writeSQLExecutor := auditdb.NewWriteSQLExecutor(contextContext, writeHandle)
 	writeStore := &audit.WriteStore{
-		SQLBuilder:  auditdbSQLBuilder,
+		SQLBuilder:  auditdbSQLBuilderApp,
 		SQLExecutor: writeSQLExecutor,
 	}
 	auditSink := &audit.Sink{
@@ -2455,7 +2455,7 @@ func newOAuthJWKSHandler(p *deps.RequestProvider) http.Handler {
 		WelcomeMessageProvider: welcomemessageProvider,
 	}
 	authorizationStore := &pq.AuthorizationStore{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	storeRedisLogger := idpsession.NewStoreRedisLogger(factory)
@@ -2481,7 +2481,7 @@ func newOAuthJWKSHandler(p *deps.RequestProvider) http.Handler {
 		Redis:       appredisHandle,
 		AppID:       appID,
 		Logger:      redisLogger,
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 		Clock:       clockClock,
 	}
@@ -2550,11 +2550,11 @@ func newOAuthUserInfoHandler(p *deps.RequestProvider) http.Handler {
 	databaseCredentials := deps.ProvideDatabaseCredentials(secretConfig)
 	appConfig := config.AppConfig
 	appID := appConfig.ID
-	sqlBuilder := appdb.NewSQLBuilder(databaseCredentials, appID)
+	sqlBuilderApp := appdb.NewSQLBuilderApp(databaseCredentials, appID)
 	contextContext := deps.ProvideRequestContext(request)
 	sqlExecutor := appdb.NewSQLExecutor(contextContext, handle)
 	store := &user.Store{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	authenticationConfig := appConfig.Authentication
@@ -2562,11 +2562,11 @@ func newOAuthUserInfoHandler(p *deps.RequestProvider) http.Handler {
 	featureConfig := config.FeatureConfig
 	identityFeatureConfig := featureConfig.Identity
 	serviceStore := &service.Store{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	loginidStore := &loginid.Store{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	loginIDConfig := identityConfig.LoginID
@@ -2591,7 +2591,7 @@ func newOAuthUserInfoHandler(p *deps.RequestProvider) http.Handler {
 		Clock:             clockClock,
 	}
 	oauthStore := &oauth3.Store{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	oauthProvider := &oauth3.Provider{
@@ -2599,7 +2599,7 @@ func newOAuthUserInfoHandler(p *deps.RequestProvider) http.Handler {
 		Clock: clockClock,
 	}
 	anonymousStore := &anonymous.Store{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	anonymousProvider := &anonymous.Provider{
@@ -2607,7 +2607,7 @@ func newOAuthUserInfoHandler(p *deps.RequestProvider) http.Handler {
 		Clock: clockClock,
 	}
 	biometricStore := &biometric.Store{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	biometricProvider := &biometric.Provider{
@@ -2625,11 +2625,11 @@ func newOAuthUserInfoHandler(p *deps.RequestProvider) http.Handler {
 		Biometric:             biometricProvider,
 	}
 	store2 := &service2.Store{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	passwordStore := &password.Store{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	authenticatorConfig := appConfig.Authenticator
@@ -2637,7 +2637,7 @@ func newOAuthUserInfoHandler(p *deps.RequestProvider) http.Handler {
 	logger := password.NewLogger(factory)
 	historyStore := &password.HistoryStore{
 		Clock:       clockClock,
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	passwordChecker := password.ProvideChecker(authenticatorPasswordConfig, historyStore)
@@ -2657,7 +2657,7 @@ func newOAuthUserInfoHandler(p *deps.RequestProvider) http.Handler {
 		Housekeeper:     housekeeper,
 	}
 	totpStore := &totp.Store{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	authenticatorTOTPConfig := authenticatorConfig.TOTP
@@ -2668,7 +2668,7 @@ func newOAuthUserInfoHandler(p *deps.RequestProvider) http.Handler {
 	}
 	authenticatorOOBConfig := authenticatorConfig.OOB
 	oobStore := &oob.Store{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	appredisHandle := appProvider.Redis
@@ -2710,7 +2710,7 @@ func newOAuthUserInfoHandler(p *deps.RequestProvider) http.Handler {
 		Clock: clockClock,
 	}
 	storePQ := &verification.StorePQ{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	verificationService := &verification.Service{
@@ -2729,7 +2729,7 @@ func newOAuthUserInfoHandler(p *deps.RequestProvider) http.Handler {
 		Clock: clockClock,
 	}
 	storeRecoveryCodePQ := &mfa.StoreRecoveryCodePQ{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	mfaService := &mfa.Service{
@@ -2768,7 +2768,7 @@ func newOAuthUserInfoHandler(p *deps.RequestProvider) http.Handler {
 	queue := appProvider.TaskQueue
 	eventLogger := event.NewLogger(factory)
 	storeImpl := &event.StoreImpl{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	hookLogger := hook.NewLogger(factory)
@@ -2790,10 +2790,10 @@ func newOAuthUserInfoHandler(p *deps.RequestProvider) http.Handler {
 	auditLogger := audit.NewLogger(factory)
 	writeHandle := appProvider.AuditWriteDatabase
 	auditDatabaseCredentials := deps.ProvideAuditDatabaseCredentials(secretConfig)
-	auditdbSQLBuilder := auditdb.NewSQLBuilder(auditDatabaseCredentials, appID)
+	auditdbSQLBuilderApp := auditdb.NewSQLBuilderApp(auditDatabaseCredentials, appID)
 	writeSQLExecutor := auditdb.NewWriteSQLExecutor(contextContext, writeHandle)
 	writeStore := &audit.WriteStore{
-		SQLBuilder:  auditdbSQLBuilder,
+		SQLBuilder:  auditdbSQLBuilderApp,
 		SQLExecutor: writeSQLExecutor,
 	}
 	auditSink := &audit.Sink{
@@ -2815,7 +2815,7 @@ func newOAuthUserInfoHandler(p *deps.RequestProvider) http.Handler {
 		WelcomeMessageProvider: welcomemessageProvider,
 	}
 	authorizationStore := &pq.AuthorizationStore{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	storeRedisLogger := idpsession.NewStoreRedisLogger(factory)
@@ -2841,7 +2841,7 @@ func newOAuthUserInfoHandler(p *deps.RequestProvider) http.Handler {
 		Redis:       appredisHandle,
 		AppID:       appID,
 		Logger:      redisLogger,
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 		Clock:       clockClock,
 	}
@@ -2914,11 +2914,11 @@ func newOAuthEndSessionHandler(p *deps.RequestProvider) http.Handler {
 	secretConfig := config.SecretConfig
 	databaseCredentials := deps.ProvideDatabaseCredentials(secretConfig)
 	appID := appConfig.ID
-	sqlBuilder := appdb.NewSQLBuilder(databaseCredentials, appID)
+	sqlBuilderApp := appdb.NewSQLBuilderApp(databaseCredentials, appID)
 	contextContext := deps.ProvideRequestContext(request)
 	sqlExecutor := appdb.NewSQLExecutor(contextContext, handle)
 	store := &user.Store{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	authenticationConfig := appConfig.Authentication
@@ -2926,11 +2926,11 @@ func newOAuthEndSessionHandler(p *deps.RequestProvider) http.Handler {
 	featureConfig := config.FeatureConfig
 	identityFeatureConfig := featureConfig.Identity
 	serviceStore := &service.Store{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	loginidStore := &loginid.Store{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	loginIDConfig := identityConfig.LoginID
@@ -2955,7 +2955,7 @@ func newOAuthEndSessionHandler(p *deps.RequestProvider) http.Handler {
 		Clock:             clockClock,
 	}
 	oauthStore := &oauth3.Store{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	oauthProvider := &oauth3.Provider{
@@ -2963,7 +2963,7 @@ func newOAuthEndSessionHandler(p *deps.RequestProvider) http.Handler {
 		Clock: clockClock,
 	}
 	anonymousStore := &anonymous.Store{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	anonymousProvider := &anonymous.Provider{
@@ -2971,7 +2971,7 @@ func newOAuthEndSessionHandler(p *deps.RequestProvider) http.Handler {
 		Clock: clockClock,
 	}
 	biometricStore := &biometric.Store{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	biometricProvider := &biometric.Provider{
@@ -2989,11 +2989,11 @@ func newOAuthEndSessionHandler(p *deps.RequestProvider) http.Handler {
 		Biometric:             biometricProvider,
 	}
 	store2 := &service2.Store{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	passwordStore := &password.Store{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	authenticatorConfig := appConfig.Authenticator
@@ -3001,7 +3001,7 @@ func newOAuthEndSessionHandler(p *deps.RequestProvider) http.Handler {
 	logger := password.NewLogger(factory)
 	historyStore := &password.HistoryStore{
 		Clock:       clockClock,
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	passwordChecker := password.ProvideChecker(authenticatorPasswordConfig, historyStore)
@@ -3021,7 +3021,7 @@ func newOAuthEndSessionHandler(p *deps.RequestProvider) http.Handler {
 		Housekeeper:     housekeeper,
 	}
 	totpStore := &totp.Store{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	authenticatorTOTPConfig := authenticatorConfig.TOTP
@@ -3032,7 +3032,7 @@ func newOAuthEndSessionHandler(p *deps.RequestProvider) http.Handler {
 	}
 	authenticatorOOBConfig := authenticatorConfig.OOB
 	oobStore := &oob.Store{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	appredisHandle := appProvider.Redis
@@ -3074,7 +3074,7 @@ func newOAuthEndSessionHandler(p *deps.RequestProvider) http.Handler {
 		Clock: clockClock,
 	}
 	storePQ := &verification.StorePQ{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	verificationService := &verification.Service{
@@ -3093,7 +3093,7 @@ func newOAuthEndSessionHandler(p *deps.RequestProvider) http.Handler {
 		Clock: clockClock,
 	}
 	storeRecoveryCodePQ := &mfa.StoreRecoveryCodePQ{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	mfaService := &mfa.Service{
@@ -3132,7 +3132,7 @@ func newOAuthEndSessionHandler(p *deps.RequestProvider) http.Handler {
 	queue := appProvider.TaskQueue
 	eventLogger := event.NewLogger(factory)
 	storeImpl := &event.StoreImpl{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	hookLogger := hook.NewLogger(factory)
@@ -3154,10 +3154,10 @@ func newOAuthEndSessionHandler(p *deps.RequestProvider) http.Handler {
 	auditLogger := audit.NewLogger(factory)
 	writeHandle := appProvider.AuditWriteDatabase
 	auditDatabaseCredentials := deps.ProvideAuditDatabaseCredentials(secretConfig)
-	auditdbSQLBuilder := auditdb.NewSQLBuilder(auditDatabaseCredentials, appID)
+	auditdbSQLBuilderApp := auditdb.NewSQLBuilderApp(auditDatabaseCredentials, appID)
 	writeSQLExecutor := auditdb.NewWriteSQLExecutor(contextContext, writeHandle)
 	writeStore := &audit.WriteStore{
-		SQLBuilder:  auditdbSQLBuilder,
+		SQLBuilder:  auditdbSQLBuilderApp,
 		SQLExecutor: writeSQLExecutor,
 	}
 	auditSink := &audit.Sink{
@@ -3179,7 +3179,7 @@ func newOAuthEndSessionHandler(p *deps.RequestProvider) http.Handler {
 		WelcomeMessageProvider: welcomemessageProvider,
 	}
 	authorizationStore := &pq.AuthorizationStore{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	storeRedisLogger := idpsession.NewStoreRedisLogger(factory)
@@ -3205,7 +3205,7 @@ func newOAuthEndSessionHandler(p *deps.RequestProvider) http.Handler {
 		Redis:       appredisHandle,
 		AppID:       appID,
 		Logger:      redisLogger,
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 		Clock:       clockClock,
 	}
@@ -3305,11 +3305,11 @@ func newOAuthAppSessionTokenHandler(p *deps.RequestProvider) http.Handler {
 	tokenHandlerLogger := handler.NewTokenHandlerLogger(factory)
 	secretConfig := config.SecretConfig
 	databaseCredentials := deps.ProvideDatabaseCredentials(secretConfig)
-	sqlBuilder := appdb.NewSQLBuilder(databaseCredentials, appID)
+	sqlBuilderApp := appdb.NewSQLBuilderApp(databaseCredentials, appID)
 	contextContext := deps.ProvideRequestContext(request)
 	sqlExecutor := appdb.NewSQLExecutor(contextContext, handle)
 	authorizationStore := &pq.AuthorizationStore{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	appredisHandle := appProvider.Redis
@@ -3320,7 +3320,7 @@ func newOAuthAppSessionTokenHandler(p *deps.RequestProvider) http.Handler {
 		Redis:       appredisHandle,
 		AppID:       appID,
 		Logger:      logger,
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 		Clock:       clockClock,
 	}
@@ -3337,11 +3337,11 @@ func newOAuthAppSessionTokenHandler(p *deps.RequestProvider) http.Handler {
 	identityConfig := appConfig.Identity
 	identityFeatureConfig := featureConfig.Identity
 	serviceStore := &service.Store{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	loginidStore := &loginid.Store{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	loginIDConfig := identityConfig.LoginID
@@ -3365,7 +3365,7 @@ func newOAuthAppSessionTokenHandler(p *deps.RequestProvider) http.Handler {
 		Clock:             clockClock,
 	}
 	oauthStore := &oauth3.Store{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	oauthProvider := &oauth3.Provider{
@@ -3373,7 +3373,7 @@ func newOAuthAppSessionTokenHandler(p *deps.RequestProvider) http.Handler {
 		Clock: clockClock,
 	}
 	anonymousStore := &anonymous.Store{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	anonymousProvider := &anonymous.Provider{
@@ -3381,7 +3381,7 @@ func newOAuthAppSessionTokenHandler(p *deps.RequestProvider) http.Handler {
 		Clock: clockClock,
 	}
 	biometricStore := &biometric.Store{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	biometricProvider := &biometric.Provider{
@@ -3399,11 +3399,11 @@ func newOAuthAppSessionTokenHandler(p *deps.RequestProvider) http.Handler {
 		Biometric:             biometricProvider,
 	}
 	store2 := &service2.Store{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	passwordStore := &password.Store{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	authenticatorConfig := appConfig.Authenticator
@@ -3411,7 +3411,7 @@ func newOAuthAppSessionTokenHandler(p *deps.RequestProvider) http.Handler {
 	passwordLogger := password.NewLogger(factory)
 	historyStore := &password.HistoryStore{
 		Clock:       clockClock,
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	passwordChecker := password.ProvideChecker(authenticatorPasswordConfig, historyStore)
@@ -3431,7 +3431,7 @@ func newOAuthAppSessionTokenHandler(p *deps.RequestProvider) http.Handler {
 		Housekeeper:     housekeeper,
 	}
 	totpStore := &totp.Store{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	authenticatorTOTPConfig := authenticatorConfig.TOTP
@@ -3442,7 +3442,7 @@ func newOAuthAppSessionTokenHandler(p *deps.RequestProvider) http.Handler {
 	}
 	authenticatorOOBConfig := authenticatorConfig.OOB
 	oobStore := &oob.Store{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	storeRedis := &oob.StoreRedis{
@@ -3483,7 +3483,7 @@ func newOAuthAppSessionTokenHandler(p *deps.RequestProvider) http.Handler {
 		Clock: clockClock,
 	}
 	storePQ := &verification.StorePQ{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	verificationService := &verification.Service{
@@ -3502,7 +3502,7 @@ func newOAuthAppSessionTokenHandler(p *deps.RequestProvider) http.Handler {
 		Clock: clockClock,
 	}
 	storeRecoveryCodePQ := &mfa.StoreRecoveryCodePQ{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	mfaService := &mfa.Service{
@@ -3513,7 +3513,7 @@ func newOAuthAppSessionTokenHandler(p *deps.RequestProvider) http.Handler {
 		RateLimiter:   limiter,
 	}
 	userStore := &user.Store{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	defaultLanguageTag := deps.ProvideDefaultLanguageTag(config)
@@ -3545,7 +3545,7 @@ func newOAuthAppSessionTokenHandler(p *deps.RequestProvider) http.Handler {
 	queue := appProvider.TaskQueue
 	eventLogger := event.NewLogger(factory)
 	storeImpl := &event.StoreImpl{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	hookLogger := hook.NewLogger(factory)
@@ -3567,10 +3567,10 @@ func newOAuthAppSessionTokenHandler(p *deps.RequestProvider) http.Handler {
 	auditLogger := audit.NewLogger(factory)
 	writeHandle := appProvider.AuditWriteDatabase
 	auditDatabaseCredentials := deps.ProvideAuditDatabaseCredentials(secretConfig)
-	auditdbSQLBuilder := auditdb.NewSQLBuilder(auditDatabaseCredentials, appID)
+	auditdbSQLBuilderApp := auditdb.NewSQLBuilderApp(auditDatabaseCredentials, appID)
 	writeSQLExecutor := auditdb.NewWriteSQLExecutor(contextContext, writeHandle)
 	writeStore := &audit.WriteStore{
-		SQLBuilder:  auditdbSQLBuilder,
+		SQLBuilder:  auditdbSQLBuilderApp,
 		SQLExecutor: writeSQLExecutor,
 	}
 	auditSink := &audit.Sink{
@@ -3891,13 +3891,13 @@ func newWebAppLoginHandler(p *deps.RequestProvider) http.Handler {
 	identityFeatureConfig := featureConfig.Identity
 	secretConfig := config.SecretConfig
 	databaseCredentials := deps.ProvideDatabaseCredentials(secretConfig)
-	sqlBuilder := appdb.NewSQLBuilder(databaseCredentials, appID)
+	sqlBuilderApp := appdb.NewSQLBuilderApp(databaseCredentials, appID)
 	store := &service.Store{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	loginidStore := &loginid.Store{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	loginIDConfig := identityConfig.LoginID
@@ -3921,7 +3921,7 @@ func newWebAppLoginHandler(p *deps.RequestProvider) http.Handler {
 		Clock:             clockClock,
 	}
 	oauthStore := &oauth3.Store{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	oauthProvider := &oauth3.Provider{
@@ -3929,7 +3929,7 @@ func newWebAppLoginHandler(p *deps.RequestProvider) http.Handler {
 		Clock: clockClock,
 	}
 	anonymousStore := &anonymous.Store{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	anonymousProvider := &anonymous.Provider{
@@ -3937,7 +3937,7 @@ func newWebAppLoginHandler(p *deps.RequestProvider) http.Handler {
 		Clock: clockClock,
 	}
 	biometricStore := &biometric.Store{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	biometricProvider := &biometric.Provider{
@@ -3955,11 +3955,11 @@ func newWebAppLoginHandler(p *deps.RequestProvider) http.Handler {
 		Biometric:             biometricProvider,
 	}
 	serviceStore := &service2.Store{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	passwordStore := &password.Store{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	authenticatorConfig := appConfig.Authenticator
@@ -3967,7 +3967,7 @@ func newWebAppLoginHandler(p *deps.RequestProvider) http.Handler {
 	passwordLogger := password.NewLogger(factory)
 	historyStore := &password.HistoryStore{
 		Clock:       clockClock,
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	passwordChecker := password.ProvideChecker(authenticatorPasswordConfig, historyStore)
@@ -3987,7 +3987,7 @@ func newWebAppLoginHandler(p *deps.RequestProvider) http.Handler {
 		Housekeeper:     housekeeper,
 	}
 	totpStore := &totp.Store{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	authenticatorTOTPConfig := authenticatorConfig.TOTP
@@ -3998,7 +3998,7 @@ func newWebAppLoginHandler(p *deps.RequestProvider) http.Handler {
 	}
 	authenticatorOOBConfig := authenticatorConfig.OOB
 	oobStore := &oob.Store{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	storeRedis := &oob.StoreRedis{
@@ -4039,7 +4039,7 @@ func newWebAppLoginHandler(p *deps.RequestProvider) http.Handler {
 		Clock: clockClock,
 	}
 	storePQ := &verification.StorePQ{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	verificationService := &verification.Service{
@@ -4058,7 +4058,7 @@ func newWebAppLoginHandler(p *deps.RequestProvider) http.Handler {
 		Clock: clockClock,
 	}
 	storeRecoveryCodePQ := &mfa.StoreRecoveryCodePQ{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	mfaService := &mfa.Service{
@@ -4069,7 +4069,7 @@ func newWebAppLoginHandler(p *deps.RequestProvider) http.Handler {
 		RateLimiter:   limiter,
 	}
 	userStore := &user.Store{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	defaultLanguageTag := deps.ProvideDefaultLanguageTag(config)
@@ -4100,7 +4100,7 @@ func newWebAppLoginHandler(p *deps.RequestProvider) http.Handler {
 	queue := appProvider.TaskQueue
 	eventLogger := event.NewLogger(factory)
 	storeImpl := &event.StoreImpl{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	hookLogger := hook.NewLogger(factory)
@@ -4122,10 +4122,10 @@ func newWebAppLoginHandler(p *deps.RequestProvider) http.Handler {
 	auditLogger := audit.NewLogger(factory)
 	writeHandle := appProvider.AuditWriteDatabase
 	auditDatabaseCredentials := deps.ProvideAuditDatabaseCredentials(secretConfig)
-	auditdbSQLBuilder := auditdb.NewSQLBuilder(auditDatabaseCredentials, appID)
+	auditdbSQLBuilderApp := auditdb.NewSQLBuilderApp(auditDatabaseCredentials, appID)
 	writeSQLExecutor := auditdb.NewWriteSQLExecutor(contextContext, writeHandle)
 	writeStore := &audit.WriteStore{
-		SQLBuilder:  auditdbSQLBuilder,
+		SQLBuilder:  auditdbSQLBuilderApp,
 		SQLExecutor: writeSQLExecutor,
 	}
 	auditSink := &audit.Sink{
@@ -4147,7 +4147,7 @@ func newWebAppLoginHandler(p *deps.RequestProvider) http.Handler {
 		WelcomeMessageProvider: welcomemessageProvider,
 	}
 	authorizationStore := &pq.AuthorizationStore{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	storeRedisLogger := idpsession.NewStoreRedisLogger(factory)
@@ -4172,7 +4172,7 @@ func newWebAppLoginHandler(p *deps.RequestProvider) http.Handler {
 		Redis:       appredisHandle,
 		AppID:       appID,
 		Logger:      redisLogger,
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 		Clock:       clockClock,
 	}
@@ -4479,13 +4479,13 @@ func newWebAppSignupHandler(p *deps.RequestProvider) http.Handler {
 	identityFeatureConfig := featureConfig.Identity
 	secretConfig := config.SecretConfig
 	databaseCredentials := deps.ProvideDatabaseCredentials(secretConfig)
-	sqlBuilder := appdb.NewSQLBuilder(databaseCredentials, appID)
+	sqlBuilderApp := appdb.NewSQLBuilderApp(databaseCredentials, appID)
 	store := &service.Store{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	loginidStore := &loginid.Store{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	loginIDConfig := identityConfig.LoginID
@@ -4509,7 +4509,7 @@ func newWebAppSignupHandler(p *deps.RequestProvider) http.Handler {
 		Clock:             clockClock,
 	}
 	oauthStore := &oauth3.Store{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	oauthProvider := &oauth3.Provider{
@@ -4517,7 +4517,7 @@ func newWebAppSignupHandler(p *deps.RequestProvider) http.Handler {
 		Clock: clockClock,
 	}
 	anonymousStore := &anonymous.Store{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	anonymousProvider := &anonymous.Provider{
@@ -4525,7 +4525,7 @@ func newWebAppSignupHandler(p *deps.RequestProvider) http.Handler {
 		Clock: clockClock,
 	}
 	biometricStore := &biometric.Store{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	biometricProvider := &biometric.Provider{
@@ -4543,11 +4543,11 @@ func newWebAppSignupHandler(p *deps.RequestProvider) http.Handler {
 		Biometric:             biometricProvider,
 	}
 	serviceStore := &service2.Store{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	passwordStore := &password.Store{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	authenticatorConfig := appConfig.Authenticator
@@ -4555,7 +4555,7 @@ func newWebAppSignupHandler(p *deps.RequestProvider) http.Handler {
 	passwordLogger := password.NewLogger(factory)
 	historyStore := &password.HistoryStore{
 		Clock:       clockClock,
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	passwordChecker := password.ProvideChecker(authenticatorPasswordConfig, historyStore)
@@ -4575,7 +4575,7 @@ func newWebAppSignupHandler(p *deps.RequestProvider) http.Handler {
 		Housekeeper:     housekeeper,
 	}
 	totpStore := &totp.Store{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	authenticatorTOTPConfig := authenticatorConfig.TOTP
@@ -4586,7 +4586,7 @@ func newWebAppSignupHandler(p *deps.RequestProvider) http.Handler {
 	}
 	authenticatorOOBConfig := authenticatorConfig.OOB
 	oobStore := &oob.Store{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	storeRedis := &oob.StoreRedis{
@@ -4627,7 +4627,7 @@ func newWebAppSignupHandler(p *deps.RequestProvider) http.Handler {
 		Clock: clockClock,
 	}
 	storePQ := &verification.StorePQ{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	verificationService := &verification.Service{
@@ -4646,7 +4646,7 @@ func newWebAppSignupHandler(p *deps.RequestProvider) http.Handler {
 		Clock: clockClock,
 	}
 	storeRecoveryCodePQ := &mfa.StoreRecoveryCodePQ{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	mfaService := &mfa.Service{
@@ -4657,7 +4657,7 @@ func newWebAppSignupHandler(p *deps.RequestProvider) http.Handler {
 		RateLimiter:   limiter,
 	}
 	userStore := &user.Store{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	defaultLanguageTag := deps.ProvideDefaultLanguageTag(config)
@@ -4688,7 +4688,7 @@ func newWebAppSignupHandler(p *deps.RequestProvider) http.Handler {
 	queue := appProvider.TaskQueue
 	eventLogger := event.NewLogger(factory)
 	storeImpl := &event.StoreImpl{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	hookLogger := hook.NewLogger(factory)
@@ -4710,10 +4710,10 @@ func newWebAppSignupHandler(p *deps.RequestProvider) http.Handler {
 	auditLogger := audit.NewLogger(factory)
 	writeHandle := appProvider.AuditWriteDatabase
 	auditDatabaseCredentials := deps.ProvideAuditDatabaseCredentials(secretConfig)
-	auditdbSQLBuilder := auditdb.NewSQLBuilder(auditDatabaseCredentials, appID)
+	auditdbSQLBuilderApp := auditdb.NewSQLBuilderApp(auditDatabaseCredentials, appID)
 	writeSQLExecutor := auditdb.NewWriteSQLExecutor(contextContext, writeHandle)
 	writeStore := &audit.WriteStore{
-		SQLBuilder:  auditdbSQLBuilder,
+		SQLBuilder:  auditdbSQLBuilderApp,
 		SQLExecutor: writeSQLExecutor,
 	}
 	auditSink := &audit.Sink{
@@ -4735,7 +4735,7 @@ func newWebAppSignupHandler(p *deps.RequestProvider) http.Handler {
 		WelcomeMessageProvider: welcomemessageProvider,
 	}
 	authorizationStore := &pq.AuthorizationStore{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	storeRedisLogger := idpsession.NewStoreRedisLogger(factory)
@@ -4760,7 +4760,7 @@ func newWebAppSignupHandler(p *deps.RequestProvider) http.Handler {
 		Redis:       appredisHandle,
 		AppID:       appID,
 		Logger:      redisLogger,
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 		Clock:       clockClock,
 	}
@@ -5067,13 +5067,13 @@ func newWebAppPromoteHandler(p *deps.RequestProvider) http.Handler {
 	identityFeatureConfig := featureConfig.Identity
 	secretConfig := config.SecretConfig
 	databaseCredentials := deps.ProvideDatabaseCredentials(secretConfig)
-	sqlBuilder := appdb.NewSQLBuilder(databaseCredentials, appID)
+	sqlBuilderApp := appdb.NewSQLBuilderApp(databaseCredentials, appID)
 	store := &service.Store{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	loginidStore := &loginid.Store{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	loginIDConfig := identityConfig.LoginID
@@ -5097,7 +5097,7 @@ func newWebAppPromoteHandler(p *deps.RequestProvider) http.Handler {
 		Clock:             clockClock,
 	}
 	oauthStore := &oauth3.Store{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	oauthProvider := &oauth3.Provider{
@@ -5105,7 +5105,7 @@ func newWebAppPromoteHandler(p *deps.RequestProvider) http.Handler {
 		Clock: clockClock,
 	}
 	anonymousStore := &anonymous.Store{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	anonymousProvider := &anonymous.Provider{
@@ -5113,7 +5113,7 @@ func newWebAppPromoteHandler(p *deps.RequestProvider) http.Handler {
 		Clock: clockClock,
 	}
 	biometricStore := &biometric.Store{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	biometricProvider := &biometric.Provider{
@@ -5131,11 +5131,11 @@ func newWebAppPromoteHandler(p *deps.RequestProvider) http.Handler {
 		Biometric:             biometricProvider,
 	}
 	serviceStore := &service2.Store{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	passwordStore := &password.Store{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	authenticatorConfig := appConfig.Authenticator
@@ -5143,7 +5143,7 @@ func newWebAppPromoteHandler(p *deps.RequestProvider) http.Handler {
 	passwordLogger := password.NewLogger(factory)
 	historyStore := &password.HistoryStore{
 		Clock:       clockClock,
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	passwordChecker := password.ProvideChecker(authenticatorPasswordConfig, historyStore)
@@ -5163,7 +5163,7 @@ func newWebAppPromoteHandler(p *deps.RequestProvider) http.Handler {
 		Housekeeper:     housekeeper,
 	}
 	totpStore := &totp.Store{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	authenticatorTOTPConfig := authenticatorConfig.TOTP
@@ -5174,7 +5174,7 @@ func newWebAppPromoteHandler(p *deps.RequestProvider) http.Handler {
 	}
 	authenticatorOOBConfig := authenticatorConfig.OOB
 	oobStore := &oob.Store{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	storeRedis := &oob.StoreRedis{
@@ -5215,7 +5215,7 @@ func newWebAppPromoteHandler(p *deps.RequestProvider) http.Handler {
 		Clock: clockClock,
 	}
 	storePQ := &verification.StorePQ{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	verificationService := &verification.Service{
@@ -5234,7 +5234,7 @@ func newWebAppPromoteHandler(p *deps.RequestProvider) http.Handler {
 		Clock: clockClock,
 	}
 	storeRecoveryCodePQ := &mfa.StoreRecoveryCodePQ{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	mfaService := &mfa.Service{
@@ -5245,7 +5245,7 @@ func newWebAppPromoteHandler(p *deps.RequestProvider) http.Handler {
 		RateLimiter:   limiter,
 	}
 	userStore := &user.Store{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	defaultLanguageTag := deps.ProvideDefaultLanguageTag(config)
@@ -5276,7 +5276,7 @@ func newWebAppPromoteHandler(p *deps.RequestProvider) http.Handler {
 	queue := appProvider.TaskQueue
 	eventLogger := event.NewLogger(factory)
 	storeImpl := &event.StoreImpl{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	hookLogger := hook.NewLogger(factory)
@@ -5298,10 +5298,10 @@ func newWebAppPromoteHandler(p *deps.RequestProvider) http.Handler {
 	auditLogger := audit.NewLogger(factory)
 	writeHandle := appProvider.AuditWriteDatabase
 	auditDatabaseCredentials := deps.ProvideAuditDatabaseCredentials(secretConfig)
-	auditdbSQLBuilder := auditdb.NewSQLBuilder(auditDatabaseCredentials, appID)
+	auditdbSQLBuilderApp := auditdb.NewSQLBuilderApp(auditDatabaseCredentials, appID)
 	writeSQLExecutor := auditdb.NewWriteSQLExecutor(contextContext, writeHandle)
 	writeStore := &audit.WriteStore{
-		SQLBuilder:  auditdbSQLBuilder,
+		SQLBuilder:  auditdbSQLBuilderApp,
 		SQLExecutor: writeSQLExecutor,
 	}
 	auditSink := &audit.Sink{
@@ -5323,7 +5323,7 @@ func newWebAppPromoteHandler(p *deps.RequestProvider) http.Handler {
 		WelcomeMessageProvider: welcomemessageProvider,
 	}
 	authorizationStore := &pq.AuthorizationStore{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	storeRedisLogger := idpsession.NewStoreRedisLogger(factory)
@@ -5348,7 +5348,7 @@ func newWebAppPromoteHandler(p *deps.RequestProvider) http.Handler {
 		Redis:       appredisHandle,
 		AppID:       appID,
 		Logger:      redisLogger,
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 		Clock:       clockClock,
 	}
@@ -5642,13 +5642,13 @@ func newWebAppSelectAccountHandler(p *deps.RequestProvider) http.Handler {
 	identityFeatureConfig := featureConfig.Identity
 	secretConfig := config.SecretConfig
 	databaseCredentials := deps.ProvideDatabaseCredentials(secretConfig)
-	sqlBuilder := appdb.NewSQLBuilder(databaseCredentials, appID)
+	sqlBuilderApp := appdb.NewSQLBuilderApp(databaseCredentials, appID)
 	store := &service.Store{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	loginidStore := &loginid.Store{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	loginIDConfig := identityConfig.LoginID
@@ -5672,7 +5672,7 @@ func newWebAppSelectAccountHandler(p *deps.RequestProvider) http.Handler {
 		Clock:             clockClock,
 	}
 	oauthStore := &oauth3.Store{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	oauthProvider := &oauth3.Provider{
@@ -5680,7 +5680,7 @@ func newWebAppSelectAccountHandler(p *deps.RequestProvider) http.Handler {
 		Clock: clockClock,
 	}
 	anonymousStore := &anonymous.Store{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	anonymousProvider := &anonymous.Provider{
@@ -5688,7 +5688,7 @@ func newWebAppSelectAccountHandler(p *deps.RequestProvider) http.Handler {
 		Clock: clockClock,
 	}
 	biometricStore := &biometric.Store{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	biometricProvider := &biometric.Provider{
@@ -5706,11 +5706,11 @@ func newWebAppSelectAccountHandler(p *deps.RequestProvider) http.Handler {
 		Biometric:             biometricProvider,
 	}
 	serviceStore := &service2.Store{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	passwordStore := &password.Store{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	authenticatorConfig := appConfig.Authenticator
@@ -5718,7 +5718,7 @@ func newWebAppSelectAccountHandler(p *deps.RequestProvider) http.Handler {
 	passwordLogger := password.NewLogger(factory)
 	historyStore := &password.HistoryStore{
 		Clock:       clockClock,
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	passwordChecker := password.ProvideChecker(authenticatorPasswordConfig, historyStore)
@@ -5738,7 +5738,7 @@ func newWebAppSelectAccountHandler(p *deps.RequestProvider) http.Handler {
 		Housekeeper:     housekeeper,
 	}
 	totpStore := &totp.Store{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	authenticatorTOTPConfig := authenticatorConfig.TOTP
@@ -5749,7 +5749,7 @@ func newWebAppSelectAccountHandler(p *deps.RequestProvider) http.Handler {
 	}
 	authenticatorOOBConfig := authenticatorConfig.OOB
 	oobStore := &oob.Store{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	storeRedis := &oob.StoreRedis{
@@ -5790,7 +5790,7 @@ func newWebAppSelectAccountHandler(p *deps.RequestProvider) http.Handler {
 		Clock: clockClock,
 	}
 	storePQ := &verification.StorePQ{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	verificationService := &verification.Service{
@@ -5809,7 +5809,7 @@ func newWebAppSelectAccountHandler(p *deps.RequestProvider) http.Handler {
 		Clock: clockClock,
 	}
 	storeRecoveryCodePQ := &mfa.StoreRecoveryCodePQ{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	mfaService := &mfa.Service{
@@ -5820,7 +5820,7 @@ func newWebAppSelectAccountHandler(p *deps.RequestProvider) http.Handler {
 		RateLimiter:   limiter,
 	}
 	userStore := &user.Store{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	defaultLanguageTag := deps.ProvideDefaultLanguageTag(config)
@@ -5851,7 +5851,7 @@ func newWebAppSelectAccountHandler(p *deps.RequestProvider) http.Handler {
 	queue := appProvider.TaskQueue
 	eventLogger := event.NewLogger(factory)
 	storeImpl := &event.StoreImpl{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	hookLogger := hook.NewLogger(factory)
@@ -5873,10 +5873,10 @@ func newWebAppSelectAccountHandler(p *deps.RequestProvider) http.Handler {
 	auditLogger := audit.NewLogger(factory)
 	writeHandle := appProvider.AuditWriteDatabase
 	auditDatabaseCredentials := deps.ProvideAuditDatabaseCredentials(secretConfig)
-	auditdbSQLBuilder := auditdb.NewSQLBuilder(auditDatabaseCredentials, appID)
+	auditdbSQLBuilderApp := auditdb.NewSQLBuilderApp(auditDatabaseCredentials, appID)
 	writeSQLExecutor := auditdb.NewWriteSQLExecutor(contextContext, writeHandle)
 	writeStore := &audit.WriteStore{
-		SQLBuilder:  auditdbSQLBuilder,
+		SQLBuilder:  auditdbSQLBuilderApp,
 		SQLExecutor: writeSQLExecutor,
 	}
 	auditSink := &audit.Sink{
@@ -5898,7 +5898,7 @@ func newWebAppSelectAccountHandler(p *deps.RequestProvider) http.Handler {
 		WelcomeMessageProvider: welcomemessageProvider,
 	}
 	authorizationStore := &pq.AuthorizationStore{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	storeRedisLogger := idpsession.NewStoreRedisLogger(factory)
@@ -5923,7 +5923,7 @@ func newWebAppSelectAccountHandler(p *deps.RequestProvider) http.Handler {
 		Redis:       appredisHandle,
 		AppID:       appID,
 		Logger:      redisLogger,
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 		Clock:       clockClock,
 	}
@@ -6218,13 +6218,13 @@ func newWebAppSSOCallbackHandler(p *deps.RequestProvider) http.Handler {
 	identityFeatureConfig := featureConfig.Identity
 	secretConfig := config.SecretConfig
 	databaseCredentials := deps.ProvideDatabaseCredentials(secretConfig)
-	sqlBuilder := appdb.NewSQLBuilder(databaseCredentials, appID)
+	sqlBuilderApp := appdb.NewSQLBuilderApp(databaseCredentials, appID)
 	store := &service.Store{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	loginidStore := &loginid.Store{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	loginIDConfig := identityConfig.LoginID
@@ -6248,7 +6248,7 @@ func newWebAppSSOCallbackHandler(p *deps.RequestProvider) http.Handler {
 		Clock:             clockClock,
 	}
 	oauthStore := &oauth3.Store{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	oauthProvider := &oauth3.Provider{
@@ -6256,7 +6256,7 @@ func newWebAppSSOCallbackHandler(p *deps.RequestProvider) http.Handler {
 		Clock: clockClock,
 	}
 	anonymousStore := &anonymous.Store{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	anonymousProvider := &anonymous.Provider{
@@ -6264,7 +6264,7 @@ func newWebAppSSOCallbackHandler(p *deps.RequestProvider) http.Handler {
 		Clock: clockClock,
 	}
 	biometricStore := &biometric.Store{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	biometricProvider := &biometric.Provider{
@@ -6282,11 +6282,11 @@ func newWebAppSSOCallbackHandler(p *deps.RequestProvider) http.Handler {
 		Biometric:             biometricProvider,
 	}
 	serviceStore := &service2.Store{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	passwordStore := &password.Store{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	authenticatorConfig := appConfig.Authenticator
@@ -6294,7 +6294,7 @@ func newWebAppSSOCallbackHandler(p *deps.RequestProvider) http.Handler {
 	passwordLogger := password.NewLogger(factory)
 	historyStore := &password.HistoryStore{
 		Clock:       clockClock,
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	passwordChecker := password.ProvideChecker(authenticatorPasswordConfig, historyStore)
@@ -6314,7 +6314,7 @@ func newWebAppSSOCallbackHandler(p *deps.RequestProvider) http.Handler {
 		Housekeeper:     housekeeper,
 	}
 	totpStore := &totp.Store{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	authenticatorTOTPConfig := authenticatorConfig.TOTP
@@ -6325,7 +6325,7 @@ func newWebAppSSOCallbackHandler(p *deps.RequestProvider) http.Handler {
 	}
 	authenticatorOOBConfig := authenticatorConfig.OOB
 	oobStore := &oob.Store{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	storeRedis := &oob.StoreRedis{
@@ -6366,7 +6366,7 @@ func newWebAppSSOCallbackHandler(p *deps.RequestProvider) http.Handler {
 		Clock: clockClock,
 	}
 	storePQ := &verification.StorePQ{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	verificationService := &verification.Service{
@@ -6385,7 +6385,7 @@ func newWebAppSSOCallbackHandler(p *deps.RequestProvider) http.Handler {
 		Clock: clockClock,
 	}
 	storeRecoveryCodePQ := &mfa.StoreRecoveryCodePQ{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	mfaService := &mfa.Service{
@@ -6396,7 +6396,7 @@ func newWebAppSSOCallbackHandler(p *deps.RequestProvider) http.Handler {
 		RateLimiter:   limiter,
 	}
 	userStore := &user.Store{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	defaultLanguageTag := deps.ProvideDefaultLanguageTag(config)
@@ -6427,7 +6427,7 @@ func newWebAppSSOCallbackHandler(p *deps.RequestProvider) http.Handler {
 	queue := appProvider.TaskQueue
 	eventLogger := event.NewLogger(factory)
 	storeImpl := &event.StoreImpl{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	hookLogger := hook.NewLogger(factory)
@@ -6449,10 +6449,10 @@ func newWebAppSSOCallbackHandler(p *deps.RequestProvider) http.Handler {
 	auditLogger := audit.NewLogger(factory)
 	writeHandle := appProvider.AuditWriteDatabase
 	auditDatabaseCredentials := deps.ProvideAuditDatabaseCredentials(secretConfig)
-	auditdbSQLBuilder := auditdb.NewSQLBuilder(auditDatabaseCredentials, appID)
+	auditdbSQLBuilderApp := auditdb.NewSQLBuilderApp(auditDatabaseCredentials, appID)
 	writeSQLExecutor := auditdb.NewWriteSQLExecutor(contextContext, writeHandle)
 	writeStore := &audit.WriteStore{
-		SQLBuilder:  auditdbSQLBuilder,
+		SQLBuilder:  auditdbSQLBuilderApp,
 		SQLExecutor: writeSQLExecutor,
 	}
 	auditSink := &audit.Sink{
@@ -6474,7 +6474,7 @@ func newWebAppSSOCallbackHandler(p *deps.RequestProvider) http.Handler {
 		WelcomeMessageProvider: welcomemessageProvider,
 	}
 	authorizationStore := &pq.AuthorizationStore{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	storeRedisLogger := idpsession.NewStoreRedisLogger(factory)
@@ -6499,7 +6499,7 @@ func newWebAppSSOCallbackHandler(p *deps.RequestProvider) http.Handler {
 		Redis:       appredisHandle,
 		AppID:       appID,
 		Logger:      redisLogger,
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 		Clock:       clockClock,
 	}
@@ -6786,13 +6786,13 @@ func newWechatAuthHandler(p *deps.RequestProvider) http.Handler {
 	identityFeatureConfig := featureConfig.Identity
 	secretConfig := config.SecretConfig
 	databaseCredentials := deps.ProvideDatabaseCredentials(secretConfig)
-	sqlBuilder := appdb.NewSQLBuilder(databaseCredentials, appID)
+	sqlBuilderApp := appdb.NewSQLBuilderApp(databaseCredentials, appID)
 	store := &service.Store{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	loginidStore := &loginid.Store{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	loginIDConfig := identityConfig.LoginID
@@ -6816,7 +6816,7 @@ func newWechatAuthHandler(p *deps.RequestProvider) http.Handler {
 		Clock:             clockClock,
 	}
 	oauthStore := &oauth3.Store{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	oauthProvider := &oauth3.Provider{
@@ -6824,7 +6824,7 @@ func newWechatAuthHandler(p *deps.RequestProvider) http.Handler {
 		Clock: clockClock,
 	}
 	anonymousStore := &anonymous.Store{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	anonymousProvider := &anonymous.Provider{
@@ -6832,7 +6832,7 @@ func newWechatAuthHandler(p *deps.RequestProvider) http.Handler {
 		Clock: clockClock,
 	}
 	biometricStore := &biometric.Store{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	biometricProvider := &biometric.Provider{
@@ -6850,11 +6850,11 @@ func newWechatAuthHandler(p *deps.RequestProvider) http.Handler {
 		Biometric:             biometricProvider,
 	}
 	serviceStore := &service2.Store{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	passwordStore := &password.Store{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	authenticatorConfig := appConfig.Authenticator
@@ -6862,7 +6862,7 @@ func newWechatAuthHandler(p *deps.RequestProvider) http.Handler {
 	passwordLogger := password.NewLogger(factory)
 	historyStore := &password.HistoryStore{
 		Clock:       clockClock,
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	passwordChecker := password.ProvideChecker(authenticatorPasswordConfig, historyStore)
@@ -6882,7 +6882,7 @@ func newWechatAuthHandler(p *deps.RequestProvider) http.Handler {
 		Housekeeper:     housekeeper,
 	}
 	totpStore := &totp.Store{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	authenticatorTOTPConfig := authenticatorConfig.TOTP
@@ -6893,7 +6893,7 @@ func newWechatAuthHandler(p *deps.RequestProvider) http.Handler {
 	}
 	authenticatorOOBConfig := authenticatorConfig.OOB
 	oobStore := &oob.Store{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	storeRedis := &oob.StoreRedis{
@@ -6934,7 +6934,7 @@ func newWechatAuthHandler(p *deps.RequestProvider) http.Handler {
 		Clock: clockClock,
 	}
 	storePQ := &verification.StorePQ{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	verificationService := &verification.Service{
@@ -6953,7 +6953,7 @@ func newWechatAuthHandler(p *deps.RequestProvider) http.Handler {
 		Clock: clockClock,
 	}
 	storeRecoveryCodePQ := &mfa.StoreRecoveryCodePQ{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	mfaService := &mfa.Service{
@@ -6964,7 +6964,7 @@ func newWechatAuthHandler(p *deps.RequestProvider) http.Handler {
 		RateLimiter:   limiter,
 	}
 	userStore := &user.Store{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	defaultLanguageTag := deps.ProvideDefaultLanguageTag(config)
@@ -6995,7 +6995,7 @@ func newWechatAuthHandler(p *deps.RequestProvider) http.Handler {
 	queue := appProvider.TaskQueue
 	eventLogger := event.NewLogger(factory)
 	storeImpl := &event.StoreImpl{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	hookLogger := hook.NewLogger(factory)
@@ -7017,10 +7017,10 @@ func newWechatAuthHandler(p *deps.RequestProvider) http.Handler {
 	auditLogger := audit.NewLogger(factory)
 	writeHandle := appProvider.AuditWriteDatabase
 	auditDatabaseCredentials := deps.ProvideAuditDatabaseCredentials(secretConfig)
-	auditdbSQLBuilder := auditdb.NewSQLBuilder(auditDatabaseCredentials, appID)
+	auditdbSQLBuilderApp := auditdb.NewSQLBuilderApp(auditDatabaseCredentials, appID)
 	writeSQLExecutor := auditdb.NewWriteSQLExecutor(contextContext, writeHandle)
 	writeStore := &audit.WriteStore{
-		SQLBuilder:  auditdbSQLBuilder,
+		SQLBuilder:  auditdbSQLBuilderApp,
 		SQLExecutor: writeSQLExecutor,
 	}
 	auditSink := &audit.Sink{
@@ -7042,7 +7042,7 @@ func newWechatAuthHandler(p *deps.RequestProvider) http.Handler {
 		WelcomeMessageProvider: welcomemessageProvider,
 	}
 	authorizationStore := &pq.AuthorizationStore{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	storeRedisLogger := idpsession.NewStoreRedisLogger(factory)
@@ -7067,7 +7067,7 @@ func newWechatAuthHandler(p *deps.RequestProvider) http.Handler {
 		Redis:       appredisHandle,
 		AppID:       appID,
 		Logger:      redisLogger,
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 		Clock:       clockClock,
 	}
@@ -7357,13 +7357,13 @@ func newWechatCallbackHandler(p *deps.RequestProvider) http.Handler {
 	identityFeatureConfig := featureConfig.Identity
 	secretConfig := config.SecretConfig
 	databaseCredentials := deps.ProvideDatabaseCredentials(secretConfig)
-	sqlBuilder := appdb.NewSQLBuilder(databaseCredentials, appID)
+	sqlBuilderApp := appdb.NewSQLBuilderApp(databaseCredentials, appID)
 	store := &service.Store{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	loginidStore := &loginid.Store{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	loginIDConfig := identityConfig.LoginID
@@ -7387,7 +7387,7 @@ func newWechatCallbackHandler(p *deps.RequestProvider) http.Handler {
 		Clock:             clockClock,
 	}
 	oauthStore := &oauth3.Store{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	oauthProvider := &oauth3.Provider{
@@ -7395,7 +7395,7 @@ func newWechatCallbackHandler(p *deps.RequestProvider) http.Handler {
 		Clock: clockClock,
 	}
 	anonymousStore := &anonymous.Store{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	anonymousProvider := &anonymous.Provider{
@@ -7403,7 +7403,7 @@ func newWechatCallbackHandler(p *deps.RequestProvider) http.Handler {
 		Clock: clockClock,
 	}
 	biometricStore := &biometric.Store{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	biometricProvider := &biometric.Provider{
@@ -7421,11 +7421,11 @@ func newWechatCallbackHandler(p *deps.RequestProvider) http.Handler {
 		Biometric:             biometricProvider,
 	}
 	serviceStore := &service2.Store{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	passwordStore := &password.Store{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	authenticatorConfig := appConfig.Authenticator
@@ -7433,7 +7433,7 @@ func newWechatCallbackHandler(p *deps.RequestProvider) http.Handler {
 	passwordLogger := password.NewLogger(factory)
 	historyStore := &password.HistoryStore{
 		Clock:       clockClock,
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	passwordChecker := password.ProvideChecker(authenticatorPasswordConfig, historyStore)
@@ -7453,7 +7453,7 @@ func newWechatCallbackHandler(p *deps.RequestProvider) http.Handler {
 		Housekeeper:     housekeeper,
 	}
 	totpStore := &totp.Store{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	authenticatorTOTPConfig := authenticatorConfig.TOTP
@@ -7464,7 +7464,7 @@ func newWechatCallbackHandler(p *deps.RequestProvider) http.Handler {
 	}
 	authenticatorOOBConfig := authenticatorConfig.OOB
 	oobStore := &oob.Store{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	storeRedis := &oob.StoreRedis{
@@ -7505,7 +7505,7 @@ func newWechatCallbackHandler(p *deps.RequestProvider) http.Handler {
 		Clock: clockClock,
 	}
 	storePQ := &verification.StorePQ{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	verificationService := &verification.Service{
@@ -7524,7 +7524,7 @@ func newWechatCallbackHandler(p *deps.RequestProvider) http.Handler {
 		Clock: clockClock,
 	}
 	storeRecoveryCodePQ := &mfa.StoreRecoveryCodePQ{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	mfaService := &mfa.Service{
@@ -7535,7 +7535,7 @@ func newWechatCallbackHandler(p *deps.RequestProvider) http.Handler {
 		RateLimiter:   limiter,
 	}
 	userStore := &user.Store{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	defaultLanguageTag := deps.ProvideDefaultLanguageTag(config)
@@ -7566,7 +7566,7 @@ func newWechatCallbackHandler(p *deps.RequestProvider) http.Handler {
 	queue := appProvider.TaskQueue
 	eventLogger := event.NewLogger(factory)
 	storeImpl := &event.StoreImpl{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	hookLogger := hook.NewLogger(factory)
@@ -7588,10 +7588,10 @@ func newWechatCallbackHandler(p *deps.RequestProvider) http.Handler {
 	auditLogger := audit.NewLogger(factory)
 	writeHandle := appProvider.AuditWriteDatabase
 	auditDatabaseCredentials := deps.ProvideAuditDatabaseCredentials(secretConfig)
-	auditdbSQLBuilder := auditdb.NewSQLBuilder(auditDatabaseCredentials, appID)
+	auditdbSQLBuilderApp := auditdb.NewSQLBuilderApp(auditDatabaseCredentials, appID)
 	writeSQLExecutor := auditdb.NewWriteSQLExecutor(contextContext, writeHandle)
 	writeStore := &audit.WriteStore{
-		SQLBuilder:  auditdbSQLBuilder,
+		SQLBuilder:  auditdbSQLBuilderApp,
 		SQLExecutor: writeSQLExecutor,
 	}
 	auditSink := &audit.Sink{
@@ -7613,7 +7613,7 @@ func newWechatCallbackHandler(p *deps.RequestProvider) http.Handler {
 		WelcomeMessageProvider: welcomemessageProvider,
 	}
 	authorizationStore := &pq.AuthorizationStore{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	storeRedisLogger := idpsession.NewStoreRedisLogger(factory)
@@ -7638,7 +7638,7 @@ func newWechatCallbackHandler(p *deps.RequestProvider) http.Handler {
 		Redis:       appredisHandle,
 		AppID:       appID,
 		Logger:      redisLogger,
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 		Clock:       clockClock,
 	}
@@ -7931,13 +7931,13 @@ func newWebAppEnterLoginIDHandler(p *deps.RequestProvider) http.Handler {
 	identityFeatureConfig := featureConfig.Identity
 	secretConfig := config.SecretConfig
 	databaseCredentials := deps.ProvideDatabaseCredentials(secretConfig)
-	sqlBuilder := appdb.NewSQLBuilder(databaseCredentials, appID)
+	sqlBuilderApp := appdb.NewSQLBuilderApp(databaseCredentials, appID)
 	store := &service.Store{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	loginidStore := &loginid.Store{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	loginIDConfig := identityConfig.LoginID
@@ -7961,7 +7961,7 @@ func newWebAppEnterLoginIDHandler(p *deps.RequestProvider) http.Handler {
 		Clock:             clockClock,
 	}
 	oauthStore := &oauth3.Store{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	oauthProvider := &oauth3.Provider{
@@ -7969,7 +7969,7 @@ func newWebAppEnterLoginIDHandler(p *deps.RequestProvider) http.Handler {
 		Clock: clockClock,
 	}
 	anonymousStore := &anonymous.Store{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	anonymousProvider := &anonymous.Provider{
@@ -7977,7 +7977,7 @@ func newWebAppEnterLoginIDHandler(p *deps.RequestProvider) http.Handler {
 		Clock: clockClock,
 	}
 	biometricStore := &biometric.Store{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	biometricProvider := &biometric.Provider{
@@ -7995,11 +7995,11 @@ func newWebAppEnterLoginIDHandler(p *deps.RequestProvider) http.Handler {
 		Biometric:             biometricProvider,
 	}
 	serviceStore := &service2.Store{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	passwordStore := &password.Store{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	authenticatorConfig := appConfig.Authenticator
@@ -8007,7 +8007,7 @@ func newWebAppEnterLoginIDHandler(p *deps.RequestProvider) http.Handler {
 	passwordLogger := password.NewLogger(factory)
 	historyStore := &password.HistoryStore{
 		Clock:       clockClock,
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	passwordChecker := password.ProvideChecker(authenticatorPasswordConfig, historyStore)
@@ -8027,7 +8027,7 @@ func newWebAppEnterLoginIDHandler(p *deps.RequestProvider) http.Handler {
 		Housekeeper:     housekeeper,
 	}
 	totpStore := &totp.Store{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	authenticatorTOTPConfig := authenticatorConfig.TOTP
@@ -8038,7 +8038,7 @@ func newWebAppEnterLoginIDHandler(p *deps.RequestProvider) http.Handler {
 	}
 	authenticatorOOBConfig := authenticatorConfig.OOB
 	oobStore := &oob.Store{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	storeRedis := &oob.StoreRedis{
@@ -8079,7 +8079,7 @@ func newWebAppEnterLoginIDHandler(p *deps.RequestProvider) http.Handler {
 		Clock: clockClock,
 	}
 	storePQ := &verification.StorePQ{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	verificationService := &verification.Service{
@@ -8098,7 +8098,7 @@ func newWebAppEnterLoginIDHandler(p *deps.RequestProvider) http.Handler {
 		Clock: clockClock,
 	}
 	storeRecoveryCodePQ := &mfa.StoreRecoveryCodePQ{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	mfaService := &mfa.Service{
@@ -8109,7 +8109,7 @@ func newWebAppEnterLoginIDHandler(p *deps.RequestProvider) http.Handler {
 		RateLimiter:   limiter,
 	}
 	userStore := &user.Store{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	defaultLanguageTag := deps.ProvideDefaultLanguageTag(config)
@@ -8140,7 +8140,7 @@ func newWebAppEnterLoginIDHandler(p *deps.RequestProvider) http.Handler {
 	queue := appProvider.TaskQueue
 	eventLogger := event.NewLogger(factory)
 	storeImpl := &event.StoreImpl{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	hookLogger := hook.NewLogger(factory)
@@ -8162,10 +8162,10 @@ func newWebAppEnterLoginIDHandler(p *deps.RequestProvider) http.Handler {
 	auditLogger := audit.NewLogger(factory)
 	writeHandle := appProvider.AuditWriteDatabase
 	auditDatabaseCredentials := deps.ProvideAuditDatabaseCredentials(secretConfig)
-	auditdbSQLBuilder := auditdb.NewSQLBuilder(auditDatabaseCredentials, appID)
+	auditdbSQLBuilderApp := auditdb.NewSQLBuilderApp(auditDatabaseCredentials, appID)
 	writeSQLExecutor := auditdb.NewWriteSQLExecutor(contextContext, writeHandle)
 	writeStore := &audit.WriteStore{
-		SQLBuilder:  auditdbSQLBuilder,
+		SQLBuilder:  auditdbSQLBuilderApp,
 		SQLExecutor: writeSQLExecutor,
 	}
 	auditSink := &audit.Sink{
@@ -8187,7 +8187,7 @@ func newWebAppEnterLoginIDHandler(p *deps.RequestProvider) http.Handler {
 		WelcomeMessageProvider: welcomemessageProvider,
 	}
 	authorizationStore := &pq.AuthorizationStore{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	storeRedisLogger := idpsession.NewStoreRedisLogger(factory)
@@ -8212,7 +8212,7 @@ func newWebAppEnterLoginIDHandler(p *deps.RequestProvider) http.Handler {
 		Redis:       appredisHandle,
 		AppID:       appID,
 		Logger:      redisLogger,
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 		Clock:       clockClock,
 	}
@@ -8502,13 +8502,13 @@ func newWebAppEnterPasswordHandler(p *deps.RequestProvider) http.Handler {
 	identityFeatureConfig := featureConfig.Identity
 	secretConfig := config.SecretConfig
 	databaseCredentials := deps.ProvideDatabaseCredentials(secretConfig)
-	sqlBuilder := appdb.NewSQLBuilder(databaseCredentials, appID)
+	sqlBuilderApp := appdb.NewSQLBuilderApp(databaseCredentials, appID)
 	store := &service.Store{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	loginidStore := &loginid.Store{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	loginIDConfig := identityConfig.LoginID
@@ -8532,7 +8532,7 @@ func newWebAppEnterPasswordHandler(p *deps.RequestProvider) http.Handler {
 		Clock:             clockClock,
 	}
 	oauthStore := &oauth3.Store{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	oauthProvider := &oauth3.Provider{
@@ -8540,7 +8540,7 @@ func newWebAppEnterPasswordHandler(p *deps.RequestProvider) http.Handler {
 		Clock: clockClock,
 	}
 	anonymousStore := &anonymous.Store{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	anonymousProvider := &anonymous.Provider{
@@ -8548,7 +8548,7 @@ func newWebAppEnterPasswordHandler(p *deps.RequestProvider) http.Handler {
 		Clock: clockClock,
 	}
 	biometricStore := &biometric.Store{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	biometricProvider := &biometric.Provider{
@@ -8566,11 +8566,11 @@ func newWebAppEnterPasswordHandler(p *deps.RequestProvider) http.Handler {
 		Biometric:             biometricProvider,
 	}
 	serviceStore := &service2.Store{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	passwordStore := &password.Store{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	authenticatorConfig := appConfig.Authenticator
@@ -8578,7 +8578,7 @@ func newWebAppEnterPasswordHandler(p *deps.RequestProvider) http.Handler {
 	passwordLogger := password.NewLogger(factory)
 	historyStore := &password.HistoryStore{
 		Clock:       clockClock,
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	passwordChecker := password.ProvideChecker(authenticatorPasswordConfig, historyStore)
@@ -8598,7 +8598,7 @@ func newWebAppEnterPasswordHandler(p *deps.RequestProvider) http.Handler {
 		Housekeeper:     housekeeper,
 	}
 	totpStore := &totp.Store{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	authenticatorTOTPConfig := authenticatorConfig.TOTP
@@ -8609,7 +8609,7 @@ func newWebAppEnterPasswordHandler(p *deps.RequestProvider) http.Handler {
 	}
 	authenticatorOOBConfig := authenticatorConfig.OOB
 	oobStore := &oob.Store{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	storeRedis := &oob.StoreRedis{
@@ -8650,7 +8650,7 @@ func newWebAppEnterPasswordHandler(p *deps.RequestProvider) http.Handler {
 		Clock: clockClock,
 	}
 	storePQ := &verification.StorePQ{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	verificationService := &verification.Service{
@@ -8669,7 +8669,7 @@ func newWebAppEnterPasswordHandler(p *deps.RequestProvider) http.Handler {
 		Clock: clockClock,
 	}
 	storeRecoveryCodePQ := &mfa.StoreRecoveryCodePQ{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	mfaService := &mfa.Service{
@@ -8680,7 +8680,7 @@ func newWebAppEnterPasswordHandler(p *deps.RequestProvider) http.Handler {
 		RateLimiter:   limiter,
 	}
 	userStore := &user.Store{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	defaultLanguageTag := deps.ProvideDefaultLanguageTag(config)
@@ -8711,7 +8711,7 @@ func newWebAppEnterPasswordHandler(p *deps.RequestProvider) http.Handler {
 	queue := appProvider.TaskQueue
 	eventLogger := event.NewLogger(factory)
 	storeImpl := &event.StoreImpl{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	hookLogger := hook.NewLogger(factory)
@@ -8733,10 +8733,10 @@ func newWebAppEnterPasswordHandler(p *deps.RequestProvider) http.Handler {
 	auditLogger := audit.NewLogger(factory)
 	writeHandle := appProvider.AuditWriteDatabase
 	auditDatabaseCredentials := deps.ProvideAuditDatabaseCredentials(secretConfig)
-	auditdbSQLBuilder := auditdb.NewSQLBuilder(auditDatabaseCredentials, appID)
+	auditdbSQLBuilderApp := auditdb.NewSQLBuilderApp(auditDatabaseCredentials, appID)
 	writeSQLExecutor := auditdb.NewWriteSQLExecutor(contextContext, writeHandle)
 	writeStore := &audit.WriteStore{
-		SQLBuilder:  auditdbSQLBuilder,
+		SQLBuilder:  auditdbSQLBuilderApp,
 		SQLExecutor: writeSQLExecutor,
 	}
 	auditSink := &audit.Sink{
@@ -8758,7 +8758,7 @@ func newWebAppEnterPasswordHandler(p *deps.RequestProvider) http.Handler {
 		WelcomeMessageProvider: welcomemessageProvider,
 	}
 	authorizationStore := &pq.AuthorizationStore{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	storeRedisLogger := idpsession.NewStoreRedisLogger(factory)
@@ -8783,7 +8783,7 @@ func newWebAppEnterPasswordHandler(p *deps.RequestProvider) http.Handler {
 		Redis:       appredisHandle,
 		AppID:       appID,
 		Logger:      redisLogger,
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 		Clock:       clockClock,
 	}
@@ -9072,13 +9072,13 @@ func newWebAppCreatePasswordHandler(p *deps.RequestProvider) http.Handler {
 	identityFeatureConfig := featureConfig.Identity
 	secretConfig := config.SecretConfig
 	databaseCredentials := deps.ProvideDatabaseCredentials(secretConfig)
-	sqlBuilder := appdb.NewSQLBuilder(databaseCredentials, appID)
+	sqlBuilderApp := appdb.NewSQLBuilderApp(databaseCredentials, appID)
 	store := &service.Store{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	loginidStore := &loginid.Store{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	loginIDConfig := identityConfig.LoginID
@@ -9102,7 +9102,7 @@ func newWebAppCreatePasswordHandler(p *deps.RequestProvider) http.Handler {
 		Clock:             clockClock,
 	}
 	oauthStore := &oauth3.Store{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	oauthProvider := &oauth3.Provider{
@@ -9110,7 +9110,7 @@ func newWebAppCreatePasswordHandler(p *deps.RequestProvider) http.Handler {
 		Clock: clockClock,
 	}
 	anonymousStore := &anonymous.Store{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	anonymousProvider := &anonymous.Provider{
@@ -9118,7 +9118,7 @@ func newWebAppCreatePasswordHandler(p *deps.RequestProvider) http.Handler {
 		Clock: clockClock,
 	}
 	biometricStore := &biometric.Store{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	biometricProvider := &biometric.Provider{
@@ -9136,11 +9136,11 @@ func newWebAppCreatePasswordHandler(p *deps.RequestProvider) http.Handler {
 		Biometric:             biometricProvider,
 	}
 	serviceStore := &service2.Store{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	passwordStore := &password.Store{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	authenticatorConfig := appConfig.Authenticator
@@ -9148,7 +9148,7 @@ func newWebAppCreatePasswordHandler(p *deps.RequestProvider) http.Handler {
 	passwordLogger := password.NewLogger(factory)
 	historyStore := &password.HistoryStore{
 		Clock:       clockClock,
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	passwordChecker := password.ProvideChecker(authenticatorPasswordConfig, historyStore)
@@ -9168,7 +9168,7 @@ func newWebAppCreatePasswordHandler(p *deps.RequestProvider) http.Handler {
 		Housekeeper:     housekeeper,
 	}
 	totpStore := &totp.Store{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	authenticatorTOTPConfig := authenticatorConfig.TOTP
@@ -9179,7 +9179,7 @@ func newWebAppCreatePasswordHandler(p *deps.RequestProvider) http.Handler {
 	}
 	authenticatorOOBConfig := authenticatorConfig.OOB
 	oobStore := &oob.Store{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	storeRedis := &oob.StoreRedis{
@@ -9220,7 +9220,7 @@ func newWebAppCreatePasswordHandler(p *deps.RequestProvider) http.Handler {
 		Clock: clockClock,
 	}
 	storePQ := &verification.StorePQ{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	verificationService := &verification.Service{
@@ -9239,7 +9239,7 @@ func newWebAppCreatePasswordHandler(p *deps.RequestProvider) http.Handler {
 		Clock: clockClock,
 	}
 	storeRecoveryCodePQ := &mfa.StoreRecoveryCodePQ{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	mfaService := &mfa.Service{
@@ -9250,7 +9250,7 @@ func newWebAppCreatePasswordHandler(p *deps.RequestProvider) http.Handler {
 		RateLimiter:   limiter,
 	}
 	userStore := &user.Store{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	defaultLanguageTag := deps.ProvideDefaultLanguageTag(config)
@@ -9281,7 +9281,7 @@ func newWebAppCreatePasswordHandler(p *deps.RequestProvider) http.Handler {
 	queue := appProvider.TaskQueue
 	eventLogger := event.NewLogger(factory)
 	storeImpl := &event.StoreImpl{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	hookLogger := hook.NewLogger(factory)
@@ -9303,10 +9303,10 @@ func newWebAppCreatePasswordHandler(p *deps.RequestProvider) http.Handler {
 	auditLogger := audit.NewLogger(factory)
 	writeHandle := appProvider.AuditWriteDatabase
 	auditDatabaseCredentials := deps.ProvideAuditDatabaseCredentials(secretConfig)
-	auditdbSQLBuilder := auditdb.NewSQLBuilder(auditDatabaseCredentials, appID)
+	auditdbSQLBuilderApp := auditdb.NewSQLBuilderApp(auditDatabaseCredentials, appID)
 	writeSQLExecutor := auditdb.NewWriteSQLExecutor(contextContext, writeHandle)
 	writeStore := &audit.WriteStore{
-		SQLBuilder:  auditdbSQLBuilder,
+		SQLBuilder:  auditdbSQLBuilderApp,
 		SQLExecutor: writeSQLExecutor,
 	}
 	auditSink := &audit.Sink{
@@ -9328,7 +9328,7 @@ func newWebAppCreatePasswordHandler(p *deps.RequestProvider) http.Handler {
 		WelcomeMessageProvider: welcomemessageProvider,
 	}
 	authorizationStore := &pq.AuthorizationStore{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	storeRedisLogger := idpsession.NewStoreRedisLogger(factory)
@@ -9353,7 +9353,7 @@ func newWebAppCreatePasswordHandler(p *deps.RequestProvider) http.Handler {
 		Redis:       appredisHandle,
 		AppID:       appID,
 		Logger:      redisLogger,
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 		Clock:       clockClock,
 	}
@@ -9643,13 +9643,13 @@ func newWebAppSetupTOTPHandler(p *deps.RequestProvider) http.Handler {
 	identityFeatureConfig := featureConfig.Identity
 	secretConfig := config.SecretConfig
 	databaseCredentials := deps.ProvideDatabaseCredentials(secretConfig)
-	sqlBuilder := appdb.NewSQLBuilder(databaseCredentials, appID)
+	sqlBuilderApp := appdb.NewSQLBuilderApp(databaseCredentials, appID)
 	store := &service.Store{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	loginidStore := &loginid.Store{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	loginIDConfig := identityConfig.LoginID
@@ -9673,7 +9673,7 @@ func newWebAppSetupTOTPHandler(p *deps.RequestProvider) http.Handler {
 		Clock:             clockClock,
 	}
 	oauthStore := &oauth3.Store{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	oauthProvider := &oauth3.Provider{
@@ -9681,7 +9681,7 @@ func newWebAppSetupTOTPHandler(p *deps.RequestProvider) http.Handler {
 		Clock: clockClock,
 	}
 	anonymousStore := &anonymous.Store{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	anonymousProvider := &anonymous.Provider{
@@ -9689,7 +9689,7 @@ func newWebAppSetupTOTPHandler(p *deps.RequestProvider) http.Handler {
 		Clock: clockClock,
 	}
 	biometricStore := &biometric.Store{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	biometricProvider := &biometric.Provider{
@@ -9707,11 +9707,11 @@ func newWebAppSetupTOTPHandler(p *deps.RequestProvider) http.Handler {
 		Biometric:             biometricProvider,
 	}
 	serviceStore := &service2.Store{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	passwordStore := &password.Store{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	authenticatorConfig := appConfig.Authenticator
@@ -9719,7 +9719,7 @@ func newWebAppSetupTOTPHandler(p *deps.RequestProvider) http.Handler {
 	passwordLogger := password.NewLogger(factory)
 	historyStore := &password.HistoryStore{
 		Clock:       clockClock,
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	passwordChecker := password.ProvideChecker(authenticatorPasswordConfig, historyStore)
@@ -9739,7 +9739,7 @@ func newWebAppSetupTOTPHandler(p *deps.RequestProvider) http.Handler {
 		Housekeeper:     housekeeper,
 	}
 	totpStore := &totp.Store{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	authenticatorTOTPConfig := authenticatorConfig.TOTP
@@ -9750,7 +9750,7 @@ func newWebAppSetupTOTPHandler(p *deps.RequestProvider) http.Handler {
 	}
 	authenticatorOOBConfig := authenticatorConfig.OOB
 	oobStore := &oob.Store{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	storeRedis := &oob.StoreRedis{
@@ -9791,7 +9791,7 @@ func newWebAppSetupTOTPHandler(p *deps.RequestProvider) http.Handler {
 		Clock: clockClock,
 	}
 	storePQ := &verification.StorePQ{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	verificationService := &verification.Service{
@@ -9810,7 +9810,7 @@ func newWebAppSetupTOTPHandler(p *deps.RequestProvider) http.Handler {
 		Clock: clockClock,
 	}
 	storeRecoveryCodePQ := &mfa.StoreRecoveryCodePQ{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	mfaService := &mfa.Service{
@@ -9821,7 +9821,7 @@ func newWebAppSetupTOTPHandler(p *deps.RequestProvider) http.Handler {
 		RateLimiter:   limiter,
 	}
 	userStore := &user.Store{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	defaultLanguageTag := deps.ProvideDefaultLanguageTag(config)
@@ -9852,7 +9852,7 @@ func newWebAppSetupTOTPHandler(p *deps.RequestProvider) http.Handler {
 	queue := appProvider.TaskQueue
 	eventLogger := event.NewLogger(factory)
 	storeImpl := &event.StoreImpl{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	hookLogger := hook.NewLogger(factory)
@@ -9874,10 +9874,10 @@ func newWebAppSetupTOTPHandler(p *deps.RequestProvider) http.Handler {
 	auditLogger := audit.NewLogger(factory)
 	writeHandle := appProvider.AuditWriteDatabase
 	auditDatabaseCredentials := deps.ProvideAuditDatabaseCredentials(secretConfig)
-	auditdbSQLBuilder := auditdb.NewSQLBuilder(auditDatabaseCredentials, appID)
+	auditdbSQLBuilderApp := auditdb.NewSQLBuilderApp(auditDatabaseCredentials, appID)
 	writeSQLExecutor := auditdb.NewWriteSQLExecutor(contextContext, writeHandle)
 	writeStore := &audit.WriteStore{
-		SQLBuilder:  auditdbSQLBuilder,
+		SQLBuilder:  auditdbSQLBuilderApp,
 		SQLExecutor: writeSQLExecutor,
 	}
 	auditSink := &audit.Sink{
@@ -9899,7 +9899,7 @@ func newWebAppSetupTOTPHandler(p *deps.RequestProvider) http.Handler {
 		WelcomeMessageProvider: welcomemessageProvider,
 	}
 	authorizationStore := &pq.AuthorizationStore{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	storeRedisLogger := idpsession.NewStoreRedisLogger(factory)
@@ -9924,7 +9924,7 @@ func newWebAppSetupTOTPHandler(p *deps.RequestProvider) http.Handler {
 		Redis:       appredisHandle,
 		AppID:       appID,
 		Logger:      redisLogger,
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 		Clock:       clockClock,
 	}
@@ -10215,13 +10215,13 @@ func newWebAppEnterTOTPHandler(p *deps.RequestProvider) http.Handler {
 	identityFeatureConfig := featureConfig.Identity
 	secretConfig := config.SecretConfig
 	databaseCredentials := deps.ProvideDatabaseCredentials(secretConfig)
-	sqlBuilder := appdb.NewSQLBuilder(databaseCredentials, appID)
+	sqlBuilderApp := appdb.NewSQLBuilderApp(databaseCredentials, appID)
 	store := &service.Store{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	loginidStore := &loginid.Store{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	loginIDConfig := identityConfig.LoginID
@@ -10245,7 +10245,7 @@ func newWebAppEnterTOTPHandler(p *deps.RequestProvider) http.Handler {
 		Clock:             clockClock,
 	}
 	oauthStore := &oauth3.Store{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	oauthProvider := &oauth3.Provider{
@@ -10253,7 +10253,7 @@ func newWebAppEnterTOTPHandler(p *deps.RequestProvider) http.Handler {
 		Clock: clockClock,
 	}
 	anonymousStore := &anonymous.Store{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	anonymousProvider := &anonymous.Provider{
@@ -10261,7 +10261,7 @@ func newWebAppEnterTOTPHandler(p *deps.RequestProvider) http.Handler {
 		Clock: clockClock,
 	}
 	biometricStore := &biometric.Store{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	biometricProvider := &biometric.Provider{
@@ -10279,11 +10279,11 @@ func newWebAppEnterTOTPHandler(p *deps.RequestProvider) http.Handler {
 		Biometric:             biometricProvider,
 	}
 	serviceStore := &service2.Store{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	passwordStore := &password.Store{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	authenticatorConfig := appConfig.Authenticator
@@ -10291,7 +10291,7 @@ func newWebAppEnterTOTPHandler(p *deps.RequestProvider) http.Handler {
 	passwordLogger := password.NewLogger(factory)
 	historyStore := &password.HistoryStore{
 		Clock:       clockClock,
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	passwordChecker := password.ProvideChecker(authenticatorPasswordConfig, historyStore)
@@ -10311,7 +10311,7 @@ func newWebAppEnterTOTPHandler(p *deps.RequestProvider) http.Handler {
 		Housekeeper:     housekeeper,
 	}
 	totpStore := &totp.Store{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	authenticatorTOTPConfig := authenticatorConfig.TOTP
@@ -10322,7 +10322,7 @@ func newWebAppEnterTOTPHandler(p *deps.RequestProvider) http.Handler {
 	}
 	authenticatorOOBConfig := authenticatorConfig.OOB
 	oobStore := &oob.Store{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	storeRedis := &oob.StoreRedis{
@@ -10363,7 +10363,7 @@ func newWebAppEnterTOTPHandler(p *deps.RequestProvider) http.Handler {
 		Clock: clockClock,
 	}
 	storePQ := &verification.StorePQ{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	verificationService := &verification.Service{
@@ -10382,7 +10382,7 @@ func newWebAppEnterTOTPHandler(p *deps.RequestProvider) http.Handler {
 		Clock: clockClock,
 	}
 	storeRecoveryCodePQ := &mfa.StoreRecoveryCodePQ{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	mfaService := &mfa.Service{
@@ -10393,7 +10393,7 @@ func newWebAppEnterTOTPHandler(p *deps.RequestProvider) http.Handler {
 		RateLimiter:   limiter,
 	}
 	userStore := &user.Store{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	defaultLanguageTag := deps.ProvideDefaultLanguageTag(config)
@@ -10424,7 +10424,7 @@ func newWebAppEnterTOTPHandler(p *deps.RequestProvider) http.Handler {
 	queue := appProvider.TaskQueue
 	eventLogger := event.NewLogger(factory)
 	storeImpl := &event.StoreImpl{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	hookLogger := hook.NewLogger(factory)
@@ -10446,10 +10446,10 @@ func newWebAppEnterTOTPHandler(p *deps.RequestProvider) http.Handler {
 	auditLogger := audit.NewLogger(factory)
 	writeHandle := appProvider.AuditWriteDatabase
 	auditDatabaseCredentials := deps.ProvideAuditDatabaseCredentials(secretConfig)
-	auditdbSQLBuilder := auditdb.NewSQLBuilder(auditDatabaseCredentials, appID)
+	auditdbSQLBuilderApp := auditdb.NewSQLBuilderApp(auditDatabaseCredentials, appID)
 	writeSQLExecutor := auditdb.NewWriteSQLExecutor(contextContext, writeHandle)
 	writeStore := &audit.WriteStore{
-		SQLBuilder:  auditdbSQLBuilder,
+		SQLBuilder:  auditdbSQLBuilderApp,
 		SQLExecutor: writeSQLExecutor,
 	}
 	auditSink := &audit.Sink{
@@ -10471,7 +10471,7 @@ func newWebAppEnterTOTPHandler(p *deps.RequestProvider) http.Handler {
 		WelcomeMessageProvider: welcomemessageProvider,
 	}
 	authorizationStore := &pq.AuthorizationStore{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	storeRedisLogger := idpsession.NewStoreRedisLogger(factory)
@@ -10496,7 +10496,7 @@ func newWebAppEnterTOTPHandler(p *deps.RequestProvider) http.Handler {
 		Redis:       appredisHandle,
 		AppID:       appID,
 		Logger:      redisLogger,
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 		Clock:       clockClock,
 	}
@@ -10785,13 +10785,13 @@ func newWebAppSetupOOBOTPHandler(p *deps.RequestProvider) http.Handler {
 	identityFeatureConfig := featureConfig.Identity
 	secretConfig := config.SecretConfig
 	databaseCredentials := deps.ProvideDatabaseCredentials(secretConfig)
-	sqlBuilder := appdb.NewSQLBuilder(databaseCredentials, appID)
+	sqlBuilderApp := appdb.NewSQLBuilderApp(databaseCredentials, appID)
 	store := &service.Store{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	loginidStore := &loginid.Store{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	loginIDConfig := identityConfig.LoginID
@@ -10815,7 +10815,7 @@ func newWebAppSetupOOBOTPHandler(p *deps.RequestProvider) http.Handler {
 		Clock:             clockClock,
 	}
 	oauthStore := &oauth3.Store{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	oauthProvider := &oauth3.Provider{
@@ -10823,7 +10823,7 @@ func newWebAppSetupOOBOTPHandler(p *deps.RequestProvider) http.Handler {
 		Clock: clockClock,
 	}
 	anonymousStore := &anonymous.Store{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	anonymousProvider := &anonymous.Provider{
@@ -10831,7 +10831,7 @@ func newWebAppSetupOOBOTPHandler(p *deps.RequestProvider) http.Handler {
 		Clock: clockClock,
 	}
 	biometricStore := &biometric.Store{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	biometricProvider := &biometric.Provider{
@@ -10849,11 +10849,11 @@ func newWebAppSetupOOBOTPHandler(p *deps.RequestProvider) http.Handler {
 		Biometric:             biometricProvider,
 	}
 	serviceStore := &service2.Store{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	passwordStore := &password.Store{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	authenticatorConfig := appConfig.Authenticator
@@ -10861,7 +10861,7 @@ func newWebAppSetupOOBOTPHandler(p *deps.RequestProvider) http.Handler {
 	passwordLogger := password.NewLogger(factory)
 	historyStore := &password.HistoryStore{
 		Clock:       clockClock,
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	passwordChecker := password.ProvideChecker(authenticatorPasswordConfig, historyStore)
@@ -10881,7 +10881,7 @@ func newWebAppSetupOOBOTPHandler(p *deps.RequestProvider) http.Handler {
 		Housekeeper:     housekeeper,
 	}
 	totpStore := &totp.Store{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	authenticatorTOTPConfig := authenticatorConfig.TOTP
@@ -10892,7 +10892,7 @@ func newWebAppSetupOOBOTPHandler(p *deps.RequestProvider) http.Handler {
 	}
 	authenticatorOOBConfig := authenticatorConfig.OOB
 	oobStore := &oob.Store{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	storeRedis := &oob.StoreRedis{
@@ -10933,7 +10933,7 @@ func newWebAppSetupOOBOTPHandler(p *deps.RequestProvider) http.Handler {
 		Clock: clockClock,
 	}
 	storePQ := &verification.StorePQ{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	verificationService := &verification.Service{
@@ -10952,7 +10952,7 @@ func newWebAppSetupOOBOTPHandler(p *deps.RequestProvider) http.Handler {
 		Clock: clockClock,
 	}
 	storeRecoveryCodePQ := &mfa.StoreRecoveryCodePQ{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	mfaService := &mfa.Service{
@@ -10963,7 +10963,7 @@ func newWebAppSetupOOBOTPHandler(p *deps.RequestProvider) http.Handler {
 		RateLimiter:   limiter,
 	}
 	userStore := &user.Store{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	defaultLanguageTag := deps.ProvideDefaultLanguageTag(config)
@@ -10994,7 +10994,7 @@ func newWebAppSetupOOBOTPHandler(p *deps.RequestProvider) http.Handler {
 	queue := appProvider.TaskQueue
 	eventLogger := event.NewLogger(factory)
 	storeImpl := &event.StoreImpl{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	hookLogger := hook.NewLogger(factory)
@@ -11016,10 +11016,10 @@ func newWebAppSetupOOBOTPHandler(p *deps.RequestProvider) http.Handler {
 	auditLogger := audit.NewLogger(factory)
 	writeHandle := appProvider.AuditWriteDatabase
 	auditDatabaseCredentials := deps.ProvideAuditDatabaseCredentials(secretConfig)
-	auditdbSQLBuilder := auditdb.NewSQLBuilder(auditDatabaseCredentials, appID)
+	auditdbSQLBuilderApp := auditdb.NewSQLBuilderApp(auditDatabaseCredentials, appID)
 	writeSQLExecutor := auditdb.NewWriteSQLExecutor(contextContext, writeHandle)
 	writeStore := &audit.WriteStore{
-		SQLBuilder:  auditdbSQLBuilder,
+		SQLBuilder:  auditdbSQLBuilderApp,
 		SQLExecutor: writeSQLExecutor,
 	}
 	auditSink := &audit.Sink{
@@ -11041,7 +11041,7 @@ func newWebAppSetupOOBOTPHandler(p *deps.RequestProvider) http.Handler {
 		WelcomeMessageProvider: welcomemessageProvider,
 	}
 	authorizationStore := &pq.AuthorizationStore{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	storeRedisLogger := idpsession.NewStoreRedisLogger(factory)
@@ -11066,7 +11066,7 @@ func newWebAppSetupOOBOTPHandler(p *deps.RequestProvider) http.Handler {
 		Redis:       appredisHandle,
 		AppID:       appID,
 		Logger:      redisLogger,
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 		Clock:       clockClock,
 	}
@@ -11355,13 +11355,13 @@ func newWebAppEnterOOBOTPHandler(p *deps.RequestProvider) http.Handler {
 	identityFeatureConfig := featureConfig.Identity
 	secretConfig := config.SecretConfig
 	databaseCredentials := deps.ProvideDatabaseCredentials(secretConfig)
-	sqlBuilder := appdb.NewSQLBuilder(databaseCredentials, appID)
+	sqlBuilderApp := appdb.NewSQLBuilderApp(databaseCredentials, appID)
 	store := &service.Store{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	loginidStore := &loginid.Store{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	loginIDConfig := identityConfig.LoginID
@@ -11385,7 +11385,7 @@ func newWebAppEnterOOBOTPHandler(p *deps.RequestProvider) http.Handler {
 		Clock:             clockClock,
 	}
 	oauthStore := &oauth3.Store{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	oauthProvider := &oauth3.Provider{
@@ -11393,7 +11393,7 @@ func newWebAppEnterOOBOTPHandler(p *deps.RequestProvider) http.Handler {
 		Clock: clockClock,
 	}
 	anonymousStore := &anonymous.Store{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	anonymousProvider := &anonymous.Provider{
@@ -11401,7 +11401,7 @@ func newWebAppEnterOOBOTPHandler(p *deps.RequestProvider) http.Handler {
 		Clock: clockClock,
 	}
 	biometricStore := &biometric.Store{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	biometricProvider := &biometric.Provider{
@@ -11419,11 +11419,11 @@ func newWebAppEnterOOBOTPHandler(p *deps.RequestProvider) http.Handler {
 		Biometric:             biometricProvider,
 	}
 	serviceStore := &service2.Store{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	passwordStore := &password.Store{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	authenticatorConfig := appConfig.Authenticator
@@ -11431,7 +11431,7 @@ func newWebAppEnterOOBOTPHandler(p *deps.RequestProvider) http.Handler {
 	passwordLogger := password.NewLogger(factory)
 	historyStore := &password.HistoryStore{
 		Clock:       clockClock,
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	passwordChecker := password.ProvideChecker(authenticatorPasswordConfig, historyStore)
@@ -11451,7 +11451,7 @@ func newWebAppEnterOOBOTPHandler(p *deps.RequestProvider) http.Handler {
 		Housekeeper:     housekeeper,
 	}
 	totpStore := &totp.Store{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	authenticatorTOTPConfig := authenticatorConfig.TOTP
@@ -11462,7 +11462,7 @@ func newWebAppEnterOOBOTPHandler(p *deps.RequestProvider) http.Handler {
 	}
 	authenticatorOOBConfig := authenticatorConfig.OOB
 	oobStore := &oob.Store{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	storeRedis := &oob.StoreRedis{
@@ -11503,7 +11503,7 @@ func newWebAppEnterOOBOTPHandler(p *deps.RequestProvider) http.Handler {
 		Clock: clockClock,
 	}
 	storePQ := &verification.StorePQ{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	verificationService := &verification.Service{
@@ -11522,7 +11522,7 @@ func newWebAppEnterOOBOTPHandler(p *deps.RequestProvider) http.Handler {
 		Clock: clockClock,
 	}
 	storeRecoveryCodePQ := &mfa.StoreRecoveryCodePQ{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	mfaService := &mfa.Service{
@@ -11533,7 +11533,7 @@ func newWebAppEnterOOBOTPHandler(p *deps.RequestProvider) http.Handler {
 		RateLimiter:   limiter,
 	}
 	userStore := &user.Store{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	defaultLanguageTag := deps.ProvideDefaultLanguageTag(config)
@@ -11564,7 +11564,7 @@ func newWebAppEnterOOBOTPHandler(p *deps.RequestProvider) http.Handler {
 	queue := appProvider.TaskQueue
 	eventLogger := event.NewLogger(factory)
 	storeImpl := &event.StoreImpl{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	hookLogger := hook.NewLogger(factory)
@@ -11586,10 +11586,10 @@ func newWebAppEnterOOBOTPHandler(p *deps.RequestProvider) http.Handler {
 	auditLogger := audit.NewLogger(factory)
 	writeHandle := appProvider.AuditWriteDatabase
 	auditDatabaseCredentials := deps.ProvideAuditDatabaseCredentials(secretConfig)
-	auditdbSQLBuilder := auditdb.NewSQLBuilder(auditDatabaseCredentials, appID)
+	auditdbSQLBuilderApp := auditdb.NewSQLBuilderApp(auditDatabaseCredentials, appID)
 	writeSQLExecutor := auditdb.NewWriteSQLExecutor(contextContext, writeHandle)
 	writeStore := &audit.WriteStore{
-		SQLBuilder:  auditdbSQLBuilder,
+		SQLBuilder:  auditdbSQLBuilderApp,
 		SQLExecutor: writeSQLExecutor,
 	}
 	auditSink := &audit.Sink{
@@ -11611,7 +11611,7 @@ func newWebAppEnterOOBOTPHandler(p *deps.RequestProvider) http.Handler {
 		WelcomeMessageProvider: welcomemessageProvider,
 	}
 	authorizationStore := &pq.AuthorizationStore{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	storeRedisLogger := idpsession.NewStoreRedisLogger(factory)
@@ -11636,7 +11636,7 @@ func newWebAppEnterOOBOTPHandler(p *deps.RequestProvider) http.Handler {
 		Redis:       appredisHandle,
 		AppID:       appID,
 		Logger:      redisLogger,
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 		Clock:       clockClock,
 	}
@@ -11927,13 +11927,13 @@ func newWebAppEnterRecoveryCodeHandler(p *deps.RequestProvider) http.Handler {
 	identityFeatureConfig := featureConfig.Identity
 	secretConfig := config.SecretConfig
 	databaseCredentials := deps.ProvideDatabaseCredentials(secretConfig)
-	sqlBuilder := appdb.NewSQLBuilder(databaseCredentials, appID)
+	sqlBuilderApp := appdb.NewSQLBuilderApp(databaseCredentials, appID)
 	store := &service.Store{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	loginidStore := &loginid.Store{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	loginIDConfig := identityConfig.LoginID
@@ -11957,7 +11957,7 @@ func newWebAppEnterRecoveryCodeHandler(p *deps.RequestProvider) http.Handler {
 		Clock:             clockClock,
 	}
 	oauthStore := &oauth3.Store{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	oauthProvider := &oauth3.Provider{
@@ -11965,7 +11965,7 @@ func newWebAppEnterRecoveryCodeHandler(p *deps.RequestProvider) http.Handler {
 		Clock: clockClock,
 	}
 	anonymousStore := &anonymous.Store{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	anonymousProvider := &anonymous.Provider{
@@ -11973,7 +11973,7 @@ func newWebAppEnterRecoveryCodeHandler(p *deps.RequestProvider) http.Handler {
 		Clock: clockClock,
 	}
 	biometricStore := &biometric.Store{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	biometricProvider := &biometric.Provider{
@@ -11991,11 +11991,11 @@ func newWebAppEnterRecoveryCodeHandler(p *deps.RequestProvider) http.Handler {
 		Biometric:             biometricProvider,
 	}
 	serviceStore := &service2.Store{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	passwordStore := &password.Store{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	authenticatorConfig := appConfig.Authenticator
@@ -12003,7 +12003,7 @@ func newWebAppEnterRecoveryCodeHandler(p *deps.RequestProvider) http.Handler {
 	passwordLogger := password.NewLogger(factory)
 	historyStore := &password.HistoryStore{
 		Clock:       clockClock,
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	passwordChecker := password.ProvideChecker(authenticatorPasswordConfig, historyStore)
@@ -12023,7 +12023,7 @@ func newWebAppEnterRecoveryCodeHandler(p *deps.RequestProvider) http.Handler {
 		Housekeeper:     housekeeper,
 	}
 	totpStore := &totp.Store{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	authenticatorTOTPConfig := authenticatorConfig.TOTP
@@ -12034,7 +12034,7 @@ func newWebAppEnterRecoveryCodeHandler(p *deps.RequestProvider) http.Handler {
 	}
 	authenticatorOOBConfig := authenticatorConfig.OOB
 	oobStore := &oob.Store{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	storeRedis := &oob.StoreRedis{
@@ -12075,7 +12075,7 @@ func newWebAppEnterRecoveryCodeHandler(p *deps.RequestProvider) http.Handler {
 		Clock: clockClock,
 	}
 	storePQ := &verification.StorePQ{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	verificationService := &verification.Service{
@@ -12094,7 +12094,7 @@ func newWebAppEnterRecoveryCodeHandler(p *deps.RequestProvider) http.Handler {
 		Clock: clockClock,
 	}
 	storeRecoveryCodePQ := &mfa.StoreRecoveryCodePQ{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	mfaService := &mfa.Service{
@@ -12105,7 +12105,7 @@ func newWebAppEnterRecoveryCodeHandler(p *deps.RequestProvider) http.Handler {
 		RateLimiter:   limiter,
 	}
 	userStore := &user.Store{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	defaultLanguageTag := deps.ProvideDefaultLanguageTag(config)
@@ -12136,7 +12136,7 @@ func newWebAppEnterRecoveryCodeHandler(p *deps.RequestProvider) http.Handler {
 	queue := appProvider.TaskQueue
 	eventLogger := event.NewLogger(factory)
 	storeImpl := &event.StoreImpl{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	hookLogger := hook.NewLogger(factory)
@@ -12158,10 +12158,10 @@ func newWebAppEnterRecoveryCodeHandler(p *deps.RequestProvider) http.Handler {
 	auditLogger := audit.NewLogger(factory)
 	writeHandle := appProvider.AuditWriteDatabase
 	auditDatabaseCredentials := deps.ProvideAuditDatabaseCredentials(secretConfig)
-	auditdbSQLBuilder := auditdb.NewSQLBuilder(auditDatabaseCredentials, appID)
+	auditdbSQLBuilderApp := auditdb.NewSQLBuilderApp(auditDatabaseCredentials, appID)
 	writeSQLExecutor := auditdb.NewWriteSQLExecutor(contextContext, writeHandle)
 	writeStore := &audit.WriteStore{
-		SQLBuilder:  auditdbSQLBuilder,
+		SQLBuilder:  auditdbSQLBuilderApp,
 		SQLExecutor: writeSQLExecutor,
 	}
 	auditSink := &audit.Sink{
@@ -12183,7 +12183,7 @@ func newWebAppEnterRecoveryCodeHandler(p *deps.RequestProvider) http.Handler {
 		WelcomeMessageProvider: welcomemessageProvider,
 	}
 	authorizationStore := &pq.AuthorizationStore{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	storeRedisLogger := idpsession.NewStoreRedisLogger(factory)
@@ -12208,7 +12208,7 @@ func newWebAppEnterRecoveryCodeHandler(p *deps.RequestProvider) http.Handler {
 		Redis:       appredisHandle,
 		AppID:       appID,
 		Logger:      redisLogger,
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 		Clock:       clockClock,
 	}
@@ -12497,13 +12497,13 @@ func newWebAppSetupRecoveryCodeHandler(p *deps.RequestProvider) http.Handler {
 	identityFeatureConfig := featureConfig.Identity
 	secretConfig := config.SecretConfig
 	databaseCredentials := deps.ProvideDatabaseCredentials(secretConfig)
-	sqlBuilder := appdb.NewSQLBuilder(databaseCredentials, appID)
+	sqlBuilderApp := appdb.NewSQLBuilderApp(databaseCredentials, appID)
 	store := &service.Store{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	loginidStore := &loginid.Store{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	loginIDConfig := identityConfig.LoginID
@@ -12527,7 +12527,7 @@ func newWebAppSetupRecoveryCodeHandler(p *deps.RequestProvider) http.Handler {
 		Clock:             clockClock,
 	}
 	oauthStore := &oauth3.Store{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	oauthProvider := &oauth3.Provider{
@@ -12535,7 +12535,7 @@ func newWebAppSetupRecoveryCodeHandler(p *deps.RequestProvider) http.Handler {
 		Clock: clockClock,
 	}
 	anonymousStore := &anonymous.Store{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	anonymousProvider := &anonymous.Provider{
@@ -12543,7 +12543,7 @@ func newWebAppSetupRecoveryCodeHandler(p *deps.RequestProvider) http.Handler {
 		Clock: clockClock,
 	}
 	biometricStore := &biometric.Store{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	biometricProvider := &biometric.Provider{
@@ -12561,11 +12561,11 @@ func newWebAppSetupRecoveryCodeHandler(p *deps.RequestProvider) http.Handler {
 		Biometric:             biometricProvider,
 	}
 	serviceStore := &service2.Store{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	passwordStore := &password.Store{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	authenticatorConfig := appConfig.Authenticator
@@ -12573,7 +12573,7 @@ func newWebAppSetupRecoveryCodeHandler(p *deps.RequestProvider) http.Handler {
 	passwordLogger := password.NewLogger(factory)
 	historyStore := &password.HistoryStore{
 		Clock:       clockClock,
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	passwordChecker := password.ProvideChecker(authenticatorPasswordConfig, historyStore)
@@ -12593,7 +12593,7 @@ func newWebAppSetupRecoveryCodeHandler(p *deps.RequestProvider) http.Handler {
 		Housekeeper:     housekeeper,
 	}
 	totpStore := &totp.Store{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	authenticatorTOTPConfig := authenticatorConfig.TOTP
@@ -12604,7 +12604,7 @@ func newWebAppSetupRecoveryCodeHandler(p *deps.RequestProvider) http.Handler {
 	}
 	authenticatorOOBConfig := authenticatorConfig.OOB
 	oobStore := &oob.Store{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	storeRedis := &oob.StoreRedis{
@@ -12645,7 +12645,7 @@ func newWebAppSetupRecoveryCodeHandler(p *deps.RequestProvider) http.Handler {
 		Clock: clockClock,
 	}
 	storePQ := &verification.StorePQ{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	verificationService := &verification.Service{
@@ -12664,7 +12664,7 @@ func newWebAppSetupRecoveryCodeHandler(p *deps.RequestProvider) http.Handler {
 		Clock: clockClock,
 	}
 	storeRecoveryCodePQ := &mfa.StoreRecoveryCodePQ{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	mfaService := &mfa.Service{
@@ -12675,7 +12675,7 @@ func newWebAppSetupRecoveryCodeHandler(p *deps.RequestProvider) http.Handler {
 		RateLimiter:   limiter,
 	}
 	userStore := &user.Store{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	defaultLanguageTag := deps.ProvideDefaultLanguageTag(config)
@@ -12706,7 +12706,7 @@ func newWebAppSetupRecoveryCodeHandler(p *deps.RequestProvider) http.Handler {
 	queue := appProvider.TaskQueue
 	eventLogger := event.NewLogger(factory)
 	storeImpl := &event.StoreImpl{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	hookLogger := hook.NewLogger(factory)
@@ -12728,10 +12728,10 @@ func newWebAppSetupRecoveryCodeHandler(p *deps.RequestProvider) http.Handler {
 	auditLogger := audit.NewLogger(factory)
 	writeHandle := appProvider.AuditWriteDatabase
 	auditDatabaseCredentials := deps.ProvideAuditDatabaseCredentials(secretConfig)
-	auditdbSQLBuilder := auditdb.NewSQLBuilder(auditDatabaseCredentials, appID)
+	auditdbSQLBuilderApp := auditdb.NewSQLBuilderApp(auditDatabaseCredentials, appID)
 	writeSQLExecutor := auditdb.NewWriteSQLExecutor(contextContext, writeHandle)
 	writeStore := &audit.WriteStore{
-		SQLBuilder:  auditdbSQLBuilder,
+		SQLBuilder:  auditdbSQLBuilderApp,
 		SQLExecutor: writeSQLExecutor,
 	}
 	auditSink := &audit.Sink{
@@ -12753,7 +12753,7 @@ func newWebAppSetupRecoveryCodeHandler(p *deps.RequestProvider) http.Handler {
 		WelcomeMessageProvider: welcomemessageProvider,
 	}
 	authorizationStore := &pq.AuthorizationStore{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	storeRedisLogger := idpsession.NewStoreRedisLogger(factory)
@@ -12778,7 +12778,7 @@ func newWebAppSetupRecoveryCodeHandler(p *deps.RequestProvider) http.Handler {
 		Redis:       appredisHandle,
 		AppID:       appID,
 		Logger:      redisLogger,
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 		Clock:       clockClock,
 	}
@@ -13067,13 +13067,13 @@ func newWebAppVerifyIdentityHandler(p *deps.RequestProvider) http.Handler {
 	identityFeatureConfig := featureConfig.Identity
 	secretConfig := config.SecretConfig
 	databaseCredentials := deps.ProvideDatabaseCredentials(secretConfig)
-	sqlBuilder := appdb.NewSQLBuilder(databaseCredentials, appID)
+	sqlBuilderApp := appdb.NewSQLBuilderApp(databaseCredentials, appID)
 	store := &service.Store{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	loginidStore := &loginid.Store{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	loginIDConfig := identityConfig.LoginID
@@ -13097,7 +13097,7 @@ func newWebAppVerifyIdentityHandler(p *deps.RequestProvider) http.Handler {
 		Clock:             clockClock,
 	}
 	oauthStore := &oauth3.Store{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	oauthProvider := &oauth3.Provider{
@@ -13105,7 +13105,7 @@ func newWebAppVerifyIdentityHandler(p *deps.RequestProvider) http.Handler {
 		Clock: clockClock,
 	}
 	anonymousStore := &anonymous.Store{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	anonymousProvider := &anonymous.Provider{
@@ -13113,7 +13113,7 @@ func newWebAppVerifyIdentityHandler(p *deps.RequestProvider) http.Handler {
 		Clock: clockClock,
 	}
 	biometricStore := &biometric.Store{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	biometricProvider := &biometric.Provider{
@@ -13131,11 +13131,11 @@ func newWebAppVerifyIdentityHandler(p *deps.RequestProvider) http.Handler {
 		Biometric:             biometricProvider,
 	}
 	serviceStore := &service2.Store{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	passwordStore := &password.Store{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	authenticatorConfig := appConfig.Authenticator
@@ -13143,7 +13143,7 @@ func newWebAppVerifyIdentityHandler(p *deps.RequestProvider) http.Handler {
 	passwordLogger := password.NewLogger(factory)
 	historyStore := &password.HistoryStore{
 		Clock:       clockClock,
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	passwordChecker := password.ProvideChecker(authenticatorPasswordConfig, historyStore)
@@ -13163,7 +13163,7 @@ func newWebAppVerifyIdentityHandler(p *deps.RequestProvider) http.Handler {
 		Housekeeper:     housekeeper,
 	}
 	totpStore := &totp.Store{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	authenticatorTOTPConfig := authenticatorConfig.TOTP
@@ -13174,7 +13174,7 @@ func newWebAppVerifyIdentityHandler(p *deps.RequestProvider) http.Handler {
 	}
 	authenticatorOOBConfig := authenticatorConfig.OOB
 	oobStore := &oob.Store{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	storeRedis := &oob.StoreRedis{
@@ -13215,7 +13215,7 @@ func newWebAppVerifyIdentityHandler(p *deps.RequestProvider) http.Handler {
 		Clock: clockClock,
 	}
 	storePQ := &verification.StorePQ{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	verificationService := &verification.Service{
@@ -13234,7 +13234,7 @@ func newWebAppVerifyIdentityHandler(p *deps.RequestProvider) http.Handler {
 		Clock: clockClock,
 	}
 	storeRecoveryCodePQ := &mfa.StoreRecoveryCodePQ{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	mfaService := &mfa.Service{
@@ -13245,7 +13245,7 @@ func newWebAppVerifyIdentityHandler(p *deps.RequestProvider) http.Handler {
 		RateLimiter:   limiter,
 	}
 	userStore := &user.Store{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	defaultLanguageTag := deps.ProvideDefaultLanguageTag(config)
@@ -13276,7 +13276,7 @@ func newWebAppVerifyIdentityHandler(p *deps.RequestProvider) http.Handler {
 	queue := appProvider.TaskQueue
 	eventLogger := event.NewLogger(factory)
 	storeImpl := &event.StoreImpl{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	hookLogger := hook.NewLogger(factory)
@@ -13298,10 +13298,10 @@ func newWebAppVerifyIdentityHandler(p *deps.RequestProvider) http.Handler {
 	auditLogger := audit.NewLogger(factory)
 	writeHandle := appProvider.AuditWriteDatabase
 	auditDatabaseCredentials := deps.ProvideAuditDatabaseCredentials(secretConfig)
-	auditdbSQLBuilder := auditdb.NewSQLBuilder(auditDatabaseCredentials, appID)
+	auditdbSQLBuilderApp := auditdb.NewSQLBuilderApp(auditDatabaseCredentials, appID)
 	writeSQLExecutor := auditdb.NewWriteSQLExecutor(contextContext, writeHandle)
 	writeStore := &audit.WriteStore{
-		SQLBuilder:  auditdbSQLBuilder,
+		SQLBuilder:  auditdbSQLBuilderApp,
 		SQLExecutor: writeSQLExecutor,
 	}
 	auditSink := &audit.Sink{
@@ -13323,7 +13323,7 @@ func newWebAppVerifyIdentityHandler(p *deps.RequestProvider) http.Handler {
 		WelcomeMessageProvider: welcomemessageProvider,
 	}
 	authorizationStore := &pq.AuthorizationStore{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	storeRedisLogger := idpsession.NewStoreRedisLogger(factory)
@@ -13348,7 +13348,7 @@ func newWebAppVerifyIdentityHandler(p *deps.RequestProvider) http.Handler {
 		Redis:       appredisHandle,
 		AppID:       appID,
 		Logger:      redisLogger,
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 		Clock:       clockClock,
 	}
@@ -13640,13 +13640,13 @@ func newWebAppVerifyIdentitySuccessHandler(p *deps.RequestProvider) http.Handler
 	identityFeatureConfig := featureConfig.Identity
 	secretConfig := config.SecretConfig
 	databaseCredentials := deps.ProvideDatabaseCredentials(secretConfig)
-	sqlBuilder := appdb.NewSQLBuilder(databaseCredentials, appID)
+	sqlBuilderApp := appdb.NewSQLBuilderApp(databaseCredentials, appID)
 	store := &service.Store{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	loginidStore := &loginid.Store{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	loginIDConfig := identityConfig.LoginID
@@ -13670,7 +13670,7 @@ func newWebAppVerifyIdentitySuccessHandler(p *deps.RequestProvider) http.Handler
 		Clock:             clockClock,
 	}
 	oauthStore := &oauth3.Store{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	oauthProvider := &oauth3.Provider{
@@ -13678,7 +13678,7 @@ func newWebAppVerifyIdentitySuccessHandler(p *deps.RequestProvider) http.Handler
 		Clock: clockClock,
 	}
 	anonymousStore := &anonymous.Store{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	anonymousProvider := &anonymous.Provider{
@@ -13686,7 +13686,7 @@ func newWebAppVerifyIdentitySuccessHandler(p *deps.RequestProvider) http.Handler
 		Clock: clockClock,
 	}
 	biometricStore := &biometric.Store{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	biometricProvider := &biometric.Provider{
@@ -13704,11 +13704,11 @@ func newWebAppVerifyIdentitySuccessHandler(p *deps.RequestProvider) http.Handler
 		Biometric:             biometricProvider,
 	}
 	serviceStore := &service2.Store{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	passwordStore := &password.Store{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	authenticatorConfig := appConfig.Authenticator
@@ -13716,7 +13716,7 @@ func newWebAppVerifyIdentitySuccessHandler(p *deps.RequestProvider) http.Handler
 	passwordLogger := password.NewLogger(factory)
 	historyStore := &password.HistoryStore{
 		Clock:       clockClock,
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	passwordChecker := password.ProvideChecker(authenticatorPasswordConfig, historyStore)
@@ -13736,7 +13736,7 @@ func newWebAppVerifyIdentitySuccessHandler(p *deps.RequestProvider) http.Handler
 		Housekeeper:     housekeeper,
 	}
 	totpStore := &totp.Store{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	authenticatorTOTPConfig := authenticatorConfig.TOTP
@@ -13747,7 +13747,7 @@ func newWebAppVerifyIdentitySuccessHandler(p *deps.RequestProvider) http.Handler
 	}
 	authenticatorOOBConfig := authenticatorConfig.OOB
 	oobStore := &oob.Store{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	storeRedis := &oob.StoreRedis{
@@ -13788,7 +13788,7 @@ func newWebAppVerifyIdentitySuccessHandler(p *deps.RequestProvider) http.Handler
 		Clock: clockClock,
 	}
 	storePQ := &verification.StorePQ{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	verificationService := &verification.Service{
@@ -13807,7 +13807,7 @@ func newWebAppVerifyIdentitySuccessHandler(p *deps.RequestProvider) http.Handler
 		Clock: clockClock,
 	}
 	storeRecoveryCodePQ := &mfa.StoreRecoveryCodePQ{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	mfaService := &mfa.Service{
@@ -13818,7 +13818,7 @@ func newWebAppVerifyIdentitySuccessHandler(p *deps.RequestProvider) http.Handler
 		RateLimiter:   limiter,
 	}
 	userStore := &user.Store{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	defaultLanguageTag := deps.ProvideDefaultLanguageTag(config)
@@ -13849,7 +13849,7 @@ func newWebAppVerifyIdentitySuccessHandler(p *deps.RequestProvider) http.Handler
 	queue := appProvider.TaskQueue
 	eventLogger := event.NewLogger(factory)
 	storeImpl := &event.StoreImpl{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	hookLogger := hook.NewLogger(factory)
@@ -13871,10 +13871,10 @@ func newWebAppVerifyIdentitySuccessHandler(p *deps.RequestProvider) http.Handler
 	auditLogger := audit.NewLogger(factory)
 	writeHandle := appProvider.AuditWriteDatabase
 	auditDatabaseCredentials := deps.ProvideAuditDatabaseCredentials(secretConfig)
-	auditdbSQLBuilder := auditdb.NewSQLBuilder(auditDatabaseCredentials, appID)
+	auditdbSQLBuilderApp := auditdb.NewSQLBuilderApp(auditDatabaseCredentials, appID)
 	writeSQLExecutor := auditdb.NewWriteSQLExecutor(contextContext, writeHandle)
 	writeStore := &audit.WriteStore{
-		SQLBuilder:  auditdbSQLBuilder,
+		SQLBuilder:  auditdbSQLBuilderApp,
 		SQLExecutor: writeSQLExecutor,
 	}
 	auditSink := &audit.Sink{
@@ -13896,7 +13896,7 @@ func newWebAppVerifyIdentitySuccessHandler(p *deps.RequestProvider) http.Handler
 		WelcomeMessageProvider: welcomemessageProvider,
 	}
 	authorizationStore := &pq.AuthorizationStore{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	storeRedisLogger := idpsession.NewStoreRedisLogger(factory)
@@ -13921,7 +13921,7 @@ func newWebAppVerifyIdentitySuccessHandler(p *deps.RequestProvider) http.Handler
 		Redis:       appredisHandle,
 		AppID:       appID,
 		Logger:      redisLogger,
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 		Clock:       clockClock,
 	}
@@ -14210,13 +14210,13 @@ func newWebAppForgotPasswordHandler(p *deps.RequestProvider) http.Handler {
 	identityFeatureConfig := featureConfig.Identity
 	secretConfig := config.SecretConfig
 	databaseCredentials := deps.ProvideDatabaseCredentials(secretConfig)
-	sqlBuilder := appdb.NewSQLBuilder(databaseCredentials, appID)
+	sqlBuilderApp := appdb.NewSQLBuilderApp(databaseCredentials, appID)
 	store := &service.Store{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	loginidStore := &loginid.Store{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	loginIDConfig := identityConfig.LoginID
@@ -14240,7 +14240,7 @@ func newWebAppForgotPasswordHandler(p *deps.RequestProvider) http.Handler {
 		Clock:             clockClock,
 	}
 	oauthStore := &oauth3.Store{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	oauthProvider := &oauth3.Provider{
@@ -14248,7 +14248,7 @@ func newWebAppForgotPasswordHandler(p *deps.RequestProvider) http.Handler {
 		Clock: clockClock,
 	}
 	anonymousStore := &anonymous.Store{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	anonymousProvider := &anonymous.Provider{
@@ -14256,7 +14256,7 @@ func newWebAppForgotPasswordHandler(p *deps.RequestProvider) http.Handler {
 		Clock: clockClock,
 	}
 	biometricStore := &biometric.Store{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	biometricProvider := &biometric.Provider{
@@ -14274,11 +14274,11 @@ func newWebAppForgotPasswordHandler(p *deps.RequestProvider) http.Handler {
 		Biometric:             biometricProvider,
 	}
 	serviceStore := &service2.Store{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	passwordStore := &password.Store{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	authenticatorConfig := appConfig.Authenticator
@@ -14286,7 +14286,7 @@ func newWebAppForgotPasswordHandler(p *deps.RequestProvider) http.Handler {
 	passwordLogger := password.NewLogger(factory)
 	historyStore := &password.HistoryStore{
 		Clock:       clockClock,
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	passwordChecker := password.ProvideChecker(authenticatorPasswordConfig, historyStore)
@@ -14306,7 +14306,7 @@ func newWebAppForgotPasswordHandler(p *deps.RequestProvider) http.Handler {
 		Housekeeper:     housekeeper,
 	}
 	totpStore := &totp.Store{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	authenticatorTOTPConfig := authenticatorConfig.TOTP
@@ -14317,7 +14317,7 @@ func newWebAppForgotPasswordHandler(p *deps.RequestProvider) http.Handler {
 	}
 	authenticatorOOBConfig := authenticatorConfig.OOB
 	oobStore := &oob.Store{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	storeRedis := &oob.StoreRedis{
@@ -14358,7 +14358,7 @@ func newWebAppForgotPasswordHandler(p *deps.RequestProvider) http.Handler {
 		Clock: clockClock,
 	}
 	storePQ := &verification.StorePQ{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	verificationService := &verification.Service{
@@ -14377,7 +14377,7 @@ func newWebAppForgotPasswordHandler(p *deps.RequestProvider) http.Handler {
 		Clock: clockClock,
 	}
 	storeRecoveryCodePQ := &mfa.StoreRecoveryCodePQ{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	mfaService := &mfa.Service{
@@ -14388,7 +14388,7 @@ func newWebAppForgotPasswordHandler(p *deps.RequestProvider) http.Handler {
 		RateLimiter:   limiter,
 	}
 	userStore := &user.Store{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	defaultLanguageTag := deps.ProvideDefaultLanguageTag(config)
@@ -14419,7 +14419,7 @@ func newWebAppForgotPasswordHandler(p *deps.RequestProvider) http.Handler {
 	queue := appProvider.TaskQueue
 	eventLogger := event.NewLogger(factory)
 	storeImpl := &event.StoreImpl{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	hookLogger := hook.NewLogger(factory)
@@ -14441,10 +14441,10 @@ func newWebAppForgotPasswordHandler(p *deps.RequestProvider) http.Handler {
 	auditLogger := audit.NewLogger(factory)
 	writeHandle := appProvider.AuditWriteDatabase
 	auditDatabaseCredentials := deps.ProvideAuditDatabaseCredentials(secretConfig)
-	auditdbSQLBuilder := auditdb.NewSQLBuilder(auditDatabaseCredentials, appID)
+	auditdbSQLBuilderApp := auditdb.NewSQLBuilderApp(auditDatabaseCredentials, appID)
 	writeSQLExecutor := auditdb.NewWriteSQLExecutor(contextContext, writeHandle)
 	writeStore := &audit.WriteStore{
-		SQLBuilder:  auditdbSQLBuilder,
+		SQLBuilder:  auditdbSQLBuilderApp,
 		SQLExecutor: writeSQLExecutor,
 	}
 	auditSink := &audit.Sink{
@@ -14466,7 +14466,7 @@ func newWebAppForgotPasswordHandler(p *deps.RequestProvider) http.Handler {
 		WelcomeMessageProvider: welcomemessageProvider,
 	}
 	authorizationStore := &pq.AuthorizationStore{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	storeRedisLogger := idpsession.NewStoreRedisLogger(factory)
@@ -14491,7 +14491,7 @@ func newWebAppForgotPasswordHandler(p *deps.RequestProvider) http.Handler {
 		Redis:       appredisHandle,
 		AppID:       appID,
 		Logger:      redisLogger,
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 		Clock:       clockClock,
 	}
@@ -14785,13 +14785,13 @@ func newWebAppForgotPasswordSuccessHandler(p *deps.RequestProvider) http.Handler
 	identityFeatureConfig := featureConfig.Identity
 	secretConfig := config.SecretConfig
 	databaseCredentials := deps.ProvideDatabaseCredentials(secretConfig)
-	sqlBuilder := appdb.NewSQLBuilder(databaseCredentials, appID)
+	sqlBuilderApp := appdb.NewSQLBuilderApp(databaseCredentials, appID)
 	store := &service.Store{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	loginidStore := &loginid.Store{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	loginIDConfig := identityConfig.LoginID
@@ -14815,7 +14815,7 @@ func newWebAppForgotPasswordSuccessHandler(p *deps.RequestProvider) http.Handler
 		Clock:             clockClock,
 	}
 	oauthStore := &oauth3.Store{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	oauthProvider := &oauth3.Provider{
@@ -14823,7 +14823,7 @@ func newWebAppForgotPasswordSuccessHandler(p *deps.RequestProvider) http.Handler
 		Clock: clockClock,
 	}
 	anonymousStore := &anonymous.Store{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	anonymousProvider := &anonymous.Provider{
@@ -14831,7 +14831,7 @@ func newWebAppForgotPasswordSuccessHandler(p *deps.RequestProvider) http.Handler
 		Clock: clockClock,
 	}
 	biometricStore := &biometric.Store{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	biometricProvider := &biometric.Provider{
@@ -14849,11 +14849,11 @@ func newWebAppForgotPasswordSuccessHandler(p *deps.RequestProvider) http.Handler
 		Biometric:             biometricProvider,
 	}
 	serviceStore := &service2.Store{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	passwordStore := &password.Store{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	authenticatorConfig := appConfig.Authenticator
@@ -14861,7 +14861,7 @@ func newWebAppForgotPasswordSuccessHandler(p *deps.RequestProvider) http.Handler
 	passwordLogger := password.NewLogger(factory)
 	historyStore := &password.HistoryStore{
 		Clock:       clockClock,
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	passwordChecker := password.ProvideChecker(authenticatorPasswordConfig, historyStore)
@@ -14881,7 +14881,7 @@ func newWebAppForgotPasswordSuccessHandler(p *deps.RequestProvider) http.Handler
 		Housekeeper:     housekeeper,
 	}
 	totpStore := &totp.Store{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	authenticatorTOTPConfig := authenticatorConfig.TOTP
@@ -14892,7 +14892,7 @@ func newWebAppForgotPasswordSuccessHandler(p *deps.RequestProvider) http.Handler
 	}
 	authenticatorOOBConfig := authenticatorConfig.OOB
 	oobStore := &oob.Store{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	storeRedis := &oob.StoreRedis{
@@ -14933,7 +14933,7 @@ func newWebAppForgotPasswordSuccessHandler(p *deps.RequestProvider) http.Handler
 		Clock: clockClock,
 	}
 	storePQ := &verification.StorePQ{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	verificationService := &verification.Service{
@@ -14952,7 +14952,7 @@ func newWebAppForgotPasswordSuccessHandler(p *deps.RequestProvider) http.Handler
 		Clock: clockClock,
 	}
 	storeRecoveryCodePQ := &mfa.StoreRecoveryCodePQ{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	mfaService := &mfa.Service{
@@ -14963,7 +14963,7 @@ func newWebAppForgotPasswordSuccessHandler(p *deps.RequestProvider) http.Handler
 		RateLimiter:   limiter,
 	}
 	userStore := &user.Store{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	defaultLanguageTag := deps.ProvideDefaultLanguageTag(config)
@@ -14994,7 +14994,7 @@ func newWebAppForgotPasswordSuccessHandler(p *deps.RequestProvider) http.Handler
 	queue := appProvider.TaskQueue
 	eventLogger := event.NewLogger(factory)
 	storeImpl := &event.StoreImpl{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	hookLogger := hook.NewLogger(factory)
@@ -15016,10 +15016,10 @@ func newWebAppForgotPasswordSuccessHandler(p *deps.RequestProvider) http.Handler
 	auditLogger := audit.NewLogger(factory)
 	writeHandle := appProvider.AuditWriteDatabase
 	auditDatabaseCredentials := deps.ProvideAuditDatabaseCredentials(secretConfig)
-	auditdbSQLBuilder := auditdb.NewSQLBuilder(auditDatabaseCredentials, appID)
+	auditdbSQLBuilderApp := auditdb.NewSQLBuilderApp(auditDatabaseCredentials, appID)
 	writeSQLExecutor := auditdb.NewWriteSQLExecutor(contextContext, writeHandle)
 	writeStore := &audit.WriteStore{
-		SQLBuilder:  auditdbSQLBuilder,
+		SQLBuilder:  auditdbSQLBuilderApp,
 		SQLExecutor: writeSQLExecutor,
 	}
 	auditSink := &audit.Sink{
@@ -15041,7 +15041,7 @@ func newWebAppForgotPasswordSuccessHandler(p *deps.RequestProvider) http.Handler
 		WelcomeMessageProvider: welcomemessageProvider,
 	}
 	authorizationStore := &pq.AuthorizationStore{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	storeRedisLogger := idpsession.NewStoreRedisLogger(factory)
@@ -15066,7 +15066,7 @@ func newWebAppForgotPasswordSuccessHandler(p *deps.RequestProvider) http.Handler
 		Redis:       appredisHandle,
 		AppID:       appID,
 		Logger:      redisLogger,
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 		Clock:       clockClock,
 	}
@@ -15355,13 +15355,13 @@ func newWebAppResetPasswordHandler(p *deps.RequestProvider) http.Handler {
 	identityFeatureConfig := featureConfig.Identity
 	secretConfig := config.SecretConfig
 	databaseCredentials := deps.ProvideDatabaseCredentials(secretConfig)
-	sqlBuilder := appdb.NewSQLBuilder(databaseCredentials, appID)
+	sqlBuilderApp := appdb.NewSQLBuilderApp(databaseCredentials, appID)
 	store := &service.Store{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	loginidStore := &loginid.Store{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	loginIDConfig := identityConfig.LoginID
@@ -15385,7 +15385,7 @@ func newWebAppResetPasswordHandler(p *deps.RequestProvider) http.Handler {
 		Clock:             clockClock,
 	}
 	oauthStore := &oauth3.Store{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	oauthProvider := &oauth3.Provider{
@@ -15393,7 +15393,7 @@ func newWebAppResetPasswordHandler(p *deps.RequestProvider) http.Handler {
 		Clock: clockClock,
 	}
 	anonymousStore := &anonymous.Store{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	anonymousProvider := &anonymous.Provider{
@@ -15401,7 +15401,7 @@ func newWebAppResetPasswordHandler(p *deps.RequestProvider) http.Handler {
 		Clock: clockClock,
 	}
 	biometricStore := &biometric.Store{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	biometricProvider := &biometric.Provider{
@@ -15419,11 +15419,11 @@ func newWebAppResetPasswordHandler(p *deps.RequestProvider) http.Handler {
 		Biometric:             biometricProvider,
 	}
 	serviceStore := &service2.Store{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	passwordStore := &password.Store{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	authenticatorConfig := appConfig.Authenticator
@@ -15431,7 +15431,7 @@ func newWebAppResetPasswordHandler(p *deps.RequestProvider) http.Handler {
 	passwordLogger := password.NewLogger(factory)
 	historyStore := &password.HistoryStore{
 		Clock:       clockClock,
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	passwordChecker := password.ProvideChecker(authenticatorPasswordConfig, historyStore)
@@ -15451,7 +15451,7 @@ func newWebAppResetPasswordHandler(p *deps.RequestProvider) http.Handler {
 		Housekeeper:     housekeeper,
 	}
 	totpStore := &totp.Store{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	authenticatorTOTPConfig := authenticatorConfig.TOTP
@@ -15462,7 +15462,7 @@ func newWebAppResetPasswordHandler(p *deps.RequestProvider) http.Handler {
 	}
 	authenticatorOOBConfig := authenticatorConfig.OOB
 	oobStore := &oob.Store{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	storeRedis := &oob.StoreRedis{
@@ -15503,7 +15503,7 @@ func newWebAppResetPasswordHandler(p *deps.RequestProvider) http.Handler {
 		Clock: clockClock,
 	}
 	storePQ := &verification.StorePQ{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	verificationService := &verification.Service{
@@ -15522,7 +15522,7 @@ func newWebAppResetPasswordHandler(p *deps.RequestProvider) http.Handler {
 		Clock: clockClock,
 	}
 	storeRecoveryCodePQ := &mfa.StoreRecoveryCodePQ{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	mfaService := &mfa.Service{
@@ -15533,7 +15533,7 @@ func newWebAppResetPasswordHandler(p *deps.RequestProvider) http.Handler {
 		RateLimiter:   limiter,
 	}
 	userStore := &user.Store{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	defaultLanguageTag := deps.ProvideDefaultLanguageTag(config)
@@ -15564,7 +15564,7 @@ func newWebAppResetPasswordHandler(p *deps.RequestProvider) http.Handler {
 	queue := appProvider.TaskQueue
 	eventLogger := event.NewLogger(factory)
 	storeImpl := &event.StoreImpl{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	hookLogger := hook.NewLogger(factory)
@@ -15586,10 +15586,10 @@ func newWebAppResetPasswordHandler(p *deps.RequestProvider) http.Handler {
 	auditLogger := audit.NewLogger(factory)
 	writeHandle := appProvider.AuditWriteDatabase
 	auditDatabaseCredentials := deps.ProvideAuditDatabaseCredentials(secretConfig)
-	auditdbSQLBuilder := auditdb.NewSQLBuilder(auditDatabaseCredentials, appID)
+	auditdbSQLBuilderApp := auditdb.NewSQLBuilderApp(auditDatabaseCredentials, appID)
 	writeSQLExecutor := auditdb.NewWriteSQLExecutor(contextContext, writeHandle)
 	writeStore := &audit.WriteStore{
-		SQLBuilder:  auditdbSQLBuilder,
+		SQLBuilder:  auditdbSQLBuilderApp,
 		SQLExecutor: writeSQLExecutor,
 	}
 	auditSink := &audit.Sink{
@@ -15611,7 +15611,7 @@ func newWebAppResetPasswordHandler(p *deps.RequestProvider) http.Handler {
 		WelcomeMessageProvider: welcomemessageProvider,
 	}
 	authorizationStore := &pq.AuthorizationStore{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	storeRedisLogger := idpsession.NewStoreRedisLogger(factory)
@@ -15636,7 +15636,7 @@ func newWebAppResetPasswordHandler(p *deps.RequestProvider) http.Handler {
 		Redis:       appredisHandle,
 		AppID:       appID,
 		Logger:      redisLogger,
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 		Clock:       clockClock,
 	}
@@ -15926,13 +15926,13 @@ func newWebAppResetPasswordSuccessHandler(p *deps.RequestProvider) http.Handler 
 	identityFeatureConfig := featureConfig.Identity
 	secretConfig := config.SecretConfig
 	databaseCredentials := deps.ProvideDatabaseCredentials(secretConfig)
-	sqlBuilder := appdb.NewSQLBuilder(databaseCredentials, appID)
+	sqlBuilderApp := appdb.NewSQLBuilderApp(databaseCredentials, appID)
 	store := &service.Store{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	loginidStore := &loginid.Store{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	loginIDConfig := identityConfig.LoginID
@@ -15956,7 +15956,7 @@ func newWebAppResetPasswordSuccessHandler(p *deps.RequestProvider) http.Handler 
 		Clock:             clockClock,
 	}
 	oauthStore := &oauth3.Store{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	oauthProvider := &oauth3.Provider{
@@ -15964,7 +15964,7 @@ func newWebAppResetPasswordSuccessHandler(p *deps.RequestProvider) http.Handler 
 		Clock: clockClock,
 	}
 	anonymousStore := &anonymous.Store{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	anonymousProvider := &anonymous.Provider{
@@ -15972,7 +15972,7 @@ func newWebAppResetPasswordSuccessHandler(p *deps.RequestProvider) http.Handler 
 		Clock: clockClock,
 	}
 	biometricStore := &biometric.Store{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	biometricProvider := &biometric.Provider{
@@ -15990,11 +15990,11 @@ func newWebAppResetPasswordSuccessHandler(p *deps.RequestProvider) http.Handler 
 		Biometric:             biometricProvider,
 	}
 	serviceStore := &service2.Store{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	passwordStore := &password.Store{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	authenticatorConfig := appConfig.Authenticator
@@ -16002,7 +16002,7 @@ func newWebAppResetPasswordSuccessHandler(p *deps.RequestProvider) http.Handler 
 	passwordLogger := password.NewLogger(factory)
 	historyStore := &password.HistoryStore{
 		Clock:       clockClock,
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	passwordChecker := password.ProvideChecker(authenticatorPasswordConfig, historyStore)
@@ -16022,7 +16022,7 @@ func newWebAppResetPasswordSuccessHandler(p *deps.RequestProvider) http.Handler 
 		Housekeeper:     housekeeper,
 	}
 	totpStore := &totp.Store{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	authenticatorTOTPConfig := authenticatorConfig.TOTP
@@ -16033,7 +16033,7 @@ func newWebAppResetPasswordSuccessHandler(p *deps.RequestProvider) http.Handler 
 	}
 	authenticatorOOBConfig := authenticatorConfig.OOB
 	oobStore := &oob.Store{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	storeRedis := &oob.StoreRedis{
@@ -16074,7 +16074,7 @@ func newWebAppResetPasswordSuccessHandler(p *deps.RequestProvider) http.Handler 
 		Clock: clockClock,
 	}
 	storePQ := &verification.StorePQ{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	verificationService := &verification.Service{
@@ -16093,7 +16093,7 @@ func newWebAppResetPasswordSuccessHandler(p *deps.RequestProvider) http.Handler 
 		Clock: clockClock,
 	}
 	storeRecoveryCodePQ := &mfa.StoreRecoveryCodePQ{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	mfaService := &mfa.Service{
@@ -16104,7 +16104,7 @@ func newWebAppResetPasswordSuccessHandler(p *deps.RequestProvider) http.Handler 
 		RateLimiter:   limiter,
 	}
 	userStore := &user.Store{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	defaultLanguageTag := deps.ProvideDefaultLanguageTag(config)
@@ -16135,7 +16135,7 @@ func newWebAppResetPasswordSuccessHandler(p *deps.RequestProvider) http.Handler 
 	queue := appProvider.TaskQueue
 	eventLogger := event.NewLogger(factory)
 	storeImpl := &event.StoreImpl{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	hookLogger := hook.NewLogger(factory)
@@ -16157,10 +16157,10 @@ func newWebAppResetPasswordSuccessHandler(p *deps.RequestProvider) http.Handler 
 	auditLogger := audit.NewLogger(factory)
 	writeHandle := appProvider.AuditWriteDatabase
 	auditDatabaseCredentials := deps.ProvideAuditDatabaseCredentials(secretConfig)
-	auditdbSQLBuilder := auditdb.NewSQLBuilder(auditDatabaseCredentials, appID)
+	auditdbSQLBuilderApp := auditdb.NewSQLBuilderApp(auditDatabaseCredentials, appID)
 	writeSQLExecutor := auditdb.NewWriteSQLExecutor(contextContext, writeHandle)
 	writeStore := &audit.WriteStore{
-		SQLBuilder:  auditdbSQLBuilder,
+		SQLBuilder:  auditdbSQLBuilderApp,
 		SQLExecutor: writeSQLExecutor,
 	}
 	auditSink := &audit.Sink{
@@ -16182,7 +16182,7 @@ func newWebAppResetPasswordSuccessHandler(p *deps.RequestProvider) http.Handler 
 		WelcomeMessageProvider: welcomemessageProvider,
 	}
 	authorizationStore := &pq.AuthorizationStore{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	storeRedisLogger := idpsession.NewStoreRedisLogger(factory)
@@ -16207,7 +16207,7 @@ func newWebAppResetPasswordSuccessHandler(p *deps.RequestProvider) http.Handler 
 		Redis:       appredisHandle,
 		AppID:       appID,
 		Logger:      redisLogger,
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 		Clock:       clockClock,
 	}
@@ -16496,13 +16496,13 @@ func newWebAppSettingsHandler(p *deps.RequestProvider) http.Handler {
 	identityFeatureConfig := featureConfig.Identity
 	secretConfig := config.SecretConfig
 	databaseCredentials := deps.ProvideDatabaseCredentials(secretConfig)
-	sqlBuilder := appdb.NewSQLBuilder(databaseCredentials, appID)
+	sqlBuilderApp := appdb.NewSQLBuilderApp(databaseCredentials, appID)
 	store := &service.Store{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	loginidStore := &loginid.Store{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	loginIDConfig := identityConfig.LoginID
@@ -16526,7 +16526,7 @@ func newWebAppSettingsHandler(p *deps.RequestProvider) http.Handler {
 		Clock:             clockClock,
 	}
 	oauthStore := &oauth3.Store{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	oauthProvider := &oauth3.Provider{
@@ -16534,7 +16534,7 @@ func newWebAppSettingsHandler(p *deps.RequestProvider) http.Handler {
 		Clock: clockClock,
 	}
 	anonymousStore := &anonymous.Store{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	anonymousProvider := &anonymous.Provider{
@@ -16542,7 +16542,7 @@ func newWebAppSettingsHandler(p *deps.RequestProvider) http.Handler {
 		Clock: clockClock,
 	}
 	biometricStore := &biometric.Store{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	biometricProvider := &biometric.Provider{
@@ -16560,11 +16560,11 @@ func newWebAppSettingsHandler(p *deps.RequestProvider) http.Handler {
 		Biometric:             biometricProvider,
 	}
 	serviceStore := &service2.Store{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	passwordStore := &password.Store{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	authenticatorConfig := appConfig.Authenticator
@@ -16572,7 +16572,7 @@ func newWebAppSettingsHandler(p *deps.RequestProvider) http.Handler {
 	passwordLogger := password.NewLogger(factory)
 	historyStore := &password.HistoryStore{
 		Clock:       clockClock,
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	passwordChecker := password.ProvideChecker(authenticatorPasswordConfig, historyStore)
@@ -16592,7 +16592,7 @@ func newWebAppSettingsHandler(p *deps.RequestProvider) http.Handler {
 		Housekeeper:     housekeeper,
 	}
 	totpStore := &totp.Store{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	authenticatorTOTPConfig := authenticatorConfig.TOTP
@@ -16603,7 +16603,7 @@ func newWebAppSettingsHandler(p *deps.RequestProvider) http.Handler {
 	}
 	authenticatorOOBConfig := authenticatorConfig.OOB
 	oobStore := &oob.Store{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	storeRedis := &oob.StoreRedis{
@@ -16644,7 +16644,7 @@ func newWebAppSettingsHandler(p *deps.RequestProvider) http.Handler {
 		Clock: clockClock,
 	}
 	storePQ := &verification.StorePQ{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	verificationService := &verification.Service{
@@ -16663,7 +16663,7 @@ func newWebAppSettingsHandler(p *deps.RequestProvider) http.Handler {
 		Clock: clockClock,
 	}
 	storeRecoveryCodePQ := &mfa.StoreRecoveryCodePQ{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	mfaService := &mfa.Service{
@@ -16674,7 +16674,7 @@ func newWebAppSettingsHandler(p *deps.RequestProvider) http.Handler {
 		RateLimiter:   limiter,
 	}
 	userStore := &user.Store{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	defaultLanguageTag := deps.ProvideDefaultLanguageTag(config)
@@ -16705,7 +16705,7 @@ func newWebAppSettingsHandler(p *deps.RequestProvider) http.Handler {
 	queue := appProvider.TaskQueue
 	eventLogger := event.NewLogger(factory)
 	storeImpl := &event.StoreImpl{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	hookLogger := hook.NewLogger(factory)
@@ -16727,10 +16727,10 @@ func newWebAppSettingsHandler(p *deps.RequestProvider) http.Handler {
 	auditLogger := audit.NewLogger(factory)
 	writeHandle := appProvider.AuditWriteDatabase
 	auditDatabaseCredentials := deps.ProvideAuditDatabaseCredentials(secretConfig)
-	auditdbSQLBuilder := auditdb.NewSQLBuilder(auditDatabaseCredentials, appID)
+	auditdbSQLBuilderApp := auditdb.NewSQLBuilderApp(auditDatabaseCredentials, appID)
 	writeSQLExecutor := auditdb.NewWriteSQLExecutor(contextContext, writeHandle)
 	writeStore := &audit.WriteStore{
-		SQLBuilder:  auditdbSQLBuilder,
+		SQLBuilder:  auditdbSQLBuilderApp,
 		SQLExecutor: writeSQLExecutor,
 	}
 	auditSink := &audit.Sink{
@@ -16752,7 +16752,7 @@ func newWebAppSettingsHandler(p *deps.RequestProvider) http.Handler {
 		WelcomeMessageProvider: welcomemessageProvider,
 	}
 	authorizationStore := &pq.AuthorizationStore{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	storeRedisLogger := idpsession.NewStoreRedisLogger(factory)
@@ -16777,7 +16777,7 @@ func newWebAppSettingsHandler(p *deps.RequestProvider) http.Handler {
 		Redis:       appredisHandle,
 		AppID:       appID,
 		Logger:      redisLogger,
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 		Clock:       clockClock,
 	}
@@ -17085,13 +17085,13 @@ func newWebAppSettingsIdentityHandler(p *deps.RequestProvider) http.Handler {
 	identityFeatureConfig := featureConfig.Identity
 	secretConfig := config.SecretConfig
 	databaseCredentials := deps.ProvideDatabaseCredentials(secretConfig)
-	sqlBuilder := appdb.NewSQLBuilder(databaseCredentials, appID)
+	sqlBuilderApp := appdb.NewSQLBuilderApp(databaseCredentials, appID)
 	store := &service.Store{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	loginidStore := &loginid.Store{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	loginIDConfig := identityConfig.LoginID
@@ -17115,7 +17115,7 @@ func newWebAppSettingsIdentityHandler(p *deps.RequestProvider) http.Handler {
 		Clock:             clockClock,
 	}
 	oauthStore := &oauth3.Store{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	oauthProvider := &oauth3.Provider{
@@ -17123,7 +17123,7 @@ func newWebAppSettingsIdentityHandler(p *deps.RequestProvider) http.Handler {
 		Clock: clockClock,
 	}
 	anonymousStore := &anonymous.Store{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	anonymousProvider := &anonymous.Provider{
@@ -17131,7 +17131,7 @@ func newWebAppSettingsIdentityHandler(p *deps.RequestProvider) http.Handler {
 		Clock: clockClock,
 	}
 	biometricStore := &biometric.Store{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	biometricProvider := &biometric.Provider{
@@ -17149,11 +17149,11 @@ func newWebAppSettingsIdentityHandler(p *deps.RequestProvider) http.Handler {
 		Biometric:             biometricProvider,
 	}
 	serviceStore := &service2.Store{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	passwordStore := &password.Store{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	authenticatorConfig := appConfig.Authenticator
@@ -17161,7 +17161,7 @@ func newWebAppSettingsIdentityHandler(p *deps.RequestProvider) http.Handler {
 	passwordLogger := password.NewLogger(factory)
 	historyStore := &password.HistoryStore{
 		Clock:       clockClock,
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	passwordChecker := password.ProvideChecker(authenticatorPasswordConfig, historyStore)
@@ -17181,7 +17181,7 @@ func newWebAppSettingsIdentityHandler(p *deps.RequestProvider) http.Handler {
 		Housekeeper:     housekeeper,
 	}
 	totpStore := &totp.Store{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	authenticatorTOTPConfig := authenticatorConfig.TOTP
@@ -17192,7 +17192,7 @@ func newWebAppSettingsIdentityHandler(p *deps.RequestProvider) http.Handler {
 	}
 	authenticatorOOBConfig := authenticatorConfig.OOB
 	oobStore := &oob.Store{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	storeRedis := &oob.StoreRedis{
@@ -17233,7 +17233,7 @@ func newWebAppSettingsIdentityHandler(p *deps.RequestProvider) http.Handler {
 		Clock: clockClock,
 	}
 	storePQ := &verification.StorePQ{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	verificationService := &verification.Service{
@@ -17252,7 +17252,7 @@ func newWebAppSettingsIdentityHandler(p *deps.RequestProvider) http.Handler {
 		Clock: clockClock,
 	}
 	storeRecoveryCodePQ := &mfa.StoreRecoveryCodePQ{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	mfaService := &mfa.Service{
@@ -17263,7 +17263,7 @@ func newWebAppSettingsIdentityHandler(p *deps.RequestProvider) http.Handler {
 		RateLimiter:   limiter,
 	}
 	userStore := &user.Store{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	defaultLanguageTag := deps.ProvideDefaultLanguageTag(config)
@@ -17294,7 +17294,7 @@ func newWebAppSettingsIdentityHandler(p *deps.RequestProvider) http.Handler {
 	queue := appProvider.TaskQueue
 	eventLogger := event.NewLogger(factory)
 	storeImpl := &event.StoreImpl{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	hookLogger := hook.NewLogger(factory)
@@ -17316,10 +17316,10 @@ func newWebAppSettingsIdentityHandler(p *deps.RequestProvider) http.Handler {
 	auditLogger := audit.NewLogger(factory)
 	writeHandle := appProvider.AuditWriteDatabase
 	auditDatabaseCredentials := deps.ProvideAuditDatabaseCredentials(secretConfig)
-	auditdbSQLBuilder := auditdb.NewSQLBuilder(auditDatabaseCredentials, appID)
+	auditdbSQLBuilderApp := auditdb.NewSQLBuilderApp(auditDatabaseCredentials, appID)
 	writeSQLExecutor := auditdb.NewWriteSQLExecutor(contextContext, writeHandle)
 	writeStore := &audit.WriteStore{
-		SQLBuilder:  auditdbSQLBuilder,
+		SQLBuilder:  auditdbSQLBuilderApp,
 		SQLExecutor: writeSQLExecutor,
 	}
 	auditSink := &audit.Sink{
@@ -17341,7 +17341,7 @@ func newWebAppSettingsIdentityHandler(p *deps.RequestProvider) http.Handler {
 		WelcomeMessageProvider: welcomemessageProvider,
 	}
 	authorizationStore := &pq.AuthorizationStore{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	storeRedisLogger := idpsession.NewStoreRedisLogger(factory)
@@ -17366,7 +17366,7 @@ func newWebAppSettingsIdentityHandler(p *deps.RequestProvider) http.Handler {
 		Redis:       appredisHandle,
 		AppID:       appID,
 		Logger:      redisLogger,
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 		Clock:       clockClock,
 	}
@@ -17657,13 +17657,13 @@ func newWebAppSettingsBiometricHandler(p *deps.RequestProvider) http.Handler {
 	identityFeatureConfig := featureConfig.Identity
 	secretConfig := config.SecretConfig
 	databaseCredentials := deps.ProvideDatabaseCredentials(secretConfig)
-	sqlBuilder := appdb.NewSQLBuilder(databaseCredentials, appID)
+	sqlBuilderApp := appdb.NewSQLBuilderApp(databaseCredentials, appID)
 	store := &service.Store{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	loginidStore := &loginid.Store{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	loginIDConfig := identityConfig.LoginID
@@ -17687,7 +17687,7 @@ func newWebAppSettingsBiometricHandler(p *deps.RequestProvider) http.Handler {
 		Clock:             clockClock,
 	}
 	oauthStore := &oauth3.Store{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	oauthProvider := &oauth3.Provider{
@@ -17695,7 +17695,7 @@ func newWebAppSettingsBiometricHandler(p *deps.RequestProvider) http.Handler {
 		Clock: clockClock,
 	}
 	anonymousStore := &anonymous.Store{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	anonymousProvider := &anonymous.Provider{
@@ -17703,7 +17703,7 @@ func newWebAppSettingsBiometricHandler(p *deps.RequestProvider) http.Handler {
 		Clock: clockClock,
 	}
 	biometricStore := &biometric.Store{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	biometricProvider := &biometric.Provider{
@@ -17721,11 +17721,11 @@ func newWebAppSettingsBiometricHandler(p *deps.RequestProvider) http.Handler {
 		Biometric:             biometricProvider,
 	}
 	serviceStore := &service2.Store{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	passwordStore := &password.Store{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	authenticatorConfig := appConfig.Authenticator
@@ -17733,7 +17733,7 @@ func newWebAppSettingsBiometricHandler(p *deps.RequestProvider) http.Handler {
 	passwordLogger := password.NewLogger(factory)
 	historyStore := &password.HistoryStore{
 		Clock:       clockClock,
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	passwordChecker := password.ProvideChecker(authenticatorPasswordConfig, historyStore)
@@ -17753,7 +17753,7 @@ func newWebAppSettingsBiometricHandler(p *deps.RequestProvider) http.Handler {
 		Housekeeper:     housekeeper,
 	}
 	totpStore := &totp.Store{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	authenticatorTOTPConfig := authenticatorConfig.TOTP
@@ -17764,7 +17764,7 @@ func newWebAppSettingsBiometricHandler(p *deps.RequestProvider) http.Handler {
 	}
 	authenticatorOOBConfig := authenticatorConfig.OOB
 	oobStore := &oob.Store{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	storeRedis := &oob.StoreRedis{
@@ -17805,7 +17805,7 @@ func newWebAppSettingsBiometricHandler(p *deps.RequestProvider) http.Handler {
 		Clock: clockClock,
 	}
 	storePQ := &verification.StorePQ{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	verificationService := &verification.Service{
@@ -17824,7 +17824,7 @@ func newWebAppSettingsBiometricHandler(p *deps.RequestProvider) http.Handler {
 		Clock: clockClock,
 	}
 	storeRecoveryCodePQ := &mfa.StoreRecoveryCodePQ{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	mfaService := &mfa.Service{
@@ -17835,7 +17835,7 @@ func newWebAppSettingsBiometricHandler(p *deps.RequestProvider) http.Handler {
 		RateLimiter:   limiter,
 	}
 	userStore := &user.Store{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	defaultLanguageTag := deps.ProvideDefaultLanguageTag(config)
@@ -17866,7 +17866,7 @@ func newWebAppSettingsBiometricHandler(p *deps.RequestProvider) http.Handler {
 	queue := appProvider.TaskQueue
 	eventLogger := event.NewLogger(factory)
 	storeImpl := &event.StoreImpl{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	hookLogger := hook.NewLogger(factory)
@@ -17888,10 +17888,10 @@ func newWebAppSettingsBiometricHandler(p *deps.RequestProvider) http.Handler {
 	auditLogger := audit.NewLogger(factory)
 	writeHandle := appProvider.AuditWriteDatabase
 	auditDatabaseCredentials := deps.ProvideAuditDatabaseCredentials(secretConfig)
-	auditdbSQLBuilder := auditdb.NewSQLBuilder(auditDatabaseCredentials, appID)
+	auditdbSQLBuilderApp := auditdb.NewSQLBuilderApp(auditDatabaseCredentials, appID)
 	writeSQLExecutor := auditdb.NewWriteSQLExecutor(contextContext, writeHandle)
 	writeStore := &audit.WriteStore{
-		SQLBuilder:  auditdbSQLBuilder,
+		SQLBuilder:  auditdbSQLBuilderApp,
 		SQLExecutor: writeSQLExecutor,
 	}
 	auditSink := &audit.Sink{
@@ -17913,7 +17913,7 @@ func newWebAppSettingsBiometricHandler(p *deps.RequestProvider) http.Handler {
 		WelcomeMessageProvider: welcomemessageProvider,
 	}
 	authorizationStore := &pq.AuthorizationStore{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	storeRedisLogger := idpsession.NewStoreRedisLogger(factory)
@@ -17938,7 +17938,7 @@ func newWebAppSettingsBiometricHandler(p *deps.RequestProvider) http.Handler {
 		Redis:       appredisHandle,
 		AppID:       appID,
 		Logger:      redisLogger,
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 		Clock:       clockClock,
 	}
@@ -18228,13 +18228,13 @@ func newWebAppSettingsMFAHandler(p *deps.RequestProvider) http.Handler {
 	identityFeatureConfig := featureConfig.Identity
 	secretConfig := config.SecretConfig
 	databaseCredentials := deps.ProvideDatabaseCredentials(secretConfig)
-	sqlBuilder := appdb.NewSQLBuilder(databaseCredentials, appID)
+	sqlBuilderApp := appdb.NewSQLBuilderApp(databaseCredentials, appID)
 	store := &service.Store{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	loginidStore := &loginid.Store{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	loginIDConfig := identityConfig.LoginID
@@ -18258,7 +18258,7 @@ func newWebAppSettingsMFAHandler(p *deps.RequestProvider) http.Handler {
 		Clock:             clockClock,
 	}
 	oauthStore := &oauth3.Store{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	oauthProvider := &oauth3.Provider{
@@ -18266,7 +18266,7 @@ func newWebAppSettingsMFAHandler(p *deps.RequestProvider) http.Handler {
 		Clock: clockClock,
 	}
 	anonymousStore := &anonymous.Store{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	anonymousProvider := &anonymous.Provider{
@@ -18274,7 +18274,7 @@ func newWebAppSettingsMFAHandler(p *deps.RequestProvider) http.Handler {
 		Clock: clockClock,
 	}
 	biometricStore := &biometric.Store{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	biometricProvider := &biometric.Provider{
@@ -18292,11 +18292,11 @@ func newWebAppSettingsMFAHandler(p *deps.RequestProvider) http.Handler {
 		Biometric:             biometricProvider,
 	}
 	serviceStore := &service2.Store{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	passwordStore := &password.Store{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	authenticatorConfig := appConfig.Authenticator
@@ -18304,7 +18304,7 @@ func newWebAppSettingsMFAHandler(p *deps.RequestProvider) http.Handler {
 	passwordLogger := password.NewLogger(factory)
 	historyStore := &password.HistoryStore{
 		Clock:       clockClock,
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	passwordChecker := password.ProvideChecker(authenticatorPasswordConfig, historyStore)
@@ -18324,7 +18324,7 @@ func newWebAppSettingsMFAHandler(p *deps.RequestProvider) http.Handler {
 		Housekeeper:     housekeeper,
 	}
 	totpStore := &totp.Store{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	authenticatorTOTPConfig := authenticatorConfig.TOTP
@@ -18335,7 +18335,7 @@ func newWebAppSettingsMFAHandler(p *deps.RequestProvider) http.Handler {
 	}
 	authenticatorOOBConfig := authenticatorConfig.OOB
 	oobStore := &oob.Store{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	storeRedis := &oob.StoreRedis{
@@ -18376,7 +18376,7 @@ func newWebAppSettingsMFAHandler(p *deps.RequestProvider) http.Handler {
 		Clock: clockClock,
 	}
 	storePQ := &verification.StorePQ{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	verificationService := &verification.Service{
@@ -18395,7 +18395,7 @@ func newWebAppSettingsMFAHandler(p *deps.RequestProvider) http.Handler {
 		Clock: clockClock,
 	}
 	storeRecoveryCodePQ := &mfa.StoreRecoveryCodePQ{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	mfaService := &mfa.Service{
@@ -18406,7 +18406,7 @@ func newWebAppSettingsMFAHandler(p *deps.RequestProvider) http.Handler {
 		RateLimiter:   limiter,
 	}
 	userStore := &user.Store{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	defaultLanguageTag := deps.ProvideDefaultLanguageTag(config)
@@ -18437,7 +18437,7 @@ func newWebAppSettingsMFAHandler(p *deps.RequestProvider) http.Handler {
 	queue := appProvider.TaskQueue
 	eventLogger := event.NewLogger(factory)
 	storeImpl := &event.StoreImpl{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	hookLogger := hook.NewLogger(factory)
@@ -18459,10 +18459,10 @@ func newWebAppSettingsMFAHandler(p *deps.RequestProvider) http.Handler {
 	auditLogger := audit.NewLogger(factory)
 	writeHandle := appProvider.AuditWriteDatabase
 	auditDatabaseCredentials := deps.ProvideAuditDatabaseCredentials(secretConfig)
-	auditdbSQLBuilder := auditdb.NewSQLBuilder(auditDatabaseCredentials, appID)
+	auditdbSQLBuilderApp := auditdb.NewSQLBuilderApp(auditDatabaseCredentials, appID)
 	writeSQLExecutor := auditdb.NewWriteSQLExecutor(contextContext, writeHandle)
 	writeStore := &audit.WriteStore{
-		SQLBuilder:  auditdbSQLBuilder,
+		SQLBuilder:  auditdbSQLBuilderApp,
 		SQLExecutor: writeSQLExecutor,
 	}
 	auditSink := &audit.Sink{
@@ -18484,7 +18484,7 @@ func newWebAppSettingsMFAHandler(p *deps.RequestProvider) http.Handler {
 		WelcomeMessageProvider: welcomemessageProvider,
 	}
 	authorizationStore := &pq.AuthorizationStore{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	storeRedisLogger := idpsession.NewStoreRedisLogger(factory)
@@ -18509,7 +18509,7 @@ func newWebAppSettingsMFAHandler(p *deps.RequestProvider) http.Handler {
 		Redis:       appredisHandle,
 		AppID:       appID,
 		Logger:      redisLogger,
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 		Clock:       clockClock,
 	}
@@ -18808,13 +18808,13 @@ func newWebAppSettingsTOTPHandler(p *deps.RequestProvider) http.Handler {
 	identityFeatureConfig := featureConfig.Identity
 	secretConfig := config.SecretConfig
 	databaseCredentials := deps.ProvideDatabaseCredentials(secretConfig)
-	sqlBuilder := appdb.NewSQLBuilder(databaseCredentials, appID)
+	sqlBuilderApp := appdb.NewSQLBuilderApp(databaseCredentials, appID)
 	store := &service.Store{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	loginidStore := &loginid.Store{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	loginIDConfig := identityConfig.LoginID
@@ -18838,7 +18838,7 @@ func newWebAppSettingsTOTPHandler(p *deps.RequestProvider) http.Handler {
 		Clock:             clockClock,
 	}
 	oauthStore := &oauth3.Store{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	oauthProvider := &oauth3.Provider{
@@ -18846,7 +18846,7 @@ func newWebAppSettingsTOTPHandler(p *deps.RequestProvider) http.Handler {
 		Clock: clockClock,
 	}
 	anonymousStore := &anonymous.Store{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	anonymousProvider := &anonymous.Provider{
@@ -18854,7 +18854,7 @@ func newWebAppSettingsTOTPHandler(p *deps.RequestProvider) http.Handler {
 		Clock: clockClock,
 	}
 	biometricStore := &biometric.Store{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	biometricProvider := &biometric.Provider{
@@ -18872,11 +18872,11 @@ func newWebAppSettingsTOTPHandler(p *deps.RequestProvider) http.Handler {
 		Biometric:             biometricProvider,
 	}
 	serviceStore := &service2.Store{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	passwordStore := &password.Store{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	authenticatorConfig := appConfig.Authenticator
@@ -18884,7 +18884,7 @@ func newWebAppSettingsTOTPHandler(p *deps.RequestProvider) http.Handler {
 	passwordLogger := password.NewLogger(factory)
 	historyStore := &password.HistoryStore{
 		Clock:       clockClock,
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	passwordChecker := password.ProvideChecker(authenticatorPasswordConfig, historyStore)
@@ -18904,7 +18904,7 @@ func newWebAppSettingsTOTPHandler(p *deps.RequestProvider) http.Handler {
 		Housekeeper:     housekeeper,
 	}
 	totpStore := &totp.Store{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	authenticatorTOTPConfig := authenticatorConfig.TOTP
@@ -18915,7 +18915,7 @@ func newWebAppSettingsTOTPHandler(p *deps.RequestProvider) http.Handler {
 	}
 	authenticatorOOBConfig := authenticatorConfig.OOB
 	oobStore := &oob.Store{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	storeRedis := &oob.StoreRedis{
@@ -18956,7 +18956,7 @@ func newWebAppSettingsTOTPHandler(p *deps.RequestProvider) http.Handler {
 		Clock: clockClock,
 	}
 	storePQ := &verification.StorePQ{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	verificationService := &verification.Service{
@@ -18975,7 +18975,7 @@ func newWebAppSettingsTOTPHandler(p *deps.RequestProvider) http.Handler {
 		Clock: clockClock,
 	}
 	storeRecoveryCodePQ := &mfa.StoreRecoveryCodePQ{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	mfaService := &mfa.Service{
@@ -18986,7 +18986,7 @@ func newWebAppSettingsTOTPHandler(p *deps.RequestProvider) http.Handler {
 		RateLimiter:   limiter,
 	}
 	userStore := &user.Store{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	defaultLanguageTag := deps.ProvideDefaultLanguageTag(config)
@@ -19017,7 +19017,7 @@ func newWebAppSettingsTOTPHandler(p *deps.RequestProvider) http.Handler {
 	queue := appProvider.TaskQueue
 	eventLogger := event.NewLogger(factory)
 	storeImpl := &event.StoreImpl{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	hookLogger := hook.NewLogger(factory)
@@ -19039,10 +19039,10 @@ func newWebAppSettingsTOTPHandler(p *deps.RequestProvider) http.Handler {
 	auditLogger := audit.NewLogger(factory)
 	writeHandle := appProvider.AuditWriteDatabase
 	auditDatabaseCredentials := deps.ProvideAuditDatabaseCredentials(secretConfig)
-	auditdbSQLBuilder := auditdb.NewSQLBuilder(auditDatabaseCredentials, appID)
+	auditdbSQLBuilderApp := auditdb.NewSQLBuilderApp(auditDatabaseCredentials, appID)
 	writeSQLExecutor := auditdb.NewWriteSQLExecutor(contextContext, writeHandle)
 	writeStore := &audit.WriteStore{
-		SQLBuilder:  auditdbSQLBuilder,
+		SQLBuilder:  auditdbSQLBuilderApp,
 		SQLExecutor: writeSQLExecutor,
 	}
 	auditSink := &audit.Sink{
@@ -19064,7 +19064,7 @@ func newWebAppSettingsTOTPHandler(p *deps.RequestProvider) http.Handler {
 		WelcomeMessageProvider: welcomemessageProvider,
 	}
 	authorizationStore := &pq.AuthorizationStore{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	storeRedisLogger := idpsession.NewStoreRedisLogger(factory)
@@ -19089,7 +19089,7 @@ func newWebAppSettingsTOTPHandler(p *deps.RequestProvider) http.Handler {
 		Redis:       appredisHandle,
 		AppID:       appID,
 		Logger:      redisLogger,
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 		Clock:       clockClock,
 	}
@@ -19379,13 +19379,13 @@ func newWebAppSettingsOOBOTPHandler(p *deps.RequestProvider) http.Handler {
 	identityFeatureConfig := featureConfig.Identity
 	secretConfig := config.SecretConfig
 	databaseCredentials := deps.ProvideDatabaseCredentials(secretConfig)
-	sqlBuilder := appdb.NewSQLBuilder(databaseCredentials, appID)
+	sqlBuilderApp := appdb.NewSQLBuilderApp(databaseCredentials, appID)
 	store := &service.Store{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	loginidStore := &loginid.Store{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	loginIDConfig := identityConfig.LoginID
@@ -19409,7 +19409,7 @@ func newWebAppSettingsOOBOTPHandler(p *deps.RequestProvider) http.Handler {
 		Clock:             clockClock,
 	}
 	oauthStore := &oauth3.Store{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	oauthProvider := &oauth3.Provider{
@@ -19417,7 +19417,7 @@ func newWebAppSettingsOOBOTPHandler(p *deps.RequestProvider) http.Handler {
 		Clock: clockClock,
 	}
 	anonymousStore := &anonymous.Store{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	anonymousProvider := &anonymous.Provider{
@@ -19425,7 +19425,7 @@ func newWebAppSettingsOOBOTPHandler(p *deps.RequestProvider) http.Handler {
 		Clock: clockClock,
 	}
 	biometricStore := &biometric.Store{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	biometricProvider := &biometric.Provider{
@@ -19443,11 +19443,11 @@ func newWebAppSettingsOOBOTPHandler(p *deps.RequestProvider) http.Handler {
 		Biometric:             biometricProvider,
 	}
 	serviceStore := &service2.Store{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	passwordStore := &password.Store{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	authenticatorConfig := appConfig.Authenticator
@@ -19455,7 +19455,7 @@ func newWebAppSettingsOOBOTPHandler(p *deps.RequestProvider) http.Handler {
 	passwordLogger := password.NewLogger(factory)
 	historyStore := &password.HistoryStore{
 		Clock:       clockClock,
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	passwordChecker := password.ProvideChecker(authenticatorPasswordConfig, historyStore)
@@ -19475,7 +19475,7 @@ func newWebAppSettingsOOBOTPHandler(p *deps.RequestProvider) http.Handler {
 		Housekeeper:     housekeeper,
 	}
 	totpStore := &totp.Store{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	authenticatorTOTPConfig := authenticatorConfig.TOTP
@@ -19486,7 +19486,7 @@ func newWebAppSettingsOOBOTPHandler(p *deps.RequestProvider) http.Handler {
 	}
 	authenticatorOOBConfig := authenticatorConfig.OOB
 	oobStore := &oob.Store{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	storeRedis := &oob.StoreRedis{
@@ -19527,7 +19527,7 @@ func newWebAppSettingsOOBOTPHandler(p *deps.RequestProvider) http.Handler {
 		Clock: clockClock,
 	}
 	storePQ := &verification.StorePQ{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	verificationService := &verification.Service{
@@ -19546,7 +19546,7 @@ func newWebAppSettingsOOBOTPHandler(p *deps.RequestProvider) http.Handler {
 		Clock: clockClock,
 	}
 	storeRecoveryCodePQ := &mfa.StoreRecoveryCodePQ{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	mfaService := &mfa.Service{
@@ -19557,7 +19557,7 @@ func newWebAppSettingsOOBOTPHandler(p *deps.RequestProvider) http.Handler {
 		RateLimiter:   limiter,
 	}
 	userStore := &user.Store{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	defaultLanguageTag := deps.ProvideDefaultLanguageTag(config)
@@ -19588,7 +19588,7 @@ func newWebAppSettingsOOBOTPHandler(p *deps.RequestProvider) http.Handler {
 	queue := appProvider.TaskQueue
 	eventLogger := event.NewLogger(factory)
 	storeImpl := &event.StoreImpl{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	hookLogger := hook.NewLogger(factory)
@@ -19610,10 +19610,10 @@ func newWebAppSettingsOOBOTPHandler(p *deps.RequestProvider) http.Handler {
 	auditLogger := audit.NewLogger(factory)
 	writeHandle := appProvider.AuditWriteDatabase
 	auditDatabaseCredentials := deps.ProvideAuditDatabaseCredentials(secretConfig)
-	auditdbSQLBuilder := auditdb.NewSQLBuilder(auditDatabaseCredentials, appID)
+	auditdbSQLBuilderApp := auditdb.NewSQLBuilderApp(auditDatabaseCredentials, appID)
 	writeSQLExecutor := auditdb.NewWriteSQLExecutor(contextContext, writeHandle)
 	writeStore := &audit.WriteStore{
-		SQLBuilder:  auditdbSQLBuilder,
+		SQLBuilder:  auditdbSQLBuilderApp,
 		SQLExecutor: writeSQLExecutor,
 	}
 	auditSink := &audit.Sink{
@@ -19635,7 +19635,7 @@ func newWebAppSettingsOOBOTPHandler(p *deps.RequestProvider) http.Handler {
 		WelcomeMessageProvider: welcomemessageProvider,
 	}
 	authorizationStore := &pq.AuthorizationStore{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	storeRedisLogger := idpsession.NewStoreRedisLogger(factory)
@@ -19660,7 +19660,7 @@ func newWebAppSettingsOOBOTPHandler(p *deps.RequestProvider) http.Handler {
 		Redis:       appredisHandle,
 		AppID:       appID,
 		Logger:      redisLogger,
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 		Clock:       clockClock,
 	}
@@ -19950,13 +19950,13 @@ func newWebAppSettingsRecoveryCodeHandler(p *deps.RequestProvider) http.Handler 
 	identityFeatureConfig := featureConfig.Identity
 	secretConfig := config.SecretConfig
 	databaseCredentials := deps.ProvideDatabaseCredentials(secretConfig)
-	sqlBuilder := appdb.NewSQLBuilder(databaseCredentials, appID)
+	sqlBuilderApp := appdb.NewSQLBuilderApp(databaseCredentials, appID)
 	store := &service.Store{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	loginidStore := &loginid.Store{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	loginIDConfig := identityConfig.LoginID
@@ -19980,7 +19980,7 @@ func newWebAppSettingsRecoveryCodeHandler(p *deps.RequestProvider) http.Handler 
 		Clock:             clockClock,
 	}
 	oauthStore := &oauth3.Store{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	oauthProvider := &oauth3.Provider{
@@ -19988,7 +19988,7 @@ func newWebAppSettingsRecoveryCodeHandler(p *deps.RequestProvider) http.Handler 
 		Clock: clockClock,
 	}
 	anonymousStore := &anonymous.Store{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	anonymousProvider := &anonymous.Provider{
@@ -19996,7 +19996,7 @@ func newWebAppSettingsRecoveryCodeHandler(p *deps.RequestProvider) http.Handler 
 		Clock: clockClock,
 	}
 	biometricStore := &biometric.Store{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	biometricProvider := &biometric.Provider{
@@ -20014,11 +20014,11 @@ func newWebAppSettingsRecoveryCodeHandler(p *deps.RequestProvider) http.Handler 
 		Biometric:             biometricProvider,
 	}
 	serviceStore := &service2.Store{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	passwordStore := &password.Store{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	authenticatorConfig := appConfig.Authenticator
@@ -20026,7 +20026,7 @@ func newWebAppSettingsRecoveryCodeHandler(p *deps.RequestProvider) http.Handler 
 	passwordLogger := password.NewLogger(factory)
 	historyStore := &password.HistoryStore{
 		Clock:       clockClock,
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	passwordChecker := password.ProvideChecker(authenticatorPasswordConfig, historyStore)
@@ -20046,7 +20046,7 @@ func newWebAppSettingsRecoveryCodeHandler(p *deps.RequestProvider) http.Handler 
 		Housekeeper:     housekeeper,
 	}
 	totpStore := &totp.Store{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	authenticatorTOTPConfig := authenticatorConfig.TOTP
@@ -20057,7 +20057,7 @@ func newWebAppSettingsRecoveryCodeHandler(p *deps.RequestProvider) http.Handler 
 	}
 	authenticatorOOBConfig := authenticatorConfig.OOB
 	oobStore := &oob.Store{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	storeRedis := &oob.StoreRedis{
@@ -20098,7 +20098,7 @@ func newWebAppSettingsRecoveryCodeHandler(p *deps.RequestProvider) http.Handler 
 		Clock: clockClock,
 	}
 	storePQ := &verification.StorePQ{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	verificationService := &verification.Service{
@@ -20117,7 +20117,7 @@ func newWebAppSettingsRecoveryCodeHandler(p *deps.RequestProvider) http.Handler 
 		Clock: clockClock,
 	}
 	storeRecoveryCodePQ := &mfa.StoreRecoveryCodePQ{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	mfaService := &mfa.Service{
@@ -20128,7 +20128,7 @@ func newWebAppSettingsRecoveryCodeHandler(p *deps.RequestProvider) http.Handler 
 		RateLimiter:   limiter,
 	}
 	userStore := &user.Store{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	defaultLanguageTag := deps.ProvideDefaultLanguageTag(config)
@@ -20159,7 +20159,7 @@ func newWebAppSettingsRecoveryCodeHandler(p *deps.RequestProvider) http.Handler 
 	queue := appProvider.TaskQueue
 	eventLogger := event.NewLogger(factory)
 	storeImpl := &event.StoreImpl{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	hookLogger := hook.NewLogger(factory)
@@ -20181,10 +20181,10 @@ func newWebAppSettingsRecoveryCodeHandler(p *deps.RequestProvider) http.Handler 
 	auditLogger := audit.NewLogger(factory)
 	writeHandle := appProvider.AuditWriteDatabase
 	auditDatabaseCredentials := deps.ProvideAuditDatabaseCredentials(secretConfig)
-	auditdbSQLBuilder := auditdb.NewSQLBuilder(auditDatabaseCredentials, appID)
+	auditdbSQLBuilderApp := auditdb.NewSQLBuilderApp(auditDatabaseCredentials, appID)
 	writeSQLExecutor := auditdb.NewWriteSQLExecutor(contextContext, writeHandle)
 	writeStore := &audit.WriteStore{
-		SQLBuilder:  auditdbSQLBuilder,
+		SQLBuilder:  auditdbSQLBuilderApp,
 		SQLExecutor: writeSQLExecutor,
 	}
 	auditSink := &audit.Sink{
@@ -20206,7 +20206,7 @@ func newWebAppSettingsRecoveryCodeHandler(p *deps.RequestProvider) http.Handler 
 		WelcomeMessageProvider: welcomemessageProvider,
 	}
 	authorizationStore := &pq.AuthorizationStore{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	storeRedisLogger := idpsession.NewStoreRedisLogger(factory)
@@ -20231,7 +20231,7 @@ func newWebAppSettingsRecoveryCodeHandler(p *deps.RequestProvider) http.Handler 
 		Redis:       appredisHandle,
 		AppID:       appID,
 		Logger:      redisLogger,
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 		Clock:       clockClock,
 	}
@@ -20522,13 +20522,13 @@ func newWebAppSettingsSessionsHandler(p *deps.RequestProvider) http.Handler {
 	identityFeatureConfig := featureConfig.Identity
 	secretConfig := config.SecretConfig
 	databaseCredentials := deps.ProvideDatabaseCredentials(secretConfig)
-	sqlBuilder := appdb.NewSQLBuilder(databaseCredentials, appID)
+	sqlBuilderApp := appdb.NewSQLBuilderApp(databaseCredentials, appID)
 	store := &service.Store{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	loginidStore := &loginid.Store{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	loginIDConfig := identityConfig.LoginID
@@ -20552,7 +20552,7 @@ func newWebAppSettingsSessionsHandler(p *deps.RequestProvider) http.Handler {
 		Clock:             clockClock,
 	}
 	oauthStore := &oauth3.Store{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	oauthProvider := &oauth3.Provider{
@@ -20560,7 +20560,7 @@ func newWebAppSettingsSessionsHandler(p *deps.RequestProvider) http.Handler {
 		Clock: clockClock,
 	}
 	anonymousStore := &anonymous.Store{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	anonymousProvider := &anonymous.Provider{
@@ -20568,7 +20568,7 @@ func newWebAppSettingsSessionsHandler(p *deps.RequestProvider) http.Handler {
 		Clock: clockClock,
 	}
 	biometricStore := &biometric.Store{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	biometricProvider := &biometric.Provider{
@@ -20586,11 +20586,11 @@ func newWebAppSettingsSessionsHandler(p *deps.RequestProvider) http.Handler {
 		Biometric:             biometricProvider,
 	}
 	serviceStore := &service2.Store{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	passwordStore := &password.Store{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	authenticatorConfig := appConfig.Authenticator
@@ -20598,7 +20598,7 @@ func newWebAppSettingsSessionsHandler(p *deps.RequestProvider) http.Handler {
 	passwordLogger := password.NewLogger(factory)
 	historyStore := &password.HistoryStore{
 		Clock:       clockClock,
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	passwordChecker := password.ProvideChecker(authenticatorPasswordConfig, historyStore)
@@ -20618,7 +20618,7 @@ func newWebAppSettingsSessionsHandler(p *deps.RequestProvider) http.Handler {
 		Housekeeper:     housekeeper,
 	}
 	totpStore := &totp.Store{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	authenticatorTOTPConfig := authenticatorConfig.TOTP
@@ -20629,7 +20629,7 @@ func newWebAppSettingsSessionsHandler(p *deps.RequestProvider) http.Handler {
 	}
 	authenticatorOOBConfig := authenticatorConfig.OOB
 	oobStore := &oob.Store{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	storeRedis := &oob.StoreRedis{
@@ -20670,7 +20670,7 @@ func newWebAppSettingsSessionsHandler(p *deps.RequestProvider) http.Handler {
 		Clock: clockClock,
 	}
 	storePQ := &verification.StorePQ{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	verificationService := &verification.Service{
@@ -20689,7 +20689,7 @@ func newWebAppSettingsSessionsHandler(p *deps.RequestProvider) http.Handler {
 		Clock: clockClock,
 	}
 	storeRecoveryCodePQ := &mfa.StoreRecoveryCodePQ{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	mfaService := &mfa.Service{
@@ -20700,7 +20700,7 @@ func newWebAppSettingsSessionsHandler(p *deps.RequestProvider) http.Handler {
 		RateLimiter:   limiter,
 	}
 	userStore := &user.Store{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	defaultLanguageTag := deps.ProvideDefaultLanguageTag(config)
@@ -20731,7 +20731,7 @@ func newWebAppSettingsSessionsHandler(p *deps.RequestProvider) http.Handler {
 	queue := appProvider.TaskQueue
 	eventLogger := event.NewLogger(factory)
 	storeImpl := &event.StoreImpl{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	hookLogger := hook.NewLogger(factory)
@@ -20753,10 +20753,10 @@ func newWebAppSettingsSessionsHandler(p *deps.RequestProvider) http.Handler {
 	auditLogger := audit.NewLogger(factory)
 	writeHandle := appProvider.AuditWriteDatabase
 	auditDatabaseCredentials := deps.ProvideAuditDatabaseCredentials(secretConfig)
-	auditdbSQLBuilder := auditdb.NewSQLBuilder(auditDatabaseCredentials, appID)
+	auditdbSQLBuilderApp := auditdb.NewSQLBuilderApp(auditDatabaseCredentials, appID)
 	writeSQLExecutor := auditdb.NewWriteSQLExecutor(contextContext, writeHandle)
 	writeStore := &audit.WriteStore{
-		SQLBuilder:  auditdbSQLBuilder,
+		SQLBuilder:  auditdbSQLBuilderApp,
 		SQLExecutor: writeSQLExecutor,
 	}
 	auditSink := &audit.Sink{
@@ -20778,7 +20778,7 @@ func newWebAppSettingsSessionsHandler(p *deps.RequestProvider) http.Handler {
 		WelcomeMessageProvider: welcomemessageProvider,
 	}
 	authorizationStore := &pq.AuthorizationStore{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	storeRedisLogger := idpsession.NewStoreRedisLogger(factory)
@@ -20803,7 +20803,7 @@ func newWebAppSettingsSessionsHandler(p *deps.RequestProvider) http.Handler {
 		Redis:       appredisHandle,
 		AppID:       appID,
 		Logger:      redisLogger,
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 		Clock:       clockClock,
 	}
@@ -21099,13 +21099,13 @@ func newWebAppChangePasswordHandler(p *deps.RequestProvider) http.Handler {
 	identityFeatureConfig := featureConfig.Identity
 	secretConfig := config.SecretConfig
 	databaseCredentials := deps.ProvideDatabaseCredentials(secretConfig)
-	sqlBuilder := appdb.NewSQLBuilder(databaseCredentials, appID)
+	sqlBuilderApp := appdb.NewSQLBuilderApp(databaseCredentials, appID)
 	store := &service.Store{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	loginidStore := &loginid.Store{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	loginIDConfig := identityConfig.LoginID
@@ -21129,7 +21129,7 @@ func newWebAppChangePasswordHandler(p *deps.RequestProvider) http.Handler {
 		Clock:             clockClock,
 	}
 	oauthStore := &oauth3.Store{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	oauthProvider := &oauth3.Provider{
@@ -21137,7 +21137,7 @@ func newWebAppChangePasswordHandler(p *deps.RequestProvider) http.Handler {
 		Clock: clockClock,
 	}
 	anonymousStore := &anonymous.Store{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	anonymousProvider := &anonymous.Provider{
@@ -21145,7 +21145,7 @@ func newWebAppChangePasswordHandler(p *deps.RequestProvider) http.Handler {
 		Clock: clockClock,
 	}
 	biometricStore := &biometric.Store{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	biometricProvider := &biometric.Provider{
@@ -21163,11 +21163,11 @@ func newWebAppChangePasswordHandler(p *deps.RequestProvider) http.Handler {
 		Biometric:             biometricProvider,
 	}
 	serviceStore := &service2.Store{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	passwordStore := &password.Store{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	authenticatorConfig := appConfig.Authenticator
@@ -21175,7 +21175,7 @@ func newWebAppChangePasswordHandler(p *deps.RequestProvider) http.Handler {
 	passwordLogger := password.NewLogger(factory)
 	historyStore := &password.HistoryStore{
 		Clock:       clockClock,
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	passwordChecker := password.ProvideChecker(authenticatorPasswordConfig, historyStore)
@@ -21195,7 +21195,7 @@ func newWebAppChangePasswordHandler(p *deps.RequestProvider) http.Handler {
 		Housekeeper:     housekeeper,
 	}
 	totpStore := &totp.Store{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	authenticatorTOTPConfig := authenticatorConfig.TOTP
@@ -21206,7 +21206,7 @@ func newWebAppChangePasswordHandler(p *deps.RequestProvider) http.Handler {
 	}
 	authenticatorOOBConfig := authenticatorConfig.OOB
 	oobStore := &oob.Store{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	storeRedis := &oob.StoreRedis{
@@ -21247,7 +21247,7 @@ func newWebAppChangePasswordHandler(p *deps.RequestProvider) http.Handler {
 		Clock: clockClock,
 	}
 	storePQ := &verification.StorePQ{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	verificationService := &verification.Service{
@@ -21266,7 +21266,7 @@ func newWebAppChangePasswordHandler(p *deps.RequestProvider) http.Handler {
 		Clock: clockClock,
 	}
 	storeRecoveryCodePQ := &mfa.StoreRecoveryCodePQ{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	mfaService := &mfa.Service{
@@ -21277,7 +21277,7 @@ func newWebAppChangePasswordHandler(p *deps.RequestProvider) http.Handler {
 		RateLimiter:   limiter,
 	}
 	userStore := &user.Store{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	defaultLanguageTag := deps.ProvideDefaultLanguageTag(config)
@@ -21308,7 +21308,7 @@ func newWebAppChangePasswordHandler(p *deps.RequestProvider) http.Handler {
 	queue := appProvider.TaskQueue
 	eventLogger := event.NewLogger(factory)
 	storeImpl := &event.StoreImpl{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	hookLogger := hook.NewLogger(factory)
@@ -21330,10 +21330,10 @@ func newWebAppChangePasswordHandler(p *deps.RequestProvider) http.Handler {
 	auditLogger := audit.NewLogger(factory)
 	writeHandle := appProvider.AuditWriteDatabase
 	auditDatabaseCredentials := deps.ProvideAuditDatabaseCredentials(secretConfig)
-	auditdbSQLBuilder := auditdb.NewSQLBuilder(auditDatabaseCredentials, appID)
+	auditdbSQLBuilderApp := auditdb.NewSQLBuilderApp(auditDatabaseCredentials, appID)
 	writeSQLExecutor := auditdb.NewWriteSQLExecutor(contextContext, writeHandle)
 	writeStore := &audit.WriteStore{
-		SQLBuilder:  auditdbSQLBuilder,
+		SQLBuilder:  auditdbSQLBuilderApp,
 		SQLExecutor: writeSQLExecutor,
 	}
 	auditSink := &audit.Sink{
@@ -21355,7 +21355,7 @@ func newWebAppChangePasswordHandler(p *deps.RequestProvider) http.Handler {
 		WelcomeMessageProvider: welcomemessageProvider,
 	}
 	authorizationStore := &pq.AuthorizationStore{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	storeRedisLogger := idpsession.NewStoreRedisLogger(factory)
@@ -21380,7 +21380,7 @@ func newWebAppChangePasswordHandler(p *deps.RequestProvider) http.Handler {
 		Redis:       appredisHandle,
 		AppID:       appID,
 		Logger:      redisLogger,
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 		Clock:       clockClock,
 	}
@@ -21670,13 +21670,13 @@ func newWebAppChangeSecondaryPasswordHandler(p *deps.RequestProvider) http.Handl
 	identityFeatureConfig := featureConfig.Identity
 	secretConfig := config.SecretConfig
 	databaseCredentials := deps.ProvideDatabaseCredentials(secretConfig)
-	sqlBuilder := appdb.NewSQLBuilder(databaseCredentials, appID)
+	sqlBuilderApp := appdb.NewSQLBuilderApp(databaseCredentials, appID)
 	store := &service.Store{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	loginidStore := &loginid.Store{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	loginIDConfig := identityConfig.LoginID
@@ -21700,7 +21700,7 @@ func newWebAppChangeSecondaryPasswordHandler(p *deps.RequestProvider) http.Handl
 		Clock:             clockClock,
 	}
 	oauthStore := &oauth3.Store{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	oauthProvider := &oauth3.Provider{
@@ -21708,7 +21708,7 @@ func newWebAppChangeSecondaryPasswordHandler(p *deps.RequestProvider) http.Handl
 		Clock: clockClock,
 	}
 	anonymousStore := &anonymous.Store{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	anonymousProvider := &anonymous.Provider{
@@ -21716,7 +21716,7 @@ func newWebAppChangeSecondaryPasswordHandler(p *deps.RequestProvider) http.Handl
 		Clock: clockClock,
 	}
 	biometricStore := &biometric.Store{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	biometricProvider := &biometric.Provider{
@@ -21734,11 +21734,11 @@ func newWebAppChangeSecondaryPasswordHandler(p *deps.RequestProvider) http.Handl
 		Biometric:             biometricProvider,
 	}
 	serviceStore := &service2.Store{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	passwordStore := &password.Store{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	authenticatorConfig := appConfig.Authenticator
@@ -21746,7 +21746,7 @@ func newWebAppChangeSecondaryPasswordHandler(p *deps.RequestProvider) http.Handl
 	passwordLogger := password.NewLogger(factory)
 	historyStore := &password.HistoryStore{
 		Clock:       clockClock,
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	passwordChecker := password.ProvideChecker(authenticatorPasswordConfig, historyStore)
@@ -21766,7 +21766,7 @@ func newWebAppChangeSecondaryPasswordHandler(p *deps.RequestProvider) http.Handl
 		Housekeeper:     housekeeper,
 	}
 	totpStore := &totp.Store{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	authenticatorTOTPConfig := authenticatorConfig.TOTP
@@ -21777,7 +21777,7 @@ func newWebAppChangeSecondaryPasswordHandler(p *deps.RequestProvider) http.Handl
 	}
 	authenticatorOOBConfig := authenticatorConfig.OOB
 	oobStore := &oob.Store{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	storeRedis := &oob.StoreRedis{
@@ -21818,7 +21818,7 @@ func newWebAppChangeSecondaryPasswordHandler(p *deps.RequestProvider) http.Handl
 		Clock: clockClock,
 	}
 	storePQ := &verification.StorePQ{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	verificationService := &verification.Service{
@@ -21837,7 +21837,7 @@ func newWebAppChangeSecondaryPasswordHandler(p *deps.RequestProvider) http.Handl
 		Clock: clockClock,
 	}
 	storeRecoveryCodePQ := &mfa.StoreRecoveryCodePQ{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	mfaService := &mfa.Service{
@@ -21848,7 +21848,7 @@ func newWebAppChangeSecondaryPasswordHandler(p *deps.RequestProvider) http.Handl
 		RateLimiter:   limiter,
 	}
 	userStore := &user.Store{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	defaultLanguageTag := deps.ProvideDefaultLanguageTag(config)
@@ -21879,7 +21879,7 @@ func newWebAppChangeSecondaryPasswordHandler(p *deps.RequestProvider) http.Handl
 	queue := appProvider.TaskQueue
 	eventLogger := event.NewLogger(factory)
 	storeImpl := &event.StoreImpl{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	hookLogger := hook.NewLogger(factory)
@@ -21901,10 +21901,10 @@ func newWebAppChangeSecondaryPasswordHandler(p *deps.RequestProvider) http.Handl
 	auditLogger := audit.NewLogger(factory)
 	writeHandle := appProvider.AuditWriteDatabase
 	auditDatabaseCredentials := deps.ProvideAuditDatabaseCredentials(secretConfig)
-	auditdbSQLBuilder := auditdb.NewSQLBuilder(auditDatabaseCredentials, appID)
+	auditdbSQLBuilderApp := auditdb.NewSQLBuilderApp(auditDatabaseCredentials, appID)
 	writeSQLExecutor := auditdb.NewWriteSQLExecutor(contextContext, writeHandle)
 	writeStore := &audit.WriteStore{
-		SQLBuilder:  auditdbSQLBuilder,
+		SQLBuilder:  auditdbSQLBuilderApp,
 		SQLExecutor: writeSQLExecutor,
 	}
 	auditSink := &audit.Sink{
@@ -21926,7 +21926,7 @@ func newWebAppChangeSecondaryPasswordHandler(p *deps.RequestProvider) http.Handl
 		WelcomeMessageProvider: welcomemessageProvider,
 	}
 	authorizationStore := &pq.AuthorizationStore{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	storeRedisLogger := idpsession.NewStoreRedisLogger(factory)
@@ -21951,7 +21951,7 @@ func newWebAppChangeSecondaryPasswordHandler(p *deps.RequestProvider) http.Handl
 		Redis:       appredisHandle,
 		AppID:       appID,
 		Logger:      redisLogger,
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 		Clock:       clockClock,
 	}
@@ -22241,13 +22241,13 @@ func newWebAppUserDisabledHandler(p *deps.RequestProvider) http.Handler {
 	identityFeatureConfig := featureConfig.Identity
 	secretConfig := config.SecretConfig
 	databaseCredentials := deps.ProvideDatabaseCredentials(secretConfig)
-	sqlBuilder := appdb.NewSQLBuilder(databaseCredentials, appID)
+	sqlBuilderApp := appdb.NewSQLBuilderApp(databaseCredentials, appID)
 	store := &service.Store{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	loginidStore := &loginid.Store{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	loginIDConfig := identityConfig.LoginID
@@ -22271,7 +22271,7 @@ func newWebAppUserDisabledHandler(p *deps.RequestProvider) http.Handler {
 		Clock:             clockClock,
 	}
 	oauthStore := &oauth3.Store{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	oauthProvider := &oauth3.Provider{
@@ -22279,7 +22279,7 @@ func newWebAppUserDisabledHandler(p *deps.RequestProvider) http.Handler {
 		Clock: clockClock,
 	}
 	anonymousStore := &anonymous.Store{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	anonymousProvider := &anonymous.Provider{
@@ -22287,7 +22287,7 @@ func newWebAppUserDisabledHandler(p *deps.RequestProvider) http.Handler {
 		Clock: clockClock,
 	}
 	biometricStore := &biometric.Store{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	biometricProvider := &biometric.Provider{
@@ -22305,11 +22305,11 @@ func newWebAppUserDisabledHandler(p *deps.RequestProvider) http.Handler {
 		Biometric:             biometricProvider,
 	}
 	serviceStore := &service2.Store{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	passwordStore := &password.Store{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	authenticatorConfig := appConfig.Authenticator
@@ -22317,7 +22317,7 @@ func newWebAppUserDisabledHandler(p *deps.RequestProvider) http.Handler {
 	passwordLogger := password.NewLogger(factory)
 	historyStore := &password.HistoryStore{
 		Clock:       clockClock,
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	passwordChecker := password.ProvideChecker(authenticatorPasswordConfig, historyStore)
@@ -22337,7 +22337,7 @@ func newWebAppUserDisabledHandler(p *deps.RequestProvider) http.Handler {
 		Housekeeper:     housekeeper,
 	}
 	totpStore := &totp.Store{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	authenticatorTOTPConfig := authenticatorConfig.TOTP
@@ -22348,7 +22348,7 @@ func newWebAppUserDisabledHandler(p *deps.RequestProvider) http.Handler {
 	}
 	authenticatorOOBConfig := authenticatorConfig.OOB
 	oobStore := &oob.Store{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	storeRedis := &oob.StoreRedis{
@@ -22389,7 +22389,7 @@ func newWebAppUserDisabledHandler(p *deps.RequestProvider) http.Handler {
 		Clock: clockClock,
 	}
 	storePQ := &verification.StorePQ{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	verificationService := &verification.Service{
@@ -22408,7 +22408,7 @@ func newWebAppUserDisabledHandler(p *deps.RequestProvider) http.Handler {
 		Clock: clockClock,
 	}
 	storeRecoveryCodePQ := &mfa.StoreRecoveryCodePQ{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	mfaService := &mfa.Service{
@@ -22419,7 +22419,7 @@ func newWebAppUserDisabledHandler(p *deps.RequestProvider) http.Handler {
 		RateLimiter:   limiter,
 	}
 	userStore := &user.Store{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	defaultLanguageTag := deps.ProvideDefaultLanguageTag(config)
@@ -22450,7 +22450,7 @@ func newWebAppUserDisabledHandler(p *deps.RequestProvider) http.Handler {
 	queue := appProvider.TaskQueue
 	eventLogger := event.NewLogger(factory)
 	storeImpl := &event.StoreImpl{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	hookLogger := hook.NewLogger(factory)
@@ -22472,10 +22472,10 @@ func newWebAppUserDisabledHandler(p *deps.RequestProvider) http.Handler {
 	auditLogger := audit.NewLogger(factory)
 	writeHandle := appProvider.AuditWriteDatabase
 	auditDatabaseCredentials := deps.ProvideAuditDatabaseCredentials(secretConfig)
-	auditdbSQLBuilder := auditdb.NewSQLBuilder(auditDatabaseCredentials, appID)
+	auditdbSQLBuilderApp := auditdb.NewSQLBuilderApp(auditDatabaseCredentials, appID)
 	writeSQLExecutor := auditdb.NewWriteSQLExecutor(contextContext, writeHandle)
 	writeStore := &audit.WriteStore{
-		SQLBuilder:  auditdbSQLBuilder,
+		SQLBuilder:  auditdbSQLBuilderApp,
 		SQLExecutor: writeSQLExecutor,
 	}
 	auditSink := &audit.Sink{
@@ -22497,7 +22497,7 @@ func newWebAppUserDisabledHandler(p *deps.RequestProvider) http.Handler {
 		WelcomeMessageProvider: welcomemessageProvider,
 	}
 	authorizationStore := &pq.AuthorizationStore{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	storeRedisLogger := idpsession.NewStoreRedisLogger(factory)
@@ -22522,7 +22522,7 @@ func newWebAppUserDisabledHandler(p *deps.RequestProvider) http.Handler {
 		Redis:       appredisHandle,
 		AppID:       appID,
 		Logger:      redisLogger,
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 		Clock:       clockClock,
 	}
@@ -22811,13 +22811,13 @@ func newWebAppLogoutHandler(p *deps.RequestProvider) http.Handler {
 	identityFeatureConfig := featureConfig.Identity
 	secretConfig := config.SecretConfig
 	databaseCredentials := deps.ProvideDatabaseCredentials(secretConfig)
-	sqlBuilder := appdb.NewSQLBuilder(databaseCredentials, appID)
+	sqlBuilderApp := appdb.NewSQLBuilderApp(databaseCredentials, appID)
 	store := &service.Store{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	loginidStore := &loginid.Store{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	loginIDConfig := identityConfig.LoginID
@@ -22841,7 +22841,7 @@ func newWebAppLogoutHandler(p *deps.RequestProvider) http.Handler {
 		Clock:             clockClock,
 	}
 	oauthStore := &oauth3.Store{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	oauthProvider := &oauth3.Provider{
@@ -22849,7 +22849,7 @@ func newWebAppLogoutHandler(p *deps.RequestProvider) http.Handler {
 		Clock: clockClock,
 	}
 	anonymousStore := &anonymous.Store{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	anonymousProvider := &anonymous.Provider{
@@ -22857,7 +22857,7 @@ func newWebAppLogoutHandler(p *deps.RequestProvider) http.Handler {
 		Clock: clockClock,
 	}
 	biometricStore := &biometric.Store{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	biometricProvider := &biometric.Provider{
@@ -22875,11 +22875,11 @@ func newWebAppLogoutHandler(p *deps.RequestProvider) http.Handler {
 		Biometric:             biometricProvider,
 	}
 	serviceStore := &service2.Store{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	passwordStore := &password.Store{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	authenticatorConfig := appConfig.Authenticator
@@ -22887,7 +22887,7 @@ func newWebAppLogoutHandler(p *deps.RequestProvider) http.Handler {
 	passwordLogger := password.NewLogger(factory)
 	historyStore := &password.HistoryStore{
 		Clock:       clockClock,
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	passwordChecker := password.ProvideChecker(authenticatorPasswordConfig, historyStore)
@@ -22907,7 +22907,7 @@ func newWebAppLogoutHandler(p *deps.RequestProvider) http.Handler {
 		Housekeeper:     housekeeper,
 	}
 	totpStore := &totp.Store{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	authenticatorTOTPConfig := authenticatorConfig.TOTP
@@ -22918,7 +22918,7 @@ func newWebAppLogoutHandler(p *deps.RequestProvider) http.Handler {
 	}
 	authenticatorOOBConfig := authenticatorConfig.OOB
 	oobStore := &oob.Store{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	storeRedis := &oob.StoreRedis{
@@ -22959,7 +22959,7 @@ func newWebAppLogoutHandler(p *deps.RequestProvider) http.Handler {
 		Clock: clockClock,
 	}
 	storePQ := &verification.StorePQ{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	verificationService := &verification.Service{
@@ -22978,7 +22978,7 @@ func newWebAppLogoutHandler(p *deps.RequestProvider) http.Handler {
 		Clock: clockClock,
 	}
 	storeRecoveryCodePQ := &mfa.StoreRecoveryCodePQ{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	mfaService := &mfa.Service{
@@ -22989,7 +22989,7 @@ func newWebAppLogoutHandler(p *deps.RequestProvider) http.Handler {
 		RateLimiter:   limiter,
 	}
 	userStore := &user.Store{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	defaultLanguageTag := deps.ProvideDefaultLanguageTag(config)
@@ -23020,7 +23020,7 @@ func newWebAppLogoutHandler(p *deps.RequestProvider) http.Handler {
 	queue := appProvider.TaskQueue
 	eventLogger := event.NewLogger(factory)
 	storeImpl := &event.StoreImpl{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	hookLogger := hook.NewLogger(factory)
@@ -23042,10 +23042,10 @@ func newWebAppLogoutHandler(p *deps.RequestProvider) http.Handler {
 	auditLogger := audit.NewLogger(factory)
 	writeHandle := appProvider.AuditWriteDatabase
 	auditDatabaseCredentials := deps.ProvideAuditDatabaseCredentials(secretConfig)
-	auditdbSQLBuilder := auditdb.NewSQLBuilder(auditDatabaseCredentials, appID)
+	auditdbSQLBuilderApp := auditdb.NewSQLBuilderApp(auditDatabaseCredentials, appID)
 	writeSQLExecutor := auditdb.NewWriteSQLExecutor(contextContext, writeHandle)
 	writeStore := &audit.WriteStore{
-		SQLBuilder:  auditdbSQLBuilder,
+		SQLBuilder:  auditdbSQLBuilderApp,
 		SQLExecutor: writeSQLExecutor,
 	}
 	auditSink := &audit.Sink{
@@ -23067,7 +23067,7 @@ func newWebAppLogoutHandler(p *deps.RequestProvider) http.Handler {
 		WelcomeMessageProvider: welcomemessageProvider,
 	}
 	authorizationStore := &pq.AuthorizationStore{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	storeRedisLogger := idpsession.NewStoreRedisLogger(factory)
@@ -23092,7 +23092,7 @@ func newWebAppLogoutHandler(p *deps.RequestProvider) http.Handler {
 		Redis:       appredisHandle,
 		AppID:       appID,
 		Logger:      redisLogger,
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 		Clock:       clockClock,
 	}
@@ -23401,13 +23401,13 @@ func newWebAppReturnHandler(p *deps.RequestProvider) http.Handler {
 	identityFeatureConfig := featureConfig.Identity
 	secretConfig := config.SecretConfig
 	databaseCredentials := deps.ProvideDatabaseCredentials(secretConfig)
-	sqlBuilder := appdb.NewSQLBuilder(databaseCredentials, appID)
+	sqlBuilderApp := appdb.NewSQLBuilderApp(databaseCredentials, appID)
 	store := &service.Store{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	loginidStore := &loginid.Store{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	loginIDConfig := identityConfig.LoginID
@@ -23431,7 +23431,7 @@ func newWebAppReturnHandler(p *deps.RequestProvider) http.Handler {
 		Clock:             clockClock,
 	}
 	oauthStore := &oauth3.Store{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	oauthProvider := &oauth3.Provider{
@@ -23439,7 +23439,7 @@ func newWebAppReturnHandler(p *deps.RequestProvider) http.Handler {
 		Clock: clockClock,
 	}
 	anonymousStore := &anonymous.Store{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	anonymousProvider := &anonymous.Provider{
@@ -23447,7 +23447,7 @@ func newWebAppReturnHandler(p *deps.RequestProvider) http.Handler {
 		Clock: clockClock,
 	}
 	biometricStore := &biometric.Store{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	biometricProvider := &biometric.Provider{
@@ -23465,11 +23465,11 @@ func newWebAppReturnHandler(p *deps.RequestProvider) http.Handler {
 		Biometric:             biometricProvider,
 	}
 	serviceStore := &service2.Store{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	passwordStore := &password.Store{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	authenticatorConfig := appConfig.Authenticator
@@ -23477,7 +23477,7 @@ func newWebAppReturnHandler(p *deps.RequestProvider) http.Handler {
 	passwordLogger := password.NewLogger(factory)
 	historyStore := &password.HistoryStore{
 		Clock:       clockClock,
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	passwordChecker := password.ProvideChecker(authenticatorPasswordConfig, historyStore)
@@ -23497,7 +23497,7 @@ func newWebAppReturnHandler(p *deps.RequestProvider) http.Handler {
 		Housekeeper:     housekeeper,
 	}
 	totpStore := &totp.Store{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	authenticatorTOTPConfig := authenticatorConfig.TOTP
@@ -23508,7 +23508,7 @@ func newWebAppReturnHandler(p *deps.RequestProvider) http.Handler {
 	}
 	authenticatorOOBConfig := authenticatorConfig.OOB
 	oobStore := &oob.Store{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	storeRedis := &oob.StoreRedis{
@@ -23549,7 +23549,7 @@ func newWebAppReturnHandler(p *deps.RequestProvider) http.Handler {
 		Clock: clockClock,
 	}
 	storePQ := &verification.StorePQ{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	verificationService := &verification.Service{
@@ -23568,7 +23568,7 @@ func newWebAppReturnHandler(p *deps.RequestProvider) http.Handler {
 		Clock: clockClock,
 	}
 	storeRecoveryCodePQ := &mfa.StoreRecoveryCodePQ{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	mfaService := &mfa.Service{
@@ -23579,7 +23579,7 @@ func newWebAppReturnHandler(p *deps.RequestProvider) http.Handler {
 		RateLimiter:   limiter,
 	}
 	userStore := &user.Store{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	defaultLanguageTag := deps.ProvideDefaultLanguageTag(config)
@@ -23610,7 +23610,7 @@ func newWebAppReturnHandler(p *deps.RequestProvider) http.Handler {
 	queue := appProvider.TaskQueue
 	eventLogger := event.NewLogger(factory)
 	storeImpl := &event.StoreImpl{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	hookLogger := hook.NewLogger(factory)
@@ -23632,10 +23632,10 @@ func newWebAppReturnHandler(p *deps.RequestProvider) http.Handler {
 	auditLogger := audit.NewLogger(factory)
 	writeHandle := appProvider.AuditWriteDatabase
 	auditDatabaseCredentials := deps.ProvideAuditDatabaseCredentials(secretConfig)
-	auditdbSQLBuilder := auditdb.NewSQLBuilder(auditDatabaseCredentials, appID)
+	auditdbSQLBuilderApp := auditdb.NewSQLBuilderApp(auditDatabaseCredentials, appID)
 	writeSQLExecutor := auditdb.NewWriteSQLExecutor(contextContext, writeHandle)
 	writeStore := &audit.WriteStore{
-		SQLBuilder:  auditdbSQLBuilder,
+		SQLBuilder:  auditdbSQLBuilderApp,
 		SQLExecutor: writeSQLExecutor,
 	}
 	auditSink := &audit.Sink{
@@ -23657,7 +23657,7 @@ func newWebAppReturnHandler(p *deps.RequestProvider) http.Handler {
 		WelcomeMessageProvider: welcomemessageProvider,
 	}
 	authorizationStore := &pq.AuthorizationStore{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	storeRedisLogger := idpsession.NewStoreRedisLogger(factory)
@@ -23682,7 +23682,7 @@ func newWebAppReturnHandler(p *deps.RequestProvider) http.Handler {
 		Redis:       appredisHandle,
 		AppID:       appID,
 		Logger:      redisLogger,
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 		Clock:       clockClock,
 	}
@@ -23971,13 +23971,13 @@ func newWebAppErrorHandler(p *deps.RequestProvider) http.Handler {
 	identityFeatureConfig := featureConfig.Identity
 	secretConfig := config.SecretConfig
 	databaseCredentials := deps.ProvideDatabaseCredentials(secretConfig)
-	sqlBuilder := appdb.NewSQLBuilder(databaseCredentials, appID)
+	sqlBuilderApp := appdb.NewSQLBuilderApp(databaseCredentials, appID)
 	store := &service.Store{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	loginidStore := &loginid.Store{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	loginIDConfig := identityConfig.LoginID
@@ -24001,7 +24001,7 @@ func newWebAppErrorHandler(p *deps.RequestProvider) http.Handler {
 		Clock:             clockClock,
 	}
 	oauthStore := &oauth3.Store{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	oauthProvider := &oauth3.Provider{
@@ -24009,7 +24009,7 @@ func newWebAppErrorHandler(p *deps.RequestProvider) http.Handler {
 		Clock: clockClock,
 	}
 	anonymousStore := &anonymous.Store{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	anonymousProvider := &anonymous.Provider{
@@ -24017,7 +24017,7 @@ func newWebAppErrorHandler(p *deps.RequestProvider) http.Handler {
 		Clock: clockClock,
 	}
 	biometricStore := &biometric.Store{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	biometricProvider := &biometric.Provider{
@@ -24035,11 +24035,11 @@ func newWebAppErrorHandler(p *deps.RequestProvider) http.Handler {
 		Biometric:             biometricProvider,
 	}
 	serviceStore := &service2.Store{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	passwordStore := &password.Store{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	authenticatorConfig := appConfig.Authenticator
@@ -24047,7 +24047,7 @@ func newWebAppErrorHandler(p *deps.RequestProvider) http.Handler {
 	passwordLogger := password.NewLogger(factory)
 	historyStore := &password.HistoryStore{
 		Clock:       clockClock,
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	passwordChecker := password.ProvideChecker(authenticatorPasswordConfig, historyStore)
@@ -24067,7 +24067,7 @@ func newWebAppErrorHandler(p *deps.RequestProvider) http.Handler {
 		Housekeeper:     housekeeper,
 	}
 	totpStore := &totp.Store{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	authenticatorTOTPConfig := authenticatorConfig.TOTP
@@ -24078,7 +24078,7 @@ func newWebAppErrorHandler(p *deps.RequestProvider) http.Handler {
 	}
 	authenticatorOOBConfig := authenticatorConfig.OOB
 	oobStore := &oob.Store{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	storeRedis := &oob.StoreRedis{
@@ -24119,7 +24119,7 @@ func newWebAppErrorHandler(p *deps.RequestProvider) http.Handler {
 		Clock: clockClock,
 	}
 	storePQ := &verification.StorePQ{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	verificationService := &verification.Service{
@@ -24138,7 +24138,7 @@ func newWebAppErrorHandler(p *deps.RequestProvider) http.Handler {
 		Clock: clockClock,
 	}
 	storeRecoveryCodePQ := &mfa.StoreRecoveryCodePQ{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	mfaService := &mfa.Service{
@@ -24149,7 +24149,7 @@ func newWebAppErrorHandler(p *deps.RequestProvider) http.Handler {
 		RateLimiter:   limiter,
 	}
 	userStore := &user.Store{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	defaultLanguageTag := deps.ProvideDefaultLanguageTag(config)
@@ -24180,7 +24180,7 @@ func newWebAppErrorHandler(p *deps.RequestProvider) http.Handler {
 	queue := appProvider.TaskQueue
 	eventLogger := event.NewLogger(factory)
 	storeImpl := &event.StoreImpl{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	hookLogger := hook.NewLogger(factory)
@@ -24202,10 +24202,10 @@ func newWebAppErrorHandler(p *deps.RequestProvider) http.Handler {
 	auditLogger := audit.NewLogger(factory)
 	writeHandle := appProvider.AuditWriteDatabase
 	auditDatabaseCredentials := deps.ProvideAuditDatabaseCredentials(secretConfig)
-	auditdbSQLBuilder := auditdb.NewSQLBuilder(auditDatabaseCredentials, appID)
+	auditdbSQLBuilderApp := auditdb.NewSQLBuilderApp(auditDatabaseCredentials, appID)
 	writeSQLExecutor := auditdb.NewWriteSQLExecutor(contextContext, writeHandle)
 	writeStore := &audit.WriteStore{
-		SQLBuilder:  auditdbSQLBuilder,
+		SQLBuilder:  auditdbSQLBuilderApp,
 		SQLExecutor: writeSQLExecutor,
 	}
 	auditSink := &audit.Sink{
@@ -24227,7 +24227,7 @@ func newWebAppErrorHandler(p *deps.RequestProvider) http.Handler {
 		WelcomeMessageProvider: welcomemessageProvider,
 	}
 	authorizationStore := &pq.AuthorizationStore{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	storeRedisLogger := idpsession.NewStoreRedisLogger(factory)
@@ -24252,7 +24252,7 @@ func newWebAppErrorHandler(p *deps.RequestProvider) http.Handler {
 		Redis:       appredisHandle,
 		AppID:       appID,
 		Logger:      redisLogger,
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 		Clock:       clockClock,
 	}
@@ -24768,11 +24768,11 @@ func newSessionMiddleware(p *deps.RequestProvider) httproute.Middleware {
 	oAuthConfig := appConfig.OAuth
 	secretConfig := config.SecretConfig
 	databaseCredentials := deps.ProvideDatabaseCredentials(secretConfig)
-	sqlBuilder := appdb.NewSQLBuilder(databaseCredentials, appID)
+	sqlBuilderApp := appdb.NewSQLBuilderApp(databaseCredentials, appID)
 	appdbHandle := appProvider.AppDatabase
 	sqlExecutor := appdb.NewSQLExecutor(contextContext, appdbHandle)
 	authorizationStore := &pq.AuthorizationStore{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	logger := redis.NewLogger(factory)
@@ -24781,7 +24781,7 @@ func newSessionMiddleware(p *deps.RequestProvider) httproute.Middleware {
 		Redis:       handle,
 		AppID:       appID,
 		Logger:      logger,
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 		Clock:       clockClock,
 	}
@@ -24794,7 +24794,7 @@ func newSessionMiddleware(p *deps.RequestProvider) httproute.Middleware {
 		OriginProvider: mainOriginProvider,
 	}
 	userStore := &user.Store{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	authenticationConfig := appConfig.Authentication
@@ -24802,11 +24802,11 @@ func newSessionMiddleware(p *deps.RequestProvider) httproute.Middleware {
 	featureConfig := config.FeatureConfig
 	identityFeatureConfig := featureConfig.Identity
 	serviceStore := &service.Store{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	loginidStore := &loginid.Store{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	loginIDConfig := identityConfig.LoginID
@@ -24830,7 +24830,7 @@ func newSessionMiddleware(p *deps.RequestProvider) httproute.Middleware {
 		Clock:             clockClock,
 	}
 	oauthStore := &oauth3.Store{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	oauthProvider := &oauth3.Provider{
@@ -24838,7 +24838,7 @@ func newSessionMiddleware(p *deps.RequestProvider) httproute.Middleware {
 		Clock: clockClock,
 	}
 	anonymousStore := &anonymous.Store{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	anonymousProvider := &anonymous.Provider{
@@ -24846,7 +24846,7 @@ func newSessionMiddleware(p *deps.RequestProvider) httproute.Middleware {
 		Clock: clockClock,
 	}
 	biometricStore := &biometric.Store{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	biometricProvider := &biometric.Provider{
@@ -24864,11 +24864,11 @@ func newSessionMiddleware(p *deps.RequestProvider) httproute.Middleware {
 		Biometric:             biometricProvider,
 	}
 	store2 := &service2.Store{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	passwordStore := &password.Store{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	authenticatorConfig := appConfig.Authenticator
@@ -24876,7 +24876,7 @@ func newSessionMiddleware(p *deps.RequestProvider) httproute.Middleware {
 	passwordLogger := password.NewLogger(factory)
 	historyStore := &password.HistoryStore{
 		Clock:       clockClock,
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	passwordChecker := password.ProvideChecker(authenticatorPasswordConfig, historyStore)
@@ -24896,7 +24896,7 @@ func newSessionMiddleware(p *deps.RequestProvider) httproute.Middleware {
 		Housekeeper:     housekeeper,
 	}
 	totpStore := &totp.Store{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	authenticatorTOTPConfig := authenticatorConfig.TOTP
@@ -24907,7 +24907,7 @@ func newSessionMiddleware(p *deps.RequestProvider) httproute.Middleware {
 	}
 	authenticatorOOBConfig := authenticatorConfig.OOB
 	oobStore := &oob.Store{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	oobStoreRedis := &oob.StoreRedis{
@@ -24948,7 +24948,7 @@ func newSessionMiddleware(p *deps.RequestProvider) httproute.Middleware {
 		Clock: clockClock,
 	}
 	storePQ := &verification.StorePQ{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	verificationService := &verification.Service{
@@ -24967,7 +24967,7 @@ func newSessionMiddleware(p *deps.RequestProvider) httproute.Middleware {
 		Clock: clockClock,
 	}
 	storeRecoveryCodePQ := &mfa.StoreRecoveryCodePQ{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	mfaService := &mfa.Service{
@@ -25005,7 +25005,7 @@ func newSessionMiddleware(p *deps.RequestProvider) httproute.Middleware {
 	queue := appProvider.TaskQueue
 	eventLogger := event.NewLogger(factory)
 	storeImpl := &event.StoreImpl{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	hookLogger := hook.NewLogger(factory)
@@ -25027,10 +25027,10 @@ func newSessionMiddleware(p *deps.RequestProvider) httproute.Middleware {
 	auditLogger := audit.NewLogger(factory)
 	writeHandle := appProvider.AuditWriteDatabase
 	auditDatabaseCredentials := deps.ProvideAuditDatabaseCredentials(secretConfig)
-	auditdbSQLBuilder := auditdb.NewSQLBuilder(auditDatabaseCredentials, appID)
+	auditdbSQLBuilderApp := auditdb.NewSQLBuilderApp(auditDatabaseCredentials, appID)
 	writeSQLExecutor := auditdb.NewWriteSQLExecutor(contextContext, writeHandle)
 	writeStore := &audit.WriteStore{
-		SQLBuilder:  auditdbSQLBuilder,
+		SQLBuilder:  auditdbSQLBuilderApp,
 		SQLExecutor: writeSQLExecutor,
 	}
 	auditSink := &audit.Sink{

--- a/pkg/auth/wire_gen.go
+++ b/pkg/auth/wire_gen.go
@@ -383,8 +383,9 @@ func newOAuthAuthorizeHandler(p *deps.RequestProvider) http.Handler {
 	welcomeMessageConfig := appConfig.WelcomeMessage
 	queue := appProvider.TaskQueue
 	eventLogger := event.NewLogger(factory)
+	sqlBuilder := appdb.NewSQLBuilder(databaseCredentials)
 	storeImpl := &event.StoreImpl{
-		SQLBuilder:  sqlBuilderApp,
+		SQLBuilder:  sqlBuilder,
 		SQLExecutor: sqlExecutor,
 	}
 	hookLogger := hook.NewLogger(factory)
@@ -967,8 +968,9 @@ func newOAuthFromWebAppHandler(p *deps.RequestProvider) http.Handler {
 	welcomeMessageConfig := appConfig.WelcomeMessage
 	queue := appProvider.TaskQueue
 	eventLogger := event.NewLogger(factory)
+	sqlBuilder := appdb.NewSQLBuilder(databaseCredentials)
 	storeImpl := &event.StoreImpl{
-		SQLBuilder:  sqlBuilderApp,
+		SQLBuilder:  sqlBuilder,
 		SQLExecutor: sqlExecutor,
 	}
 	hookLogger := hook.NewLogger(factory)
@@ -1499,8 +1501,9 @@ func newOAuthTokenHandler(p *deps.RequestProvider) http.Handler {
 	welcomeMessageConfig := appConfig.WelcomeMessage
 	queue := appProvider.TaskQueue
 	eventLogger := event.NewLogger(factory)
+	sqlBuilder := appdb.NewSQLBuilder(databaseCredentials)
 	storeImpl := &event.StoreImpl{
-		SQLBuilder:  sqlBuilderApp,
+		SQLBuilder:  sqlBuilder,
 		SQLExecutor: sqlExecutor,
 	}
 	hookLogger := hook.NewLogger(factory)
@@ -2015,8 +2018,9 @@ func newOAuthRevokeHandler(p *deps.RequestProvider) http.Handler {
 	welcomeMessageConfig := appConfig.WelcomeMessage
 	queue := appProvider.TaskQueue
 	eventLogger := event.NewLogger(factory)
+	sqlBuilder := appdb.NewSQLBuilder(databaseCredentials)
 	storeImpl := &event.StoreImpl{
-		SQLBuilder:  sqlBuilderApp,
+		SQLBuilder:  sqlBuilder,
 		SQLExecutor: sqlExecutor,
 	}
 	hookLogger := hook.NewLogger(factory)
@@ -2407,8 +2411,9 @@ func newOAuthJWKSHandler(p *deps.RequestProvider) http.Handler {
 	welcomeMessageConfig := appConfig.WelcomeMessage
 	queue := appProvider.TaskQueue
 	eventLogger := event.NewLogger(factory)
+	sqlBuilder := appdb.NewSQLBuilder(databaseCredentials)
 	storeImpl := &event.StoreImpl{
-		SQLBuilder:  sqlBuilderApp,
+		SQLBuilder:  sqlBuilder,
 		SQLExecutor: sqlExecutor,
 	}
 	hookLogger := hook.NewLogger(factory)
@@ -2767,8 +2772,9 @@ func newOAuthUserInfoHandler(p *deps.RequestProvider) http.Handler {
 	welcomeMessageConfig := appConfig.WelcomeMessage
 	queue := appProvider.TaskQueue
 	eventLogger := event.NewLogger(factory)
+	sqlBuilder := appdb.NewSQLBuilder(databaseCredentials)
 	storeImpl := &event.StoreImpl{
-		SQLBuilder:  sqlBuilderApp,
+		SQLBuilder:  sqlBuilder,
 		SQLExecutor: sqlExecutor,
 	}
 	hookLogger := hook.NewLogger(factory)
@@ -3131,8 +3137,9 @@ func newOAuthEndSessionHandler(p *deps.RequestProvider) http.Handler {
 	welcomeMessageConfig := appConfig.WelcomeMessage
 	queue := appProvider.TaskQueue
 	eventLogger := event.NewLogger(factory)
+	sqlBuilder := appdb.NewSQLBuilder(databaseCredentials)
 	storeImpl := &event.StoreImpl{
-		SQLBuilder:  sqlBuilderApp,
+		SQLBuilder:  sqlBuilder,
 		SQLExecutor: sqlExecutor,
 	}
 	hookLogger := hook.NewLogger(factory)
@@ -3544,8 +3551,9 @@ func newOAuthAppSessionTokenHandler(p *deps.RequestProvider) http.Handler {
 	welcomeMessageConfig := appConfig.WelcomeMessage
 	queue := appProvider.TaskQueue
 	eventLogger := event.NewLogger(factory)
+	sqlBuilder := appdb.NewSQLBuilder(databaseCredentials)
 	storeImpl := &event.StoreImpl{
-		SQLBuilder:  sqlBuilderApp,
+		SQLBuilder:  sqlBuilder,
 		SQLExecutor: sqlExecutor,
 	}
 	hookLogger := hook.NewLogger(factory)
@@ -4099,8 +4107,9 @@ func newWebAppLoginHandler(p *deps.RequestProvider) http.Handler {
 	welcomeMessageConfig := appConfig.WelcomeMessage
 	queue := appProvider.TaskQueue
 	eventLogger := event.NewLogger(factory)
+	sqlBuilder := appdb.NewSQLBuilder(databaseCredentials)
 	storeImpl := &event.StoreImpl{
-		SQLBuilder:  sqlBuilderApp,
+		SQLBuilder:  sqlBuilder,
 		SQLExecutor: sqlExecutor,
 	}
 	hookLogger := hook.NewLogger(factory)
@@ -4687,8 +4696,9 @@ func newWebAppSignupHandler(p *deps.RequestProvider) http.Handler {
 	welcomeMessageConfig := appConfig.WelcomeMessage
 	queue := appProvider.TaskQueue
 	eventLogger := event.NewLogger(factory)
+	sqlBuilder := appdb.NewSQLBuilder(databaseCredentials)
 	storeImpl := &event.StoreImpl{
-		SQLBuilder:  sqlBuilderApp,
+		SQLBuilder:  sqlBuilder,
 		SQLExecutor: sqlExecutor,
 	}
 	hookLogger := hook.NewLogger(factory)
@@ -5275,8 +5285,9 @@ func newWebAppPromoteHandler(p *deps.RequestProvider) http.Handler {
 	welcomeMessageConfig := appConfig.WelcomeMessage
 	queue := appProvider.TaskQueue
 	eventLogger := event.NewLogger(factory)
+	sqlBuilder := appdb.NewSQLBuilder(databaseCredentials)
 	storeImpl := &event.StoreImpl{
-		SQLBuilder:  sqlBuilderApp,
+		SQLBuilder:  sqlBuilder,
 		SQLExecutor: sqlExecutor,
 	}
 	hookLogger := hook.NewLogger(factory)
@@ -5850,8 +5861,9 @@ func newWebAppSelectAccountHandler(p *deps.RequestProvider) http.Handler {
 	welcomeMessageConfig := appConfig.WelcomeMessage
 	queue := appProvider.TaskQueue
 	eventLogger := event.NewLogger(factory)
+	sqlBuilder := appdb.NewSQLBuilder(databaseCredentials)
 	storeImpl := &event.StoreImpl{
-		SQLBuilder:  sqlBuilderApp,
+		SQLBuilder:  sqlBuilder,
 		SQLExecutor: sqlExecutor,
 	}
 	hookLogger := hook.NewLogger(factory)
@@ -6426,8 +6438,9 @@ func newWebAppSSOCallbackHandler(p *deps.RequestProvider) http.Handler {
 	welcomeMessageConfig := appConfig.WelcomeMessage
 	queue := appProvider.TaskQueue
 	eventLogger := event.NewLogger(factory)
+	sqlBuilder := appdb.NewSQLBuilder(databaseCredentials)
 	storeImpl := &event.StoreImpl{
-		SQLBuilder:  sqlBuilderApp,
+		SQLBuilder:  sqlBuilder,
 		SQLExecutor: sqlExecutor,
 	}
 	hookLogger := hook.NewLogger(factory)
@@ -6994,8 +7007,9 @@ func newWechatAuthHandler(p *deps.RequestProvider) http.Handler {
 	welcomeMessageConfig := appConfig.WelcomeMessage
 	queue := appProvider.TaskQueue
 	eventLogger := event.NewLogger(factory)
+	sqlBuilder := appdb.NewSQLBuilder(databaseCredentials)
 	storeImpl := &event.StoreImpl{
-		SQLBuilder:  sqlBuilderApp,
+		SQLBuilder:  sqlBuilder,
 		SQLExecutor: sqlExecutor,
 	}
 	hookLogger := hook.NewLogger(factory)
@@ -7565,8 +7579,9 @@ func newWechatCallbackHandler(p *deps.RequestProvider) http.Handler {
 	welcomeMessageConfig := appConfig.WelcomeMessage
 	queue := appProvider.TaskQueue
 	eventLogger := event.NewLogger(factory)
+	sqlBuilder := appdb.NewSQLBuilder(databaseCredentials)
 	storeImpl := &event.StoreImpl{
-		SQLBuilder:  sqlBuilderApp,
+		SQLBuilder:  sqlBuilder,
 		SQLExecutor: sqlExecutor,
 	}
 	hookLogger := hook.NewLogger(factory)
@@ -8139,8 +8154,9 @@ func newWebAppEnterLoginIDHandler(p *deps.RequestProvider) http.Handler {
 	welcomeMessageConfig := appConfig.WelcomeMessage
 	queue := appProvider.TaskQueue
 	eventLogger := event.NewLogger(factory)
+	sqlBuilder := appdb.NewSQLBuilder(databaseCredentials)
 	storeImpl := &event.StoreImpl{
-		SQLBuilder:  sqlBuilderApp,
+		SQLBuilder:  sqlBuilder,
 		SQLExecutor: sqlExecutor,
 	}
 	hookLogger := hook.NewLogger(factory)
@@ -8710,8 +8726,9 @@ func newWebAppEnterPasswordHandler(p *deps.RequestProvider) http.Handler {
 	welcomeMessageConfig := appConfig.WelcomeMessage
 	queue := appProvider.TaskQueue
 	eventLogger := event.NewLogger(factory)
+	sqlBuilder := appdb.NewSQLBuilder(databaseCredentials)
 	storeImpl := &event.StoreImpl{
-		SQLBuilder:  sqlBuilderApp,
+		SQLBuilder:  sqlBuilder,
 		SQLExecutor: sqlExecutor,
 	}
 	hookLogger := hook.NewLogger(factory)
@@ -9280,8 +9297,9 @@ func newWebAppCreatePasswordHandler(p *deps.RequestProvider) http.Handler {
 	welcomeMessageConfig := appConfig.WelcomeMessage
 	queue := appProvider.TaskQueue
 	eventLogger := event.NewLogger(factory)
+	sqlBuilder := appdb.NewSQLBuilder(databaseCredentials)
 	storeImpl := &event.StoreImpl{
-		SQLBuilder:  sqlBuilderApp,
+		SQLBuilder:  sqlBuilder,
 		SQLExecutor: sqlExecutor,
 	}
 	hookLogger := hook.NewLogger(factory)
@@ -9851,8 +9869,9 @@ func newWebAppSetupTOTPHandler(p *deps.RequestProvider) http.Handler {
 	welcomeMessageConfig := appConfig.WelcomeMessage
 	queue := appProvider.TaskQueue
 	eventLogger := event.NewLogger(factory)
+	sqlBuilder := appdb.NewSQLBuilder(databaseCredentials)
 	storeImpl := &event.StoreImpl{
-		SQLBuilder:  sqlBuilderApp,
+		SQLBuilder:  sqlBuilder,
 		SQLExecutor: sqlExecutor,
 	}
 	hookLogger := hook.NewLogger(factory)
@@ -10423,8 +10442,9 @@ func newWebAppEnterTOTPHandler(p *deps.RequestProvider) http.Handler {
 	welcomeMessageConfig := appConfig.WelcomeMessage
 	queue := appProvider.TaskQueue
 	eventLogger := event.NewLogger(factory)
+	sqlBuilder := appdb.NewSQLBuilder(databaseCredentials)
 	storeImpl := &event.StoreImpl{
-		SQLBuilder:  sqlBuilderApp,
+		SQLBuilder:  sqlBuilder,
 		SQLExecutor: sqlExecutor,
 	}
 	hookLogger := hook.NewLogger(factory)
@@ -10993,8 +11013,9 @@ func newWebAppSetupOOBOTPHandler(p *deps.RequestProvider) http.Handler {
 	welcomeMessageConfig := appConfig.WelcomeMessage
 	queue := appProvider.TaskQueue
 	eventLogger := event.NewLogger(factory)
+	sqlBuilder := appdb.NewSQLBuilder(databaseCredentials)
 	storeImpl := &event.StoreImpl{
-		SQLBuilder:  sqlBuilderApp,
+		SQLBuilder:  sqlBuilder,
 		SQLExecutor: sqlExecutor,
 	}
 	hookLogger := hook.NewLogger(factory)
@@ -11563,8 +11584,9 @@ func newWebAppEnterOOBOTPHandler(p *deps.RequestProvider) http.Handler {
 	welcomeMessageConfig := appConfig.WelcomeMessage
 	queue := appProvider.TaskQueue
 	eventLogger := event.NewLogger(factory)
+	sqlBuilder := appdb.NewSQLBuilder(databaseCredentials)
 	storeImpl := &event.StoreImpl{
-		SQLBuilder:  sqlBuilderApp,
+		SQLBuilder:  sqlBuilder,
 		SQLExecutor: sqlExecutor,
 	}
 	hookLogger := hook.NewLogger(factory)
@@ -12135,8 +12157,9 @@ func newWebAppEnterRecoveryCodeHandler(p *deps.RequestProvider) http.Handler {
 	welcomeMessageConfig := appConfig.WelcomeMessage
 	queue := appProvider.TaskQueue
 	eventLogger := event.NewLogger(factory)
+	sqlBuilder := appdb.NewSQLBuilder(databaseCredentials)
 	storeImpl := &event.StoreImpl{
-		SQLBuilder:  sqlBuilderApp,
+		SQLBuilder:  sqlBuilder,
 		SQLExecutor: sqlExecutor,
 	}
 	hookLogger := hook.NewLogger(factory)
@@ -12705,8 +12728,9 @@ func newWebAppSetupRecoveryCodeHandler(p *deps.RequestProvider) http.Handler {
 	welcomeMessageConfig := appConfig.WelcomeMessage
 	queue := appProvider.TaskQueue
 	eventLogger := event.NewLogger(factory)
+	sqlBuilder := appdb.NewSQLBuilder(databaseCredentials)
 	storeImpl := &event.StoreImpl{
-		SQLBuilder:  sqlBuilderApp,
+		SQLBuilder:  sqlBuilder,
 		SQLExecutor: sqlExecutor,
 	}
 	hookLogger := hook.NewLogger(factory)
@@ -13275,8 +13299,9 @@ func newWebAppVerifyIdentityHandler(p *deps.RequestProvider) http.Handler {
 	welcomeMessageConfig := appConfig.WelcomeMessage
 	queue := appProvider.TaskQueue
 	eventLogger := event.NewLogger(factory)
+	sqlBuilder := appdb.NewSQLBuilder(databaseCredentials)
 	storeImpl := &event.StoreImpl{
-		SQLBuilder:  sqlBuilderApp,
+		SQLBuilder:  sqlBuilder,
 		SQLExecutor: sqlExecutor,
 	}
 	hookLogger := hook.NewLogger(factory)
@@ -13848,8 +13873,9 @@ func newWebAppVerifyIdentitySuccessHandler(p *deps.RequestProvider) http.Handler
 	welcomeMessageConfig := appConfig.WelcomeMessage
 	queue := appProvider.TaskQueue
 	eventLogger := event.NewLogger(factory)
+	sqlBuilder := appdb.NewSQLBuilder(databaseCredentials)
 	storeImpl := &event.StoreImpl{
-		SQLBuilder:  sqlBuilderApp,
+		SQLBuilder:  sqlBuilder,
 		SQLExecutor: sqlExecutor,
 	}
 	hookLogger := hook.NewLogger(factory)
@@ -14418,8 +14444,9 @@ func newWebAppForgotPasswordHandler(p *deps.RequestProvider) http.Handler {
 	welcomeMessageConfig := appConfig.WelcomeMessage
 	queue := appProvider.TaskQueue
 	eventLogger := event.NewLogger(factory)
+	sqlBuilder := appdb.NewSQLBuilder(databaseCredentials)
 	storeImpl := &event.StoreImpl{
-		SQLBuilder:  sqlBuilderApp,
+		SQLBuilder:  sqlBuilder,
 		SQLExecutor: sqlExecutor,
 	}
 	hookLogger := hook.NewLogger(factory)
@@ -14993,8 +15020,9 @@ func newWebAppForgotPasswordSuccessHandler(p *deps.RequestProvider) http.Handler
 	welcomeMessageConfig := appConfig.WelcomeMessage
 	queue := appProvider.TaskQueue
 	eventLogger := event.NewLogger(factory)
+	sqlBuilder := appdb.NewSQLBuilder(databaseCredentials)
 	storeImpl := &event.StoreImpl{
-		SQLBuilder:  sqlBuilderApp,
+		SQLBuilder:  sqlBuilder,
 		SQLExecutor: sqlExecutor,
 	}
 	hookLogger := hook.NewLogger(factory)
@@ -15563,8 +15591,9 @@ func newWebAppResetPasswordHandler(p *deps.RequestProvider) http.Handler {
 	welcomeMessageConfig := appConfig.WelcomeMessage
 	queue := appProvider.TaskQueue
 	eventLogger := event.NewLogger(factory)
+	sqlBuilder := appdb.NewSQLBuilder(databaseCredentials)
 	storeImpl := &event.StoreImpl{
-		SQLBuilder:  sqlBuilderApp,
+		SQLBuilder:  sqlBuilder,
 		SQLExecutor: sqlExecutor,
 	}
 	hookLogger := hook.NewLogger(factory)
@@ -16134,8 +16163,9 @@ func newWebAppResetPasswordSuccessHandler(p *deps.RequestProvider) http.Handler 
 	welcomeMessageConfig := appConfig.WelcomeMessage
 	queue := appProvider.TaskQueue
 	eventLogger := event.NewLogger(factory)
+	sqlBuilder := appdb.NewSQLBuilder(databaseCredentials)
 	storeImpl := &event.StoreImpl{
-		SQLBuilder:  sqlBuilderApp,
+		SQLBuilder:  sqlBuilder,
 		SQLExecutor: sqlExecutor,
 	}
 	hookLogger := hook.NewLogger(factory)
@@ -16704,8 +16734,9 @@ func newWebAppSettingsHandler(p *deps.RequestProvider) http.Handler {
 	welcomeMessageConfig := appConfig.WelcomeMessage
 	queue := appProvider.TaskQueue
 	eventLogger := event.NewLogger(factory)
+	sqlBuilder := appdb.NewSQLBuilder(databaseCredentials)
 	storeImpl := &event.StoreImpl{
-		SQLBuilder:  sqlBuilderApp,
+		SQLBuilder:  sqlBuilder,
 		SQLExecutor: sqlExecutor,
 	}
 	hookLogger := hook.NewLogger(factory)
@@ -17293,8 +17324,9 @@ func newWebAppSettingsIdentityHandler(p *deps.RequestProvider) http.Handler {
 	welcomeMessageConfig := appConfig.WelcomeMessage
 	queue := appProvider.TaskQueue
 	eventLogger := event.NewLogger(factory)
+	sqlBuilder := appdb.NewSQLBuilder(databaseCredentials)
 	storeImpl := &event.StoreImpl{
-		SQLBuilder:  sqlBuilderApp,
+		SQLBuilder:  sqlBuilder,
 		SQLExecutor: sqlExecutor,
 	}
 	hookLogger := hook.NewLogger(factory)
@@ -17865,8 +17897,9 @@ func newWebAppSettingsBiometricHandler(p *deps.RequestProvider) http.Handler {
 	welcomeMessageConfig := appConfig.WelcomeMessage
 	queue := appProvider.TaskQueue
 	eventLogger := event.NewLogger(factory)
+	sqlBuilder := appdb.NewSQLBuilder(databaseCredentials)
 	storeImpl := &event.StoreImpl{
-		SQLBuilder:  sqlBuilderApp,
+		SQLBuilder:  sqlBuilder,
 		SQLExecutor: sqlExecutor,
 	}
 	hookLogger := hook.NewLogger(factory)
@@ -18436,8 +18469,9 @@ func newWebAppSettingsMFAHandler(p *deps.RequestProvider) http.Handler {
 	welcomeMessageConfig := appConfig.WelcomeMessage
 	queue := appProvider.TaskQueue
 	eventLogger := event.NewLogger(factory)
+	sqlBuilder := appdb.NewSQLBuilder(databaseCredentials)
 	storeImpl := &event.StoreImpl{
-		SQLBuilder:  sqlBuilderApp,
+		SQLBuilder:  sqlBuilder,
 		SQLExecutor: sqlExecutor,
 	}
 	hookLogger := hook.NewLogger(factory)
@@ -19016,8 +19050,9 @@ func newWebAppSettingsTOTPHandler(p *deps.RequestProvider) http.Handler {
 	welcomeMessageConfig := appConfig.WelcomeMessage
 	queue := appProvider.TaskQueue
 	eventLogger := event.NewLogger(factory)
+	sqlBuilder := appdb.NewSQLBuilder(databaseCredentials)
 	storeImpl := &event.StoreImpl{
-		SQLBuilder:  sqlBuilderApp,
+		SQLBuilder:  sqlBuilder,
 		SQLExecutor: sqlExecutor,
 	}
 	hookLogger := hook.NewLogger(factory)
@@ -19587,8 +19622,9 @@ func newWebAppSettingsOOBOTPHandler(p *deps.RequestProvider) http.Handler {
 	welcomeMessageConfig := appConfig.WelcomeMessage
 	queue := appProvider.TaskQueue
 	eventLogger := event.NewLogger(factory)
+	sqlBuilder := appdb.NewSQLBuilder(databaseCredentials)
 	storeImpl := &event.StoreImpl{
-		SQLBuilder:  sqlBuilderApp,
+		SQLBuilder:  sqlBuilder,
 		SQLExecutor: sqlExecutor,
 	}
 	hookLogger := hook.NewLogger(factory)
@@ -20158,8 +20194,9 @@ func newWebAppSettingsRecoveryCodeHandler(p *deps.RequestProvider) http.Handler 
 	welcomeMessageConfig := appConfig.WelcomeMessage
 	queue := appProvider.TaskQueue
 	eventLogger := event.NewLogger(factory)
+	sqlBuilder := appdb.NewSQLBuilder(databaseCredentials)
 	storeImpl := &event.StoreImpl{
-		SQLBuilder:  sqlBuilderApp,
+		SQLBuilder:  sqlBuilder,
 		SQLExecutor: sqlExecutor,
 	}
 	hookLogger := hook.NewLogger(factory)
@@ -20730,8 +20767,9 @@ func newWebAppSettingsSessionsHandler(p *deps.RequestProvider) http.Handler {
 	welcomeMessageConfig := appConfig.WelcomeMessage
 	queue := appProvider.TaskQueue
 	eventLogger := event.NewLogger(factory)
+	sqlBuilder := appdb.NewSQLBuilder(databaseCredentials)
 	storeImpl := &event.StoreImpl{
-		SQLBuilder:  sqlBuilderApp,
+		SQLBuilder:  sqlBuilder,
 		SQLExecutor: sqlExecutor,
 	}
 	hookLogger := hook.NewLogger(factory)
@@ -21307,8 +21345,9 @@ func newWebAppChangePasswordHandler(p *deps.RequestProvider) http.Handler {
 	welcomeMessageConfig := appConfig.WelcomeMessage
 	queue := appProvider.TaskQueue
 	eventLogger := event.NewLogger(factory)
+	sqlBuilder := appdb.NewSQLBuilder(databaseCredentials)
 	storeImpl := &event.StoreImpl{
-		SQLBuilder:  sqlBuilderApp,
+		SQLBuilder:  sqlBuilder,
 		SQLExecutor: sqlExecutor,
 	}
 	hookLogger := hook.NewLogger(factory)
@@ -21878,8 +21917,9 @@ func newWebAppChangeSecondaryPasswordHandler(p *deps.RequestProvider) http.Handl
 	welcomeMessageConfig := appConfig.WelcomeMessage
 	queue := appProvider.TaskQueue
 	eventLogger := event.NewLogger(factory)
+	sqlBuilder := appdb.NewSQLBuilder(databaseCredentials)
 	storeImpl := &event.StoreImpl{
-		SQLBuilder:  sqlBuilderApp,
+		SQLBuilder:  sqlBuilder,
 		SQLExecutor: sqlExecutor,
 	}
 	hookLogger := hook.NewLogger(factory)
@@ -22449,8 +22489,9 @@ func newWebAppUserDisabledHandler(p *deps.RequestProvider) http.Handler {
 	welcomeMessageConfig := appConfig.WelcomeMessage
 	queue := appProvider.TaskQueue
 	eventLogger := event.NewLogger(factory)
+	sqlBuilder := appdb.NewSQLBuilder(databaseCredentials)
 	storeImpl := &event.StoreImpl{
-		SQLBuilder:  sqlBuilderApp,
+		SQLBuilder:  sqlBuilder,
 		SQLExecutor: sqlExecutor,
 	}
 	hookLogger := hook.NewLogger(factory)
@@ -23019,8 +23060,9 @@ func newWebAppLogoutHandler(p *deps.RequestProvider) http.Handler {
 	welcomeMessageConfig := appConfig.WelcomeMessage
 	queue := appProvider.TaskQueue
 	eventLogger := event.NewLogger(factory)
+	sqlBuilder := appdb.NewSQLBuilder(databaseCredentials)
 	storeImpl := &event.StoreImpl{
-		SQLBuilder:  sqlBuilderApp,
+		SQLBuilder:  sqlBuilder,
 		SQLExecutor: sqlExecutor,
 	}
 	hookLogger := hook.NewLogger(factory)
@@ -23609,8 +23651,9 @@ func newWebAppReturnHandler(p *deps.RequestProvider) http.Handler {
 	welcomeMessageConfig := appConfig.WelcomeMessage
 	queue := appProvider.TaskQueue
 	eventLogger := event.NewLogger(factory)
+	sqlBuilder := appdb.NewSQLBuilder(databaseCredentials)
 	storeImpl := &event.StoreImpl{
-		SQLBuilder:  sqlBuilderApp,
+		SQLBuilder:  sqlBuilder,
 		SQLExecutor: sqlExecutor,
 	}
 	hookLogger := hook.NewLogger(factory)
@@ -24179,8 +24222,9 @@ func newWebAppErrorHandler(p *deps.RequestProvider) http.Handler {
 	welcomeMessageConfig := appConfig.WelcomeMessage
 	queue := appProvider.TaskQueue
 	eventLogger := event.NewLogger(factory)
+	sqlBuilder := appdb.NewSQLBuilder(databaseCredentials)
 	storeImpl := &event.StoreImpl{
-		SQLBuilder:  sqlBuilderApp,
+		SQLBuilder:  sqlBuilder,
 		SQLExecutor: sqlExecutor,
 	}
 	hookLogger := hook.NewLogger(factory)
@@ -25004,8 +25048,9 @@ func newSessionMiddleware(p *deps.RequestProvider) httproute.Middleware {
 	welcomeMessageConfig := appConfig.WelcomeMessage
 	queue := appProvider.TaskQueue
 	eventLogger := event.NewLogger(factory)
+	sqlBuilder := appdb.NewSQLBuilder(databaseCredentials)
 	storeImpl := &event.StoreImpl{
-		SQLBuilder:  sqlBuilderApp,
+		SQLBuilder:  sqlBuilder,
 		SQLExecutor: sqlExecutor,
 	}
 	hookLogger := hook.NewLogger(factory)

--- a/pkg/lib/analytic/auditdb_store.go
+++ b/pkg/lib/analytic/auditdb_store.go
@@ -54,7 +54,7 @@ func (s *AuditDBStore) UpsertCounts(counts []*Count) error {
 }
 
 func (s *AuditDBStore) upsertCounts(counts []*Count) error {
-	builder := s.SQLBuilder.
+	builder := s.SQLBuilder.WithoutAppID().
 		Insert(s.SQLBuilder.TableName("_audit_analytic_count")).
 		Columns(
 			"id",

--- a/pkg/lib/analytic/auditdb_store.go
+++ b/pkg/lib/analytic/auditdb_store.go
@@ -54,7 +54,7 @@ func (s *AuditDBStore) UpsertCounts(counts []*Count) error {
 }
 
 func (s *AuditDBStore) upsertCounts(counts []*Count) error {
-	builder := s.SQLBuilder.Global().
+	builder := s.SQLBuilder.
 		Insert(s.SQLBuilder.TableName("_audit_analytic_count")).
 		Columns(
 			"id",

--- a/pkg/lib/analytic/globaldb_store.go
+++ b/pkg/lib/analytic/globaldb_store.go
@@ -12,7 +12,7 @@ type GlobalDBStore struct {
 }
 
 func (s *GlobalDBStore) GetAppOwners(rangeFrom *time.Time, rangeTo *time.Time) ([]*AppCollaborator, error) {
-	builder := s.SQLBuilder.Global().
+	builder := s.SQLBuilder.
 		Select(
 			"app_id",
 			"user_id",
@@ -50,7 +50,7 @@ func (s *GlobalDBStore) GetAppOwners(rangeFrom *time.Time, rangeTo *time.Time) (
 }
 
 func (s *GlobalDBStore) GetAppIDs() (appIDs []string, err error) {
-	builder := s.SQLBuilder.Global().
+	builder := s.SQLBuilder.
 		Select(
 			"app_id",
 		).

--- a/pkg/lib/audit/read_store.go
+++ b/pkg/lib/audit/read_store.go
@@ -34,12 +34,12 @@ func (o QueryPageOptions) Apply(q db.SelectBuilder) db.SelectBuilder {
 }
 
 type ReadStore struct {
-	SQLBuilder  *auditdb.SQLBuilder
+	SQLBuilder  *auditdb.SQLBuilderApp
 	SQLExecutor *auditdb.ReadSQLExecutor
 }
 
 func (s *ReadStore) Count(opts QueryPageOptions) (uint64, error) {
-	query := s.SQLBuilder.Tenant().
+	query := s.SQLBuilder.
 		Select("count(*)").
 		From(s.SQLBuilder.TableName("_audit_log"))
 
@@ -111,7 +111,7 @@ func (s *ReadStore) GetByIDs(ids []string) ([]*Log, error) {
 }
 
 func (s *ReadStore) selectQuery() db.SelectBuilder {
-	return s.SQLBuilder.Tenant().
+	return s.SQLBuilder.
 		Select(
 			"id",
 			"created_at",

--- a/pkg/lib/audit/write_store.go
+++ b/pkg/lib/audit/write_store.go
@@ -7,7 +7,7 @@ import (
 )
 
 type WriteStore struct {
-	SQLBuilder  *auditdb.SQLBuilder
+	SQLBuilder  *auditdb.SQLBuilderApp
 	SQLExecutor *auditdb.WriteSQLExecutor
 }
 
@@ -17,7 +17,7 @@ func (s *WriteStore) PersistLog(logEntry *Log) (err error) {
 		return
 	}
 
-	builder := s.SQLBuilder.Tenant().
+	builder := s.SQLBuilder.
 		Insert(s.SQLBuilder.TableName("_audit_log")).
 		Columns(
 			"id",

--- a/pkg/lib/authn/authenticator/oob/store.go
+++ b/pkg/lib/authn/authenticator/oob/store.go
@@ -14,12 +14,12 @@ import (
 )
 
 type Store struct {
-	SQLBuilder  *appdb.SQLBuilder
+	SQLBuilder  *appdb.SQLBuilderApp
 	SQLExecutor *appdb.SQLExecutor
 }
 
 func (s *Store) selectQuery() db.SelectBuilder {
-	return s.SQLBuilder.Tenant().
+	return s.SQLBuilder.
 		Select(
 			"a.id",
 			"a.type",
@@ -119,7 +119,7 @@ func (s *Store) List(userID string) ([]*Authenticator, error) {
 }
 
 func (s *Store) Delete(id string) error {
-	q := s.SQLBuilder.Tenant().
+	q := s.SQLBuilder.
 		Delete(s.SQLBuilder.TableName("_auth_authenticator_oob")).
 		Where("id = ?", id)
 	_, err := s.SQLExecutor.ExecWith(q)
@@ -127,7 +127,7 @@ func (s *Store) Delete(id string) error {
 		return err
 	}
 
-	q = s.SQLBuilder.Tenant().
+	q = s.SQLBuilder.
 		Delete(s.SQLBuilder.TableName("_auth_authenticator")).
 		Where("id = ?", id)
 	_, err = s.SQLExecutor.ExecWith(q)
@@ -149,7 +149,7 @@ func (s *Store) Create(a *Authenticator) error {
 		return errors.New("invalid oob authenticator type")
 	}
 
-	q := s.SQLBuilder.Tenant().
+	q := s.SQLBuilder.
 		Insert(s.SQLBuilder.TableName("_auth_authenticator")).
 		Columns(
 			"id",
@@ -176,7 +176,7 @@ func (s *Store) Create(a *Authenticator) error {
 		return err
 	}
 
-	q = s.SQLBuilder.Tenant().
+	q = s.SQLBuilder.
 		Insert(s.SQLBuilder.TableName("_auth_authenticator_oob")).
 		Columns(
 			"id",

--- a/pkg/lib/authn/authenticator/password/history_store.go
+++ b/pkg/lib/authn/authenticator/password/history_store.go
@@ -15,7 +15,7 @@ import (
 
 type HistoryStore struct {
 	Clock       clock.Clock
-	SQLBuilder  *appdb.SQLBuilder
+	SQLBuilder  *appdb.SQLBuilderApp
 	SQLExecutor *appdb.SQLExecutor
 }
 
@@ -78,7 +78,7 @@ func (p *HistoryStore) RemovePasswordHistory(userID string, historySize int, his
 		ids = append(ids, h.ID)
 	}
 
-	builder := p.SQLBuilder.Tenant().
+	builder := p.SQLBuilder.
 		Delete(p.SQLBuilder.TableName("_auth_password_history")).
 		Where("user_id = ?", userID).
 		Where("id != ALL (?)", pq.Array(ids)).
@@ -89,7 +89,7 @@ func (p *HistoryStore) RemovePasswordHistory(userID string, historySize int, his
 }
 
 func (p *HistoryStore) ResetPasswordHistory(userID string) error {
-	builder := p.SQLBuilder.Tenant().
+	builder := p.SQLBuilder.
 		Delete(p.SQLBuilder.TableName("_auth_password_history")).
 		Where("user_id = ?", userID)
 
@@ -98,7 +98,7 @@ func (p *HistoryStore) ResetPasswordHistory(userID string) error {
 }
 
 func (p *HistoryStore) basePasswordHistoryBuilder(userID string) db.SelectBuilder {
-	return p.SQLBuilder.Tenant().
+	return p.SQLBuilder.
 		Select("id", "user_id", "password", "created_at").
 		From(p.SQLBuilder.TableName("_auth_password_history")).
 		Where("user_id = ?", userID).
@@ -106,7 +106,7 @@ func (p *HistoryStore) basePasswordHistoryBuilder(userID string) db.SelectBuilde
 }
 
 func (p *HistoryStore) insertPasswordHistoryBuilder(userID string, hashedPassword []byte, createdAt time.Time) db.InsertBuilder {
-	return p.SQLBuilder.Tenant().
+	return p.SQLBuilder.
 		Insert(p.SQLBuilder.TableName("_auth_password_history")).
 		Columns(
 			"id",

--- a/pkg/lib/authn/authenticator/password/store.go
+++ b/pkg/lib/authn/authenticator/password/store.go
@@ -14,12 +14,12 @@ import (
 )
 
 type Store struct {
-	SQLBuilder  *appdb.SQLBuilder
+	SQLBuilder  *appdb.SQLBuilderApp
 	SQLExecutor *appdb.SQLExecutor
 }
 
 func (s *Store) selectQuery() db.SelectBuilder {
-	return s.SQLBuilder.Tenant().
+	return s.SQLBuilder.
 		Select(
 			"a.id",
 			"a.labels",
@@ -115,7 +115,7 @@ func (s *Store) List(userID string) ([]*Authenticator, error) {
 }
 
 func (s *Store) Delete(id string) error {
-	q := s.SQLBuilder.Tenant().
+	q := s.SQLBuilder.
 		Delete(s.SQLBuilder.TableName("_auth_authenticator_password")).
 		Where("id = ?", id)
 	_, err := s.SQLExecutor.ExecWith(q)
@@ -123,7 +123,7 @@ func (s *Store) Delete(id string) error {
 		return err
 	}
 
-	q = s.SQLBuilder.Tenant().
+	q = s.SQLBuilder.
 		Delete(s.SQLBuilder.TableName("_auth_authenticator")).
 		Where("id = ?", id)
 	_, err = s.SQLExecutor.ExecWith(q)
@@ -140,7 +140,7 @@ func (s *Store) Create(a *Authenticator) error {
 		return err
 	}
 
-	q := s.SQLBuilder.Tenant().
+	q := s.SQLBuilder.
 		Insert(s.SQLBuilder.TableName("_auth_authenticator")).
 		Columns(
 			"id",
@@ -167,7 +167,7 @@ func (s *Store) Create(a *Authenticator) error {
 		return err
 	}
 
-	q = s.SQLBuilder.Tenant().
+	q = s.SQLBuilder.
 		Insert(s.SQLBuilder.TableName("_auth_authenticator_password")).
 		Columns(
 			"id",
@@ -186,7 +186,7 @@ func (s *Store) Create(a *Authenticator) error {
 }
 
 func (s *Store) UpdatePasswordHash(a *Authenticator) error {
-	q := s.SQLBuilder.Tenant().
+	q := s.SQLBuilder.
 		Update(s.SQLBuilder.TableName("_auth_authenticator_password")).
 		Set("password_hash", a.PasswordHash).
 		Where("id = ?", a.ID)
@@ -195,7 +195,7 @@ func (s *Store) UpdatePasswordHash(a *Authenticator) error {
 		return err
 	}
 
-	q = s.SQLBuilder.Tenant().
+	q = s.SQLBuilder.
 		Update(s.SQLBuilder.TableName("_auth_authenticator")).
 		Set("updated_at", a.UpdatedAt).
 		Where("id = ?", a.ID)

--- a/pkg/lib/authn/authenticator/service/store.go
+++ b/pkg/lib/authn/authenticator/service/store.go
@@ -8,12 +8,12 @@ import (
 )
 
 type Store struct {
-	SQLBuilder  *appdb.SQLBuilder
+	SQLBuilder  *appdb.SQLBuilderApp
 	SQLExecutor *appdb.SQLExecutor
 }
 
 func (s *Store) Count(userID string) (uint64, error) {
-	builder := s.SQLBuilder.Tenant().
+	builder := s.SQLBuilder.
 		Select("count(*)").
 		Where("user_id = ?", userID).
 		From(s.SQLBuilder.TableName("_auth_authenticator"))
@@ -31,7 +31,7 @@ func (s *Store) Count(userID string) (uint64, error) {
 }
 
 func (s *Store) ListRefsByUsers(userIDs []string) ([]*authenticator.Ref, error) {
-	builder := s.SQLBuilder.Tenant().
+	builder := s.SQLBuilder.
 		Select("id", "type", "user_id", "created_at", "updated_at").
 		Where("user_id = ANY (?)", pq.Array(userIDs)).
 		From(s.SQLBuilder.TableName("_auth_authenticator"))

--- a/pkg/lib/authn/authenticator/totp/store.go
+++ b/pkg/lib/authn/authenticator/totp/store.go
@@ -14,12 +14,12 @@ import (
 )
 
 type Store struct {
-	SQLBuilder  *appdb.SQLBuilder
+	SQLBuilder  *appdb.SQLBuilderApp
 	SQLExecutor *appdb.SQLExecutor
 }
 
 func (s *Store) selectQuery() db.SelectBuilder {
-	return s.SQLBuilder.Tenant().
+	return s.SQLBuilder.
 		Select(
 			"a.id",
 			"a.labels",
@@ -121,7 +121,7 @@ func (s *Store) List(userID string) ([]*Authenticator, error) {
 }
 
 func (s *Store) Delete(id string) error {
-	q := s.SQLBuilder.Tenant().
+	q := s.SQLBuilder.
 		Delete(s.SQLBuilder.TableName("_auth_authenticator_totp")).
 		Where("id = ?", id)
 	_, err := s.SQLExecutor.ExecWith(q)
@@ -129,7 +129,7 @@ func (s *Store) Delete(id string) error {
 		return err
 	}
 
-	q = s.SQLBuilder.Tenant().
+	q = s.SQLBuilder.
 		Delete(s.SQLBuilder.TableName("_auth_authenticator")).
 		Where("id = ?", id)
 	_, err = s.SQLExecutor.ExecWith(q)
@@ -146,7 +146,7 @@ func (s *Store) Create(a *Authenticator) error {
 		return err
 	}
 
-	q := s.SQLBuilder.Tenant().
+	q := s.SQLBuilder.
 		Insert(s.SQLBuilder.TableName("_auth_authenticator")).
 		Columns(
 			"id",
@@ -173,7 +173,7 @@ func (s *Store) Create(a *Authenticator) error {
 		return err
 	}
 
-	q = s.SQLBuilder.Tenant().
+	q = s.SQLBuilder.
 		Insert(s.SQLBuilder.TableName("_auth_authenticator_totp")).
 		Columns(
 			"id",

--- a/pkg/lib/authn/identity/anonymous/store.go
+++ b/pkg/lib/authn/identity/anonymous/store.go
@@ -14,12 +14,12 @@ import (
 )
 
 type Store struct {
-	SQLBuilder  *appdb.SQLBuilder
+	SQLBuilder  *appdb.SQLBuilderApp
 	SQLExecutor *appdb.SQLExecutor
 }
 
 func (s *Store) selectQuery() db.SelectBuilder {
-	return s.SQLBuilder.Tenant().
+	return s.SQLBuilder.
 		Select(
 			"p.id",
 			"p.labels",
@@ -152,7 +152,7 @@ func (s *Store) Create(i *Identity) error {
 		return err
 	}
 
-	builder := s.SQLBuilder.Tenant().
+	builder := s.SQLBuilder.
 		Insert(s.SQLBuilder.TableName("_auth_identity")).
 		Columns(
 			"id",
@@ -176,7 +176,7 @@ func (s *Store) Create(i *Identity) error {
 		return err
 	}
 
-	q := s.SQLBuilder.Tenant().
+	q := s.SQLBuilder.
 		Insert(s.SQLBuilder.TableName("_auth_identity_anonymous")).
 		Columns(
 			"id",
@@ -198,7 +198,7 @@ func (s *Store) Create(i *Identity) error {
 }
 
 func (s *Store) Delete(i *Identity) error {
-	q := s.SQLBuilder.Tenant().
+	q := s.SQLBuilder.
 		Delete(s.SQLBuilder.TableName("_auth_identity_anonymous")).
 		Where("id = ?", i.ID)
 
@@ -207,7 +207,7 @@ func (s *Store) Delete(i *Identity) error {
 		return err
 	}
 
-	q = s.SQLBuilder.Tenant().
+	q = s.SQLBuilder.
 		Delete(s.SQLBuilder.TableName("_auth_identity")).
 		Where("id = ?", i.ID)
 

--- a/pkg/lib/authn/identity/biometric/store.go
+++ b/pkg/lib/authn/identity/biometric/store.go
@@ -14,12 +14,12 @@ import (
 )
 
 type Store struct {
-	SQLBuilder  *appdb.SQLBuilder
+	SQLBuilder  *appdb.SQLBuilderApp
 	SQLExecutor *appdb.SQLExecutor
 }
 
 func (s *Store) selectQuery() db.SelectBuilder {
-	return s.SQLBuilder.Tenant().
+	return s.SQLBuilder.
 		Select(
 			"p.id",
 			"p.labels",
@@ -164,7 +164,7 @@ func (s *Store) Create(i *Identity) error {
 		return err
 	}
 
-	builder := s.SQLBuilder.Tenant().
+	builder := s.SQLBuilder.
 		Insert(s.SQLBuilder.TableName("_auth_identity")).
 		Columns(
 			"id",
@@ -188,7 +188,7 @@ func (s *Store) Create(i *Identity) error {
 		return err
 	}
 
-	q := s.SQLBuilder.Tenant().
+	q := s.SQLBuilder.
 		Insert(s.SQLBuilder.TableName("_auth_identity_biometric")).
 		Columns(
 			"id",
@@ -212,7 +212,7 @@ func (s *Store) Create(i *Identity) error {
 }
 
 func (s *Store) Delete(i *Identity) error {
-	q := s.SQLBuilder.Tenant().
+	q := s.SQLBuilder.
 		Delete(s.SQLBuilder.TableName("_auth_identity_biometric")).
 		Where("id = ?", i.ID)
 
@@ -221,7 +221,7 @@ func (s *Store) Delete(i *Identity) error {
 		return err
 	}
 
-	q = s.SQLBuilder.Tenant().
+	q = s.SQLBuilder.
 		Delete(s.SQLBuilder.TableName("_auth_identity")).
 		Where("id = ?", i.ID)
 

--- a/pkg/lib/authn/identity/loginid/store.go
+++ b/pkg/lib/authn/identity/loginid/store.go
@@ -15,12 +15,12 @@ import (
 )
 
 type Store struct {
-	SQLBuilder  *appdb.SQLBuilder
+	SQLBuilder  *appdb.SQLBuilderApp
 	SQLExecutor *appdb.SQLExecutor
 }
 
 func (s *Store) selectQuery() db.SelectBuilder {
-	return s.SQLBuilder.Tenant().
+	return s.SQLBuilder.
 		Select(
 			"p.id",
 			"p.labels",
@@ -173,7 +173,7 @@ func (s *Store) Create(i *Identity) error {
 		return err
 	}
 
-	builder := s.SQLBuilder.Tenant().
+	builder := s.SQLBuilder.
 		Insert(s.SQLBuilder.TableName("_auth_identity")).
 		Columns(
 			"id",
@@ -202,7 +202,7 @@ func (s *Store) Create(i *Identity) error {
 		return err
 	}
 
-	q := s.SQLBuilder.Tenant().
+	q := s.SQLBuilder.
 		Insert(s.SQLBuilder.TableName("_auth_identity_login_id")).
 		Columns(
 			"id",
@@ -237,7 +237,7 @@ func (s *Store) Update(i *Identity) error {
 		return err
 	}
 
-	q := s.SQLBuilder.Tenant().
+	q := s.SQLBuilder.
 		Update(s.SQLBuilder.TableName("_auth_identity_login_id")).
 		Set("login_id", i.LoginID).
 		Set("original_login_id", i.OriginalLoginID).
@@ -261,7 +261,7 @@ func (s *Store) Update(i *Identity) error {
 		panic(fmt.Sprintf("identity_oauth: want 1 row updated, got %v", rowsAffected))
 	}
 
-	q = s.SQLBuilder.Tenant().
+	q = s.SQLBuilder.
 		Update(s.SQLBuilder.TableName("_auth_identity")).
 		Set("updated_at", i.UpdatedAt).
 		Where("id = ?", i.ID)
@@ -275,7 +275,7 @@ func (s *Store) Update(i *Identity) error {
 }
 
 func (s *Store) Delete(i *Identity) error {
-	q := s.SQLBuilder.Tenant().
+	q := s.SQLBuilder.
 		Delete(s.SQLBuilder.TableName("_auth_identity_login_id")).
 		Where("id = ?", i.ID)
 
@@ -284,7 +284,7 @@ func (s *Store) Delete(i *Identity) error {
 		return err
 	}
 
-	q = s.SQLBuilder.Tenant().
+	q = s.SQLBuilder.
 		Delete(s.SQLBuilder.TableName("_auth_identity")).
 		Where("id = ?", i.ID)
 

--- a/pkg/lib/authn/identity/oauth/store.go
+++ b/pkg/lib/authn/identity/oauth/store.go
@@ -16,12 +16,12 @@ import (
 )
 
 type Store struct {
-	SQLBuilder  *appdb.SQLBuilder
+	SQLBuilder  *appdb.SQLBuilderApp
 	SQLExecutor *appdb.SQLExecutor
 }
 
 func (s *Store) selectQuery() db.SelectBuilder {
-	return s.SQLBuilder.Tenant().
+	return s.SQLBuilder.
 		Select(
 			"p.id",
 			"p.labels",
@@ -194,7 +194,7 @@ func (s *Store) Create(i *Identity) error {
 		return err
 	}
 
-	builder := s.SQLBuilder.Tenant().
+	builder := s.SQLBuilder.
 		Insert(s.SQLBuilder.TableName("_auth_identity")).
 		Columns(
 			"id",
@@ -231,7 +231,7 @@ func (s *Store) Create(i *Identity) error {
 		return err
 	}
 
-	q := s.SQLBuilder.Tenant().
+	q := s.SQLBuilder.
 		Insert(s.SQLBuilder.TableName("_auth_identity_oauth")).
 		Columns(
 			"id",
@@ -268,7 +268,7 @@ func (s *Store) Update(i *Identity) error {
 		return err
 	}
 
-	q := s.SQLBuilder.Tenant().
+	q := s.SQLBuilder.
 		Update(s.SQLBuilder.TableName("_auth_identity_oauth")).
 		Set("claims", claims).
 		Set("profile", profile).
@@ -290,7 +290,7 @@ func (s *Store) Update(i *Identity) error {
 		panic(fmt.Sprintf("identity_oauth: want 1 row updated, got %v", rowsAffected))
 	}
 
-	q = s.SQLBuilder.Tenant().
+	q = s.SQLBuilder.
 		Update(s.SQLBuilder.TableName("_auth_identity")).
 		Set("updated_at", i.UpdatedAt).
 		Where("id = ?", i.ID)
@@ -304,7 +304,7 @@ func (s *Store) Update(i *Identity) error {
 }
 
 func (s *Store) Delete(i *Identity) error {
-	q := s.SQLBuilder.Tenant().
+	q := s.SQLBuilder.
 		Delete(s.SQLBuilder.TableName("_auth_identity_oauth")).
 		Where("id = ?", i.ID)
 
@@ -313,7 +313,7 @@ func (s *Store) Delete(i *Identity) error {
 		return err
 	}
 
-	q = s.SQLBuilder.Tenant().
+	q = s.SQLBuilder.
 		Delete(s.SQLBuilder.TableName("_auth_identity")).
 		Where("id = ?", i.ID)
 

--- a/pkg/lib/authn/identity/service/store.go
+++ b/pkg/lib/authn/identity/service/store.go
@@ -8,12 +8,12 @@ import (
 )
 
 type Store struct {
-	SQLBuilder  *appdb.SQLBuilder
+	SQLBuilder  *appdb.SQLBuilderApp
 	SQLExecutor *appdb.SQLExecutor
 }
 
 func (s *Store) Count(userID string) (uint64, error) {
-	builder := s.SQLBuilder.Tenant().
+	builder := s.SQLBuilder.
 		Select("count(*)").
 		Where("user_id = ?", userID).
 		From(s.SQLBuilder.TableName("_auth_identity"))
@@ -31,7 +31,7 @@ func (s *Store) Count(userID string) (uint64, error) {
 }
 
 func (s *Store) ListRefsByUsers(userIDs []string) ([]*identity.Ref, error) {
-	builder := s.SQLBuilder.Tenant().
+	builder := s.SQLBuilder.
 		Select("id", "type", "user_id", "created_at", "updated_at").
 		Where("user_id = ANY (?)", pq.Array(userIDs)).
 		From(s.SQLBuilder.TableName("_auth_identity"))

--- a/pkg/lib/authn/mfa/store_recovery_code_pq.go
+++ b/pkg/lib/authn/mfa/store_recovery_code_pq.go
@@ -10,12 +10,12 @@ import (
 )
 
 type StoreRecoveryCodePQ struct {
-	SQLBuilder  *appdb.SQLBuilder
+	SQLBuilder  *appdb.SQLBuilderApp
 	SQLExecutor *appdb.SQLExecutor
 }
 
 func (s *StoreRecoveryCodePQ) List(userID string) ([]*RecoveryCode, error) {
-	builder := s.SQLBuilder.Tenant().
+	builder := s.SQLBuilder.
 		Select(
 			"rc.id",
 			"rc.user_id",
@@ -54,7 +54,7 @@ func (s *StoreRecoveryCodePQ) List(userID string) ([]*RecoveryCode, error) {
 }
 
 func (s *StoreRecoveryCodePQ) Get(userID string, code string) (*RecoveryCode, error) {
-	builder := s.SQLBuilder.Tenant().
+	builder := s.SQLBuilder.
 		Select(
 			"rc.id",
 			"rc.user_id",
@@ -92,7 +92,7 @@ func (s *StoreRecoveryCodePQ) Get(userID string, code string) (*RecoveryCode, er
 
 func (s *StoreRecoveryCodePQ) DeleteAll(userID string) error {
 	ids, err := func() ([]string, error) {
-		builder := s.SQLBuilder.Tenant().
+		builder := s.SQLBuilder.
 			Select("rc.id").
 			From(s.SQLBuilder.TableName("_auth_recovery_code"), "rc").
 			Where("rc.user_id = ?", userID)
@@ -122,7 +122,7 @@ func (s *StoreRecoveryCodePQ) DeleteAll(userID string) error {
 		return nil
 	}
 
-	q := s.SQLBuilder.Tenant().
+	q := s.SQLBuilder.
 		Delete(s.SQLBuilder.TableName("_auth_recovery_code")).
 		Where("id = ANY (?)", pq.Array(ids))
 	_, err = s.SQLExecutor.ExecWith(q)
@@ -134,7 +134,7 @@ func (s *StoreRecoveryCodePQ) DeleteAll(userID string) error {
 }
 
 func (s *StoreRecoveryCodePQ) CreateAll(codes []*RecoveryCode) error {
-	q := s.SQLBuilder.Tenant().
+	q := s.SQLBuilder.
 		Insert(s.SQLBuilder.TableName("_auth_recovery_code")).
 		Columns(
 			"id",
@@ -165,7 +165,7 @@ func (s *StoreRecoveryCodePQ) CreateAll(codes []*RecoveryCode) error {
 }
 
 func (s *StoreRecoveryCodePQ) UpdateConsumed(code *RecoveryCode) error {
-	q := s.SQLBuilder.Tenant().
+	q := s.SQLBuilder.
 		Update(s.SQLBuilder.TableName("_auth_recovery_code")).
 		Where("id = ?", code.ID).
 		Set("consumed", code.Consumed).

--- a/pkg/lib/authn/user/store.go
+++ b/pkg/lib/authn/user/store.go
@@ -26,7 +26,7 @@ type store interface {
 }
 
 type Store struct {
-	SQLBuilder  *appdb.SQLBuilder
+	SQLBuilder  *appdb.SQLBuilderApp
 	SQLExecutor *appdb.SQLExecutor
 }
 
@@ -36,7 +36,7 @@ func (s *Store) Create(u *User) error {
 		return err
 	}
 
-	builder := s.SQLBuilder.Tenant().
+	builder := s.SQLBuilder.
 		Insert(s.SQLBuilder.TableName("_auth_user")).
 		Columns(
 			"id",
@@ -68,7 +68,7 @@ func (s *Store) Create(u *User) error {
 }
 
 func (s *Store) selectQuery() db.SelectBuilder {
-	return s.SQLBuilder.Tenant().
+	return s.SQLBuilder.
 		Select(
 			"id",
 			"labels",
@@ -146,7 +146,7 @@ func (s *Store) GetByIDs(userIDs []string) ([]*User, error) {
 }
 
 func (s *Store) Count() (uint64, error) {
-	builder := s.SQLBuilder.Tenant().
+	builder := s.SQLBuilder.
 		Select("count(*)").
 		From(s.SQLBuilder.TableName("_auth_user"))
 	scanner, err := s.SQLExecutor.QueryRowWith(builder)
@@ -191,7 +191,7 @@ func (s *Store) QueryPage(sortOption SortOption, pageArgs graphqlutil.PageArgs) 
 }
 
 func (s *Store) UpdateLoginTime(userID string, loginAt time.Time) error {
-	builder := s.SQLBuilder.Tenant().
+	builder := s.SQLBuilder.
 		Update(s.SQLBuilder.TableName("_auth_user")).
 		Set("last_login_at", squirrel.Expr("login_at")).
 		Set("login_at", loginAt).
@@ -206,7 +206,7 @@ func (s *Store) UpdateLoginTime(userID string, loginAt time.Time) error {
 }
 
 func (s *Store) UpdateDisabledStatus(userID string, isDisabled bool, reason *string) error {
-	builder := s.SQLBuilder.Tenant().
+	builder := s.SQLBuilder.
 		Update(s.SQLBuilder.TableName("_auth_user")).
 		Set("is_disabled", isDisabled).
 		Set("disable_reason", reason).
@@ -221,7 +221,7 @@ func (s *Store) UpdateDisabledStatus(userID string, isDisabled bool, reason *str
 }
 
 func (s *Store) Delete(userID string) error {
-	builder := s.SQLBuilder.Tenant().
+	builder := s.SQLBuilder.
 		Delete(s.SQLBuilder.TableName("_auth_user")).
 		Where("id = ?", userID)
 

--- a/pkg/lib/config/configsource/store.go
+++ b/pkg/lib/config/configsource/store.go
@@ -6,6 +6,8 @@ import (
 	"errors"
 	"fmt"
 
+	sq "github.com/Masterminds/squirrel"
+
 	"github.com/authgear/authgear-server/pkg/lib/infra/db"
 	"github.com/authgear/authgear-server/pkg/lib/infra/db/globaldb"
 )
@@ -15,8 +17,8 @@ type Store struct {
 	SQLExecutor *globaldb.SQLExecutor
 }
 
-func (s *Store) selectConfigSourceQuery() db.SelectBuilder {
-	return s.SQLBuilder.Global().
+func (s *Store) selectConfigSourceQuery() sq.SelectBuilder {
+	return s.SQLBuilder.
 		Select(
 			"id",
 			"app_id",
@@ -54,7 +56,7 @@ func (s *Store) scanConfigSource(scn db.Scanner) (*DatabaseSource, error) {
 }
 
 func (s *Store) GetAppIDByDomain(domain string) (string, error) {
-	builder := s.SQLBuilder.Global().
+	builder := s.SQLBuilder.
 		Select(
 			"app_id",
 		).
@@ -103,7 +105,7 @@ func (s *Store) CreateDatabaseSource(dbs *DatabaseSource) error {
 		return err
 	}
 
-	builder := s.SQLBuilder.Global().
+	builder := s.SQLBuilder.
 		Insert(s.SQLBuilder.TableName("_portal_config_source")).
 		Columns(
 			"id",
@@ -136,7 +138,7 @@ func (s *Store) UpdateDatabaseSource(dbs *DatabaseSource) error {
 		return err
 	}
 
-	q := s.SQLBuilder.Global().
+	q := s.SQLBuilder.
 		Update(s.SQLBuilder.TableName("_portal_config_source")).
 		Set("updated_at", dbs.UpdatedAt).
 		Set("data", data).

--- a/pkg/lib/event/store.go
+++ b/pkg/lib/event/store.go
@@ -7,12 +7,12 @@ import (
 )
 
 type StoreImpl struct {
-	SQLBuilder  *appdb.SQLBuilderApp
+	SQLBuilder  *appdb.SQLBuilder
 	SQLExecutor *appdb.SQLExecutor
 }
 
 func (s *StoreImpl) NextSequenceNumber() (seq int64, err error) {
-	builder := s.SQLBuilder.
+	builder := s.SQLBuilder.WithoutAppID().
 		Select(fmt.Sprintf("nextval('%s')", s.SQLBuilder.TableName("_auth_event_sequence")))
 	row, err := s.SQLExecutor.QueryRowWith(builder)
 	if err != nil {

--- a/pkg/lib/event/store.go
+++ b/pkg/lib/event/store.go
@@ -7,12 +7,12 @@ import (
 )
 
 type StoreImpl struct {
-	SQLBuilder  *appdb.SQLBuilder
+	SQLBuilder  *appdb.SQLBuilderApp
 	SQLExecutor *appdb.SQLExecutor
 }
 
 func (s *StoreImpl) NextSequenceNumber() (seq int64, err error) {
-	builder := s.SQLBuilder.Global().
+	builder := s.SQLBuilder.
 		Select(fmt.Sprintf("nextval('%s')", s.SQLBuilder.TableName("_auth_event_sequence")))
 	row, err := s.SQLExecutor.QueryRowWith(builder)
 	if err != nil {

--- a/pkg/lib/feature/verification/store_pq.go
+++ b/pkg/lib/feature/verification/store_pq.go
@@ -9,12 +9,12 @@ import (
 )
 
 type StorePQ struct {
-	SQLBuilder  *appdb.SQLBuilder
+	SQLBuilder  *appdb.SQLBuilderApp
 	SQLExecutor *appdb.SQLExecutor
 }
 
 func (s *StorePQ) selectQuery() db.SelectBuilder {
-	return s.SQLBuilder.Tenant().
+	return s.SQLBuilder.
 		Select(
 			"id",
 			"user_id",
@@ -97,7 +97,7 @@ func (s *StorePQ) Get(userID string, claimName string, claimValue string) (*Clai
 }
 
 func (s *StorePQ) Create(claim *Claim) error {
-	q := s.SQLBuilder.Tenant().
+	q := s.SQLBuilder.
 		Insert(s.SQLBuilder.TableName("_auth_verified_claim")).
 		Columns(
 			"id",
@@ -122,7 +122,7 @@ func (s *StorePQ) Create(claim *Claim) error {
 }
 
 func (s *StorePQ) Delete(id string) error {
-	q := s.SQLBuilder.Tenant().
+	q := s.SQLBuilder.
 		Delete(s.SQLBuilder.TableName("_auth_verified_claim")).
 		Where("id = ?", id)
 	_, err := s.SQLExecutor.ExecWith(q)
@@ -134,7 +134,7 @@ func (s *StorePQ) Delete(id string) error {
 }
 
 func (s *StorePQ) DeleteAll(userID string) error {
-	q := s.SQLBuilder.Tenant().
+	q := s.SQLBuilder.
 		Delete(s.SQLBuilder.TableName("_auth_verified_claim")).
 		Where("user_id = ?", userID)
 	_, err := s.SQLExecutor.ExecWith(q)

--- a/pkg/lib/infra/db/appdb/deps.go
+++ b/pkg/lib/infra/db/appdb/deps.go
@@ -17,12 +17,27 @@ var DependencySet = wire.NewSet(
 )
 
 type SQLBuilder struct {
-	db.SQLBuilder
+	builder *db.SQLBuilder
+}
+
+func (b SQLBuilder) WithoutAppID() *db.SQLBuilder {
+	return b.builder
+}
+
+func (b SQLBuilder) WithAppID(appID string) *SQLBuilderApp {
+	return &SQLBuilderApp{
+		SQLBuilderApp: db.NewSQLBuilderApp(b.builder.Schema, appID),
+	}
+}
+
+func (b SQLBuilder) TableName(table string) string {
+	return b.builder.TableName(table)
 }
 
 func NewSQLBuilder(c *config.DatabaseCredentials) *SQLBuilder {
+	builder := db.NewSQLBuilder(c.DatabaseSchema)
 	return &SQLBuilder{
-		db.NewSQLBuilder(c.DatabaseSchema),
+		builder: &builder,
 	}
 }
 

--- a/pkg/lib/infra/db/appdb/deps.go
+++ b/pkg/lib/infra/db/appdb/deps.go
@@ -13,15 +13,30 @@ import (
 var DependencySet = wire.NewSet(
 	NewSQLExecutor,
 	NewSQLBuilder,
+	NewSQLBuilderApp,
 )
 
 type SQLBuilder struct {
 	db.SQLBuilder
 }
 
-func NewSQLBuilder(c *config.DatabaseCredentials, id config.AppID) *SQLBuilder {
+func NewSQLBuilder(c *config.DatabaseCredentials) *SQLBuilder {
 	return &SQLBuilder{
-		db.NewSQLBuilder(c.DatabaseSchema, string(id)),
+		db.NewSQLBuilder(c.DatabaseSchema),
+	}
+}
+
+type SQLBuilderApp struct {
+	db.SQLBuilderApp
+}
+
+func NewSQLBuilderApp(c *config.DatabaseCredentials, id config.AppID) *SQLBuilderApp {
+	if c == nil {
+		return nil
+	}
+
+	return &SQLBuilderApp{
+		db.NewSQLBuilderApp(c.DatabaseSchema, string(id)),
 	}
 }
 

--- a/pkg/lib/infra/db/auditdb/deps.go
+++ b/pkg/lib/infra/db/auditdb/deps.go
@@ -14,19 +14,34 @@ var DependencySet = wire.NewSet(
 	NewReadSQLExecutor,
 	NewWriteSQLExecutor,
 	NewSQLBuilder,
+	NewSQLBuilderApp,
 )
 
 type SQLBuilder struct {
 	db.SQLBuilder
 }
 
-func NewSQLBuilder(c *config.AuditDatabaseCredentials, id config.AppID) *SQLBuilder {
+func NewSQLBuilder(c *config.AuditDatabaseCredentials) *SQLBuilder {
 	if c == nil {
 		return nil
 	}
 
 	return &SQLBuilder{
-		db.NewSQLBuilder(c.DatabaseSchema, string(id)),
+		db.NewSQLBuilder(c.DatabaseSchema),
+	}
+}
+
+type SQLBuilderApp struct {
+	db.SQLBuilderApp
+}
+
+func NewSQLBuilderApp(c *config.AuditDatabaseCredentials, id config.AppID) *SQLBuilderApp {
+	if c == nil {
+		return nil
+	}
+
+	return &SQLBuilderApp{
+		db.NewSQLBuilderApp(c.DatabaseSchema, string(id)),
 	}
 }
 

--- a/pkg/lib/infra/db/auditdb/deps.go
+++ b/pkg/lib/infra/db/auditdb/deps.go
@@ -18,7 +18,21 @@ var DependencySet = wire.NewSet(
 )
 
 type SQLBuilder struct {
-	db.SQLBuilder
+	builder *db.SQLBuilder
+}
+
+func (b SQLBuilder) WithoutAppID() *db.SQLBuilder {
+	return b.builder
+}
+
+func (b SQLBuilder) WithAppID(appID string) *SQLBuilderApp {
+	return &SQLBuilderApp{
+		SQLBuilderApp: db.NewSQLBuilderApp(b.builder.Schema, appID),
+	}
+}
+
+func (b SQLBuilder) TableName(table string) string {
+	return b.builder.TableName(table)
 }
 
 func NewSQLBuilder(c *config.AuditDatabaseCredentials) *SQLBuilder {
@@ -26,8 +40,9 @@ func NewSQLBuilder(c *config.AuditDatabaseCredentials) *SQLBuilder {
 		return nil
 	}
 
+	builder := db.NewSQLBuilder(c.DatabaseSchema)
 	return &SQLBuilder{
-		db.NewSQLBuilder(c.DatabaseSchema),
+		builder: &builder,
 	}
 }
 

--- a/pkg/lib/infra/db/globaldb/deps.go
+++ b/pkg/lib/infra/db/globaldb/deps.go
@@ -23,7 +23,7 @@ type SQLBuilder struct {
 
 func NewSQLBuilder(c *config.DatabaseEnvironmentConfig) *SQLBuilder {
 	return &SQLBuilder{
-		db.NewSQLBuilder(c.DatabaseSchema, ""),
+		db.NewSQLBuilder(c.DatabaseSchema),
 	}
 }
 

--- a/pkg/lib/infra/db/pagination_test.go
+++ b/pkg/lib/infra/db/pagination_test.go
@@ -11,7 +11,7 @@ import (
 
 func TestApplyPageArgs(t *testing.T) {
 	Convey("ApplyPageArgs", t, func() {
-		builder := db.NewSQLBuilder("", "my-app").Tenant().
+		builder := db.NewSQLBuilderApp("", "my-app").
 			Select("id", "value").
 			From("values")
 

--- a/pkg/lib/infra/db/sql_builder.go
+++ b/pkg/lib/infra/db/sql_builder.go
@@ -24,10 +24,6 @@ type SQLBuilder struct {
 	sqlBuilderSchema
 }
 
-func (b SQLBuilder) WithAppID(appID string) SQLBuilderApp {
-	return NewSQLBuilderApp(b.Schema, appID)
-}
-
 func NewSQLBuilder(schema string) SQLBuilder {
 	return SQLBuilder{
 		StatementBuilderType: newStatementBuilderType(),

--- a/pkg/lib/infra/db/sql_builder.go
+++ b/pkg/lib/infra/db/sql_builder.go
@@ -7,103 +7,84 @@ import (
 	"github.com/lib/pq"
 )
 
-type SQLBuilder struct {
-	sq.StatementBuilderType
-
-	schema string
-	appID  string
+type sqlBuilderSchema struct {
+	Schema string
 }
 
-func newSQLBuilder() sq.StatementBuilderType {
+func (b sqlBuilderSchema) TableName(table string) string {
+	return pq.QuoteIdentifier(b.Schema) + "." + pq.QuoteIdentifier(table)
+}
+
+func newStatementBuilderType() sq.StatementBuilderType {
 	return sq.StatementBuilder.PlaceholderFormat(sq.Dollar)
 }
 
-func NewSQLBuilder(schema string, appID string) SQLBuilder {
+type SQLBuilder struct {
+	sq.StatementBuilderType
+	sqlBuilderSchema
+}
+
+func (b SQLBuilder) WithAppID(appID string) SQLBuilderApp {
+	return NewSQLBuilderApp(b.Schema, appID)
+}
+
+func NewSQLBuilder(schema string) SQLBuilder {
 	return SQLBuilder{
-		StatementBuilderType: newSQLBuilder(),
-		schema:               schema,
-		appID:                appID,
+		StatementBuilderType: newStatementBuilderType(),
+		sqlBuilderSchema: sqlBuilderSchema{
+			Schema: schema,
+		},
 	}
 }
 
-func (b SQLBuilder) TableName(table string) string {
-	return pq.QuoteIdentifier(b.schema) + "." + pq.QuoteIdentifier(table)
-}
-
-func (b SQLBuilder) Tenant() SQLStatementBuilder {
-	if b.appID == "" {
-		panic("no appID to build tenant sql, should not call Tenant() on global sql builder")
-	}
-	return SQLStatementBuilder{
-		builder:   b.StatementBuilderType,
-		forTenant: true,
-		appID:     b.appID,
-	}
-}
-
-func (b SQLBuilder) Global() SQLStatementBuilder {
-	return SQLStatementBuilder{
-		builder:   b.StatementBuilderType,
-		forTenant: false,
-	}
-}
-
-func (b SQLBuilder) WithAppID(appID string) SQLStatementBuilder {
-	return SQLStatementBuilder{
-		builder:   b.StatementBuilderType,
-		forTenant: true,
-		appID:     appID,
-	}
-}
-
-type SQLStatementBuilder struct {
+type SQLBuilderApp struct {
+	sqlBuilderSchema
 	builder sq.StatementBuilderType
-
-	forTenant bool
-	appID     string
+	appID   string
 }
 
-func (b SQLStatementBuilder) Select(columns ...string) SelectBuilder {
+func NewSQLBuilderApp(schema string, appID string) SQLBuilderApp {
+	return SQLBuilderApp{
+		builder: newStatementBuilderType(),
+		sqlBuilderSchema: sqlBuilderSchema{
+			Schema: schema,
+		},
+		appID: appID,
+	}
+}
+
+func (b SQLBuilderApp) Select(columns ...string) SelectBuilder {
 	builder := b.builder.Select(columns...)
 	return SelectBuilder{
-		builder:   builder,
-		forTenant: b.forTenant,
-		appID:     b.appID,
+		builder: builder,
+		appID:   b.appID,
 	}
 }
 
-func (b SQLStatementBuilder) Insert(into string) InsertBuilder {
+func (b SQLBuilderApp) Insert(into string) InsertBuilder {
 	builder := b.builder.Insert(into)
-	if b.forTenant {
-		builder = builder.Columns("app_id")
-	}
+	builder = builder.Columns("app_id")
 	return InsertBuilder{
-		builder:   builder,
-		forTenant: b.forTenant,
-		appID:     b.appID,
+		builder: builder,
+		appID:   b.appID,
 	}
 }
 
-func (b SQLStatementBuilder) Update(table string) sq.UpdateBuilder {
+func (b SQLBuilderApp) Update(table string) sq.UpdateBuilder {
 	builder := b.builder.Update(table)
-	if b.forTenant {
-		builder = builder.Where("app_id = ?", b.appID)
-	}
+	builder = builder.Where("app_id = ?", b.appID)
 	return builder
 }
 
-func (b SQLStatementBuilder) Delete(from string) sq.DeleteBuilder {
+func (b SQLBuilderApp) Delete(from string) sq.DeleteBuilder {
 	builder := b.builder.Delete(from)
-	if b.forTenant {
-		builder = builder.Where("app_id = ?", b.appID)
-	}
+	builder = builder.Where("app_id = ?", b.appID)
 	return builder
 }
 
 type InsertBuilder struct {
-	builder   sq.InsertBuilder
-	forTenant bool
-	appID     string
+	builder sq.InsertBuilder
+	appID   string
 }
 
 // nolint: golint
@@ -117,9 +98,7 @@ func (b InsertBuilder) Columns(columns ...string) InsertBuilder {
 }
 
 func (b InsertBuilder) Values(values ...interface{}) InsertBuilder {
-	if b.forTenant {
-		values = append([]interface{}{b.appID}, values...)
-	}
+	values = append([]interface{}{b.appID}, values...)
 	b.builder = b.builder.Values(values...)
 	return b
 }
@@ -130,9 +109,8 @@ func (b InsertBuilder) Suffix(sql string, args ...interface{}) InsertBuilder {
 }
 
 type SelectBuilder struct {
-	builder   sq.SelectBuilder
-	forTenant bool
-	appID     string
+	builder sq.SelectBuilder
+	appID   string
 }
 
 // nolint: golint
@@ -144,14 +122,10 @@ func (b SelectBuilder) From(from string, alias ...string) SelectBuilder {
 	if len(alias) > 0 {
 		from = fmt.Sprintf("%s AS %s", from, alias[0])
 		b.builder = b.builder.From(from)
-		if b.forTenant {
-			b.builder = b.builder.Where(alias[0]+".app_id = ?", b.appID)
-		}
+		b.builder = b.builder.Where(alias[0]+".app_id = ?", b.appID)
 	} else {
 		b.builder = b.builder.From(from)
-		if b.forTenant {
-			b.builder = b.builder.Where("app_id = ?", b.appID)
-		}
+		b.builder = b.builder.Where("app_id = ?", b.appID)
 	}
 	return b
 }
@@ -159,9 +133,7 @@ func (b SelectBuilder) From(from string, alias ...string) SelectBuilder {
 func (b SelectBuilder) Join(from string, alias string, pred string, args ...interface{}) SelectBuilder {
 	join := fmt.Sprintf("%s AS %s ON %s", from, alias, pred)
 	b.builder = b.builder.Join(join, args...)
-	if b.forTenant {
-		b.builder = b.builder.Where(alias+".app_id = ?", b.appID)
-	}
+	b.builder = b.builder.Where(alias+".app_id = ?", b.appID)
 	return b
 }
 

--- a/pkg/lib/oauth/pq/store_authz.go
+++ b/pkg/lib/oauth/pq/store_authz.go
@@ -13,12 +13,12 @@ import (
 )
 
 type AuthorizationStore struct {
-	SQLBuilder  *appdb.SQLBuilder
+	SQLBuilder  *appdb.SQLBuilderApp
 	SQLExecutor *appdb.SQLExecutor
 }
 
 func (s *AuthorizationStore) selectQuery() db.SelectBuilder {
-	return s.SQLBuilder.Tenant().Select(
+	return s.SQLBuilder.Select(
 		"id",
 		"labels",
 		"app_id",
@@ -101,7 +101,7 @@ func (s *AuthorizationStore) Create(authz *oauth.Authorization) error {
 		return err
 	}
 
-	builder := s.SQLBuilder.Tenant().
+	builder := s.SQLBuilder.
 		Insert(s.SQLBuilder.TableName("_auth_oauth_authorization")).
 		Columns(
 			"id",
@@ -131,7 +131,7 @@ func (s *AuthorizationStore) Create(authz *oauth.Authorization) error {
 }
 
 func (s *AuthorizationStore) Delete(authz *oauth.Authorization) error {
-	builder := s.SQLBuilder.Tenant().
+	builder := s.SQLBuilder.
 		Delete(s.SQLBuilder.TableName("_auth_oauth_authorization")).
 		Where("id = ?", authz.ID)
 
@@ -144,7 +144,7 @@ func (s *AuthorizationStore) Delete(authz *oauth.Authorization) error {
 }
 
 func (s *AuthorizationStore) ResetAll(userID string) error {
-	builder := s.SQLBuilder.Tenant().
+	builder := s.SQLBuilder.
 		Delete(s.SQLBuilder.TableName("_auth_oauth_authorization")).
 		Where("user_id = ?", userID)
 
@@ -162,7 +162,7 @@ func (s *AuthorizationStore) UpdateScopes(authz *oauth.Authorization) error {
 		return err
 	}
 
-	builder := s.SQLBuilder.Tenant().
+	builder := s.SQLBuilder.
 		Update(s.SQLBuilder.TableName("_auth_oauth_authorization")).
 		Set("updated_at", authz.UpdatedAt).
 		Set("scopes", scopeBytes).

--- a/pkg/lib/oauth/redis/store.go
+++ b/pkg/lib/oauth/redis/store.go
@@ -30,7 +30,7 @@ type Store struct {
 	Redis       *appredis.Handle
 	AppID       config.AppID
 	Logger      Logger
-	SQLBuilder  *appdb.SQLBuilder
+	SQLBuilder  *appdb.SQLBuilderApp
 	SQLExecutor *appdb.SQLExecutor
 	Clock       clock.Clock
 }

--- a/pkg/portal/lib/plan/store.go
+++ b/pkg/portal/lib/plan/store.go
@@ -6,6 +6,8 @@ import (
 	"errors"
 	"fmt"
 
+	sq "github.com/Masterminds/squirrel"
+
 	"github.com/authgear/authgear-server/pkg/lib/infra/db"
 	"github.com/authgear/authgear-server/pkg/lib/infra/db/globaldb"
 	"github.com/authgear/authgear-server/pkg/portal/model"
@@ -32,7 +34,7 @@ func (s *Store) Create(plan *model.Plan) error {
 	if err != nil {
 		return err
 	}
-	q := s.SQLBuilder.Global().
+	q := s.SQLBuilder.
 		Insert(s.SQLBuilder.TableName("_portal_plan")).
 		Columns(
 			"id",
@@ -60,7 +62,7 @@ func (s *Store) Update(plan *model.Plan) error {
 	if err != nil {
 		return err
 	}
-	q := s.SQLBuilder.Global().
+	q := s.SQLBuilder.
 		Update(s.SQLBuilder.TableName("_portal_plan")).
 		Set("feature_config", configData).
 		Set("updated_at", s.Clock.NowUTC()).
@@ -85,8 +87,8 @@ func (s *Store) Update(plan *model.Plan) error {
 	return nil
 }
 
-func (s *Store) selectQuery() db.SelectBuilder {
-	return s.SQLBuilder.Global().
+func (s *Store) selectQuery() sq.SelectBuilder {
+	return s.SQLBuilder.
 		Select(
 			"id",
 			"name",

--- a/pkg/resolver/wire_gen.go
+++ b/pkg/resolver/wire_gen.go
@@ -158,11 +158,11 @@ func newSessionMiddleware(p *deps.RequestProvider) httproute.Middleware {
 	oAuthConfig := appConfig.OAuth
 	secretConfig := config.SecretConfig
 	databaseCredentials := deps.ProvideDatabaseCredentials(secretConfig)
-	sqlBuilder := appdb.NewSQLBuilder(databaseCredentials, appID)
+	sqlBuilderApp := appdb.NewSQLBuilderApp(databaseCredentials, appID)
 	appdbHandle := appProvider.AppDatabase
 	sqlExecutor := appdb.NewSQLExecutor(contextContext, appdbHandle)
 	authorizationStore := &pq.AuthorizationStore{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	logger := redis.NewLogger(factory)
@@ -171,7 +171,7 @@ func newSessionMiddleware(p *deps.RequestProvider) httproute.Middleware {
 		Redis:       handle,
 		AppID:       appID,
 		Logger:      logger,
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 		Clock:       clock,
 	}
@@ -180,7 +180,7 @@ func newSessionMiddleware(p *deps.RequestProvider) httproute.Middleware {
 		HTTP: httpConfig,
 	}
 	userStore := &user.Store{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	authenticationConfig := appConfig.Authentication
@@ -188,11 +188,11 @@ func newSessionMiddleware(p *deps.RequestProvider) httproute.Middleware {
 	featureConfig := config.FeatureConfig
 	identityFeatureConfig := featureConfig.Identity
 	serviceStore := &service.Store{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	loginidStore := &loginid.Store{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	loginIDConfig := identityConfig.LoginID
@@ -216,7 +216,7 @@ func newSessionMiddleware(p *deps.RequestProvider) httproute.Middleware {
 		Clock:             clock,
 	}
 	oauthStore := &oauth.Store{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	oauthProvider := &oauth.Provider{
@@ -224,7 +224,7 @@ func newSessionMiddleware(p *deps.RequestProvider) httproute.Middleware {
 		Clock: clock,
 	}
 	anonymousStore := &anonymous.Store{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	anonymousProvider := &anonymous.Provider{
@@ -232,7 +232,7 @@ func newSessionMiddleware(p *deps.RequestProvider) httproute.Middleware {
 		Clock: clock,
 	}
 	biometricStore := &biometric.Store{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	biometricProvider := &biometric.Provider{
@@ -250,11 +250,11 @@ func newSessionMiddleware(p *deps.RequestProvider) httproute.Middleware {
 		Biometric:             biometricProvider,
 	}
 	store2 := &service2.Store{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	passwordStore := &password.Store{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	authenticatorConfig := appConfig.Authenticator
@@ -262,7 +262,7 @@ func newSessionMiddleware(p *deps.RequestProvider) httproute.Middleware {
 	passwordLogger := password.NewLogger(factory)
 	historyStore := &password.HistoryStore{
 		Clock:       clock,
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	passwordChecker := password.ProvideChecker(authenticatorPasswordConfig, historyStore)
@@ -282,7 +282,7 @@ func newSessionMiddleware(p *deps.RequestProvider) httproute.Middleware {
 		Housekeeper:     housekeeper,
 	}
 	totpStore := &totp.Store{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	authenticatorTOTPConfig := authenticatorConfig.TOTP
@@ -293,7 +293,7 @@ func newSessionMiddleware(p *deps.RequestProvider) httproute.Middleware {
 	}
 	authenticatorOOBConfig := authenticatorConfig.OOB
 	oobStore := &oob.Store{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	oobStoreRedis := &oob.StoreRedis{
@@ -334,7 +334,7 @@ func newSessionMiddleware(p *deps.RequestProvider) httproute.Middleware {
 		Clock: clock,
 	}
 	storePQ := &verification.StorePQ{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	verificationService := &verification.Service{
@@ -353,7 +353,7 @@ func newSessionMiddleware(p *deps.RequestProvider) httproute.Middleware {
 		Clock: clock,
 	}
 	storeRecoveryCodePQ := &mfa.StoreRecoveryCodePQ{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	mfaService := &mfa.Service{
@@ -391,7 +391,7 @@ func newSessionMiddleware(p *deps.RequestProvider) httproute.Middleware {
 	queue := appProvider.TaskQueue
 	eventLogger := event.NewLogger(factory)
 	storeImpl := &event.StoreImpl{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	hookLogger := hook.NewLogger(factory)
@@ -413,10 +413,10 @@ func newSessionMiddleware(p *deps.RequestProvider) httproute.Middleware {
 	auditLogger := audit.NewLogger(factory)
 	writeHandle := appProvider.AuditWriteDatabase
 	auditDatabaseCredentials := deps.ProvideAuditDatabaseCredentials(secretConfig)
-	auditdbSQLBuilder := auditdb.NewSQLBuilder(auditDatabaseCredentials, appID)
+	auditdbSQLBuilderApp := auditdb.NewSQLBuilderApp(auditDatabaseCredentials, appID)
 	writeSQLExecutor := auditdb.NewWriteSQLExecutor(contextContext, writeHandle)
 	writeStore := &audit.WriteStore{
-		SQLBuilder:  auditdbSQLBuilder,
+		SQLBuilder:  auditdbSQLBuilderApp,
 		SQLExecutor: writeSQLExecutor,
 	}
 	auditSink := &audit.Sink{
@@ -541,16 +541,16 @@ func newSessionResolveHandler(p *deps.RequestProvider) http.Handler {
 	secretConfig := config.SecretConfig
 	databaseCredentials := deps.ProvideDatabaseCredentials(secretConfig)
 	appID := appConfig.ID
-	sqlBuilder := appdb.NewSQLBuilder(databaseCredentials, appID)
+	sqlBuilderApp := appdb.NewSQLBuilderApp(databaseCredentials, appID)
 	request := p.Request
 	contextContext := deps.ProvideRequestContext(request)
 	sqlExecutor := appdb.NewSQLExecutor(contextContext, handle)
 	store := &service.Store{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	loginidStore := &loginid.Store{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	loginIDConfig := identityConfig.LoginID
@@ -575,7 +575,7 @@ func newSessionResolveHandler(p *deps.RequestProvider) http.Handler {
 		Clock:             clockClock,
 	}
 	oauthStore := &oauth.Store{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	oauthProvider := &oauth.Provider{
@@ -583,7 +583,7 @@ func newSessionResolveHandler(p *deps.RequestProvider) http.Handler {
 		Clock: clockClock,
 	}
 	anonymousStore := &anonymous.Store{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	anonymousProvider := &anonymous.Provider{
@@ -591,7 +591,7 @@ func newSessionResolveHandler(p *deps.RequestProvider) http.Handler {
 		Clock: clockClock,
 	}
 	biometricStore := &biometric.Store{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	biometricProvider := &biometric.Provider{
@@ -621,7 +621,7 @@ func newSessionResolveHandler(p *deps.RequestProvider) http.Handler {
 		Clock: clockClock,
 	}
 	storePQ := &verification.StorePQ{
-		SQLBuilder:  sqlBuilder,
+		SQLBuilder:  sqlBuilderApp,
 		SQLExecutor: sqlExecutor,
 	}
 	ratelimitLogger := ratelimit.NewLogger(factory)

--- a/pkg/resolver/wire_gen.go
+++ b/pkg/resolver/wire_gen.go
@@ -390,8 +390,9 @@ func newSessionMiddleware(p *deps.RequestProvider) httproute.Middleware {
 	welcomeMessageConfig := appConfig.WelcomeMessage
 	queue := appProvider.TaskQueue
 	eventLogger := event.NewLogger(factory)
+	sqlBuilder := appdb.NewSQLBuilder(databaseCredentials)
 	storeImpl := &event.StoreImpl{
-		SQLBuilder:  sqlBuilderApp,
+		SQLBuilder:  sqlBuilder,
 		SQLExecutor: sqlExecutor,
 	}
 	hookLogger := hook.NewLogger(factory)


### PR DESCRIPTION
Refactor SQLBuilder to SQLBuilder and SQLBuilderApp

So the stores have flexibility to use SQLBuilder and provide app id in runtime
