### PR TITLE
[Migration needed] Remove deprecate `if_requested` secondary authentication mode

### DIFF
--- a/pkg/lib/config/authentication.go
+++ b/pkg/lib/config/authentication.go
@@ -90,22 +90,21 @@ func (c *AuthenticationConfig) SetDefaults() {
 var _ = Schema.Add("SecondaryAuthenticationMode", `
 {
 	"type": "string",
-	"enum": ["disabled", "if_requested", "if_exists", "required"]
+	"enum": ["disabled", "if_exists", "required"]
 }
 `)
 
 type SecondaryAuthenticationMode string
 
 const (
-	SecondaryAuthenticationModeDefault     SecondaryAuthenticationMode = ""
-	SecondaryAuthenticationModeDisabled    SecondaryAuthenticationMode = "disabled"
-	SecondaryAuthenticationModeIfRequested SecondaryAuthenticationMode = "if_requested"
-	SecondaryAuthenticationModeIfExists    SecondaryAuthenticationMode = "if_exists"
-	SecondaryAuthenticationModeRequired    SecondaryAuthenticationMode = "required"
+	SecondaryAuthenticationModeDefault  SecondaryAuthenticationMode = ""
+	SecondaryAuthenticationModeDisabled SecondaryAuthenticationMode = "disabled"
+	SecondaryAuthenticationModeIfExists SecondaryAuthenticationMode = "if_exists"
+	SecondaryAuthenticationModeRequired SecondaryAuthenticationMode = "required"
 )
 
 func (m SecondaryAuthenticationMode) IsDisabled() bool {
-	return m == SecondaryAuthenticationModeDisabled || m == SecondaryAuthenticationModeIfRequested
+	return m == SecondaryAuthenticationModeDisabled
 }
 
 var _ = Schema.Add("DeviceTokenConfig", `

--- a/pkg/lib/config/config.go
+++ b/pkg/lib/config/config.go
@@ -158,6 +158,15 @@ func (c *AppConfig) Validate(ctx *validation.Context) {
 		}
 	}
 
+	if !c.Authentication.SecondaryAuthenticationMode.IsDisabled() {
+		if len(*c.Authentication.SecondaryAuthenticators) <= 0 {
+			ctx.Child("authentication", "secondary_authentication_mode").
+				EmitError(
+					"noSecondaryAuthenticator",
+					map[string]interface{}{"secondary_authentication_mode": c.Authentication.SecondaryAuthenticationMode})
+		}
+	}
+
 	phoneInputPinnedOK := true
 	phoneInputAllowListMap := make(map[string]bool)
 	for _, alpha2 := range c.UI.PhoneInput.AllowList {

--- a/pkg/lib/config/testdata/config_tests.yaml
+++ b/pkg/lib/config/testdata/config_tests.yaml
@@ -318,7 +318,6 @@ config:
   authentication:
     identities: [login_id]
     primary_authenticators: [oob_otp_email]
-    secondary_authenticators: []
   identity:
     login_id:
       keys:
@@ -338,7 +337,6 @@ config:
   authentication:
     identities: [login_id]
     primary_authenticators: []
-    secondary_authenticators: []
   identity:
     login_id:
       keys:
@@ -358,7 +356,6 @@ config:
   authentication:
     identities: [login_id]
     primary_authenticators: [oob_otp_email]
-    secondary_authenticators: []
   identity:
     login_id:
       keys:
@@ -375,12 +372,49 @@ config:
   authentication:
     identities: [login_id]
     primary_authenticators: [oob_otp_sms]
-    secondary_authenticators: []
   identity:
     login_id:
       keys:
         - key: phone
           type: phone
+
+---
+name: no-secondary-authenticator-for-default-secondary-authentication-mode
+error: |-
+  invalid configuration:
+  /authentication/secondary_authentication_mode: noSecondaryAuthenticator
+    map[secondary_authentication_mode:if_exists]
+config:
+  id: test
+  http:
+    public_origin: http://test
+  authentication:
+    secondary_authenticators: []
+
+---
+name: no-secondary-authenticator-for-secondary-authentication-mode-required
+error: |-
+  invalid configuration:
+  /authentication/secondary_authentication_mode: noSecondaryAuthenticator
+    map[secondary_authentication_mode:required]
+config:
+  id: test
+  http:
+    public_origin: http://test
+  authentication:
+    secondary_authenticators: []
+    secondary_authentication_mode: required
+
+---
+name: allow-no-secondary-authenticator-for-secondary-authentication-mode-disabled
+error: null
+config:
+  id: test
+  http:
+    public_origin: http://test
+  authentication:
+    secondary_authenticators: []
+    secondary_authentication_mode: disabled
 
 ---
 name: login-id-email-blocklist-allowlist-mutually-exclusive

--- a/pkg/lib/interaction/nodes/authn_begin.go
+++ b/pkg/lib/interaction/nodes/authn_begin.go
@@ -94,8 +94,7 @@ func (n *NodeAuthenticationBegin) GetAuthenticationEdges() ([]interaction.Edge, 
 			for t := range existingAuths {
 				required = append(required, t)
 			}
-		case config.SecondaryAuthenticationModeDisabled,
-			config.SecondaryAuthenticationModeIfRequested:
+		case config.SecondaryAuthenticationModeDisabled:
 			// When MFA is disabled, treat it as if the user has no authenticators.
 			availableAuthenticators = nil
 			required = nil

--- a/portal/src/error/parse.ts
+++ b/portal/src/error/parse.ts
@@ -69,6 +69,7 @@ const errorCauseMessageIDs = {
   maxLength: "errors.validation.maxLength",
   blocked: "errors.validation.blocked",
   noPrimaryAuthenticator: "errors.validation.noPrimaryAuthenticator",
+  noSecondaryAuthenticator: "errors.validation.noSecondaryAuthenticator",
 };
 
 function parseCause(cause: ValidationFailedErrorInfoCause): ParsedAPIError {

--- a/portal/src/error/validation.ts
+++ b/portal/src/error/validation.ts
@@ -21,7 +21,8 @@ export type ValidationFailedErrorInfoCause =
   | MinLengthErrorCause
   | MaxLengthErrorCause
   | BlockedErrorCause
-  | NoPrimaryAuthenticatorErrorCause;
+  | NoPrimaryAuthenticatorErrorCause
+  | NoSecondaryAuthenticatorErrorCause;
 
 export interface LocalErrorCause {
   location: string;
@@ -115,6 +116,14 @@ export interface NoPrimaryAuthenticatorErrorCause {
   kind: "noPrimaryAuthenticator";
   details: {
     login_id_type: string;
+  };
+}
+
+export interface NoSecondaryAuthenticatorErrorCause {
+  location: string;
+  kind: "noSecondaryAuthenticator";
+  details: {
+    secondary_authentication_mode: string;
   };
 }
 

--- a/portal/src/graphql/portal/AuthenticatorConfigurationScreen.tsx
+++ b/portal/src/graphql/portal/AuthenticatorConfigurationScreen.tsx
@@ -165,9 +165,6 @@ function constructConfig(
 const ALL_REQUIRE_MFA_OPTIONS: SecondaryAuthenticationMode[] = [
   ...secondaryAuthenticationModes,
 ];
-const HIDDEN_REQUIRE_MFA_OPTIONS: SecondaryAuthenticationMode[] = [
-  "if_requested",
-];
 
 const primaryAuthenticatorNameIds = {
   oob_otp_email: "AuthenticatorType.primary.oob-otp-email",
@@ -302,8 +299,6 @@ const AuthenticationAuthenticatorSettingsContent: React.FC<AuthenticationAuthent
             "AuthenticatorConfigurationScreen.secondary-authenticators.mode.required",
           if_exists:
             "AuthenticatorConfigurationScreen.secondary-authenticators.mode.if-exists",
-          if_requested:
-            "AuthenticatorConfigurationScreen.secondary-authenticators.mode.if-requested",
         };
 
         return renderToString(messageIdMap[key]);
@@ -321,9 +316,7 @@ const AuthenticationAuthenticatorSettingsContent: React.FC<AuthenticationAuthent
           }));
         },
         state.mfaMode,
-        renderSecondaryAuthenticatorMode,
-        // NOTE: not supported yet
-        new Set(HIDDEN_REQUIRE_MFA_OPTIONS)
+        renderSecondaryAuthenticatorMode
       );
 
     const onRecoveryCodeNumberChange = useCallback(

--- a/portal/src/graphql/portal/OnboardingConfigAppScreen.tsx
+++ b/portal/src/graphql/portal/OnboardingConfigAppScreen.tsx
@@ -560,13 +560,6 @@ const SecondaryAuthenticationModeContent: React.FC<SecondaryAuthenticationModeCo
             "Onboarding.secondary-authentication-mode.required"
           ),
         },
-        {
-          key: "if_requested",
-          text: renderToString(
-            "Onboarding.secondary-authentication-mode.if-requested"
-          ),
-          hidden: true,
-        },
       ],
       [renderToString]
     );

--- a/portal/src/locale-data/en.json
+++ b/portal/src/locale-data/en.json
@@ -73,6 +73,7 @@
   "errors.validation.minLength": "Expect string with length greater than or equal to {expected, plural, one{1 character} other{# characters}}",
   "errors.validation.maxLength": "Expect string with length less than or equal to {expected, plural, one{1 character} other{# characters}}",
   "errors.validation.noPrimaryAuthenticator": "Can't save the config. At least one authenticator for type {login_id_type, select, email {email} username {username} phone {phone} other {}} is needed.",
+  "errors.validation.noSecondaryAuthenticator": "Can't save the config. At least one secondary authenticator is needed.",
   "errors.validation.blocked": "{reason, select, EmailDomainBlocklist{Email} EmailDomainAllowlist{Email} UsernameReserved{Username} UsernameExcludedKeywords{Username} other {}} is not allowed",
   "errors.password-mismatch": "New password does not match with confirm password, please double check",
   "errors.password-policy.password-reused": "Password cannot be reused, please check password policies below",

--- a/portal/src/locale-data/en.json
+++ b/portal/src/locale-data/en.json
@@ -153,7 +153,6 @@
   "Onboarding.secondary-authentication-mode.disabled": "Disabled",
   "Onboarding.secondary-authentication-mode.required": "Always required",
   "Onboarding.secondary-authentication-mode.if-exists": "Required if user has Mutli-factor Authenticator",
-  "Onboarding.secondary-authentication-mode.if-requested": "Disabled (Deprecated)",
 
   "Onboarding.verification.email-enabled.title" :"Should we verify email?",
   "Onboarding.verification.phone-enabled.title" :"Should we verify phone?",
@@ -356,7 +355,6 @@
   "AuthenticatorConfigurationScreen.secondary-authenticators.mode.disabled": "Disabled",
   "AuthenticatorConfigurationScreen.secondary-authenticators.mode.required": "Always Required",
   "AuthenticatorConfigurationScreen.secondary-authenticators.mode.if-exists": "Required if user has Secondary Authenticator",
-  "AuthenticatorConfigurationScreen.secondary-authenticators.mode.if-requested": "Disabled (Deprecated)",
   "AuthenticatorConfigurationScreen.secondary-authenticators.disable-device-token.label": "Disable \"Do not ask again on this device\" for the Secondary Authenticator",
 
   "AuthenticatorConfigurationScreen.recovery-code.title": "Recovery code",

--- a/portal/src/types.ts
+++ b/portal/src/types.ts
@@ -218,7 +218,6 @@ export type IdentityType = typeof identityTypes[number];
 
 export const secondaryAuthenticationModes = [
   "disabled",
-  "if_requested",
   "if_exists",
   "required",
 ] as const;


### PR DESCRIPTION
ref #1705 

Should merge and deploy after #1751
When deploying this change, should re-run migration script in #1751 to ensure all configs don't have deprecated options