### PR TITLE
Fix failed to open whatsapp otp page when verifying phone via whatsapp

### DIFF
--- a/pkg/auth/handler/webapp/whatsapp_otp.go
+++ b/pkg/auth/handler/webapp/whatsapp_otp.go
@@ -83,6 +83,7 @@ func (h *WhatsappOTPHandler) GetData(r *http.Request, rw http.ResponseWriter, se
 	default:
 		// identity verification
 		// alternatives are provided in PhoneOTPAlternativeStepsViewModel
+		alternatives = &viewmodels.AlternativeStepsViewModel{}
 	}
 
 	viewmodels.Embed(data, baseViewModel)


### PR DESCRIPTION
fix #2305 

In whatsapp otp page, alternatives should be empty. Provide empty
AlternativeStepsViewModel for this case.