### PR TITLE
Fix admin adding identity to anonymous user

### DIFF
--- a/pkg/lib/interaction/intents/add_identity.go
+++ b/pkg/lib/interaction/intents/add_identity.go
@@ -63,6 +63,8 @@ func (i *IntentAddIdentity) DeriveEdgesForNode(graph *interaction.Graph, node in
 		}, nil
 
 	case *nodes.NodeDoUseIdentity:
+		return []interaction.Edge{&nodes.EdgeEnsureRemoveAnonymousIdentity{}}, nil
+	case *nodes.NodeEnsureRemoveAnonymousIdentity:
 		return []interaction.Edge{
 			&nodes.EdgeCreateAuthenticatorBegin{
 				Stage: authn.AuthenticationStagePrimary,

--- a/pkg/lib/interaction/nodes/ensure_remove_anonymous_identity.go
+++ b/pkg/lib/interaction/nodes/ensure_remove_anonymous_identity.go
@@ -1,0 +1,73 @@
+package nodes
+
+import (
+	"github.com/authgear/authgear-server/pkg/api/model"
+	"github.com/authgear/authgear-server/pkg/lib/authn/identity"
+	"github.com/authgear/authgear-server/pkg/lib/interaction"
+)
+
+func init() {
+	interaction.RegisterNode(&NodeEnsureRemoveAnonymousIdentity{})
+}
+
+type EdgeEnsureRemoveAnonymousIdentity struct{}
+
+func (e *EdgeEnsureRemoveAnonymousIdentity) Instantiate(ctx *interaction.Context, graph *interaction.Graph, rawInput interface{}) (interaction.Node, error) {
+	return &NodeEnsureRemoveAnonymousIdentity{}, nil
+}
+
+type NodeEnsureRemoveAnonymousIdentity struct {
+	AnonymousIdentity *identity.Info `json:"anonymous_identity,omitempty"`
+}
+
+func (n *NodeEnsureRemoveAnonymousIdentity) Prepare(ctx *interaction.Context, graph *interaction.Graph) error {
+	userID := graph.MustGetUserID()
+	iis, err := ctx.Identities.ListByUser(graph.MustGetUserID())
+	if err != nil {
+		return err
+	}
+	anonymousIdentities := identity.ApplyFilters(
+		iis,
+		identity.KeepType(model.IdentityTypeAnonymous),
+	)
+	if len(anonymousIdentities) > 1 {
+		panic("interaction: more than 1 anonymous identities: " + userID)
+	}
+	if len(anonymousIdentities) == 1 {
+		n.AnonymousIdentity = anonymousIdentities[0]
+	}
+	return nil
+}
+
+func (n *NodeEnsureRemoveAnonymousIdentity) GetEffects() ([]interaction.Effect, error) {
+	return []interaction.Effect{
+		interaction.EffectRun(func(ctx *interaction.Context, graph *interaction.Graph, nodeIndex int) error {
+			if n.AnonymousIdentity == nil {
+				return nil
+			}
+			userID := graph.MustGetUserID()
+			identities, err := ctx.Identities.ListByUser(userID)
+			if err != nil {
+				return err
+			}
+			remaining := identity.ApplyFilters(
+				identities,
+				identity.KeepIdentifiable,
+				identity.OmitID(n.AnonymousIdentity.ID),
+			)
+			if len(remaining) < 1 {
+				// This node should be run after adding a identifiable identity
+				panic("interaction: missing identifiable identities")
+			}
+			err = ctx.Identities.Delete(n.AnonymousIdentity)
+			if err != nil {
+				return err
+			}
+			return nil
+		}),
+	}, nil
+}
+
+func (n *NodeEnsureRemoveAnonymousIdentity) DeriveEdges(graph *interaction.Graph) ([]interaction.Edge, error) {
+	return graph.Intent.DeriveEdgesForNode(graph, n)
+}

--- a/pkg/lib/interaction/nodes/ensure_remove_anonymous_identity.go
+++ b/pkg/lib/interaction/nodes/ensure_remove_anonymous_identity.go
@@ -1,6 +1,7 @@
 package nodes
 
 import (
+	"github.com/authgear/authgear-server/pkg/api/event/nonblocking"
 	"github.com/authgear/authgear-server/pkg/api/model"
 	"github.com/authgear/authgear-server/pkg/lib/authn/identity"
 	"github.com/authgear/authgear-server/pkg/lib/interaction"
@@ -12,12 +13,15 @@ func init() {
 
 type EdgeEnsureRemoveAnonymousIdentity struct{}
 
-func (e *EdgeEnsureRemoveAnonymousIdentity) Instantiate(ctx *interaction.Context, graph *interaction.Graph, rawInput interface{}) (interaction.Node, error) {
-	return &NodeEnsureRemoveAnonymousIdentity{}, nil
+func (e *EdgeEnsureRemoveAnonymousIdentity) Instantiate(ctx *interaction.Context, graph *interaction.Graph, input interface{}) (interaction.Node, error) {
+	return &NodeEnsureRemoveAnonymousIdentity{
+		IsAdminAPI: interaction.IsAdminAPI(input),
+	}, nil
 }
 
 type NodeEnsureRemoveAnonymousIdentity struct {
 	AnonymousIdentity *identity.Info `json:"anonymous_identity,omitempty"`
+	IsAdminAPI        bool           `json:"is_admin_api"`
 }
 
 func (n *NodeEnsureRemoveAnonymousIdentity) Prepare(ctx *interaction.Context, graph *interaction.Graph) error {
@@ -34,6 +38,12 @@ func (n *NodeEnsureRemoveAnonymousIdentity) Prepare(ctx *interaction.Context, gr
 		panic("interaction: more than 1 anonymous identities: " + userID)
 	}
 	if len(anonymousIdentities) == 1 {
+		if !n.IsAdminAPI {
+			// This node is used when adding new identity
+			// when admin add a new identifiable identity to the anonymous user
+			// anonymous will be removed
+			panic("interaction: unexpected anonymous user adding identity")
+		}
 		n.AnonymousIdentity = anonymousIdentities[0]
 	}
 	return nil
@@ -63,6 +73,35 @@ func (n *NodeEnsureRemoveAnonymousIdentity) GetEffects() ([]interaction.Effect, 
 			if err != nil {
 				return err
 			}
+			return nil
+		}),
+		interaction.EffectOnCommit(func(ctx *interaction.Context, graph *interaction.Graph, nodeIndex int) error {
+			if n.AnonymousIdentity == nil {
+				return nil
+			}
+			// if anonymous identity is removed during adding identity
+			// it is a promotion flow
+			userID := graph.MustGetUserID()
+			anonUserRef := model.UserRef{
+				Meta: model.Meta{
+					ID: userID,
+				},
+			}
+			var identityModels []model.Identity
+			for _, info := range graph.GetUserNewIdentities() {
+				identityModels = append(identityModels, info.ToModel())
+			}
+
+			err := ctx.Events.DispatchEvent(&nonblocking.UserAnonymousPromotedEventPayload{
+				AnonymousUserRef: anonUserRef,
+				UserRef:          anonUserRef,
+				Identities:       identityModels,
+				AdminAPI:         n.IsAdminAPI,
+			})
+			if err != nil {
+				return err
+			}
+
 			return nil
 		}),
 	}, nil

--- a/portal/src/locale-data/en.json
+++ b/portal/src/locale-data/en.json
@@ -253,6 +253,8 @@
   "UserDetails.connected-identities.username": "Username",
   "UserDetails.connected-identities.biometric": "Biometric",
   "UserDetails.connected-identities.biometric.unknown-device": "Unknown Device",
+  "UserDetails.connected-identities.anonymous": "Anonymous",
+  "UserDetails.connected-identities.anonymous.anonymous-user": "Anonymous User",
 
   "UserDetails.connected-identities.connected-on": "Connected on {datetime}",
   "UserDetails.connected-identities.added-on": "Added on {datetime}",


### PR DESCRIPTION
fix #1762 

- Remove anonymous identity when admin add identity to anonymous user 
- Trigger promote non-blocking event
- Fix not able to add email / phone through portal in the follow scenarios
    - when OOB OTP is disabled 
    - when OOB OTP is enabled but priority is lower than password