### PR TITLE
Fix failed to redirect to a custom URI after logout via end_session_endpoint

### DIFF
--- a/pkg/lib/oauth/handler/result_authz.go
+++ b/pkg/lib/oauth/handler/result_authz.go
@@ -6,6 +6,7 @@ import (
 	"net/url"
 	"sort"
 
+	"github.com/authgear/authgear-server/pkg/lib/oauth"
 	"github.com/authgear/authgear-server/pkg/lib/oauth/protocol"
 	"github.com/authgear/authgear-server/pkg/util/httputil"
 )
@@ -29,7 +30,7 @@ func (a authorizationResultCode) WriteResponse(rw http.ResponseWriter, r *http.R
 	for _, cookie := range a.Cookies {
 		httputil.UpdateCookie(rw, cookie)
 	}
-	writeResponse(rw, r, a.RedirectURI, a.ResponseMode, a.Response)
+	oauth.WriteResponse(rw, r, a.RedirectURI, a.ResponseMode, a.Response)
 }
 
 func (a authorizationResultCode) IsInternalError() bool {
@@ -38,7 +39,7 @@ func (a authorizationResultCode) IsInternalError() bool {
 
 func (a authorizationResultError) WriteResponse(rw http.ResponseWriter, r *http.Request) {
 	if a.RedirectURI != nil {
-		writeResponse(rw, r, a.RedirectURI, a.ResponseMode, a.Response)
+		oauth.WriteResponse(rw, r, a.RedirectURI, a.ResponseMode, a.Response)
 	} else {
 		err := "Invalid OAuth authorization request:\n"
 		keys := make([]string, 0, len(a.Response))

--- a/pkg/lib/oauth/oidc/handler/handler_end_session.go
+++ b/pkg/lib/oauth/oidc/handler/handler_end_session.go
@@ -5,6 +5,7 @@ import (
 	"net/url"
 
 	"github.com/authgear/authgear-server/pkg/lib/config"
+	"github.com/authgear/authgear-server/pkg/lib/oauth"
 	"github.com/authgear/authgear-server/pkg/lib/oauth/oidc"
 	"github.com/authgear/authgear-server/pkg/lib/oauth/oidc/protocol"
 	"github.com/authgear/authgear-server/pkg/lib/session"
@@ -78,7 +79,7 @@ func (h *EndSessionHandler) Handle(s session.Session, req protocol.EndSessionReq
 		redirectURI = urlutil.WithQueryParamsAdded(uri, map[string]string{"state": state}).String()
 	}
 
-	http.Redirect(rw, r, redirectURI, http.StatusFound)
+	oauth.HTMLRedirect(rw, redirectURI)
 	return nil
 }
 

--- a/pkg/lib/oauth/response_mode.go
+++ b/pkg/lib/oauth/response_mode.go
@@ -1,4 +1,4 @@
-package handler
+package oauth
 
 import (
 	"fmt"
@@ -59,27 +59,28 @@ func init() {
 	}
 }
 
-func writeResponse(w http.ResponseWriter, r *http.Request, redirectURI *url.URL, responseMode string, response map[string]string) {
+func WriteResponse(w http.ResponseWriter, r *http.Request, redirectURI *url.URL, responseMode string, response map[string]string) {
 	if responseMode == "" {
 		responseMode = "query"
 	}
 
 	switch responseMode {
 	case "query":
-		htmlRedirect(w, urlutil.WithQueryParamsAdded(redirectURI, response).String())
+		HTMLRedirect(w, urlutil.WithQueryParamsAdded(redirectURI, response).String())
 	case "fragment":
-		htmlRedirect(w, urlutil.WithQueryParamsSetToFragment(redirectURI, response).String())
+		HTMLRedirect(w, urlutil.WithQueryParamsSetToFragment(redirectURI, response).String())
 	case "form_post":
-		formPost(w, redirectURI, response)
+		FormPost(w, redirectURI, response)
 	default:
 		http.Error(w, fmt.Sprintf("oauth: invalid response_mode %s", responseMode), http.StatusBadRequest)
 	}
 }
 
-func htmlRedirect(rw http.ResponseWriter, redirectURI string) {
+func HTMLRedirect(rw http.ResponseWriter, redirectURI string) {
 	rw.Header().Set("Content-Type", "text/html; charset=utf-8")
 	// XHR and redirect.
 	//
+
 	// Normally we should use HTTP 302 to redirect.
 	// However, when XHR is used, redirect is followed automatically.
 	// The final redirect URI may be custom URI which is considered unsecure by user agent.
@@ -94,7 +95,7 @@ func htmlRedirect(rw http.ResponseWriter, redirectURI string) {
 	}
 }
 
-func formPost(w http.ResponseWriter, redirectURI *url.URL, response map[string]string) {
+func FormPost(w http.ResponseWriter, redirectURI *url.URL, response map[string]string) {
 	w.Header().Set("Content-Type", "text/html; charset=utf-8")
 
 	err := formPostTemplate.Execute(w, map[string]interface{}{

--- a/pkg/lib/oauth/response_mode_test.go
+++ b/pkg/lib/oauth/response_mode_test.go
@@ -1,4 +1,4 @@
-package handler
+package oauth
 
 import (
 	"net/http"
@@ -10,7 +10,7 @@ import (
 )
 
 func TestWriteResponse(t *testing.T) {
-	Convey("writeResponse", t, func() {
+	Convey("WriteResponse", t, func() {
 		test := func(responseMode string, expected string) {
 			w := httptest.NewRecorder()
 			r, _ := http.NewRequest("GET", "/", nil)
@@ -19,7 +19,7 @@ func TestWriteResponse(t *testing.T) {
 				"code":  "this_is_the_code",
 				"state": "this_is_the_state",
 			}
-			writeResponse(w, r, redirectURI, responseMode, response)
+			WriteResponse(w, r, redirectURI, responseMode, response)
 			So(w.Body.String(), ShouldEqual, expected)
 		}
 


### PR DESCRIPTION
ref #1869 

To test:
1. Use updated JS SDK that will redirect to `end_session_endpoint` (https://github.com/authgear/authgear-sdk-js/pull/196)
2. Start the web app example and use different etld+1 domain, `sessionType` set to `refresh_token`
3. Add the post logout uri to the oauth client config
4. Login via the web app
5. Login via `/login` link
6. Logout from the web app
