### PR TITLE
Add back missing case check for SIWE identity type

### DIFF
--- a/pkg/lib/authn/identity/info.go
+++ b/pkg/lib/authn/identity/info.go
@@ -255,6 +255,8 @@ func (i *Info) AllStandardClaims() map[string]interface{} {
 		break
 	case model.IdentityTypePasskey:
 		break
+	case model.IdentityTypeSIWE:
+		break
 	default:
 		panic(fmt.Errorf("identity: unexpected identity type %v", i.Type))
 	}


### PR DESCRIPTION
- Prevent yielding error after https://github.com/authgear/authgear-nft-indexer/pull/25#issuecomment-1267896019 due to no nft collection
- Added missing case check for SIWE identity in AllStandardClaims