### PR TITLE
Fix tag based CI job not running

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -5,6 +5,8 @@ on:
     branches:
     - '*'
     - '!gh-pages'
+    tags:
+    - '*'
   pull_request:
     branches:
     - '*'


### PR DESCRIPTION
Need to add `tags: '*'` at the top first. Tested working in xamarin sdk.