### PR TITLE
Prevent CSP violation for MetaMask on SIWE pages

### DIFF
--- a/authui/src/authgear.ts
+++ b/authui/src/authgear.ts
@@ -32,11 +32,7 @@ import {
   PasskeyRequestController,
   PasskeyAutofillController,
 } from "./passkey";
-import {
-  WalletConnectionController,
-  WalletConfirmationController,
-  WalletIconController,
-} from "./web3";
+import { WalletConfirmationController, WalletIconController } from "./web3";
 // FIXME(css): Build CSS files one by one with another tool
 // webpack bundles all CSS files into one bundle.
 
@@ -92,6 +88,5 @@ Stimulus.register("passkey-creation", PasskeyCreationController);
 Stimulus.register("passkey-request", PasskeyRequestController);
 Stimulus.register("passkey-autofill", PasskeyAutofillController);
 
-Stimulus.register("web3-wallet-connection", WalletConnectionController);
 Stimulus.register("web3-wallet-confirmation", WalletConfirmationController);
 Stimulus.register("web3-wallet-icon", WalletIconController);

--- a/authui/src/web3.ts
+++ b/authui/src/web3.ts
@@ -111,51 +111,6 @@ function handleError(err: unknown) {
   }
   return;
 }
-
-export class WalletConnectionController extends Controller {
-  static targets = ["button"];
-  static values = {
-    provider: String,
-  };
-
-  declare buttonTarget: HTMLButtonElement;
-
-  declare providerValue: string;
-  declare provider: ethers.providers.Web3Provider | null;
-
-  connect() {
-    getProvider(this.providerValue)
-      .then((provider) => {
-        this.provider = provider;
-      })
-      .catch((err) => {
-        handleError(err);
-      });
-  }
-
-  connectWallet(e: MouseEvent) {
-    e.preventDefault();
-    e.stopPropagation();
-
-    this._connectWallet();
-  }
-
-  async _connectWallet() {
-    if (!this.provider) {
-      visit(`/missing_web3_wallet?provider=${this.providerValue}`);
-      return;
-    }
-
-    try {
-      // Ensure wallet is connected
-      await this.provider.send("eth_requestAccounts", []);
-      visit(`/confirm_web3_account?provider=${this.providerValue}`);
-    } catch (err) {
-      handleError(err);
-    }
-  }
-}
-
 export class WalletIconController extends Controller {
   static targets = ["iconContainer"];
   static values = {

--- a/authui/src/web3.ts
+++ b/authui/src/web3.ts
@@ -192,6 +192,7 @@ export class WalletConfirmationController extends Controller {
   }
 
   connect() {
+    this.displayedTarget.textContent = "-";
     getProvider(this.providerValue)
       .then((provider) => {
         if (!provider) {

--- a/authui/src/web3.ts
+++ b/authui/src/web3.ts
@@ -192,7 +192,6 @@ export class WalletConfirmationController extends Controller {
   }
 
   connect() {
-    this.displayedTarget.textContent = "-";
     getProvider(this.providerValue)
       .then((provider) => {
         if (!provider) {
@@ -219,6 +218,7 @@ export class WalletConfirmationController extends Controller {
     if (!this.provider) {
       return;
     }
+    this.displayedTarget.textContent = "-";
 
     await this.provider.send("eth_requestAccounts", []);
 

--- a/authui/src/web3.ts
+++ b/authui/src/web3.ts
@@ -236,6 +236,9 @@ export class WalletConfirmationController extends Controller {
       return;
     }
 
+    // Ensure at least one account is connected if user has rejected the initial request
+    await this._getAccount();
+
     try {
       const nonceResp = await axios("/siwe/nonce", {
         method: "get",

--- a/pkg/auth/handler/webapp/confirm_web3_account.go
+++ b/pkg/auth/handler/webapp/confirm_web3_account.go
@@ -14,8 +14,8 @@ import (
 	"github.com/authgear/authgear-server/pkg/util/validation"
 )
 
-var TemplateWebConfirmWeb3AccountHTML = template.RegisterHTML(
-	"web/confirm_web3_account.html",
+var TemplateWebConnectWeb3AccountHTML = template.RegisterHTML(
+	"web/connect_web3_account.html",
 	components...,
 )
 
@@ -30,17 +30,17 @@ var Web3AccountConfirmationSchema = validation.NewSimpleSchema(`
 	}
 `)
 
-func ConfigureConfirmWeb3AccountRoute(route httproute.Route) httproute.Route {
+func ConfigureConnectWeb3AccountRoute(route httproute.Route) httproute.Route {
 	return route.
 		WithMethods("OPTIONS", "POST", "GET").
 		WithPathPattern("/confirm_web3_account")
 }
 
-type ConfirmWeb3AccountViewModel struct {
+type ConnectWeb3AccountViewModel struct {
 	Provider string
 }
 
-type ConfirmWeb3AccountHandler struct {
+type ConnectWeb3AccountHandler struct {
 	ControllerFactory         ControllerFactory
 	BaseViewModel             *viewmodels.BaseViewModeler
 	AuthenticationViewModel   *viewmodels.AuthenticationViewModeler
@@ -49,7 +49,7 @@ type ConfirmWeb3AccountHandler struct {
 	AuthenticationConfig      *config.AuthenticationConfig
 }
 
-func (h *ConfirmWeb3AccountHandler) GetData(r *http.Request, rw http.ResponseWriter, graph *interaction.Graph) (map[string]interface{}, error) {
+func (h *ConnectWeb3AccountHandler) GetData(r *http.Request, rw http.ResponseWriter, graph *interaction.Graph) (map[string]interface{}, error) {
 	data := map[string]interface{}{}
 
 	baseViewModel := h.BaseViewModel.ViewModel(r, rw)
@@ -61,7 +61,7 @@ func (h *ConfirmWeb3AccountHandler) GetData(r *http.Request, rw http.ResponseWri
 		provider = p
 	}
 
-	confirmWeb3AccountViewModel := ConfirmWeb3AccountViewModel{
+	confirmWeb3AccountViewModel := ConnectWeb3AccountViewModel{
 		Provider: provider,
 	}
 
@@ -73,7 +73,7 @@ func (h *ConfirmWeb3AccountHandler) GetData(r *http.Request, rw http.ResponseWri
 	return data, nil
 }
 
-func (h *ConfirmWeb3AccountHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+func (h *ConnectWeb3AccountHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	ctrl, err := h.ControllerFactory.New(r, w)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusBadRequest)
@@ -124,7 +124,7 @@ func (h *ConfirmWeb3AccountHandler) ServeHTTP(w http.ResponseWriter, r *http.Req
 			return err
 		}
 
-		h.Renderer.RenderHTML(w, r, TemplateWebConfirmWeb3AccountHTML, data)
+		h.Renderer.RenderHTML(w, r, TemplateWebConnectWeb3AccountHTML, data)
 		return nil
 	})
 

--- a/pkg/auth/handler/webapp/deps.go
+++ b/pkg/auth/handler/webapp/deps.go
@@ -74,7 +74,7 @@ var DependencySet = wire.NewSet(
 	NewWhatsappWATICallbackHandlerLogger,
 	wire.Struct(new(PasskeyCreationOptionsHandler), "*"),
 	wire.Struct(new(PasskeyRequestOptionsHandler), "*"),
-	wire.Struct(new(ConfirmWeb3AccountHandler), "*"),
+	wire.Struct(new(ConnectWeb3AccountHandler), "*"),
 	wire.Struct(new(MissingWeb3WalletHandler), "*"),
 
 	wire.Struct(new(ResponseWriter), "*"),

--- a/pkg/auth/routes.go
+++ b/pkg/auth/routes.go
@@ -197,7 +197,7 @@ func NewRouter(p *deps.RootProvider, configSource *configsource.ConfigSource) *h
 	router.Add(webapphandler.ConfigureErrorRoute(webappPageRoute), p.Handler(newWebAppErrorHandler))
 	router.Add(webapphandler.ConfigureForceChangePasswordRoute(webappPageRoute), p.Handler(newWebAppForceChangePasswordHandler))
 	router.Add(webapphandler.ConfigureForceChangeSecondaryPasswordRoute(webappPageRoute), p.Handler(newWebAppForceChangeSecondaryPasswordHandler))
-	router.Add(webapphandler.ConfigureConfirmWeb3AccountRoute(webappPageRoute), p.Handler(newWebAppConfirmWeb3AccountHandler))
+	router.Add(webapphandler.ConfigureConnectWeb3AccountRoute(webappPageRoute), p.Handler(newWebAppConnectWeb3AccountHandler))
 	router.Add(webapphandler.ConfigureMissingWeb3WalletRoute(webappPageRoute), p.Handler(newWebAppMissingWeb3WalletHandler))
 
 	router.Add(webapphandler.ConfigureForgotPasswordSuccessRoute(webappSuccessPageRoute), p.Handler(newWebAppForgotPasswordSuccessHandler))

--- a/pkg/auth/webapp/dynamic_csp_middleware.go
+++ b/pkg/auth/webapp/dynamic_csp_middleware.go
@@ -22,9 +22,10 @@ var CSPNonceCookieDef = &httputil.CookieDef{
 }
 
 type DynamicCSPMiddleware struct {
-	Cookies       CookieManager
-	HTTPConfig    *config.HTTPConfig
-	WebAppCDNHost config.WebAppCDNHost
+	Cookies           CookieManager
+	HTTPConfig        *config.HTTPConfig
+	WebAppCDNHost     config.WebAppCDNHost
+	AllowInlineScript bool
 }
 
 func (m *DynamicCSPMiddleware) Handle(next http.Handler) http.Handler {
@@ -41,7 +42,7 @@ func (m *DynamicCSPMiddleware) Handle(next http.Handler) http.Handler {
 
 		r = r.WithContext(web.WithCSPNonce(r.Context(), nonce))
 
-		cspDirectives, err := web.CSPDirectives(m.HTTPConfig.PublicOrigin, nonce, string(m.WebAppCDNHost))
+		cspDirectives, err := web.CSPDirectives(m.HTTPConfig.PublicOrigin, nonce, string(m.WebAppCDNHost), m.AllowInlineScript)
 		if err != nil {
 			panic(err)
 		}

--- a/pkg/auth/wire_gen.go
+++ b/pkg/auth/wire_gen.go
@@ -46106,7 +46106,7 @@ func newCORSMiddleware(p *deps.RequestProvider) httproute.Middleware {
 	return corsMiddleware
 }
 
-func newDynamicCSPMiddleware(p *deps.RequestProvider) httproute.Middleware {
+func newDynamicCSPMiddleware(p *deps.RequestProvider, allowInlineScript bool) httproute.Middleware {
 	request := p.Request
 	appProvider := p.AppProvider
 	rootProvider := appProvider.RootProvider
@@ -46118,9 +46118,10 @@ func newDynamicCSPMiddleware(p *deps.RequestProvider) httproute.Middleware {
 	cookieManager := deps.NewCookieManager(request, trustProxy, httpConfig)
 	webAppCDNHost := environmentConfig.WebAppCDNHost
 	dynamicCSPMiddleware := &webapp2.DynamicCSPMiddleware{
-		Cookies:       cookieManager,
-		HTTPConfig:    httpConfig,
-		WebAppCDNHost: webAppCDNHost,
+		Cookies:           cookieManager,
+		HTTPConfig:        httpConfig,
+		WebAppCDNHost:     webAppCDNHost,
+		AllowInlineScript: allowInlineScript,
 	}
 	return dynamicCSPMiddleware
 }

--- a/pkg/auth/wire_gen.go
+++ b/pkg/auth/wire_gen.go
@@ -44447,7 +44447,7 @@ func newWebAppPasskeyRequestOptionsHandler(p *deps.RequestProvider) http.Handler
 	return passkeyRequestOptionsHandler
 }
 
-func newWebAppConfirmWeb3AccountHandler(p *deps.RequestProvider) http.Handler {
+func newWebAppConnectWeb3AccountHandler(p *deps.RequestProvider) http.Handler {
 	appProvider := p.AppProvider
 	factory := appProvider.LoggerFactory
 	handle := appProvider.AppDatabase
@@ -45194,7 +45194,7 @@ func newWebAppConfirmWeb3AccountHandler(p *deps.RequestProvider) http.Handler {
 	alternativeStepsViewModeler := &viewmodels.AlternativeStepsViewModeler{
 		AuthenticationConfig: authenticationConfig,
 	}
-	confirmWeb3AccountHandler := &webapp.ConfirmWeb3AccountHandler{
+	connectWeb3AccountHandler := &webapp.ConnectWeb3AccountHandler{
 		ControllerFactory:         controllerFactory,
 		BaseViewModel:             baseViewModeler,
 		AuthenticationViewModel:   authenticationViewModeler,
@@ -45202,7 +45202,7 @@ func newWebAppConfirmWeb3AccountHandler(p *deps.RequestProvider) http.Handler {
 		Renderer:                  responseRenderer,
 		AuthenticationConfig:      authenticationConfig,
 	}
-	return confirmWeb3AccountHandler
+	return connectWeb3AccountHandler
 }
 
 func newWebAppMissingWeb3WalletHandler(p *deps.RequestProvider) http.Handler {

--- a/pkg/auth/wire_handler.go
+++ b/pkg/auth/wire_handler.go
@@ -518,10 +518,10 @@ func newWebAppPasskeyRequestOptionsHandler(p *deps.RequestProvider) http.Handler
 	))
 }
 
-func newWebAppConfirmWeb3AccountHandler(p *deps.RequestProvider) http.Handler {
+func newWebAppConnectWeb3AccountHandler(p *deps.RequestProvider) http.Handler {
 	panic(wire.Build(
 		DependencySet,
-		wire.Bind(new(http.Handler), new(*handlerwebapp.ConfirmWeb3AccountHandler)),
+		wire.Bind(new(http.Handler), new(*handlerwebapp.ConnectWeb3AccountHandler)),
 	))
 }
 

--- a/pkg/auth/wire_middleware.go
+++ b/pkg/auth/wire_middleware.go
@@ -59,7 +59,7 @@ func newCORSMiddleware(p *deps.RequestProvider) httproute.Middleware {
 	))
 }
 
-func newDynamicCSPMiddleware(p *deps.RequestProvider) httproute.Middleware {
+func newDynamicCSPMiddleware(p *deps.RequestProvider, allowInlineScript bool) httproute.Middleware {
 	panic(wire.Build(
 		DependencySet,
 		wire.Bind(new(httproute.Middleware), new(*webapp.DynamicCSPMiddleware)),

--- a/pkg/lib/web/csp_test.go
+++ b/pkg/lib/web/csp_test.go
@@ -8,13 +8,13 @@ import (
 
 func TestCSPDirectives(t *testing.T) {
 	Convey("CSPDirectives", t, func() {
-		test := func(publicOrigin string, nonce string, cdnHost string, expected []string) {
-			actual, err := CSPDirectives(publicOrigin, nonce, cdnHost)
+		test := func(publicOrigin string, nonce string, cdnHost string, allowInlineScript bool, expected []string) {
+			actual, err := CSPDirectives(publicOrigin, nonce, cdnHost, allowInlineScript)
 			So(err, ShouldBeNil)
 			So(actual, ShouldResemble, expected)
 		}
 
-		test("http://localhost:3000", "N0NC5", "", []string{
+		test("http://localhost:3000", "N0NC5", "", false, []string{
 			"default-src 'self'",
 			"script-src 'self' 'nonce-N0NC5' www.googletagmanager.com",
 			"frame-src 'self' www.googletagmanager.com",
@@ -28,9 +28,23 @@ func TestCSPDirectives(t *testing.T) {
 			"frame-ancestors 'none'",
 		})
 
-		test("http://localhost:3000", "N0NC5", "cdn.localhost:3000", []string{
+		test("http://localhost:3000", "N0NC5", "cdn.localhost:3000", false, []string{
 			"default-src 'self'",
 			"script-src 'self' cdn.localhost:3000 'nonce-N0NC5' www.googletagmanager.com",
+			"frame-src 'self' www.googletagmanager.com",
+			"font-src 'self' cdn.localhost:3000 cdnjs.cloudflare.com static2.sharepointonline.com fonts.googleapis.com fonts.gstatic.com",
+			"style-src 'self' cdn.localhost:3000 'unsafe-inline' cdnjs.cloudflare.com www.googletagmanager.com fonts.googleapis.com",
+			"img-src 'self' cdn.localhost:3000 http: https: data:",
+			"object-src 'none'",
+			"base-uri 'none'",
+			"connect-src 'self' https://www.google-analytics.com ws://localhost:3000 wss://localhost:3000",
+			"block-all-mixed-content",
+			"frame-ancestors 'none'",
+		})
+
+		test("http://localhost:3000", "N0NC5", "cdn.localhost:3000", true, []string{
+			"default-src 'self'",
+			"script-src 'self' cdn.localhost:3000 'unsafe-inline' www.googletagmanager.com",
 			"frame-src 'self' www.googletagmanager.com",
 			"font-src 'self' cdn.localhost:3000 cdnjs.cloudflare.com static2.sharepointonline.com fonts.googleapis.com fonts.gstatic.com",
 			"style-src 'self' cdn.localhost:3000 'unsafe-inline' cdnjs.cloudflare.com www.googletagmanager.com fonts.googleapis.com",

--- a/resources/authgear/templates/en/translation.json
+++ b/resources/authgear/templates/en/translation.json
@@ -196,10 +196,10 @@
   "web3-provider-metamask": "MetaMask",
   "web3-provider-metamask-install": "Install MetaMask",
 
-  "confirm-web3-account-page-title": "Account Connected",
-  "confirm-web3-account-page-description": "Connected with {provider}",
-  "confirm-web3-account-page-next": "Next",
-  "confirm-web3-account-page-change-account": "You can change the connected account by opening the MetaMask extension",
+  "connect-web3-account-page-title": "Account Connected",
+  "connect-web3-account-page-description": "Connected with {provider}",
+  "connect-web3-account-page-next": "Next",
+  "connect-web3-account-page-change-account": "You can change the connected account by opening the MetaMask extension",
 
   "missing-web3-wallet-page-title": "Install Wallet",
   "missing-web3-wallet-page-description": "{provider} is either missing or not supported for your browser.",

--- a/resources/authgear/templates/en/web/connect_web3_account.html
+++ b/resources/authgear/templates/en/web/connect_web3_account.html
@@ -27,7 +27,8 @@
         <span
           class="text-xl leading-6 font-semibold primary-txt"
           data-web3-wallet-confirmation-target="displayed"
-        ></span>
+          >-</span
+        >
       </div>
       <form class="flex flex-col items-center w-full" method="post" novalidate>
         {{ $.CSRFField }}

--- a/resources/authgear/templates/en/web/connect_web3_account.html
+++ b/resources/authgear/templates/en/web/connect_web3_account.html
@@ -3,11 +3,11 @@
   class="pane twc-container-vertical pt-8 pb-5 px-6 tablet:px-8 desktop:px-8"
 >
   <h1 class="m-0 primary-txt text-center text-xl font-bold">
-    {{ template "confirm-web3-account-page-title" }}
+    {{ template "connect-web3-account-page-title" }}
   </h1>
 
   <div class="text-sm break-words primary-txt text-center">
-    {{ template "confirm-web3-account-page-description" (dict "provider"
+    {{ template "connect-web3-account-page-description" (dict "provider"
     ($.Translations.RenderText (printf "web3-provider-%s" $.Provider) nil)) }}
   </div>
 
@@ -54,14 +54,14 @@
           type="button"
           data-action="click->web3-wallet-confirmation#performSIWE"
         >
-          {{ template "confirm-web3-account-page-next" }}
+          {{ template "connect-web3-account-page-next" }}
         </button>
       </form>
     </div>
   </div>
 
   <div class="text-sm break-words primary-txt text-center">
-    {{ template "confirm-web3-account-page-change-account" (dict "provider"
+    {{ template "connect-web3-account-page-change-account" (dict "provider"
     ($.Translations.RenderText (printf "web3-provider-%s" $.Provider) nil)) }}
   </div>
 

--- a/resources/authgear/templates/en/web/login.html
+++ b/resources/authgear/templates/en/web/login.html
@@ -122,6 +122,7 @@
 				<a
 				class="not-a btn wallet-btn metamask"
 				href="/confirm_web3_account?provider=metamask"
+				data-turbo="false"
 				data-authgear-event="authgear.button.connect_wallet"
 				>
 					<div class="wallet-btn-content">

--- a/resources/authgear/templates/en/web/login.html
+++ b/resources/authgear/templates/en/web/login.html
@@ -118,19 +118,17 @@
 			</form>
 
 			{{ if $has_siwe }}
-			<div data-controller="web3-wallet-connection" data-web3-wallet-connection-provider-value="metamask">
-				<button
-				class="btn wallet-btn metamask"
-				type="button"
-				data-action="click->web3-wallet-connection#connectWallet"
-				data-web3-wallet-connection-target="button"
+			<div class="twc-container-vertical">
+				<a
+				class="not-a btn wallet-btn metamask"
+				href="/confirm_web3_account?provider=metamask"
 				data-authgear-event="authgear.button.connect_wallet"
 				>
 					<div class="wallet-btn-content">
 						<div class="wallet-btn-icon metamask-icon"></div>
 						<span class="text-base leading-5 font-semibold">{{ template "web3-provider-metamask" }}</span>
 					</div>
-				</button>
+				</a>
 			</div>
 			{{ end }}
 

--- a/resources/authgear/templates/en/web/signup.html
+++ b/resources/authgear/templates/en/web/signup.html
@@ -122,6 +122,7 @@
 				<a
 				class="not-a btn wallet-btn metamask"
 				href="/confirm_web3_account?provider=metamask"
+				data-turbo="false"
 				data-authgear-event="authgear.button.connect_wallet"
 				>
 					<div class="wallet-btn-content">

--- a/resources/authgear/templates/en/web/signup.html
+++ b/resources/authgear/templates/en/web/signup.html
@@ -118,19 +118,17 @@
 
 
 			{{ if $has_siwe }}
-			<div data-controller="web3-wallet-connection" data-web3-wallet-connection-provider-value="metamask">
-				<button
-				class="btn wallet-btn metamask"
-				type="button"
-				data-action="click->web3-wallet-connection#connectWallet"
-				data-web3-wallet-connection-target="button"
+			<div class="twc-container-vertical">
+				<a
+				class="not-a btn wallet-btn metamask"
+				href="/confirm_web3_account?provider=metamask"
 				data-authgear-event="authgear.button.connect_wallet"
 				>
 					<div class="wallet-btn-content">
 						<div class="wallet-btn-icon metamask-icon"></div>
 						<span class="text-base leading-5 font-semibold">{{ template "web3-provider-metamask" }}</span>
 					</div>
-				</button>
+				</a>
 			</div>
 			{{ end }}
 

--- a/resources/authgear/templates/zh-HK/translation.json
+++ b/resources/authgear/templates/zh-HK/translation.json
@@ -196,10 +196,10 @@
   "web3-provider-metamask": "MetaMask",
   "web3-provider-metamask-install": "安裝 MetaMask",
 
-  "confirm-web3-account-page-title": "帳號已連接",
-  "confirm-web3-account-page-description": "已連接到 {provider}",
-  "confirm-web3-account-page-next": "下一步",
-  "confirm-web3-account-page-change-account": "打開 {provider} 擴充功能來更改已連接的帳戶",
+  "connect-web3-account-page-title": "帳號已連接",
+  "connect-web3-account-page-description": "已連接到 {provider}",
+  "connect-web3-account-page-next": "下一步",
+  "connect-web3-account-page-change-account": "打開 {provider} 擴充功能來更改已連接的帳戶",
 
   "missing-web3-wallet-page-title": "安裝密碼貨幣錢包",
   "missing-web3-wallet-page-description": "您的瀏覽器中沒有找到或尚未支援 {provider} 密碼貨幣錢包",

--- a/resources/authgear/templates/zh-TW/translation.json
+++ b/resources/authgear/templates/zh-TW/translation.json
@@ -196,10 +196,10 @@
   "web3-provider-metamask": "MetaMask",
   "web3-provider-metamask-install": "安裝 MetaMask",
 
-  "confirm-web3-account-page-title": "帳戶已連接",
-  "confirm-web3-account-page-description": "已連接到 {provider}",
-  "confirm-web3-account-page-next": "下一步",
-  "confirm-web3-account-page-change-account": "打開 {provider} 擴充功能來更改已連接的帳戶",
+  "connect-web3-account-page-title": "帳戶已連接",
+  "connect-web3-account-page-description": "已連接到 {provider}",
+  "connect-web3-account-page-next": "下一步",
+  "connect-web3-account-page-change-account": "打開 {provider} 擴充功能來更改已連接的帳戶",
 
   "missing-web3-wallet-page-title": "安裝密碼貨幣錢包",
   "missing-web3-wallet-page-description": "您的瀏覽器中沒有找到或尚未支援 {provider} 密碼貨幣錢包",


### PR DESCRIPTION
# Notes
- Show dash and dummy logo if no account has been connected yet 
- If account connection is rejected, prompt again for connection when Next button is clicked and will proceed directly to the SIWE flow

@fungc-io @louischan-oursky see if these changes make sense to you


<img width="1917" alt="Screenshot 2022-10-07 at 10 23 00 AM" src="https://user-images.githubusercontent.com/18374475/194455909-c3a2443e-a3f3-4ae9-a599-fafb4642ec79.png">


refs #2507 #2539 