### PR TITLE
Fix the widget layout when it is not extensible

### DIFF
--- a/portal/src/Widget.tsx
+++ b/portal/src/Widget.tsx
@@ -72,7 +72,7 @@ const Widget: React.VFC<WidgetProps> = function Widget(props: WidgetProps) {
       style={{
         boxShadow: DefaultEffects.elevation4,
         maxHeight:
-          measuredHeight == null
+          measuredHeight == null || !showToggleButton
             ? undefined
             : extended
             ? `${measuredHeight}px`


### PR DESCRIPTION
ref #2417 

Some widgets failed to get the correct height and this fix is a workaround that doesn't set max height when it is not extensible.
