### PR TITLE
Adjust the cropped image size to at most 1024x1024

### DIFF
--- a/authui/src/imagepicker.ts
+++ b/authui/src/imagepicker.ts
@@ -86,9 +86,34 @@ function onClickSave(e: Event) {
     return;
   }
 
+  const maxDimensions = 1024;
+  const dimensionsOptions = (function () {
+    const imageData = cropper.getImageData();
+    const cropBoxData = cropper.getCropBoxData();
+    // assume the cropped area is square
+    if (
+      imageData.naturalWidth > 0 &&
+      imageData.width > 0 &&
+      cropBoxData.width > 0
+    ) {
+      const imageScale = imageData.naturalWidth / imageData.width;
+      const croppedImageWidth = Math.floor(cropBoxData.width * imageScale);
+      const resultDimensions = Math.min(croppedImageWidth, maxDimensions);
+      return {
+        width: resultDimensions,
+        height: resultDimensions,
+      };
+    }
+
+    // last resort when any of the image or crop box data is unavailable
+    return {
+      maxWidth: maxDimensions,
+      maxHeight: maxDimensions,
+    };
+  })();
+
   const canvas = cropper.getCroppedCanvas({
-    width: 240,
-    height: 240,
+    ...dimensionsOptions,
     imageSmoothingQuality: "high",
   });
   canvas.toBlob(async (blob) => {

--- a/nginx.conf
+++ b/nginx.conf
@@ -143,6 +143,7 @@ http {
         }
 
         location /_images {
+            client_max_body_size 10M;
             proxy_pass http://host.docker.internal:3004;
             proxy_http_version 1.1;
             proxy_set_header Host $http_host;


### PR DESCRIPTION
refs #1871 

I found that there are options `maxWidth` and `minWidth` for `getCroppedCanvas` which is suitable for our case, see the [doc](https://github.com/fengyuanchen/cropperjs#getcroppedcanvasoptions). When I tried using the placeholder images, it works as expected. But when I tried a very large image and crop an area which should be larger than 1024x1024, I expected I should be able to get an image with 1024x1024, but the result image is smaller. No idea yet :(

The placeholder images:

![2046](https://user-images.githubusercontent.com/388892/158456599-2c1364ee-c29b-4dc8-afc3-c7f49addbdd8.png)
![1024](https://user-images.githubusercontent.com/388892/158456605-a96f0a1a-f5b4-42bd-9faa-a49921d16d6a.png)
![512](https://user-images.githubusercontent.com/388892/158456609-a3133212-5055-4558-9d4d-d8a6a05d5c06.png)

The large images:
![153853716-065103b0-f4f8-4cfb-9fb5-d857b9e2fe09](https://user-images.githubusercontent.com/388892/158456717-4ab34325-0aa7-48c3-8682-f9d83779fd29.png)

