### PR TITLE
Show generic error message when the request is too large

### DIFF
--- a/portal/src/error/error.ts
+++ b/portal/src/error/error.ts
@@ -37,6 +37,11 @@ export interface NetworkError {
   reason: "NetworkFailed";
 }
 
+export interface RequestEntityTooLargeError {
+  errorName: "RequestEntityTooLarge";
+  reason: "RequestEntityTooLarge";
+}
+
 export interface UnknownError {
   errorName: "Unknown";
   reason: "Unknown";
@@ -47,6 +52,7 @@ export interface UnknownError {
 
 export type APIError =
   | NetworkError
+  | RequestEntityTooLargeError
   | UnknownError
   | WebHookDisallowedError
   | WebHookDeliveryTimeoutError

--- a/portal/src/locale-data/en.json
+++ b/portal/src/locale-data/en.json
@@ -80,7 +80,7 @@
   "errors.password-policy.password-reused": "Password cannot be reused, please check password policies below",
   "errors.password-policy.containing-excluded-keywords": "Password contains excluded keywords, please check password policies below",
   "errors.password-policy.unknown": "Password is invalid; please check password policies",
-  "errors.resource-too-large": "The {resourceType, select, favicon{favicon } app_logo{app logo } other{}}file size is too large. Please upload a JPG, PNG or GIF file smaller than {maxSize} KB.",
+  "errors.resource-too-large": "The {resourceType, select, favicon{favicon } app_logo{app logo } app_logo_dark{app logo } other{}}file size is too large. Please upload a JPG, PNG or GIF file smaller than {maxSize} KB.",
   "errors.webhook.disallowed": "Operation is disallowed by one of your webhook handler. Raw info: {code, react, children{{info}}}",
   "errors.webhook.timeout": "Operation is disallowed because the webhook delivery resulted in a timeout. Make sure your webhook handlers return a valid response in reasonable time.",
   "errors.webhook.invalid-response": "Operation is disallowed because one of your webhook handler returned an invalid response. See {ExternalLink, react, href{https://docs.authgear.com/webhooks/webhooks} children{the documentation}} for details.",

--- a/portal/src/locale-data/en.json
+++ b/portal/src/locale-data/en.json
@@ -85,6 +85,7 @@
   "errors.webhook.timeout": "Operation is disallowed because the webhook delivery resulted in a timeout. Make sure your webhook handlers return a valid response in reasonable time.",
   "errors.webhook.invalid-response": "Operation is disallowed because one of your webhook handler returned an invalid response. See {ExternalLink, react, href{https://docs.authgear.com/webhooks/webhooks} children{the documentation}} for details.",
   "errors.network": "There is a problem with the network",
+  "errors.request-entity-too-large": "The file size is too large. Please upload a file that is within the size limit.",
   "errors.unknown": "Unknown error: {message}",
 
   "TodoButtonWrapper.dialog-title": "Feature Not Ready",


### PR DESCRIPTION
refs #1786 

When user uploads a large app icon, the request may be blocked by the load
balancer with 413 error code. Show "file is too large" error message
for this case.
