### PR TITLE
Fix parseJSONPointer with escape character

### DIFF
--- a/portal/src/util/jsonpointer.test.ts
+++ b/portal/src/util/jsonpointer.test.ts
@@ -15,6 +15,9 @@ describe("parseJSONPointer", () => {
     expect(f("/")).toEqual([""]);
     expect(f("//")).toEqual(["", ""]);
     expect(f("/a")).toEqual(["a"]);
+    expect(f("/a~0")).toEqual(["a~"]);
+    expect(f("/a~1")).toEqual(["a/"]);
+    expect(f("/a~1b")).toEqual(["a/b"]);
   });
 });
 
@@ -25,6 +28,9 @@ describe("jsonPointerToString", () => {
     expect(f([""])).toEqual("/");
     expect(f(["", ""])).toEqual("//");
     expect(f(["a"])).toEqual("/a");
+    expect(f(["a~"])).toEqual("/a~0");
+    expect(f(["a/"])).toEqual("/a~1");
+    expect(f(["a/b"])).toEqual("/a~1b");
   });
 });
 

--- a/portal/src/util/jsonpointer.ts
+++ b/portal/src/util/jsonpointer.ts
@@ -36,9 +36,11 @@ export function parseJSONPointer(pointer: string): string[] {
         switch (r) {
           case "0":
             w?.writeString("~");
+            state = State.CHAR;
             break;
           case "1":
             w?.writeString("/");
+            state = State.CHAR;
             break;
           default:
             throw new Error("expecting 0 or 1 but found: " + r);


### PR DESCRIPTION
To fix the portal crash when typing characters which need to be escaped in the custom attribute name