### PR TITLE
Change whatsapp callback error log level to info

### DIFF
--- a/pkg/auth/handler/webapp/whatsapp_wati_callback.go
+++ b/pkg/auth/handler/webapp/whatsapp_wati_callback.go
@@ -93,7 +93,7 @@ func (h *WhatsappWATICallbackHandler) ServeHTTP(w http.ResponseWriter, r *http.R
 	defer func() {
 		// always return OK and logs the error if any
 		if err != nil {
-			h.Logger.WithError(err).Warn("failed to consume message")
+			h.Logger.WithError(err).Info("failed to consume message")
 		}
 		w.WriteHeader(http.StatusOK)
 	}()


### PR DESCRIPTION
It is common to have errors in the whatsapp callback, especially when
we reuse the same whatsapp number in different environment. Webhooks
will be sent to all environments, unexpected webhooks will be received.