### PR TITLE
Enable automatic tax for subscription

### DIFF
--- a/pkg/portal/libstripe/service.go
+++ b/pkg/portal/libstripe/service.go
@@ -260,6 +260,9 @@ func (s *Service) CreateSubscriptionIfNotExists(checkoutSessionID string, subscr
 		Customer:           customerID,
 		Items:              subscriptionItems,
 		BillingCycleAnchor: &billingCycleAnchorUnix,
+		AutomaticTax: &stripe.SubscriptionAutomaticTaxParams{
+			Enabled: stripe.Bool(true),
+		},
 	})
 	if err != nil {
 		return err

--- a/portal/src/graphql/portal/SubscriptionPlanCard.module.css
+++ b/portal/src/graphql/portal/SubscriptionPlanCard.module.css
@@ -30,6 +30,10 @@
   text-align: center;
 }
 
+.basePriceTagRemarks {
+  color: #c8c8c8;
+}
+
 .mauRestriction {
   text-align: center;
 }

--- a/portal/src/graphql/portal/SubscriptionPlanCard.tsx
+++ b/portal/src/graphql/portal/SubscriptionPlanCard.tsx
@@ -119,6 +119,7 @@ export function BasePriceTag(props: BasePriceTagProps): React.ReactElement {
   return (
     <Text block={true} variant="xLarge" className={styles.basePriceTag}>
       {children}
+      <span className={styles.basePriceTagRemarks}>*</span>
     </Text>
   );
 }

--- a/portal/src/graphql/portal/SubscriptionScreen.tsx
+++ b/portal/src/graphql/portal/SubscriptionScreen.tsx
@@ -816,6 +816,9 @@ function SubscriptionScreenContent(props: SubscriptionScreenContentProps) {
         </div>
         <div className={styles.footer}>
           <Text block={true}>
+            <FormattedMessage id="SubscriptionScreen.footer.tax" />
+          </Text>
+          <Text block={true}>
             <FormattedMessage
               id="SubscriptionScreen.footer.enterprise-plan"
               values={{

--- a/portal/src/locale-data/en.json
+++ b/portal/src/locale-data/en.json
@@ -921,6 +921,7 @@
   "SubscriptionPlanCard.sms.other-regions": "USD {unitAmount} per SMS (Other regions)",
   "SubscriptionPlanCard.mau": "USD {unitAmount}/mo per {divisor} additional MAUs",
 
+  "SubscriptionScreen.footer.tax": "* Local VAT and taxes may apply.",
   "SubscriptionScreen.footer.enterprise-plan": "Get 50,000+ MAUs and customization with our {ExternalLink, react, onClick{{onClick}} children{Enterprise Plan}}",
   "SubscriptionScreen.footer.pricing-details": "Check out more details and compare plan features on our {ExternalLink, react, href{https://www.authgear.com/pricing} children{pricing page}}",
   "SubscriptionScreen.footer.usage-delay-disclaimer": "Reporting is not realtime. The MAU and SMS numbers are delayed up to 24 hours.",


### PR DESCRIPTION
ref #2268 

To support automatic tax we need to
1. Update the price items to become tax exclusive in Stripe portal 
2. Mark automatic tax enabled when creating the subscriptions

Finally I found that we can test the tax settings in the sandbox environment and I updated the dev env for testing.

