### PR TITLE
Complete the interaction when user login with an invalid account

### DIFF
--- a/pkg/auth/handler/webapp/account_status.go
+++ b/pkg/auth/handler/webapp/account_status.go
@@ -4,6 +4,7 @@ import (
 	"net/http"
 
 	"github.com/authgear/authgear-server/pkg/auth/handler/webapp/viewmodels"
+	"github.com/authgear/authgear-server/pkg/auth/webapp"
 	"github.com/authgear/authgear-server/pkg/lib/interaction"
 	"github.com/authgear/authgear-server/pkg/lib/interaction/nodes"
 	"github.com/authgear/authgear-server/pkg/util/httproute"
@@ -54,6 +55,16 @@ func (h *AccountStatusHandler) ServeHTTP(w http.ResponseWriter, r *http.Request)
 		data, err := h.GetData(r, w, graph)
 		if err != nil {
 			return err
+		}
+
+		webSession := webapp.GetSession(r.Context())
+		if webSession != nil {
+			// complete the interaction when user login with account
+			// which has been disabled / deactivated / scheduled deletion
+			err := ctrl.DeleteSession(webSession.ID)
+			if err != nil {
+				return err
+			}
 		}
 
 		h.Renderer.RenderHTML(w, r, TemplateWebAccountStatusHTML, data)

--- a/pkg/auth/handler/webapp/controller.go
+++ b/pkg/auth/handler/webapp/controller.go
@@ -165,6 +165,11 @@ func (c *Controller) renderError(err error) {
 
 	// Show WebUIInvalidSession error in different page.
 	u := *c.request.URL
+	// If the request method is Get, avoid redirect back to the same path
+	// which causes infinite redirect loop
+	if c.request.Method == http.MethodGet {
+		u.Path = "/error"
+	}
 	if apierror.Reason == webapp.WebUIInvalidSession.Reason {
 		u.Path = "/error"
 	}

--- a/resources/authgear/templates/en/web/__error.html
+++ b/resources/authgear/templates/en/web/__error.html
@@ -61,7 +61,7 @@
                         {{ else if (call $.SliceContains .details.missing "x_e164" ) }}
                             <li>{{ template "error-phone-number-required" }}</li>
                         {{ else }}
-                            <li>{{ . }}</li>
+                            <li>{{ .Error.message }}</li>
                         {{ end }}
                     {{ else if (eq .kind "format") }}
                         {{ if (eq .details.format "phone") }}
@@ -81,7 +81,7 @@
                         {{ else if (eq .details.format "uri") }}
                             <li>{{ template "error-uri-format" }}</li>
                         {{ else }}
-                            <li>{{ . }}</li>
+                            <li>{{ .Error.message }}</li>
                         {{ end }}
                     {{ else if (eq .kind "maxLength") }}
                         <li>{{ template "error-max-length" (dict "expected" .details.expected) }}</li>
@@ -103,7 +103,7 @@
                     {{ else if (eq .kind "general") }}
                         <li>{{ .details.msg }}</li>
                     {{ else }}
-                        <li>{{ . }}</li>
+                        <li>{{ .Error.message }}</li>
                     {{ end }}
                 {{ end }}
             {{ else if eq .Error.reason "UserNotFound" }}
@@ -131,7 +131,7 @@
                 {{ else if (eq $cause.kind "NoAuthenticator") }}
                     <li>{{ template "error-developer-reauthentication" }}</li>
                 {{ else }}
-                    <li>{{ . }}</li>
+                    <li>{{ .Error.message }}</li>
                 {{ end }}
             {{ else if eq .Error.reason "InvalidVerificationCode" }}
                 <li>


### PR DESCRIPTION
refs #1814 

- After user login an invalid account and see the account status page, complete the interaction so that user won't be able to click the browser back and resubmit again
- When there is an unexpected error in the interaction, redirect to `/error` if the original request is a `GET` request to avoid infinite redirect loop
    - To test, delete the user in the middle of the authentication interaction