### PR TITLE
Identify portal user and track page view in mixpanel

### DIFF
--- a/docs/portal/gtm.md
+++ b/docs/portal/gtm.md
@@ -63,7 +63,7 @@ This document describes how to setup portal tracking to send data to Mixpanel vi
           });
         </script>
         ```
-      - Trigger: All Pages
+      - Trigger: Initialization - All Pages
     - `Mixpanel Track Click`
       - Type: Custom HTML
       - HTML:

--- a/docs/portal/gtm.md
+++ b/docs/portal/gtm.md
@@ -15,6 +15,11 @@ This document describes how to setup portal tracking to send data to Mixpanel vi
       - Event name: `ag.event.*`
       - Use regex matching: true
       - Fires on: All Custom Events
+    - `ag.lifecycle.identified`
+      - Type: Custom Event
+      - Event name: `ag.lifecycle.identified`
+      - Use regex matching: true
+      - Fires on: All Custom Events
   - Built-In Variables
     - Select all
   - User-Defined Variables
@@ -27,7 +32,37 @@ This document describes how to setup portal tracking to send data to Mixpanel vi
   - Tags
     - `Mixpanel Initialize`
       - Type: Custom HTML
-      - HTML: [Initialization code with mixpanel.init call](https://developer.mixpanel.com/docs/javascript-quickstart#installation-option-2-html).
+      - HTML: Use the following HTML script tag snippet, replace the mixpanel init script based on the [doc](https://developer.mixpanel.com/docs/javascript-quickstart#installation-option-2-html) and replace the `YOUR_PROJECT_TOKEN`.
+        ```html
+        <script type="text/javascript">
+          // REPLACE WITH MIXPANEL INIT SCRIPT
+
+          window._agMixpanelIdentifyIfNeeded = function (mixpanel) {
+            if (window._agUserData == null) {
+              return;
+            }
+            try {
+              var distinctID = mixpanel.get_distinct_id();
+              if (distinctID === window._agUserData.user_id) {
+                return;
+              }
+              mixpanel.reset();
+              mixpanel.identify(window._agUserData.user_id);
+              if (window._agUserData.email) {
+                mixpanel.people.set({ $email: window._agUserData.email });
+              }
+            } catch (_) {}
+          };
+
+          // REPLACE THE MIXPANEL PROJECT TOKEN
+          mixpanel.init("YOUR_PROJECT_TOKEN", {
+            debug: false,
+            loaded: function (mixpanel) {
+              window._agMixpanelIdentifyIfNeeded(mixpanel);
+            },
+          });
+        </script>
+        ```
       - Trigger: All Pages
     - `Mixpanel Track Click`
       - Type: Custom HTML
@@ -65,3 +100,16 @@ This document describes how to setup portal tracking to send data to Mixpanel vi
         </script>
         ```
       - Trigger: `ag.event.*`
+    - `Mixpanel Identify`
+      - Type: Custom HTML
+      - HTML:
+        ```html
+        <script type="text/javascript">
+          var event = {{Event}};
+          if (event === "ag.lifecycle.identified") {
+            window._agUserData = {{event_data}};
+            window._agMixpanelIdentifyIfNeeded(mixpanel);
+          }
+        </script>
+        ```
+      - Trigger: `ag.lifecycle.identified`

--- a/docs/portal/gtm.md
+++ b/docs/portal/gtm.md
@@ -2,6 +2,8 @@
 
 This document describes how to setup portal tracking to send data to Mixpanel via Google Tag Manager.
 
+## Setup
+
 1. Create Mixpanel project and obtain project token from settings page
 1. Create following resources in Google Tag Manager
   - Triggers
@@ -43,14 +45,14 @@ This document describes how to setup portal tracking to send data to Mixpanel vi
             }
             try {
               var distinctID = mixpanel.get_distinct_id();
-              if (distinctID === window._agUserData.user_id) {
-                return;
+              if (distinctID !== window._agUserData.user_id) {
+                mixpanel.reset();
+                mixpanel.identify(window._agUserData.user_id);
+                if (window._agUserData.email) {
+                  mixpanel.people.set({ $email: window._agUserData.email });
+                }
               }
-              mixpanel.reset();
-              mixpanel.identify(window._agUserData.user_id);
-              if (window._agUserData.email) {
-                mixpanel.people.set({ $email: window._agUserData.email });
-              }
+              mixpanel.track("Pageview", { page_path: {{Page Path}} });
             } catch (_) {}
           };
 
@@ -116,3 +118,20 @@ This document describes how to setup portal tracking to send data to Mixpanel vi
         </script>
         ```
       - Trigger: `ag.lifecycle.identified`
+    - `Mixpanel Track Pageview`
+      - Type: Custom HTML
+      - HTML:
+        ```html
+        <script type="text/javascript">
+          var event = {{Event}};
+          if (event === "gtm.historyChange") {
+            mixpanel.track("Pageview", { page_path: {{Page Path}} });
+          }
+        </script>
+        ```
+      - Trigger: History Change
+
+## Implementation Details
+
+Initial page view is tracked after `mixpanel.identify` to ensure the events are
+associated with the correct user.

--- a/docs/portal/gtm.md
+++ b/docs/portal/gtm.md
@@ -94,9 +94,12 @@ This document describes how to setup portal tracking to send data to Mixpanel vi
       - HTML:
         ```html
         <script type="text/javascript">
