### PR TITLE
Fix weekly tab doesn't work in analytics page

### DIFF
--- a/portal/src/graphql/portal/AnalyticsActivityWidget.tsx
+++ b/portal/src/graphql/portal/AnalyticsActivityWidget.tsx
@@ -194,7 +194,7 @@ const AnalyticsActivityWidget: React.FC<AnalyticsActivityWidgetProps> =
         const itemKey = item?.props.itemKey;
         if (itemKey) {
           if (itemKey !== periodical) {
-            if (itemKey in Periodical) {
+            if (Object.values(Periodical).includes(itemKey as Periodical)) {
               onPeriodicalChange(itemKey as Periodical);
             }
           }


### PR DESCRIPTION
ref #2182 

We should compare the string with the values of Periodical enum but not
the keys.
It was working since the keys and values of the enum were the same, and
it broke after the keys were changed from uppercase to capitalize string.