### PR TITLE
Fix setup passkey dialog copywriting grammar

### DIFF
--- a/resources/authgear/templates/en/translation.json
+++ b/resources/authgear/templates/en/translation.json
@@ -204,7 +204,7 @@
   "missing-web3-wallet-page-description": "{provider} is either missing or not supported for your browser.",
 
   "prompt-create-passkey-page-title": "Set up a passkey",
-  "prompt-create-passkey-page-description": "Your device support passkey authentication. Set up a passkey for faster and safer login. If you use biometrics, we will never see or store your biometric data.",
+  "prompt-create-passkey-page-description": "Your device supports passkey authentication. Set up a passkey for faster and safer logins. If you use biometrics, we will never see or store your biometric data.",
   "prompt-create-passkey-skip-label": "Not now",
 
   "use-passkey-page-title": "Use passkey",


### PR DESCRIPTION
Original:
<img width="490" alt="Screenshot 2022-09-16 at 09 51 40" src="https://user-images.githubusercontent.com/70891443/190599060-d4bd3dee-c51f-4d14-8b3e-b26858b58d94.png">

Should be `Your device supports passkey...faster and safer logins...`