### PR TITLE
Fix missing error message when inputting invalid phone number in portal

### DIFF
--- a/portal/src/graphql/adminapi/UserProfileForm.tsx
+++ b/portal/src/graphql/adminapi/UserProfileForm.tsx
@@ -304,7 +304,7 @@ function CustomAttributeControl(props: CustomAttributeControlProps) {
 
       onChangeCustomAttributes({
         ...customAttributes,
-        [pointer]: valid,
+        [pointer]: valid ? valid : input,
         ["phone_number" + pointer]: input,
       });
     },


### PR DESCRIPTION
refs #1789 

Submit the current input even it is invalid for phone number input

So that the admin api server can validate the phone value and show the
error on portal, submitting empty value will cause removing the custom
attribute value.