### PR TITLE
Avoid duplicate subscription more robustly

### DIFF
--- a/pkg/portal/libstripe/error.go
+++ b/pkg/portal/libstripe/error.go
@@ -6,3 +6,4 @@ import (
 
 var ErrUnknownEvent = errors.New("unknown stripe event")
 var ErrCustomerAlreadySubscribed = errors.New("custom already subscribed")
+var ErrAppAlreadySubscribed = errors.New("app already subscribed")

--- a/pkg/portal/transport/stripe_webhook_handler.go
+++ b/pkg/portal/transport/stripe_webhook_handler.go
@@ -128,6 +128,15 @@ func (h *StripeWebhookHandler) handleCheckoutSessionCompletedEvent(event *libstr
 				Info("customer already subscribed")
 			return nil
 		}
+		if errors.Is(err, libstripe.ErrAppAlreadySubscribed) {
+			// The app has stripe subscription already
+			// Tolerate it
+			h.Logger.
+				WithField("app_id", event.AppID).
+				WithField("stripe_checkout_session_id", event.StripeCheckoutSessionID).
+				Warn("app already has stripe subscription")
+			return nil
+		}
 		return err
 	}
 


### PR DESCRIPTION
It will happen only if 2 users subscribe plan for the same app at the same time.
Or the server failed to receive webhook event of the 1st checkout and the user
repeats the checkout flow again.