### PR TITLE
Fix showing large number incorrectly in scientific notation for custom attribute

### DIFF
--- a/pkg/util/template/func.go
+++ b/pkg/util/template/func.go
@@ -1,7 +1,9 @@
 package template
 
 import (
+	"fmt"
 	"reflect"
+	"strconv"
 	"time"
 
 	"github.com/Masterminds/sprig"
@@ -14,6 +16,7 @@ func MakeTemplateFuncMap() map[string]interface{} {
 	templateFuncMap["rfc3339"] = RFC3339
 	templateFuncMap["ensureTime"] = EnsureTime
 	templateFuncMap["isNil"] = IsNil
+	templateFuncMap["showAttributeValue"] = ShowAttributeValue
 	return templateFuncMap
 }
 
@@ -54,6 +57,30 @@ func EnsureTime(anyValue interface{}) interface{} {
 func IsNil(v interface{}) bool {
 	return v == nil ||
 		(reflect.ValueOf(v).Kind() == reflect.Ptr && reflect.ValueOf(v).IsNil())
+}
+
+func ShowAttributeValue(v interface{}) string {
+	value := reflect.ValueOf(v)
+	if value.Kind() == reflect.Ptr {
+		if !value.IsNil() {
+			return ShowAttributeValue(reflect.ValueOf(v).Elem().Interface())
+		}
+		return ""
+	}
+
+	switch v := v.(type) {
+	case string:
+		return v
+	case float64:
+		return strconv.FormatFloat(v, 'f', -1, 64)
+	case float32:
+		return strconv.FormatFloat(float64(v), 'f', -1, 32)
+	case nil:
+		return ""
+	default:
+		return fmt.Sprintf("%v", v)
+
+	}
 }
 
 var DefaultFuncMap = MakeTemplateFuncMap()

--- a/pkg/util/template/func_test.go
+++ b/pkg/util/template/func_test.go
@@ -42,4 +42,53 @@ func TestRFC3339(t *testing.T) {
 		p = nil
 		So(IsNil(p), ShouldBeTrue)
 	})
+
+	Convey("ShowAttributeValue", t, func() {
+		newString := func(s string) *string {
+			return &s
+		}
+
+		newInt := func(i int64) *int64 {
+			return &i
+		}
+
+		newFloat := func(f float64) *float64 {
+			return &f
+		}
+
+		So(ShowAttributeValue(nil), ShouldEqual, "")
+		So(ShowAttributeValue(1), ShouldEqual, "1")
+		So(ShowAttributeValue(1.2), ShouldEqual, "1.2")
+		So(ShowAttributeValue(100000000), ShouldEqual, "100000000")
+		So(ShowAttributeValue(100000000.002), ShouldEqual, "100000000.002")
+		So(ShowAttributeValue("test"), ShouldEqual, "test")
+
+		var ip *int64
+		So(ShowAttributeValue(ip), ShouldEqual, "")
+
+		ip = newInt(100000000)
+		So(ShowAttributeValue(ip), ShouldEqual, "100000000")
+
+		var f32 float32 = 0.00002
+		So(ShowAttributeValue(f32), ShouldEqual, "0.00002")
+
+		var f64 float64 = 0.00002
+		So(ShowAttributeValue(f64), ShouldEqual, "0.00002")
+
+		var fp *float64
+		So(ShowAttributeValue(fp), ShouldEqual, "")
+
+		fp = newFloat(0)
+		So(ShowAttributeValue(fp), ShouldEqual, "0")
+
+		fp = newFloat(100000000.01)
+		So(ShowAttributeValue(fp), ShouldEqual, "100000000.01")
+
+		var sp *string
+		So(ShowAttributeValue(sp), ShouldEqual, "")
+
+		sp = newString("test")
+		So(ShowAttributeValue(sp), ShouldEqual, "test")
+
+	})
 }

--- a/resources/authgear/templates/en/web/settings_profile.html
+++ b/resources/authgear/templates/en/web/settings_profile.html
@@ -204,7 +204,7 @@
         {{ else if eq .Type "country_code" }}
           {{ .Value }} - {{ $.Translations.RenderText (printf "territory-%s" .Value) nil }}
         {{ else }}
-          {{ .Value }}
+          {{ showAttributeValue .Value }}
         {{ end }}
       {{ end }}
     </span>

--- a/resources/authgear/templates/en/web/settings_profile_edit.html
+++ b/resources/authgear/templates/en/web/settings_profile_edit.html
@@ -226,7 +226,7 @@
     {{/* The control */}}
 
     {{ if (eq $ca.Type "string") }}
