### PR TITLE
[WIP] Transform picture attribute from authgearimages:// to https://

### DIFF
--- a/cmd/authgear/background/wire_gen.go
+++ b/cmd/authgear/background/wire_gen.go
@@ -347,12 +347,19 @@ func newUserService(ctx context.Context, p *deps.BackgroundProvider, appID strin
 		ClaimStore:        storePQ,
 		RateLimiter:       limiter,
 	}
+	request := NewDummyHTTPRequest()
+	imagesCDNHost := environmentConfig.ImagesCDNHost
+	pictureAttrProcessor := stdattrs.NewPictureAttrProcessor(request, configAppID, imagesCDNHost)
+	processorFactory := stdattrs.ProcessorFactory{
+		PictureAttrProcessor: pictureAttrProcessor,
+	}
 	serviceNoEvent := &stdattrs.ServiceNoEvent{
 		UserProfileConfig: userProfileConfig,
 		Identities:        serviceService,
 		UserQueries:       rawQueries,
 		UserStore:         store,
 		ClaimStore:        storePQ,
+		ProcessorFactory:  processorFactory,
 	}
 	customattrsServiceNoEvent := &customattrs.ServiceNoEvent{
 		Config:      userProfileConfig,
@@ -465,7 +472,6 @@ func newUserService(ctx context.Context, p *deps.BackgroundProvider, appID strin
 		Logger: storeRedisLogger,
 	}
 	sessionConfig := appConfig.Session
-	request := NewDummyHTTPRequest()
 	trustProxy := environmentConfig.TrustProxy
 	cookieManager := deps.NewCookieManager(request, trustProxy, httpConfig)
 	cookieDef := session.NewSessionCookieDef(sessionConfig)

--- a/pkg/admin/wire_gen.go
+++ b/pkg/admin/wire_gen.go
@@ -326,12 +326,18 @@ func newGraphQLHandler(p *deps.RequestProvider) http.Handler {
 		ClaimStore:        storePQ,
 		RateLimiter:       limiter,
 	}
+	imagesCDNHost := environmentConfig.ImagesCDNHost
+	pictureAttrProcessor := stdattrs.NewPictureAttrProcessor(request, appID, imagesCDNHost)
+	processorFactory := stdattrs.ProcessorFactory{
+		PictureAttrProcessor: pictureAttrProcessor,
+	}
 	serviceNoEvent := &stdattrs.ServiceNoEvent{
 		UserProfileConfig: userProfileConfig,
 		Identities:        serviceService,
 		UserQueries:       rawQueries,
 		UserStore:         store,
 		ClaimStore:        storePQ,
+		ProcessorFactory:  processorFactory,
 	}
 	customattrsServiceNoEvent := &customattrs.ServiceNoEvent{
 		Config:      userProfileConfig,

--- a/pkg/auth/wire_gen.go
+++ b/pkg/auth/wire_gen.go
@@ -362,12 +362,18 @@ func newOAuthAuthorizeHandler(p *deps.RequestProvider) http.Handler {
 		ClaimStore:        storePQ,
 		RateLimiter:       limiter,
 	}
+	imagesCDNHost := environmentConfig.ImagesCDNHost
+	pictureAttrProcessor := stdattrs.NewPictureAttrProcessor(request, appID, imagesCDNHost)
+	processorFactory := stdattrs.ProcessorFactory{
+		PictureAttrProcessor: pictureAttrProcessor,
+	}
 	serviceNoEvent := &stdattrs.ServiceNoEvent{
 		UserProfileConfig: userProfileConfig,
 		Identities:        serviceService,
 		UserQueries:       rawQueries,
 		UserStore:         userStore,
 		ClaimStore:        storePQ,
+		ProcessorFactory:  processorFactory,
 	}
 	customattrsServiceNoEvent := &customattrs.ServiceNoEvent{
 		Config:      userProfileConfig,
@@ -1005,12 +1011,18 @@ func newOAuthFromWebAppHandler(p *deps.RequestProvider) http.Handler {
 		ClaimStore:        storePQ,
 		RateLimiter:       limiter,
 	}
+	imagesCDNHost := environmentConfig.ImagesCDNHost
+	pictureAttrProcessor := stdattrs.NewPictureAttrProcessor(request, appID, imagesCDNHost)
+	processorFactory := stdattrs.ProcessorFactory{
+		PictureAttrProcessor: pictureAttrProcessor,
+	}
 	serviceNoEvent := &stdattrs.ServiceNoEvent{
 		UserProfileConfig: userProfileConfig,
 		Identities:        serviceService,
 		UserQueries:       rawQueries,
 		UserStore:         userStore,
 		ClaimStore:        storePQ,
+		ProcessorFactory:  processorFactory,
 	}
 	customattrsServiceNoEvent := &customattrs.ServiceNoEvent{
 		Config:      userProfileConfig,
@@ -1585,12 +1597,18 @@ func newOAuthTokenHandler(p *deps.RequestProvider) http.Handler {
 		ClaimStore:        storePQ,
 		RateLimiter:       limiter,
 	}
+	imagesCDNHost := environmentConfig.ImagesCDNHost
+	pictureAttrProcessor := stdattrs.NewPictureAttrProcessor(request, appID, imagesCDNHost)
+	processorFactory := stdattrs.ProcessorFactory{
+		PictureAttrProcessor: pictureAttrProcessor,
+	}
 	serviceNoEvent := &stdattrs.ServiceNoEvent{
 		UserProfileConfig: userProfileConfig,
 		Identities:        serviceService,
 		UserQueries:       rawQueries,
 		UserStore:         userStore,
 		ClaimStore:        storePQ,
+		ProcessorFactory:  processorFactory,
 	}
 	customattrsServiceNoEvent := &customattrs.ServiceNoEvent{
 		Config:      userProfileConfig,
@@ -2202,12 +2220,18 @@ func newOAuthRevokeHandler(p *deps.RequestProvider) http.Handler {
 		ClaimStore:        storePQ,
 		RateLimiter:       limiter,
 	}
+	imagesCDNHost := environmentConfig.ImagesCDNHost
+	pictureAttrProcessor := stdattrs.NewPictureAttrProcessor(request, appID, imagesCDNHost)
+	processorFactory := stdattrs.ProcessorFactory{
+		PictureAttrProcessor: pictureAttrProcessor,
+	}
 	serviceNoEvent := &stdattrs.ServiceNoEvent{
 		UserProfileConfig: userProfileConfig,
 		Identities:        serviceService,
 		UserQueries:       rawQueries,
 		UserStore:         userStore,
 		ClaimStore:        storePQ,
+		ProcessorFactory:  processorFactory,
 	}
 	customattrsServiceNoEvent := &customattrs.ServiceNoEvent{
 		Config:      userProfileConfig,
@@ -2508,12 +2532,18 @@ func newOAuthJWKSHandler(p *deps.RequestProvider) http.Handler {
 		ClaimStore:        storePQ,
 		RateLimiter:       limiter,
 	}
+	imagesCDNHost := environmentConfig.ImagesCDNHost
+	pictureAttrProcessor := stdattrs.NewPictureAttrProcessor(request, appID, imagesCDNHost)
+	processorFactory := stdattrs.ProcessorFactory{
+		PictureAttrProcessor: pictureAttrProcessor,
+	}
 	serviceNoEvent := &stdattrs.ServiceNoEvent{
 		UserProfileConfig: userProfileConfig,
 		Identities:        serviceService,
 		UserQueries:       rawQueries,
 		UserStore:         store,
 		ClaimStore:        storePQ,
+		ProcessorFactory:  processorFactory,
 	}
 	customattrsServiceNoEvent := &customattrs.ServiceNoEvent{
 		Config:      userProfileConfig,
@@ -2745,12 +2775,18 @@ func newOAuthUserInfoHandler(p *deps.RequestProvider) http.Handler {
 		ClaimStore:        storePQ,
 		RateLimiter:       limiter,
 	}
+	imagesCDNHost := environmentConfig.ImagesCDNHost
+	pictureAttrProcessor := stdattrs.NewPictureAttrProcessor(request, appID, imagesCDNHost)
+	processorFactory := stdattrs.ProcessorFactory{
+		PictureAttrProcessor: pictureAttrProcessor,
+	}
 	serviceNoEvent := &stdattrs.ServiceNoEvent{
 		UserProfileConfig: userProfileConfig,
 		Identities:        serviceService,
 		UserQueries:       rawQueries,
 		UserStore:         store,
 		ClaimStore:        storePQ,
+		ProcessorFactory:  processorFactory,
 	}
 	customattrsServiceNoEvent := &customattrs.ServiceNoEvent{
 		Config:      userProfileConfig,
@@ -3027,12 +3063,18 @@ func newOAuthEndSessionHandler(p *deps.RequestProvider) http.Handler {
 		ClaimStore:        storePQ,
 		RateLimiter:       limiter,
 	}
+	imagesCDNHost := environmentConfig.ImagesCDNHost
+	pictureAttrProcessor := stdattrs.NewPictureAttrProcessor(request, appID, imagesCDNHost)
+	processorFactory := stdattrs.ProcessorFactory{
+		PictureAttrProcessor: pictureAttrProcessor,
+	}
 	serviceNoEvent := &stdattrs.ServiceNoEvent{
 		UserProfileConfig: userProfileConfig,
 		Identities:        serviceService,
 		UserQueries:       rawQueries,
 		UserStore:         userStore,
 		ClaimStore:        storePQ,
+		ProcessorFactory:  processorFactory,
 	}
 	customattrsServiceNoEvent := &customattrs.ServiceNoEvent{
 		Config:      userProfileConfig,
@@ -3352,12 +3394,18 @@ func newOAuthAppSessionTokenHandler(p *deps.RequestProvider) http.Handler {
 		ClaimStore:        storePQ,
 		RateLimiter:       limiter,
 	}
+	imagesCDNHost := environmentConfig.ImagesCDNHost
+	pictureAttrProcessor := stdattrs.NewPictureAttrProcessor(request, appID, imagesCDNHost)
+	processorFactory := stdattrs.ProcessorFactory{
+		PictureAttrProcessor: pictureAttrProcessor,
+	}
 	serviceNoEvent := &stdattrs.ServiceNoEvent{
 		UserProfileConfig: userProfileConfig,
 		Identities:        serviceService,
 		UserQueries:       rawQueries,
 		UserStore:         userStore,
 		ClaimStore:        storePQ,
+		ProcessorFactory:  processorFactory,
 	}
 	customattrsServiceNoEvent := &customattrs.ServiceNoEvent{
 		Config:      userProfileConfig,
@@ -3942,12 +3990,18 @@ func newAPIAnonymousUserSignupHandler(p *deps.RequestProvider) http.Handler {
 		ClaimStore:        storePQ,
 		RateLimiter:       limiter,
 	}
+	imagesCDNHost := environmentConfig.ImagesCDNHost
+	pictureAttrProcessor := stdattrs.NewPictureAttrProcessor(request, appID, imagesCDNHost)
+	processorFactory := stdattrs.ProcessorFactory{
+		PictureAttrProcessor: pictureAttrProcessor,
+	}
 	serviceNoEvent := &stdattrs.ServiceNoEvent{
 		UserProfileConfig: userProfileConfig,
 		Identities:        serviceService,
 		UserQueries:       rawQueries,
 		UserStore:         store,
 		ClaimStore:        storePQ,
+		ProcessorFactory:  processorFactory,
 	}
 	customattrsServiceNoEvent := &customattrs.ServiceNoEvent{
 		Config:      userProfileConfig,
@@ -4552,12 +4606,18 @@ func newAPIAnonymousUserPromotionCodeHandler(p *deps.RequestProvider) http.Handl
 		ClaimStore:        storePQ,
 		RateLimiter:       limiter,
 	}
+	imagesCDNHost := environmentConfig.ImagesCDNHost
+	pictureAttrProcessor := stdattrs.NewPictureAttrProcessor(request, appID, imagesCDNHost)
+	processorFactory := stdattrs.ProcessorFactory{
+		PictureAttrProcessor: pictureAttrProcessor,
+	}
 	serviceNoEvent := &stdattrs.ServiceNoEvent{
 		UserProfileConfig: userProfileConfig,
 		Identities:        serviceService,
 		UserQueries:       rawQueries,
 		UserStore:         store,
 		ClaimStore:        storePQ,
+		ProcessorFactory:  processorFactory,
 	}
 	customattrsServiceNoEvent := &customattrs.ServiceNoEvent{
 		Config:      userProfileConfig,
@@ -5195,12 +5255,18 @@ func newWebAppLoginHandler(p *deps.RequestProvider) http.Handler {
 		ClaimStore:        storePQ,
 		RateLimiter:       limiter,
 	}
+	imagesCDNHost := environmentConfig.ImagesCDNHost
+	pictureAttrProcessor := stdattrs.NewPictureAttrProcessor(request, appID, imagesCDNHost)
+	processorFactory := stdattrs.ProcessorFactory{
+		PictureAttrProcessor: pictureAttrProcessor,
+	}
 	serviceNoEvent := &stdattrs.ServiceNoEvent{
 		UserProfileConfig: userProfileConfig,
 		Identities:        serviceService,
 		UserQueries:       rawQueries,
 		UserStore:         store,
 		ClaimStore:        storePQ,
+		ProcessorFactory:  processorFactory,
 	}
 	customattrsServiceNoEvent := &customattrs.ServiceNoEvent{
 		Config:      userProfileConfig,
@@ -5836,12 +5902,18 @@ func newWebAppSignupHandler(p *deps.RequestProvider) http.Handler {
 		ClaimStore:        storePQ,
 		RateLimiter:       limiter,
 	}
+	imagesCDNHost := environmentConfig.ImagesCDNHost
+	pictureAttrProcessor := stdattrs.NewPictureAttrProcessor(request, appID, imagesCDNHost)
+	processorFactory := stdattrs.ProcessorFactory{
+		PictureAttrProcessor: pictureAttrProcessor,
+	}
 	serviceNoEvent := &stdattrs.ServiceNoEvent{
 		UserProfileConfig: userProfileConfig,
 		Identities:        serviceService,
 		UserQueries:       rawQueries,
 		UserStore:         store,
 		ClaimStore:        storePQ,
+		ProcessorFactory:  processorFactory,
 	}
 	customattrsServiceNoEvent := &customattrs.ServiceNoEvent{
 		Config:      userProfileConfig,
@@ -6477,12 +6549,18 @@ func newWebAppPromoteHandler(p *deps.RequestProvider) http.Handler {
 		ClaimStore:        storePQ,
 		RateLimiter:       limiter,
 	}
+	imagesCDNHost := environmentConfig.ImagesCDNHost
+	pictureAttrProcessor := stdattrs.NewPictureAttrProcessor(request, appID, imagesCDNHost)
+	processorFactory := stdattrs.ProcessorFactory{
+		PictureAttrProcessor: pictureAttrProcessor,
+	}
 	serviceNoEvent := &stdattrs.ServiceNoEvent{
 		UserProfileConfig: userProfileConfig,
 		Identities:        serviceService,
 		UserQueries:       rawQueries,
 		UserStore:         store,
 		ClaimStore:        storePQ,
+		ProcessorFactory:  processorFactory,
 	}
 	customattrsServiceNoEvent := &customattrs.ServiceNoEvent{
 		Config:      userProfileConfig,
@@ -7105,12 +7183,18 @@ func newWebAppSelectAccountHandler(p *deps.RequestProvider) http.Handler {
 		ClaimStore:        storePQ,
 		RateLimiter:       limiter,
 	}
+	imagesCDNHost := environmentConfig.ImagesCDNHost
+	pictureAttrProcessor := stdattrs.NewPictureAttrProcessor(request, appID, imagesCDNHost)
+	processorFactory := stdattrs.ProcessorFactory{
+		PictureAttrProcessor: pictureAttrProcessor,
+	}
 	serviceNoEvent := &stdattrs.ServiceNoEvent{
 		UserProfileConfig: userProfileConfig,
 		Identities:        serviceService,
 		UserQueries:       rawQueries,
 		UserStore:         store,
 		ClaimStore:        storePQ,
+		ProcessorFactory:  processorFactory,
 	}
 	customattrsServiceNoEvent := &customattrs.ServiceNoEvent{
 		Config:      userProfileConfig,
@@ -7734,12 +7818,18 @@ func newWebAppSSOCallbackHandler(p *deps.RequestProvider) http.Handler {
 		ClaimStore:        storePQ,
 		RateLimiter:       limiter,
 	}
+	imagesCDNHost := environmentConfig.ImagesCDNHost
+	pictureAttrProcessor := stdattrs.NewPictureAttrProcessor(request, appID, imagesCDNHost)
+	processorFactory := stdattrs.ProcessorFactory{
+		PictureAttrProcessor: pictureAttrProcessor,
+	}
 	serviceNoEvent := &stdattrs.ServiceNoEvent{
 		UserProfileConfig: userProfileConfig,
 		Identities:        serviceService,
 		UserQueries:       rawQueries,
 		UserStore:         store,
 		ClaimStore:        storePQ,
+		ProcessorFactory:  processorFactory,
 	}
 	customattrsServiceNoEvent := &customattrs.ServiceNoEvent{
 		Config:      userProfileConfig,
@@ -8355,12 +8445,18 @@ func newWechatAuthHandler(p *deps.RequestProvider) http.Handler {
 		ClaimStore:        storePQ,
 		RateLimiter:       limiter,
 	}
+	imagesCDNHost := environmentConfig.ImagesCDNHost
+	pictureAttrProcessor := stdattrs.NewPictureAttrProcessor(request, appID, imagesCDNHost)
+	processorFactory := stdattrs.ProcessorFactory{
+		PictureAttrProcessor: pictureAttrProcessor,
+	}
 	serviceNoEvent := &stdattrs.ServiceNoEvent{
 		UserProfileConfig: userProfileConfig,
 		Identities:        serviceService,
 		UserQueries:       rawQueries,
 		UserStore:         store,
 		ClaimStore:        storePQ,
+		ProcessorFactory:  processorFactory,
 	}
 	customattrsServiceNoEvent := &customattrs.ServiceNoEvent{
 		Config:      userProfileConfig,
@@ -8979,12 +9075,18 @@ func newWechatCallbackHandler(p *deps.RequestProvider) http.Handler {
 		ClaimStore:        storePQ,
 		RateLimiter:       limiter,
 	}
+	imagesCDNHost := environmentConfig.ImagesCDNHost
+	pictureAttrProcessor := stdattrs.NewPictureAttrProcessor(request, appID, imagesCDNHost)
+	processorFactory := stdattrs.ProcessorFactory{
+		PictureAttrProcessor: pictureAttrProcessor,
+	}
 	serviceNoEvent := &stdattrs.ServiceNoEvent{
 		UserProfileConfig: userProfileConfig,
 		Identities:        serviceService,
 		UserQueries:       rawQueries,
 		UserStore:         store,
 		ClaimStore:        storePQ,
+		ProcessorFactory:  processorFactory,
 	}
 	customattrsServiceNoEvent := &customattrs.ServiceNoEvent{
 		Config:      userProfileConfig,
@@ -9606,12 +9708,18 @@ func newWebAppEnterLoginIDHandler(p *deps.RequestProvider) http.Handler {
 		ClaimStore:        storePQ,
 		RateLimiter:       limiter,
 	}
+	imagesCDNHost := environmentConfig.ImagesCDNHost
+	pictureAttrProcessor := stdattrs.NewPictureAttrProcessor(request, appID, imagesCDNHost)
+	processorFactory := stdattrs.ProcessorFactory{
+		PictureAttrProcessor: pictureAttrProcessor,
+	}
 	serviceNoEvent := &stdattrs.ServiceNoEvent{
 		UserProfileConfig: userProfileConfig,
 		Identities:        serviceService,
 		UserQueries:       rawQueries,
 		UserStore:         store,
 		ClaimStore:        storePQ,
+		ProcessorFactory:  processorFactory,
 	}
 	customattrsServiceNoEvent := &customattrs.ServiceNoEvent{
 		Config:      userProfileConfig,
@@ -10230,12 +10338,18 @@ func newWebAppEnterPasswordHandler(p *deps.RequestProvider) http.Handler {
 		ClaimStore:        storePQ,
 		RateLimiter:       limiter,
 	}
+	imagesCDNHost := environmentConfig.ImagesCDNHost
+	pictureAttrProcessor := stdattrs.NewPictureAttrProcessor(request, appID, imagesCDNHost)
+	processorFactory := stdattrs.ProcessorFactory{
+		PictureAttrProcessor: pictureAttrProcessor,
+	}
 	serviceNoEvent := &stdattrs.ServiceNoEvent{
 		UserProfileConfig: userProfileConfig,
 		Identities:        serviceService,
 		UserQueries:       rawQueries,
 		UserStore:         store,
 		ClaimStore:        storePQ,
+		ProcessorFactory:  processorFactory,
 	}
 	customattrsServiceNoEvent := &customattrs.ServiceNoEvent{
 		Config:      userProfileConfig,
@@ -10853,12 +10967,18 @@ func newWebAppCreatePasswordHandler(p *deps.RequestProvider) http.Handler {
 		ClaimStore:        storePQ,
 		RateLimiter:       limiter,
 	}
+	imagesCDNHost := environmentConfig.ImagesCDNHost
+	pictureAttrProcessor := stdattrs.NewPictureAttrProcessor(request, appID, imagesCDNHost)
+	processorFactory := stdattrs.ProcessorFactory{
+		PictureAttrProcessor: pictureAttrProcessor,
+	}
 	serviceNoEvent := &stdattrs.ServiceNoEvent{
 		UserProfileConfig: userProfileConfig,
 		Identities:        serviceService,
 		UserQueries:       rawQueries,
 		UserStore:         store,
 		ClaimStore:        storePQ,
+		ProcessorFactory:  processorFactory,
 	}
 	customattrsServiceNoEvent := &customattrs.ServiceNoEvent{
 		Config:      userProfileConfig,
@@ -11477,12 +11597,18 @@ func newWebAppSetupTOTPHandler(p *deps.RequestProvider) http.Handler {
 		ClaimStore:        storePQ,
 		RateLimiter:       limiter,
 	}
+	imagesCDNHost := environmentConfig.ImagesCDNHost
+	pictureAttrProcessor := stdattrs.NewPictureAttrProcessor(request, appID, imagesCDNHost)
+	processorFactory := stdattrs.ProcessorFactory{
+		PictureAttrProcessor: pictureAttrProcessor,
+	}
 	serviceNoEvent := &stdattrs.ServiceNoEvent{
 		UserProfileConfig: userProfileConfig,
 		Identities:        serviceService,
 		UserQueries:       rawQueries,
 		UserStore:         store,
 		ClaimStore:        storePQ,
+		ProcessorFactory:  processorFactory,
 	}
 	customattrsServiceNoEvent := &customattrs.ServiceNoEvent{
 		Config:      userProfileConfig,
@@ -12102,12 +12228,18 @@ func newWebAppEnterTOTPHandler(p *deps.RequestProvider) http.Handler {
 		ClaimStore:        storePQ,
 		RateLimiter:       limiter,
 	}
+	imagesCDNHost := environmentConfig.ImagesCDNHost
+	pictureAttrProcessor := stdattrs.NewPictureAttrProcessor(request, appID, imagesCDNHost)
+	processorFactory := stdattrs.ProcessorFactory{
+		PictureAttrProcessor: pictureAttrProcessor,
+	}
 	serviceNoEvent := &stdattrs.ServiceNoEvent{
 		UserProfileConfig: userProfileConfig,
 		Identities:        serviceService,
 		UserQueries:       rawQueries,
 		UserStore:         store,
 		ClaimStore:        storePQ,
+		ProcessorFactory:  processorFactory,
 	}
 	customattrsServiceNoEvent := &customattrs.ServiceNoEvent{
 		Config:      userProfileConfig,
@@ -12725,12 +12857,18 @@ func newWebAppSetupOOBOTPHandler(p *deps.RequestProvider) http.Handler {
 		ClaimStore:        storePQ,
 		RateLimiter:       limiter,
 	}
+	imagesCDNHost := environmentConfig.ImagesCDNHost
+	pictureAttrProcessor := stdattrs.NewPictureAttrProcessor(request, appID, imagesCDNHost)
+	processorFactory := stdattrs.ProcessorFactory{
+		PictureAttrProcessor: pictureAttrProcessor,
+	}
 	serviceNoEvent := &stdattrs.ServiceNoEvent{
 		UserProfileConfig: userProfileConfig,
 		Identities:        serviceService,
 		UserQueries:       rawQueries,
 		UserStore:         store,
 		ClaimStore:        storePQ,
+		ProcessorFactory:  processorFactory,
 	}
 	customattrsServiceNoEvent := &customattrs.ServiceNoEvent{
 		Config:      userProfileConfig,
@@ -13348,12 +13486,18 @@ func newWebAppEnterOOBOTPHandler(p *deps.RequestProvider) http.Handler {
 		ClaimStore:        storePQ,
 		RateLimiter:       limiter,
 	}
+	imagesCDNHost := environmentConfig.ImagesCDNHost
+	pictureAttrProcessor := stdattrs.NewPictureAttrProcessor(request, appID, imagesCDNHost)
+	processorFactory := stdattrs.ProcessorFactory{
+		PictureAttrProcessor: pictureAttrProcessor,
+	}
 	serviceNoEvent := &stdattrs.ServiceNoEvent{
 		UserProfileConfig: userProfileConfig,
 		Identities:        serviceService,
 		UserQueries:       rawQueries,
 		UserStore:         store,
 		ClaimStore:        storePQ,
+		ProcessorFactory:  processorFactory,
 	}
 	customattrsServiceNoEvent := &customattrs.ServiceNoEvent{
 		Config:      userProfileConfig,
@@ -13973,12 +14117,18 @@ func newWebAppEnterRecoveryCodeHandler(p *deps.RequestProvider) http.Handler {
 		ClaimStore:        storePQ,
 		RateLimiter:       limiter,
 	}
+	imagesCDNHost := environmentConfig.ImagesCDNHost
+	pictureAttrProcessor := stdattrs.NewPictureAttrProcessor(request, appID, imagesCDNHost)
+	processorFactory := stdattrs.ProcessorFactory{
+		PictureAttrProcessor: pictureAttrProcessor,
+	}
 	serviceNoEvent := &stdattrs.ServiceNoEvent{
 		UserProfileConfig: userProfileConfig,
 		Identities:        serviceService,
 		UserQueries:       rawQueries,
 		UserStore:         store,
 		ClaimStore:        storePQ,
+		ProcessorFactory:  processorFactory,
 	}
 	customattrsServiceNoEvent := &customattrs.ServiceNoEvent{
 		Config:      userProfileConfig,
@@ -14596,12 +14746,18 @@ func newWebAppSetupRecoveryCodeHandler(p *deps.RequestProvider) http.Handler {
 		ClaimStore:        storePQ,
 		RateLimiter:       limiter,
 	}
+	imagesCDNHost := environmentConfig.ImagesCDNHost
+	pictureAttrProcessor := stdattrs.NewPictureAttrProcessor(request, appID, imagesCDNHost)
+	processorFactory := stdattrs.ProcessorFactory{
+		PictureAttrProcessor: pictureAttrProcessor,
+	}
 	serviceNoEvent := &stdattrs.ServiceNoEvent{
 		UserProfileConfig: userProfileConfig,
 		Identities:        serviceService,
 		UserQueries:       rawQueries,
 		UserStore:         store,
 		ClaimStore:        storePQ,
+		ProcessorFactory:  processorFactory,
 	}
 	customattrsServiceNoEvent := &customattrs.ServiceNoEvent{
 		Config:      userProfileConfig,
@@ -15219,12 +15375,18 @@ func newWebAppVerifyIdentityHandler(p *deps.RequestProvider) http.Handler {
 		ClaimStore:        storePQ,
 		RateLimiter:       limiter,
 	}
+	imagesCDNHost := environmentConfig.ImagesCDNHost
+	pictureAttrProcessor := stdattrs.NewPictureAttrProcessor(request, appID, imagesCDNHost)
+	processorFactory := stdattrs.ProcessorFactory{
+		PictureAttrProcessor: pictureAttrProcessor,
+	}
 	serviceNoEvent := &stdattrs.ServiceNoEvent{
 		UserProfileConfig: userProfileConfig,
 		Identities:        serviceService,
 		UserQueries:       rawQueries,
 		UserStore:         store,
 		ClaimStore:        storePQ,
+		ProcessorFactory:  processorFactory,
 	}
 	customattrsServiceNoEvent := &customattrs.ServiceNoEvent{
 		Config:      userProfileConfig,
@@ -15845,12 +16007,18 @@ func newWebAppVerifyIdentitySuccessHandler(p *deps.RequestProvider) http.Handler
 		ClaimStore:        storePQ,
 		RateLimiter:       limiter,
 	}
+	imagesCDNHost := environmentConfig.ImagesCDNHost
+	pictureAttrProcessor := stdattrs.NewPictureAttrProcessor(request, appID, imagesCDNHost)
+	processorFactory := stdattrs.ProcessorFactory{
+		PictureAttrProcessor: pictureAttrProcessor,
+	}
 	serviceNoEvent := &stdattrs.ServiceNoEvent{
 		UserProfileConfig: userProfileConfig,
 		Identities:        serviceService,
 		UserQueries:       rawQueries,
 		UserStore:         store,
 		ClaimStore:        storePQ,
+		ProcessorFactory:  processorFactory,
 	}
 	customattrsServiceNoEvent := &customattrs.ServiceNoEvent{
 		Config:      userProfileConfig,
@@ -16468,12 +16636,18 @@ func newWebAppForgotPasswordHandler(p *deps.RequestProvider) http.Handler {
 		ClaimStore:        storePQ,
 		RateLimiter:       limiter,
 	}
+	imagesCDNHost := environmentConfig.ImagesCDNHost
+	pictureAttrProcessor := stdattrs.NewPictureAttrProcessor(request, appID, imagesCDNHost)
+	processorFactory := stdattrs.ProcessorFactory{
+		PictureAttrProcessor: pictureAttrProcessor,
+	}
 	serviceNoEvent := &stdattrs.ServiceNoEvent{
 		UserProfileConfig: userProfileConfig,
 		Identities:        serviceService,
 		UserQueries:       rawQueries,
 		UserStore:         store,
 		ClaimStore:        storePQ,
+		ProcessorFactory:  processorFactory,
 	}
 	customattrsServiceNoEvent := &customattrs.ServiceNoEvent{
 		Config:      userProfileConfig,
@@ -17096,12 +17270,18 @@ func newWebAppForgotPasswordSuccessHandler(p *deps.RequestProvider) http.Handler
 		ClaimStore:        storePQ,
 		RateLimiter:       limiter,
 	}
+	imagesCDNHost := environmentConfig.ImagesCDNHost
+	pictureAttrProcessor := stdattrs.NewPictureAttrProcessor(request, appID, imagesCDNHost)
+	processorFactory := stdattrs.ProcessorFactory{
+		PictureAttrProcessor: pictureAttrProcessor,
+	}
 	serviceNoEvent := &stdattrs.ServiceNoEvent{
 		UserProfileConfig: userProfileConfig,
 		Identities:        serviceService,
 		UserQueries:       rawQueries,
 		UserStore:         store,
 		ClaimStore:        storePQ,
+		ProcessorFactory:  processorFactory,
 	}
 	customattrsServiceNoEvent := &customattrs.ServiceNoEvent{
 		Config:      userProfileConfig,
@@ -17719,12 +17899,18 @@ func newWebAppResetPasswordHandler(p *deps.RequestProvider) http.Handler {
 		ClaimStore:        storePQ,
 		RateLimiter:       limiter,
 	}
+	imagesCDNHost := environmentConfig.ImagesCDNHost
+	pictureAttrProcessor := stdattrs.NewPictureAttrProcessor(request, appID, imagesCDNHost)
+	processorFactory := stdattrs.ProcessorFactory{
+		PictureAttrProcessor: pictureAttrProcessor,
+	}
 	serviceNoEvent := &stdattrs.ServiceNoEvent{
 		UserProfileConfig: userProfileConfig,
 		Identities:        serviceService,
 		UserQueries:       rawQueries,
 		UserStore:         store,
 		ClaimStore:        storePQ,
+		ProcessorFactory:  processorFactory,
 	}
 	customattrsServiceNoEvent := &customattrs.ServiceNoEvent{
 		Config:      userProfileConfig,
@@ -18343,12 +18529,18 @@ func newWebAppResetPasswordSuccessHandler(p *deps.RequestProvider) http.Handler 
 		ClaimStore:        storePQ,
 		RateLimiter:       limiter,
 	}
+	imagesCDNHost := environmentConfig.ImagesCDNHost
+	pictureAttrProcessor := stdattrs.NewPictureAttrProcessor(request, appID, imagesCDNHost)
+	processorFactory := stdattrs.ProcessorFactory{
+		PictureAttrProcessor: pictureAttrProcessor,
+	}
 	serviceNoEvent := &stdattrs.ServiceNoEvent{
 		UserProfileConfig: userProfileConfig,
 		Identities:        serviceService,
 		UserQueries:       rawQueries,
 		UserStore:         store,
 		ClaimStore:        storePQ,
+		ProcessorFactory:  processorFactory,
 	}
 	customattrsServiceNoEvent := &customattrs.ServiceNoEvent{
 		Config:      userProfileConfig,
@@ -18966,12 +19158,18 @@ func newWebAppSettingsHandler(p *deps.RequestProvider) http.Handler {
 		ClaimStore:        storePQ,
 		RateLimiter:       limiter,
 	}
+	imagesCDNHost := environmentConfig.ImagesCDNHost
+	pictureAttrProcessor := stdattrs.NewPictureAttrProcessor(request, appID, imagesCDNHost)
+	processorFactory := stdattrs.ProcessorFactory{
+		PictureAttrProcessor: pictureAttrProcessor,
+	}
 	serviceNoEvent := &stdattrs.ServiceNoEvent{
 		UserProfileConfig: userProfileConfig,
 		Identities:        serviceService,
 		UserQueries:       rawQueries,
 		UserStore:         store,
 		ClaimStore:        storePQ,
+		ProcessorFactory:  processorFactory,
 	}
 	customattrsServiceNoEvent := &customattrs.ServiceNoEvent{
 		Config:      userProfileConfig,
@@ -19612,12 +19810,18 @@ func newWebAppSettingsProfileHandler(p *deps.RequestProvider) http.Handler {
 		ClaimStore:        storePQ,
 		RateLimiter:       limiter,
 	}
+	imagesCDNHost := environmentConfig.ImagesCDNHost
+	pictureAttrProcessor := stdattrs.NewPictureAttrProcessor(request, appID, imagesCDNHost)
+	processorFactory := stdattrs.ProcessorFactory{
+		PictureAttrProcessor: pictureAttrProcessor,
+	}
 	serviceNoEvent := &stdattrs.ServiceNoEvent{
 		UserProfileConfig: userProfileConfig,
 		Identities:        serviceService,
 		UserQueries:       rawQueries,
 		UserStore:         store,
 		ClaimStore:        storePQ,
+		ProcessorFactory:  processorFactory,
 	}
 	customattrsServiceNoEvent := &customattrs.ServiceNoEvent{
 		Config:      userProfileConfig,
@@ -20246,12 +20450,18 @@ func newWebAppSettingsProfileEditHandler(p *deps.RequestProvider) http.Handler {
 		ClaimStore:        storePQ,
 		RateLimiter:       limiter,
 	}
+	imagesCDNHost := environmentConfig.ImagesCDNHost
+	pictureAttrProcessor := stdattrs.NewPictureAttrProcessor(request, appID, imagesCDNHost)
+	processorFactory := stdattrs.ProcessorFactory{
+		PictureAttrProcessor: pictureAttrProcessor,
+	}
 	serviceNoEvent := &stdattrs.ServiceNoEvent{
 		UserProfileConfig: userProfileConfig,
 		Identities:        serviceService,
 		UserQueries:       rawQueries,
 		UserStore:         store,
 		ClaimStore:        storePQ,
+		ProcessorFactory:  processorFactory,
 	}
 	customattrsServiceNoEvent := &customattrs.ServiceNoEvent{
 		Config:      userProfileConfig,
@@ -20893,12 +21103,18 @@ func newWebAppSettingsIdentityHandler(p *deps.RequestProvider) http.Handler {
 		ClaimStore:        storePQ,
 		RateLimiter:       limiter,
 	}
+	imagesCDNHost := environmentConfig.ImagesCDNHost
+	pictureAttrProcessor := stdattrs.NewPictureAttrProcessor(request, appID, imagesCDNHost)
+	processorFactory := stdattrs.ProcessorFactory{
+		PictureAttrProcessor: pictureAttrProcessor,
+	}
 	serviceNoEvent := &stdattrs.ServiceNoEvent{
 		UserProfileConfig: userProfileConfig,
 		Identities:        serviceService,
 		UserQueries:       rawQueries,
 		UserStore:         store,
 		ClaimStore:        storePQ,
+		ProcessorFactory:  processorFactory,
 	}
 	customattrsServiceNoEvent := &customattrs.ServiceNoEvent{
 		Config:      userProfileConfig,
@@ -21519,12 +21735,18 @@ func newWebAppSettingsBiometricHandler(p *deps.RequestProvider) http.Handler {
 		ClaimStore:        storePQ,
 		RateLimiter:       limiter,
 	}
+	imagesCDNHost := environmentConfig.ImagesCDNHost
+	pictureAttrProcessor := stdattrs.NewPictureAttrProcessor(request, appID, imagesCDNHost)
+	processorFactory := stdattrs.ProcessorFactory{
+		PictureAttrProcessor: pictureAttrProcessor,
+	}
 	serviceNoEvent := &stdattrs.ServiceNoEvent{
 		UserProfileConfig: userProfileConfig,
 		Identities:        serviceService,
 		UserQueries:       rawQueries,
 		UserStore:         store,
 		ClaimStore:        storePQ,
+		ProcessorFactory:  processorFactory,
 	}
 	customattrsServiceNoEvent := &customattrs.ServiceNoEvent{
 		Config:      userProfileConfig,
@@ -22143,12 +22365,18 @@ func newWebAppSettingsMFAHandler(p *deps.RequestProvider) http.Handler {
 		ClaimStore:        storePQ,
 		RateLimiter:       limiter,
 	}
+	imagesCDNHost := environmentConfig.ImagesCDNHost
+	pictureAttrProcessor := stdattrs.NewPictureAttrProcessor(request, appID, imagesCDNHost)
+	processorFactory := stdattrs.ProcessorFactory{
+		PictureAttrProcessor: pictureAttrProcessor,
+	}
 	serviceNoEvent := &stdattrs.ServiceNoEvent{
 		UserProfileConfig: userProfileConfig,
 		Identities:        serviceService,
 		UserQueries:       rawQueries,
 		UserStore:         store,
 		ClaimStore:        storePQ,
+		ProcessorFactory:  processorFactory,
 	}
 	customattrsServiceNoEvent := &customattrs.ServiceNoEvent{
 		Config:      userProfileConfig,
@@ -22776,12 +23004,18 @@ func newWebAppSettingsTOTPHandler(p *deps.RequestProvider) http.Handler {
 		ClaimStore:        storePQ,
 		RateLimiter:       limiter,
 	}
+	imagesCDNHost := environmentConfig.ImagesCDNHost
+	pictureAttrProcessor := stdattrs.NewPictureAttrProcessor(request, appID, imagesCDNHost)
+	processorFactory := stdattrs.ProcessorFactory{
+		PictureAttrProcessor: pictureAttrProcessor,
+	}
 	serviceNoEvent := &stdattrs.ServiceNoEvent{
 		UserProfileConfig: userProfileConfig,
 		Identities:        serviceService,
 		UserQueries:       rawQueries,
 		UserStore:         store,
 		ClaimStore:        storePQ,
+		ProcessorFactory:  processorFactory,
 	}
 	customattrsServiceNoEvent := &customattrs.ServiceNoEvent{
 		Config:      userProfileConfig,
@@ -23400,12 +23634,18 @@ func newWebAppSettingsOOBOTPHandler(p *deps.RequestProvider) http.Handler {
 		ClaimStore:        storePQ,
 		RateLimiter:       limiter,
 	}
+	imagesCDNHost := environmentConfig.ImagesCDNHost
+	pictureAttrProcessor := stdattrs.NewPictureAttrProcessor(request, appID, imagesCDNHost)
+	processorFactory := stdattrs.ProcessorFactory{
+		PictureAttrProcessor: pictureAttrProcessor,
+	}
 	serviceNoEvent := &stdattrs.ServiceNoEvent{
 		UserProfileConfig: userProfileConfig,
 		Identities:        serviceService,
 		UserQueries:       rawQueries,
 		UserStore:         store,
 		ClaimStore:        storePQ,
+		ProcessorFactory:  processorFactory,
 	}
 	customattrsServiceNoEvent := &customattrs.ServiceNoEvent{
 		Config:      userProfileConfig,
@@ -24024,12 +24264,18 @@ func newWebAppSettingsRecoveryCodeHandler(p *deps.RequestProvider) http.Handler 
 		ClaimStore:        storePQ,
 		RateLimiter:       limiter,
 	}
+	imagesCDNHost := environmentConfig.ImagesCDNHost
+	pictureAttrProcessor := stdattrs.NewPictureAttrProcessor(request, appID, imagesCDNHost)
+	processorFactory := stdattrs.ProcessorFactory{
+		PictureAttrProcessor: pictureAttrProcessor,
+	}
 	serviceNoEvent := &stdattrs.ServiceNoEvent{
 		UserProfileConfig: userProfileConfig,
 		Identities:        serviceService,
 		UserQueries:       rawQueries,
 		UserStore:         store,
 		ClaimStore:        storePQ,
+		ProcessorFactory:  processorFactory,
 	}
 	customattrsServiceNoEvent := &customattrs.ServiceNoEvent{
 		Config:      userProfileConfig,
@@ -24649,12 +24895,18 @@ func newWebAppSettingsSessionsHandler(p *deps.RequestProvider) http.Handler {
 		ClaimStore:        storePQ,
 		RateLimiter:       limiter,
 	}
+	imagesCDNHost := environmentConfig.ImagesCDNHost
+	pictureAttrProcessor := stdattrs.NewPictureAttrProcessor(request, appID, imagesCDNHost)
+	processorFactory := stdattrs.ProcessorFactory{
+		PictureAttrProcessor: pictureAttrProcessor,
+	}
 	serviceNoEvent := &stdattrs.ServiceNoEvent{
 		UserProfileConfig: userProfileConfig,
 		Identities:        serviceService,
 		UserQueries:       rawQueries,
 		UserStore:         store,
 		ClaimStore:        storePQ,
+		ProcessorFactory:  processorFactory,
 	}
 	customattrsServiceNoEvent := &customattrs.ServiceNoEvent{
 		Config:      userProfileConfig,
@@ -25278,12 +25530,18 @@ func newWebAppForceChangePasswordHandler(p *deps.RequestProvider) http.Handler {
 		ClaimStore:        storePQ,
 		RateLimiter:       limiter,
 	}
+	imagesCDNHost := environmentConfig.ImagesCDNHost
+	pictureAttrProcessor := stdattrs.NewPictureAttrProcessor(request, appID, imagesCDNHost)
+	processorFactory := stdattrs.ProcessorFactory{
+		PictureAttrProcessor: pictureAttrProcessor,
+	}
 	serviceNoEvent := &stdattrs.ServiceNoEvent{
 		UserProfileConfig: userProfileConfig,
 		Identities:        serviceService,
 		UserQueries:       rawQueries,
 		UserStore:         store,
 		ClaimStore:        storePQ,
+		ProcessorFactory:  processorFactory,
 	}
 	customattrsServiceNoEvent := &customattrs.ServiceNoEvent{
 		Config:      userProfileConfig,
@@ -25902,12 +26160,18 @@ func newWebAppSettingsChangePasswordHandler(p *deps.RequestProvider) http.Handle
 		ClaimStore:        storePQ,
 		RateLimiter:       limiter,
 	}
+	imagesCDNHost := environmentConfig.ImagesCDNHost
+	pictureAttrProcessor := stdattrs.NewPictureAttrProcessor(request, appID, imagesCDNHost)
+	processorFactory := stdattrs.ProcessorFactory{
+		PictureAttrProcessor: pictureAttrProcessor,
+	}
 	serviceNoEvent := &stdattrs.ServiceNoEvent{
 		UserProfileConfig: userProfileConfig,
 		Identities:        serviceService,
 		UserQueries:       rawQueries,
 		UserStore:         store,
 		ClaimStore:        storePQ,
+		ProcessorFactory:  processorFactory,
 	}
 	customattrsServiceNoEvent := &customattrs.ServiceNoEvent{
 		Config:      userProfileConfig,
@@ -26526,12 +26790,18 @@ func newWebAppForceChangeSecondaryPasswordHandler(p *deps.RequestProvider) http.
 		ClaimStore:        storePQ,
 		RateLimiter:       limiter,
 	}
+	imagesCDNHost := environmentConfig.ImagesCDNHost
+	pictureAttrProcessor := stdattrs.NewPictureAttrProcessor(request, appID, imagesCDNHost)
+	processorFactory := stdattrs.ProcessorFactory{
+		PictureAttrProcessor: pictureAttrProcessor,
+	}
 	serviceNoEvent := &stdattrs.ServiceNoEvent{
 		UserProfileConfig: userProfileConfig,
 		Identities:        serviceService,
 		UserQueries:       rawQueries,
 		UserStore:         store,
 		ClaimStore:        storePQ,
+		ProcessorFactory:  processorFactory,
 	}
 	customattrsServiceNoEvent := &customattrs.ServiceNoEvent{
 		Config:      userProfileConfig,
@@ -27150,12 +27420,18 @@ func newWebAppSettingsChangeSecondaryPasswordHandler(p *deps.RequestProvider) ht
 		ClaimStore:        storePQ,
 		RateLimiter:       limiter,
 	}
+	imagesCDNHost := environmentConfig.ImagesCDNHost
+	pictureAttrProcessor := stdattrs.NewPictureAttrProcessor(request, appID, imagesCDNHost)
+	processorFactory := stdattrs.ProcessorFactory{
+		PictureAttrProcessor: pictureAttrProcessor,
+	}
 	serviceNoEvent := &stdattrs.ServiceNoEvent{
 		UserProfileConfig: userProfileConfig,
 		Identities:        serviceService,
 		UserQueries:       rawQueries,
 		UserStore:         store,
 		ClaimStore:        storePQ,
+		ProcessorFactory:  processorFactory,
 	}
 	customattrsServiceNoEvent := &customattrs.ServiceNoEvent{
 		Config:      userProfileConfig,
@@ -27774,12 +28050,18 @@ func newWebAppSettingsDeleteAccountHandler(p *deps.RequestProvider) http.Handler
 		ClaimStore:        storePQ,
 		RateLimiter:       limiter,
 	}
+	imagesCDNHost := environmentConfig.ImagesCDNHost
+	pictureAttrProcessor := stdattrs.NewPictureAttrProcessor(request, appID, imagesCDNHost)
+	processorFactory := stdattrs.ProcessorFactory{
+		PictureAttrProcessor: pictureAttrProcessor,
+	}
 	serviceNoEvent := &stdattrs.ServiceNoEvent{
 		UserProfileConfig: userProfileConfig,
 		Identities:        serviceService,
 		UserQueries:       rawQueries,
 		UserStore:         store,
 		ClaimStore:        storePQ,
+		ProcessorFactory:  processorFactory,
 	}
 	customattrsServiceNoEvent := &customattrs.ServiceNoEvent{
 		Config:      userProfileConfig,
@@ -28405,12 +28687,18 @@ func newWebAppSettingsDeleteAccountSuccessHandler(p *deps.RequestProvider) http.
 		ClaimStore:        storePQ,
 		RateLimiter:       limiter,
 	}
+	imagesCDNHost := environmentConfig.ImagesCDNHost
+	pictureAttrProcessor := stdattrs.NewPictureAttrProcessor(request, appID, imagesCDNHost)
+	processorFactory := stdattrs.ProcessorFactory{
+		PictureAttrProcessor: pictureAttrProcessor,
+	}
 	serviceNoEvent := &stdattrs.ServiceNoEvent{
 		UserProfileConfig: userProfileConfig,
 		Identities:        serviceService,
 		UserQueries:       rawQueries,
 		UserStore:         store,
 		ClaimStore:        storePQ,
+		ProcessorFactory:  processorFactory,
 	}
 	customattrsServiceNoEvent := &customattrs.ServiceNoEvent{
 		Config:      userProfileConfig,
@@ -29030,12 +29318,18 @@ func newWebAppAccountStatusHandler(p *deps.RequestProvider) http.Handler {
 		ClaimStore:        storePQ,
 		RateLimiter:       limiter,
 	}
+	imagesCDNHost := environmentConfig.ImagesCDNHost
+	pictureAttrProcessor := stdattrs.NewPictureAttrProcessor(request, appID, imagesCDNHost)
+	processorFactory := stdattrs.ProcessorFactory{
+		PictureAttrProcessor: pictureAttrProcessor,
+	}
 	serviceNoEvent := &stdattrs.ServiceNoEvent{
 		UserProfileConfig: userProfileConfig,
 		Identities:        serviceService,
 		UserQueries:       rawQueries,
 		UserStore:         store,
 		ClaimStore:        storePQ,
+		ProcessorFactory:  processorFactory,
 	}
 	customattrsServiceNoEvent := &customattrs.ServiceNoEvent{
 		Config:      userProfileConfig,
@@ -29653,12 +29947,18 @@ func newWebAppLogoutHandler(p *deps.RequestProvider) http.Handler {
 		ClaimStore:        storePQ,
 		RateLimiter:       limiter,
 	}
+	imagesCDNHost := environmentConfig.ImagesCDNHost
+	pictureAttrProcessor := stdattrs.NewPictureAttrProcessor(request, appID, imagesCDNHost)
+	processorFactory := stdattrs.ProcessorFactory{
+		PictureAttrProcessor: pictureAttrProcessor,
+	}
 	serviceNoEvent := &stdattrs.ServiceNoEvent{
 		UserProfileConfig: userProfileConfig,
 		Identities:        serviceService,
 		UserQueries:       rawQueries,
 		UserStore:         store,
 		ClaimStore:        storePQ,
+		ProcessorFactory:  processorFactory,
 	}
 	customattrsServiceNoEvent := &customattrs.ServiceNoEvent{
 		Config:      userProfileConfig,
@@ -30295,12 +30595,18 @@ func newWebAppReturnHandler(p *deps.RequestProvider) http.Handler {
 		ClaimStore:        storePQ,
 		RateLimiter:       limiter,
 	}
+	imagesCDNHost := environmentConfig.ImagesCDNHost
+	pictureAttrProcessor := stdattrs.NewPictureAttrProcessor(request, appID, imagesCDNHost)
+	processorFactory := stdattrs.ProcessorFactory{
+		PictureAttrProcessor: pictureAttrProcessor,
+	}
 	serviceNoEvent := &stdattrs.ServiceNoEvent{
 		UserProfileConfig: userProfileConfig,
 		Identities:        serviceService,
 		UserQueries:       rawQueries,
 		UserStore:         store,
 		ClaimStore:        storePQ,
+		ProcessorFactory:  processorFactory,
 	}
 	customattrsServiceNoEvent := &customattrs.ServiceNoEvent{
 		Config:      userProfileConfig,
@@ -30918,12 +31224,18 @@ func newWebAppErrorHandler(p *deps.RequestProvider) http.Handler {
 		ClaimStore:        storePQ,
 		RateLimiter:       limiter,
 	}
+	imagesCDNHost := environmentConfig.ImagesCDNHost
+	pictureAttrProcessor := stdattrs.NewPictureAttrProcessor(request, appID, imagesCDNHost)
+	processorFactory := stdattrs.ProcessorFactory{
+		PictureAttrProcessor: pictureAttrProcessor,
+	}
 	serviceNoEvent := &stdattrs.ServiceNoEvent{
 		UserProfileConfig: userProfileConfig,
 		Identities:        serviceService,
 		UserQueries:       rawQueries,
 		UserStore:         store,
 		ClaimStore:        storePQ,
+		ProcessorFactory:  processorFactory,
 	}
 	customattrsServiceNoEvent := &customattrs.ServiceNoEvent{
 		Config:      userProfileConfig,
@@ -31784,12 +32096,18 @@ func newSessionMiddleware(p *deps.RequestProvider) httproute.Middleware {
 		ClaimStore:        storePQ,
 		RateLimiter:       limiter,
 	}
+	imagesCDNHost := environmentConfig.ImagesCDNHost
+	pictureAttrProcessor := stdattrs.NewPictureAttrProcessor(request, appID, imagesCDNHost)
+	processorFactory := stdattrs.ProcessorFactory{
+		PictureAttrProcessor: pictureAttrProcessor,
+	}
 	serviceNoEvent := &stdattrs.ServiceNoEvent{
 		UserProfileConfig: userProfileConfig,
 		Identities:        serviceService,
 		UserQueries:       rawQueries,
 		UserStore:         userStore,
 		ClaimStore:        storePQ,
+		ProcessorFactory:  processorFactory,
 	}
 	customattrsServiceNoEvent := &customattrs.ServiceNoEvent{
 		Config:      userProfileConfig,
@@ -32157,12 +32475,18 @@ func newSettingsSubRoutesMiddleware(p *deps.RequestProvider) httproute.Middlewar
 		ClaimStore:        storePQ,
 		RateLimiter:       limiter,
 	}
+	imagesCDNHost := environmentConfig.ImagesCDNHost
+	pictureAttrProcessor := stdattrs.NewPictureAttrProcessor(request, appID, imagesCDNHost)
+	processorFactory := stdattrs.ProcessorFactory{
+		PictureAttrProcessor: pictureAttrProcessor,
+	}
 	serviceNoEvent := &stdattrs.ServiceNoEvent{
 		UserProfileConfig: userProfileConfig,
 		Identities:        serviceService,
 		UserQueries:       rawQueries,
 		UserStore:         store,
 		ClaimStore:        storePQ,
+		ProcessorFactory:  processorFactory,
 	}
 	customattrsServiceNoEvent := &customattrs.ServiceNoEvent{
 		Config:      userProfileConfig,

--- a/pkg/lib/config/environment.go
+++ b/pkg/lib/config/environment.go
@@ -23,4 +23,7 @@ type EnvironmentConfig struct {
 	Database DatabaseEnvironmentConfig `envconfig:"DATABASE"`
 	// AuditDatabase configures the audit database
 	AuditDatabase DatabaseCredentialsEnvironmentConfig `envconfig:"AUDIT_DATABASE"`
+	// ImagesCDNHost is the host of the Authgear images CDN
+	// It needs to be set only when setting up CDN for the images server
+	ImagesCDNHost ImagesCDNHost `envconfig:"IMAGES_CDN_HOST"`
 }

--- a/pkg/lib/config/images.go
+++ b/pkg/lib/config/images.go
@@ -1,0 +1,3 @@
+package config
+
+type ImagesCDNHost string

--- a/pkg/lib/deps/deps_provider.go
+++ b/pkg/lib/deps/deps_provider.go
@@ -26,6 +26,7 @@ var envConfigDeps = wire.NewSet(
 		"SentryDSN",
 		"StaticAssetURLPrefix",
 		"Database",
+		"ImagesCDNHost",
 	),
 )
 

--- a/pkg/lib/feature/stdattrs/deps.go
+++ b/pkg/lib/feature/stdattrs/deps.go
@@ -5,4 +5,6 @@ import "github.com/google/wire"
 var DependencySet = wire.NewSet(
 	wire.Struct(new(Service), "*"),
 	wire.Struct(new(ServiceNoEvent), "*"),
+	wire.Struct(new(ProcessorFactory), "*"),
+	NewPictureAttrProcessor,
 )

--- a/pkg/lib/feature/stdattrs/processor.go
+++ b/pkg/lib/feature/stdattrs/processor.go
@@ -1,0 +1,70 @@
+package stdattrs
+
+import (
+	"fmt"
+	"net/http"
+	"net/url"
+	"strings"
+
+	"github.com/authgear/authgear-server/pkg/lib/authn/stdattrs"
+	"github.com/authgear/authgear-server/pkg/lib/config"
+)
+
+type Processor interface {
+	Process(input interface{}) (out interface{}, err error)
+}
+
+type ProcessorFactory struct {
+	PictureAttrProcessor *PictureAttrProcessor
+}
+
+func (f *ProcessorFactory) ProcessorWithAttrKey(key string) Processor {
+	if key == stdattrs.Picture {
+		return f.PictureAttrProcessor
+	}
+	return nil
+}
+
+func NewPictureAttrProcessor(
+	r *http.Request,
+	appID config.AppID,
+	ImagesCDNHost config.ImagesCDNHost,
+) *PictureAttrProcessor {
+	imagesHost := ImagesCDNHost
+	if imagesHost == "" {
+		imagesHost = config.ImagesCDNHost(r.Host)
+	}
+
+	return &PictureAttrProcessor{
+		ImagesHost: imagesHost,
+		AppID:      appID,
+	}
+}
+
+type PictureAttrProcessor struct {
+	ImagesHost config.ImagesCDNHost
+	AppID      config.AppID
+}
+
+func (p *PictureAttrProcessor) Process(input interface{}) (out interface{}, err error) {
+	out = input
+	if str, ok := input.(string); ok {
+		u, err := url.Parse(str)
+		if err != nil {
+			return nil, fmt.Errorf("invalid profile url: %s: %w", str, err)
+		}
+		if u.Scheme == "authgearimages" {
+			parts := strings.Split(u.Path, "/")
+			if len(parts) >= 2 {
+				objectID := parts[1]
+				return fmt.Sprintf(
+					"https://%s/_images/%s/%s/profile",
+					p.ImagesHost,
+					p.AppID,
+					objectID,
+				), nil
+			}
+		}
+	}
+	return
+}

--- a/pkg/lib/feature/stdattrs/processor_test.go
+++ b/pkg/lib/feature/stdattrs/processor_test.go
@@ -1,0 +1,32 @@
+package stdattrs_test
+
+import (
+	"testing"
+
+	"github.com/authgear/authgear-server/pkg/lib/config"
+	"github.com/authgear/authgear-server/pkg/lib/feature/stdattrs"
+	. "github.com/smartystreets/goconvey/convey"
+)
+
+func TestProcessor(t *testing.T) {
+	Convey("Processor", t, func() {
+		Convey("PictureAttrProcessor", func() {
+
+			p := stdattrs.PictureAttrProcessor{
+				ImagesHost: config.ImagesCDNHost("imagescdn.com"),
+				AppID:      "app1",
+			}
+
+			test := func(input string, expected string) {
+				result, err := p.Process(input)
+				So(err, ShouldBeNil)
+				So(result, ShouldEqual, expected)
+			}
+
+			test("https://example.com/image", "https://example.com/image")
+			test("authgearimages:///objectid", "https://imagescdn.com/_images/app1/objectid/profile")
+			test("authgearimages://host/objectid", "https://imagescdn.com/_images/app1/objectid/profile")
+			test("authgearimages://host/objectid?abc=1", "https://imagescdn.com/_images/app1/objectid/profile")
+		})
+	})
+}

--- a/pkg/resolver/wire_gen.go
+++ b/pkg/resolver/wire_gen.go
@@ -339,12 +339,18 @@ func newSessionMiddleware(p *deps.RequestProvider) httproute.Middleware {
 		ClaimStore:        storePQ,
 		RateLimiter:       limiter,
 	}
+	imagesCDNHost := environmentConfig.ImagesCDNHost
+	pictureAttrProcessor := stdattrs.NewPictureAttrProcessor(request, appID, imagesCDNHost)
+	processorFactory := stdattrs.ProcessorFactory{
+		PictureAttrProcessor: pictureAttrProcessor,
+	}
 	serviceNoEvent := &stdattrs.ServiceNoEvent{
 		UserProfileConfig: userProfileConfig,
 		Identities:        serviceService,
 		UserQueries:       rawQueries,
 		UserStore:         userStore,
 		ClaimStore:        storePQ,
+		ProcessorFactory:  processorFactory,
 	}
 	customattrsServiceNoEvent := &customattrs.ServiceNoEvent{
 		Config:      userProfileConfig,


### PR DESCRIPTION
refs #1848

Completed transforming picture attribute from `authgearimages://` to `https://`, but two problems are find.

1. Now we cannot set `authgearimages:///OBJECT_ID` to the picture, as the validation requires the uri to be absolute that means the host cannot be empty.
    1. Add a new validation format that allows empty host and use it in picture attribute
    2. Or we add a dummy host to the authgear images url. e.g. `authgearimages://host/OBJECT_ID`
1. When I set the picture url to `authgearimages://host/OBJECT_ID` in the portal, the url will be transformed to `https`. When I click save again, the `https` value will be saved and the `authgearimages` url cannot be preserved.
    1. Maybe when we update an attribute, we run the processor on the original value and check if it has been changed. If the value is the same, don't update that attribute? 