-          var appID = {{app_id}};
-          var eventData = {{event_data}};
-          mixpanel.track({{Event}}, Object.assign({app_id: appID}, eventData));
+          var event = {{Event}};
+          if (event.startsWith("ag.event.")) {
+            var appID = {{app_id}};
+            var eventData = {{event_data}};
+            mixpanel.track({{Event}}, Object.assign({app_id: appID}, eventData));
+          }
         </script>
         ```
       - Trigger: `ag.event.*`

--- a/pkg/portal/loader/user.go
+++ b/pkg/portal/loader/user.go
@@ -42,10 +42,7 @@ func (l *UserLoader) LoadFunc(keys []interface{}) ([]interface{}, error) {
 			nodes(ids: $ids) {
 				... on User {
 					id
-					verifiedClaims {
-						name
-						value
-					}
+					standardAttributes
 				}
 			}
 		}
@@ -91,15 +88,10 @@ func (l *UserLoader) LoadFunc(keys []interface{}) ([]interface{}, error) {
 			resolvedNodeID := relay.FromGlobalID(globalID)
 			userModel.ID = resolvedNodeID.ID
 
-			// Use the last email claim.
-			verifiedClaims := userNode["verifiedClaims"].([]interface{})
-			for _, iface := range verifiedClaims {
-				claim := iface.(map[string]interface{})
-				name := claim["name"].(string)
-				value := claim["value"].(string)
-				if name == "email" {
-					userModel.Email = value
-				}
+			standardAttributes := userNode["standardAttributes"].(map[string]interface{})
+			email, ok := standardAttributes["email"].(string)
+			if ok {
+				userModel.Email = email
 			}
 
 			userModels = append(userModels, userModel)

--- a/pkg/portal/loader/user.go
+++ b/pkg/portal/loader/user.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"net/http"
 
-	"github.com/authgear/graphql-go-relay"
+	relay "github.com/authgear/graphql-go-relay"
 
 	"github.com/authgear/authgear-server/pkg/portal/model"
 	"github.com/authgear/authgear-server/pkg/util/graphqlutil"
@@ -88,7 +88,8 @@ func (l *UserLoader) LoadFunc(keys []interface{}) ([]interface{}, error) {
 		} else {
 			userModel := &model.User{}
 			globalID := userNode["id"].(string)
-			userModel.ID = globalID
+			resolvedNodeID := relay.FromGlobalID(globalID)
+			userModel.ID = resolvedNodeID.ID
 
 			// Use the last email claim.
 			verifiedClaims := userNode["verifiedClaims"].([]interface{})

--- a/portal/src/GTMProvider.tsx
+++ b/portal/src/GTMProvider.tsx
@@ -27,6 +27,7 @@ export enum AuthgearGTMEventType {
   ClickedDocLink = "ag.event.clickedDocLink",
   ClickedNextInProjectWizard = "ag.event.clickedNextInProjectWizard",
   ClickedSkipInProjectWizard = "ag.event.clickedSkipInProjectWizard",
+  Identified = "ag.lifecycle.identified",
 }
 
 export function useAuthgearGTMEventBase(): AuthgearGTMEventBase {

--- a/portal/src/ReactApp.tsx
+++ b/portal/src/ReactApp.tsx
@@ -236,8 +236,7 @@ const LoadCurrentUser: React.FC<LoadCurrentUserProps> =
           ...gtmEvent,
           event: AuthgearGTMEventType.Identified,
           event_data: {
-            // fixme: userid encoded twice
-            user_id: extractRawID(extractRawID(viewer.id)),
+            user_id: extractRawID(viewer.id),
             email: viewer.email ?? undefined,
           },
         };


### PR DESCRIPTION
ref #2206 

~~Per discussion, changed to another approach to compare the mixpanel distinct id and user id, only call `reset` and `identify` when the distinct id is changed. The checking will be done after `mixpanel.init` or `ag.lifecycle.identified` event.~~

After more testing, I found that it is better to call GTM in React instead of pasting the script in index.html. It is because:

1. To ensure the events are associated with the correct user, all the events should be tracked after `mixpanel.identify` including page view.
1. Even we pasting the code in index.html, the initial history change events only fire occasionally.

So I changed the implementation,

1. Keep the mixpanel installation script in the initialization phase, but move `mixpanel.init` to `ag.event.identify`. To ensure no events can be send before the user is identified.
2. Call `mixpanel.track("PageView", ...)` in `ag.event.identify` after `mixpanel.identify`, and this is the initial page view event.
3. Also call `mixpanel.track("PageView", ...)` in the `gtm.historyChange` events to track the pageview after the page is loaded.

See if it looks good?