-    <input type="text" class="primary-txt input text-input text-base" name="{{ $ca.Pointer }}" value="{{ $ca.Value }}">
+    <input type="text" class="primary-txt input text-input text-base" name="{{ $ca.Pointer }}" value="{{ showAttributeValue $ca.Value }}">
     {{ end }}
 
     {{ if (eq $ca.Type "number") }}
@@ -235,7 +235,7 @@
       inputmode="decimal"
       class="primary-txt input text-input text-base"
       name="{{ $ca.Pointer }}"
-      value="{{ $ca.Value }}">
+      value="{{ showAttributeValue $ca.Value }}">
     {{ end }}
 
     {{ if (eq $ca.Type "integer") }}
@@ -244,7 +244,7 @@
       inputmode="numeric"
       class="primary-txt input text-input text-base"
       name="{{ $ca.Pointer }}"
-      value="{{ $ca.Value }}">
+      value="{{ showAttributeValue $ca.Value }}">
     {{ end }}
 
     {{ if (eq $ca.Type "enum") }}
@@ -255,7 +255,7 @@
       {{ range $ca.Enum }}
       {{ $label_key := printf "custom-attribute-enum-label-%s-%s" $ca.Pointer .Value }}
       {{ $has_key := $.Translations.HasKey $label_key }}
-      <option value="{{ .Value }}" {{ if (eq $ca.Value .Value) }}selected{{ end }}>
+      <option value="{{ showAttributeValue .Value }}" {{ if (eq $ca.Value .Value) }}selected{{ end }}>
 	{{ if $has_key }}
 	  {{ $.Translations.RenderText $label_key nil }}
 	{{ else }}
@@ -274,7 +274,7 @@
       inputmode="tel"
       class="primary-txt input text-input text-base w-full"
       name="{{ $ca.Pointer }}"
-      value="{{ $ca.Value }}">
+      value="{{ showAttributeValue $ca.Value }}">
     {{ end }}
 
     {{ if (eq $ca.Type "email") }}
@@ -283,7 +283,7 @@
       inputmode="email"
       class="primary-txt input text-input text-base"
       name="{{ $ca.Pointer }}"
-      value="{{ $ca.Value }}">
+      value="{{ showAttributeValue $ca.Value }}">
     {{ end }}
 
     {{ if (eq $ca.Type "url") }}
@@ -292,7 +292,7 @@
       inputmode="url"
       class="primary-txt input text-input text-base"
       name="{{ $ca.Pointer }}"
-      value="{{ $ca.Value }}">
+      value="{{ showAttributeValue $ca.Value }}">
     {{ end }}
 
     {{ if (eq $ca.Type "country_code") }}
@@ -311,11 +311,11 @@
   {{ if (or (eq $ca.Type "number") (eq $ca.Type "integer")) }}
   {{ if (and (isNil $ca.Minimum) (isNil $ca.Maximum)) }}
   {{ else if (and (not (isNil $ca.Minimum)) (isNil $ca.Maximum)) }}
-    <span class="primary-txt text-sm">{{ template "custom-attribute-numeric-hint-minimum" (dict "minimum" $ca.Minimum) }}</span>
+    <span class="primary-txt text-sm">{{ template "custom-attribute-numeric-hint-minimum" (dict "minimum" (showAttributeValue $ca.Minimum)) }}</span>
   {{ else if (and (isNil $ca.Minimum) (not (isNil $ca.Maximum))) }}
-    <span class="primary-txt text-sm">{{ template "custom-attribute-numeric-hint-maximum" (dict "maximum" $ca.Maximum) }}</span>
+    <span class="primary-txt text-sm">{{ template "custom-attribute-numeric-hint-maximum" (dict "maximum" (showAttributeValue $ca.Maximum)) }}</span>
   {{ else }}
-    <span class="primary-txt text-sm">{{ template "custom-attribute-numeric-hint-minimum-maximum" (dict "minimum" $ca.Minimum "maximum" $ca.Maximum) }}</span>
+    <span class="primary-txt text-sm">{{ template "custom-attribute-numeric-hint-minimum-maximum" (dict "minimum" (showAttributeValue $ca.Minimum) "maximum" (showAttributeValue $ca.Maximum)) }}</span>
   {{ end }}
   {{ end }}
 


### PR DESCRIPTION
refs #1791 