### PR TITLE
Fix mixpanel distinct_id keep changing when refresh

### DIFF
--- a/docs/portal/gtm.md
+++ b/docs/portal/gtm.md
@@ -90,6 +90,7 @@ This document describes how to setup portal tracking to send data to Mixpanel vi
             // REPLACE THE MIXPANEL PROJECT TOKEN
             mixpanel.init("YOUR_PROJECT_TOKEN", {
               debug: false,
+              cookie_domain: window.location.hostname,
               loaded: function (mixpanel) {
                 var distinctID = mixpanel.get_distinct_id();
                 if (distinctID !== agUserData.user_id) {


### PR DESCRIPTION
ref #2206 

When `cookie_domain` is not provided, mixpanel doesn't write the cookie and the distinct_id will keep changing when refresh.