### PR TITLE
Separate trimmed zero hexstring parser and make ContractID support parameters

### DIFF
--- a/pkg/lib/feature/web3/service.go
+++ b/pkg/lib/feature/web3/service.go
@@ -48,7 +48,7 @@ func (s *Service) GetWeb3Info(identities []*identity.Info) (*model.UserWeb3Info,
 		switch identity.Type {
 		case model.IdentityTypeSIWE:
 			// SIWE means blockchain has to be ethereum
-			id, err := web3.NewContractID("ethereum", strconv.Itoa(identity.SIWE.ChainID), identity.SIWE.Address)
+			id, err := web3.NewContractID("ethereum", strconv.Itoa(identity.SIWE.ChainID), identity.SIWE.Address, nil)
 			if err != nil {
 				return nil, err
 			}

--- a/pkg/util/hexstring/hexstring.go
+++ b/pkg/util/hexstring/hexstring.go
@@ -39,9 +39,16 @@ func NewFromBigInt(v *big.Int) (T, error) {
 }
 
 func Parse(s string) (T, error) {
+	if parseRegExp.MatchString(s) {
+		return T(strings.ToLower(s)), nil
+	}
+	return "", fmt.Errorf("hex string must match the regexp %q", parseRegExp)
+}
+
+func TrimmedParse(s string) (T, error) {
 	m := parseRegExp.FindStringSubmatch(s)
 	if len(m) == 3 {
-		return T(strings.ToLower(strings.Join(m[1:], ""))), nil
+		return Parse(strings.Join(m[1:], ""))
 	}
 	return "", fmt.Errorf("hex string must match the regexp %q", parseRegExp)
 }

--- a/pkg/util/hexstring/hexstring_test.go
+++ b/pkg/util/hexstring/hexstring_test.go
@@ -61,6 +61,10 @@ func TestHexCmp(t *testing.T) {
 		h3, err := hexstring.Parse("0x0")
 		So(err, ShouldBeNil)
 		So(h3, ShouldEqual, "0x0")
+
+		h4, err := hexstring.Parse("0x000018")
+		So(err, ShouldBeNil)
+		So(h4, ShouldEqual, "0x000018")
 	})
 
 	Convey("Parse failure", t, func() {
@@ -100,7 +104,7 @@ func TestHexCmp(t *testing.T) {
 		So(i, ShouldEqual, -1)
 	})
 	Convey("Parse remove leading zeros", t, func() {
-		h, err := hexstring.Parse("0x000000000000000000000DEADBEEF")
+		h, err := hexstring.TrimmedParse("0x000000000000000000000DEADBEEF")
 		So(err, ShouldBeNil)
 		So(h, ShouldEqual, "0xdeadbeef")
 	})

--- a/pkg/util/web3/contractid.go
+++ b/pkg/util/web3/contractid.go
@@ -12,9 +12,10 @@ type ContractID struct {
 	Blockchain string
 	Network    string
 	Address    string
+	Query      *url.Values
 }
 
-func NewContractID(blockchain string, network string, address string) (*ContractID, error) {
+func NewContractID(blockchain string, network string, address string, query *url.Values) (*ContractID, error) {
 	hexaddr, err := hexstring.Parse(address)
 	if err != nil {
 		return nil, err
@@ -24,6 +25,7 @@ func NewContractID(blockchain string, network string, address string) (*Contract
 		Blockchain: blockchain,
 		Network:    network,
 		Address:    hexaddr.String(),
+		Query:      query,
 	}, nil
 }
 
@@ -42,11 +44,7 @@ func ParseContractID(contractURL string) (*ContractID, error) {
 			return nil, err
 		}
 
-		return &ContractID{
-			Blockchain: "ethereum",
-			Network:    strconv.Itoa(eip681.ChainID),
-			Address:    eip681.Address,
-		}, nil
+		return NewContractID("ethereum", strconv.Itoa(eip681.ChainID), eip681.Address, eip681.Query)
 	default:
 		return nil, fmt.Errorf("contract_id: unknown protocol: %s", protocol)
 	}
@@ -55,18 +53,15 @@ func ParseContractID(contractURL string) (*ContractID, error) {
 func (cid *ContractID) URL() (*url.URL, error) {
 	switch cid.Blockchain {
 	case "ethereum":
+
 		chainID, err := strconv.Atoi(cid.Network)
 		if err != nil {
 			return nil, err
 		}
 
-		if chainID <= 0 {
+		eip681, err := NewEIP681(chainID, cid.Address, cid.Query)
+		if err != nil {
 			return nil, err
-		}
-
-		eip681 := &EIP681{
-			ChainID: chainID,
-			Address: cid.Address,
 		}
 
 		return eip681.URL(), nil

--- a/pkg/util/web3/contractid.go
+++ b/pkg/util/web3/contractid.go
@@ -12,10 +12,10 @@ type ContractID struct {
 	Blockchain string
 	Network    string
 	Address    string
-	Query      *url.Values
+	Query      url.Values
 }
 
-func NewContractID(blockchain string, network string, address string, query *url.Values) (*ContractID, error) {
+func NewContractID(blockchain string, network string, address string, query url.Values) (*ContractID, error) {
 	hexaddr, err := hexstring.Parse(address)
 	if err != nil {
 		return nil, err

--- a/pkg/util/web3/contractid_test.go
+++ b/pkg/util/web3/contractid_test.go
@@ -21,14 +21,14 @@ func TestNew(t *testing.T) {
 				Blockchain: "ethereum",
 				Network:    "1",
 				Address:    "0xbc4ca0eda7647a8ab7c2061c2e118a18a936f13d",
-				Query:      nil,
+				Query:      url.Values{},
 			})
 
 			test("ethereum:0xbc4ca0eda7647a8ab7c2061c2e118a18a936f13d@1?token_ids=0x1&token_ids=0x2", &web3.ContractID{
 				Blockchain: "ethereum",
 				Network:    "1",
 				Address:    "0xbc4ca0eda7647a8ab7c2061c2e118a18a936f13d",
-				Query: &url.Values{
+				Query: url.Values{
 					"token_ids": []string{
 						"0x1", "0x2",
 					},
@@ -56,7 +56,7 @@ func TestNew(t *testing.T) {
 				Blockchain: "ethereum",
 				Network:    "1",
 				Address:    "0xbc4ca0eda7647a8ab7c2061c2e118a18a936f13d",
-				Query: &url.Values{
+				Query: url.Values{
 					"token_ids": []string{
 						"0x1", "0x2",
 					},
@@ -69,7 +69,7 @@ func TestNew(t *testing.T) {
 		})
 
 		Convey("create new contract_id", func() {
-			test := func(blockchain string, network string, address string, query *url.Values, expected *web3.ContractID) {
+			test := func(blockchain string, network string, address string, query url.Values, expected *web3.ContractID) {
 				cid, err := web3.NewContractID(blockchain, network, address, query)
 				So(err, ShouldBeNil)
 				So(cid, ShouldResemble, expected)
@@ -79,10 +79,9 @@ func TestNew(t *testing.T) {
 				Blockchain: "ethereum",
 				Network:    "1",
 				Address:    "0xbc4ca0eda7647a8ab7c2061c2e118a18a936f13d",
-				Query:      nil,
 			})
 
-			test("ethereum", "1", "0xbc4ca0eda7647a8ab7c2061c2e118a18a936f13d", &url.Values{
+			test("ethereum", "1", "0xbc4ca0eda7647a8ab7c2061c2e118a18a936f13d", url.Values{
 				"token_ids": []string{
 					"0x1", "0x2",
 				},
@@ -90,7 +89,7 @@ func TestNew(t *testing.T) {
 				Blockchain: "ethereum",
 				Network:    "1",
 				Address:    "0xbc4ca0eda7647a8ab7c2061c2e118a18a936f13d",
-				Query: &url.Values{
+				Query: url.Values{
 					"token_ids": []string{
 						"0x1", "0x2",
 					},

--- a/pkg/util/web3/contractid_test.go
+++ b/pkg/util/web3/contractid_test.go
@@ -21,6 +21,18 @@ func TestNew(t *testing.T) {
 				Blockchain: "ethereum",
 				Network:    "1",
 				Address:    "0xbc4ca0eda7647a8ab7c2061c2e118a18a936f13d",
+				Query:      nil,
+			})
+
+			test("ethereum:0xbc4ca0eda7647a8ab7c2061c2e118a18a936f13d@1?token_ids=0x1&token_ids=0x2", &web3.ContractID{
+				Blockchain: "ethereum",
+				Network:    "1",
+				Address:    "0xbc4ca0eda7647a8ab7c2061c2e118a18a936f13d",
+				Query: &url.Values{
+					"token_ids": []string{
+						"0x1", "0x2",
+					},
+				},
 			})
 		})
 
@@ -39,19 +51,50 @@ func TestNew(t *testing.T) {
 				Scheme: "ethereum",
 				Opaque: "0xbc4ca0eda7647a8ab7c2061c2e118a18a936f13d@1",
 			})
+
+			test(&web3.ContractID{
+				Blockchain: "ethereum",
+				Network:    "1",
+				Address:    "0xbc4ca0eda7647a8ab7c2061c2e118a18a936f13d",
+				Query: &url.Values{
+					"token_ids": []string{
+						"0x1", "0x2",
+					},
+				},
+			}, &url.URL{
+				Scheme:   "ethereum",
+				Opaque:   "0xbc4ca0eda7647a8ab7c2061c2e118a18a936f13d@1",
+				RawQuery: "token_ids=0x1&token_ids=0x2",
+			})
 		})
 
 		Convey("create new contract_id", func() {
-			test := func(blockchain string, network string, address string, expected *web3.ContractID) {
-				cid, err := web3.NewContractID(blockchain, network, address)
+			test := func(blockchain string, network string, address string, query *url.Values, expected *web3.ContractID) {
+				cid, err := web3.NewContractID(blockchain, network, address, query)
 				So(err, ShouldBeNil)
 				So(cid, ShouldResemble, expected)
 			}
 
-			test("ethereum", "1", "0xbc4ca0eda7647a8ab7c2061c2e118a18a936f13d", &web3.ContractID{
+			test("ethereum", "1", "0xbc4ca0eda7647a8ab7c2061c2e118a18a936f13d", nil, &web3.ContractID{
 				Blockchain: "ethereum",
 				Network:    "1",
 				Address:    "0xbc4ca0eda7647a8ab7c2061c2e118a18a936f13d",
+				Query:      nil,
+			})
+
+			test("ethereum", "1", "0xbc4ca0eda7647a8ab7c2061c2e118a18a936f13d", &url.Values{
+				"token_ids": []string{
+					"0x1", "0x2",
+				},
+			}, &web3.ContractID{
+				Blockchain: "ethereum",
+				Network:    "1",
+				Address:    "0xbc4ca0eda7647a8ab7c2061c2e118a18a936f13d",
+				Query: &url.Values{
+					"token_ids": []string{
+						"0x1", "0x2",
+					},
+				},
 			})
 		})
 	})

--- a/pkg/util/web3/eip681.go
+++ b/pkg/util/web3/eip681.go
@@ -13,17 +13,42 @@ import (
 type EIP681 struct {
 	ChainID int
 	Address string
+	Query   *url.Values
 }
 
 func (eip681 *EIP681) URL() *url.URL {
+	query := ""
+	if eip681.Query != nil {
+		query = eip681.Query.Encode()
+	}
 	return &url.URL{
-		Scheme: "ethereum",
-		Opaque: fmt.Sprintf("%s@%d", eip681.Address, eip681.ChainID),
+		Scheme:   "ethereum",
+		Opaque:   fmt.Sprintf("%s@%d", eip681.Address, eip681.ChainID),
+		RawQuery: query,
 	}
 }
 
+func NewEIP681(chainID int, address string, query *url.Values) (*EIP681, error) {
+
+	if chainID <= 0 {
+		return nil, fmt.Errorf("chain ID must be positive")
+	}
+
+	addrHex, err := hexstring.Parse(address)
+	if err != nil {
+		return nil, err
+	}
+
+	return &EIP681{
+		ChainID: chainID,
+		Address: addrHex.String(),
+		Query:   query,
+	}, nil
+}
+
 func ParseEIP681(uri string) (*EIP681, error) {
-	protocolURI := strings.Split(uri, ":")
+	queryString := strings.Split(uri, "?")
+	protocolURI := strings.Split(queryString[0], ":")
 
 	if len(protocolURI) != 2 {
 		return nil, fmt.Errorf("invalid uri: %s", uri)
@@ -54,9 +79,19 @@ func ParseEIP681(uri string) (*EIP681, error) {
 		return nil, fmt.Errorf("chain id cannot be negative: %d", chainID)
 	}
 
+	values := (*url.Values)(nil)
+	if len(queryString) > 1 {
+		query, err := url.ParseQuery(queryString[1])
+		if err != nil {
+			return nil, fmt.Errorf("invalid query: %s", queryString[1])
+		}
+		values = &query
+	}
+
 	return &EIP681{
 		ChainID: chainID,
 		Address: string(address),
+		Query:   values,
 	}, nil
 
 }

--- a/pkg/util/web3/eip681.go
+++ b/pkg/util/web3/eip681.go
@@ -13,22 +13,18 @@ import (
 type EIP681 struct {
 	ChainID int
 	Address string
-	Query   *url.Values
+	Query   url.Values
 }
 
 func (eip681 *EIP681) URL() *url.URL {
-	query := ""
-	if eip681.Query != nil {
-		query = eip681.Query.Encode()
-	}
 	return &url.URL{
 		Scheme:   "ethereum",
 		Opaque:   fmt.Sprintf("%s@%d", eip681.Address, eip681.ChainID),
-		RawQuery: query,
+		RawQuery: eip681.Query.Encode(),
 	}
 }
 
-func NewEIP681(chainID int, address string, query *url.Values) (*EIP681, error) {
+func NewEIP681(chainID int, address string, query url.Values) (*EIP681, error) {
 
 	if chainID <= 0 {
 		return nil, fmt.Errorf("chain ID must be positive")
@@ -47,18 +43,17 @@ func NewEIP681(chainID int, address string, query *url.Values) (*EIP681, error) 
 }
 
 func ParseEIP681(uri string) (*EIP681, error) {
-	queryString := strings.Split(uri, "?")
-	protocolURI := strings.Split(queryString[0], ":")
 
-	if len(protocolURI) != 2 {
+	url, err := url.Parse(uri)
+	if err != nil {
 		return nil, fmt.Errorf("invalid uri: %s", uri)
 	}
 
-	if protocolURI[0] != "ethereum" {
-		return nil, fmt.Errorf("invalid protocol: %s", protocolURI[0])
+	if url.Scheme != "ethereum" {
+		return nil, fmt.Errorf("invalid protocol: %s", url.Scheme)
 	}
 
-	addressURI := strings.Split(protocolURI[1], "@")
+	addressURI := strings.Split(url.Opaque, "@")
 
 	if len(addressURI) != 2 {
 		return nil, fmt.Errorf("invalid uri: %s", uri)
@@ -79,19 +74,10 @@ func ParseEIP681(uri string) (*EIP681, error) {
 		return nil, fmt.Errorf("chain id cannot be negative: %d", chainID)
 	}
 
-	values := (*url.Values)(nil)
-	if len(queryString) > 1 {
-		query, err := url.ParseQuery(queryString[1])
-		if err != nil {
-			return nil, fmt.Errorf("invalid query: %s", queryString[1])
-		}
-		values = &query
-	}
-
 	return &EIP681{
 		ChainID: chainID,
 		Address: string(address),
-		Query:   values,
+		Query:   url.Query(),
 	}, nil
 
 }

--- a/pkg/util/web3/eip681_test.go
+++ b/pkg/util/web3/eip681_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 func TestEIP681(t *testing.T) {
-	Convey("ceip681", t, func() {
+	Convey("eip681", t, func() {
 		Convey("parse eip681", func() {
 			test := func(uri string, expected *web3.EIP681) {
 				eip681, err := web3.ParseEIP681(uri)
@@ -20,21 +20,35 @@ func TestEIP681(t *testing.T) {
 			test("ethereum:0xbc4ca0eda7647a8ab7c2061c2e118a18a936f13d@1", &web3.EIP681{
 				ChainID: 1,
 				Address: "0xbc4ca0eda7647a8ab7c2061c2e118a18a936f13d",
+				Query:   nil,
 			})
 
 			test("ethereum:0xdc0479cc5bba033b3e7de9f178607150b3abce1f@1231", &web3.EIP681{
 				ChainID: 1231,
 				Address: "0xdc0479cc5bba033b3e7de9f178607150b3abce1f",
+				Query:   nil,
 			})
 
 			test("ethereum:0x71c7656ec7ab88b098defb751b7401b5f6d8976f@23821", &web3.EIP681{
 				ChainID: 23821,
 				Address: "0x71c7656ec7ab88b098defb751b7401b5f6d8976f",
+				Query:   nil,
 			})
 
 			test("ethereum:0x71C7656EC7AB88B098DEFB751B7401B5F6D8976F@23821", &web3.EIP681{
 				ChainID: 23821,
 				Address: "0x71c7656ec7ab88b098defb751b7401b5f6d8976f",
+				Query:   nil,
+			})
+
+			test("ethereum:0x71c7656ec7ab88b098defb751b7401b5f6d8976f@23821?token_ids=0x1&token_ids=0x2", &web3.EIP681{
+				ChainID: 23821,
+				Address: "0x71c7656ec7ab88b098defb751b7401b5f6d8976f",
+				Query: &url.Values{
+					"token_ids": []string{
+						"0x1", "0x2",
+					},
+				},
 			})
 		})
 
@@ -66,6 +80,20 @@ func TestEIP681(t *testing.T) {
 			}, &url.URL{
 				Scheme: "ethereum",
 				Opaque: "0x71c7656ec7ab88b098defb751b7401b5f6d8976f@23821",
+			})
+
+			test(&web3.EIP681{
+				ChainID: 23821,
+				Address: "0x71c7656ec7ab88b098defb751b7401b5f6d8976f",
+				Query: &url.Values{
+					"token_ids": []string{
+						"0x1", "0x2",
+					},
+				},
+			}, &url.URL{
+				Scheme:   "ethereum",
+				Opaque:   "0x71c7656ec7ab88b098defb751b7401b5f6d8976f@23821",
+				RawQuery: "token_ids=0x1&token_ids=0x2",
 			})
 		})
 	})

--- a/pkg/util/web3/eip681_test.go
+++ b/pkg/util/web3/eip681_test.go
@@ -20,31 +20,31 @@ func TestEIP681(t *testing.T) {
 			test("ethereum:0xbc4ca0eda7647a8ab7c2061c2e118a18a936f13d@1", &web3.EIP681{
 				ChainID: 1,
 				Address: "0xbc4ca0eda7647a8ab7c2061c2e118a18a936f13d",
-				Query:   nil,
+				Query:   url.Values{},
 			})
 
 			test("ethereum:0xdc0479cc5bba033b3e7de9f178607150b3abce1f@1231", &web3.EIP681{
 				ChainID: 1231,
 				Address: "0xdc0479cc5bba033b3e7de9f178607150b3abce1f",
-				Query:   nil,
+				Query:   url.Values{},
 			})
 
 			test("ethereum:0x71c7656ec7ab88b098defb751b7401b5f6d8976f@23821", &web3.EIP681{
 				ChainID: 23821,
 				Address: "0x71c7656ec7ab88b098defb751b7401b5f6d8976f",
-				Query:   nil,
+				Query:   url.Values{},
 			})
 
 			test("ethereum:0x71C7656EC7AB88B098DEFB751B7401B5F6D8976F@23821", &web3.EIP681{
 				ChainID: 23821,
 				Address: "0x71c7656ec7ab88b098defb751b7401b5f6d8976f",
-				Query:   nil,
+				Query:   url.Values{},
 			})
 
 			test("ethereum:0x71c7656ec7ab88b098defb751b7401b5f6d8976f@23821?token_ids=0x1&token_ids=0x2", &web3.EIP681{
 				ChainID: 23821,
 				Address: "0x71c7656ec7ab88b098defb751b7401b5f6d8976f",
-				Query: &url.Values{
+				Query: url.Values{
 					"token_ids": []string{
 						"0x1", "0x2",
 					},
@@ -85,7 +85,7 @@ func TestEIP681(t *testing.T) {
 			test(&web3.EIP681{
 				ChainID: 23821,
 				Address: "0x71c7656ec7ab88b098defb751b7401b5f6d8976f",
-				Query: &url.Values{
+				Query: url.Values{
 					"token_ids": []string{
 						"0x1", "0x2",
 					},

--- a/portal/src/util/contractId.test.ts
+++ b/portal/src/util/contractId.test.ts
@@ -14,6 +14,19 @@ describe("ContractID", () => {
       network: "1",
       address: "0xbc4ca0eda7647a8ab7c2061c2e118a18a936f13d",
     });
+
+    test(
+      "ethereum:0xbc4ca0eda7647a8ab7c2061c2e118a18a936f13d@1?token_ids=0x1&token_ids=0x2",
+      {
+        blockchain: "ethereum",
+        network: "1",
+        address: "0xbc4ca0eda7647a8ab7c2061c2e118a18a936f13d",
+        query: new URLSearchParams([
+          ["token_ids", "0x1"],
+          ["token_ids", "0x2"],
+        ]),
+      }
+    );
   });
 
   it("generate contract id url", () => {
@@ -30,6 +43,19 @@ describe("ContractID", () => {
         address: "0xbc4ca0eda7647a8ab7c2061c2e118a18a936f13d",
       },
       "ethereum:0xbc4ca0eda7647a8ab7c2061c2e118a18a936f13d@1"
+    );
+
+    test(
+      {
+        blockchain: "ethereum",
+        network: "1",
+        address: "0xbc4ca0eda7647a8ab7c2061c2e118a18a936f13d",
+        query: new URLSearchParams([
+          ["token_ids", "0x1"],
+          ["token_ids", "0x2"],
+        ]),
+      },
+      "ethereum:0xbc4ca0eda7647a8ab7c2061c2e118a18a936f13d@1?token_ids=0x1&token_ids=0x2"
     );
   });
 });

--- a/portal/src/util/contractId.ts
+++ b/portal/src/util/contractId.ts
@@ -4,6 +4,7 @@ export interface ContractID {
   blockchain: string;
   network: string;
   address: string;
+  query?: URLSearchParams;
 }
 
 export function parseContractID(
@@ -22,6 +23,7 @@ export function parseContractID(
         blockchain: "ethereum",
         network: eip681.chainId.toString(),
         address: eip681.address,
+        query: eip681.query,
       };
     }
 
@@ -36,6 +38,7 @@ export function createContractIDURL(contractId: ContractID): string {
       return createEIP681URL({
         chainId: parseInt(contractId.network, 10),
         address: contractId.address,
+        query: contractId.query,
       });
     default:
       throw new Error(`Unknown blockchain: ${contractId.blockchain}`);

--- a/portal/src/util/eip681.test.ts
+++ b/portal/src/util/eip681.test.ts
@@ -32,6 +32,18 @@ describe("EIP681", () => {
       chainId: 23821,
       address: "0x71c7656ec7ab88b098defb751b7401b5f6d8976f",
     });
+
+    test(
+      "ethereum:0x71c7656ec7ab88b098defb751b7401b5f6d8976f@23821?token_ids=0x1&token_ids=0x2",
+      {
+        chainId: 23821,
+        address: "0x71c7656ec7ab88b098defb751b7401b5f6d8976f",
+        query: new URLSearchParams([
+          ["token_ids", "0x1"],
+          ["token_ids", "0x2"],
+        ]),
+      }
+    );
   });
 
   it("parses eip681 without address check", () => {

--- a/portal/src/util/eip681.ts
+++ b/portal/src/util/eip681.ts
@@ -7,24 +7,18 @@ export interface EIP681 {
 }
 
 export function parseEIP681(
-  url: string,
+  uri: string,
   skipAddressCheck: boolean = false
 ): EIP681 {
-  const queryURI = url.split("?");
-  const protocolURI = queryURI[0].split(":");
-
-  if (protocolURI.length !== 2) {
-    throw new Error(`Invalid URI: ${url}`);
+  const url = new URL(uri);
+  if (url.protocol !== "ethereum:") {
+    throw new Error(`Invalid protocol: ${url.protocol}`);
   }
 
-  if (protocolURI[0] !== "ethereum") {
-    throw new Error(`Invalid protocol: ${protocolURI[0]}`);
-  }
-
-  const addressURI = protocolURI[1].split("@");
+  const addressURI = url.pathname.split("@");
 
   if (addressURI.length !== 2) {
-    throw new Error(`Invalid URI: ${url}`);
+    throw new Error(`Invalid URI: ${url.pathname}`);
   }
 
   const address = addressURI[0];
@@ -38,7 +32,7 @@ export function parseEIP681(
   }
 
   const query =
-    queryURI.length > 1 ? new URLSearchParams(queryURI[1]) : undefined;
+    url.searchParams.toString() !== "" ? url.searchParams : undefined;
 
   return {
     chainId,
@@ -51,9 +45,9 @@ export function createEIP681URL(
   eip681: EIP681,
   skipAddressCheck: boolean = false
 ): string {
-  const query = eip681.query?.toString();
+  const query = eip681.query?.toString() ?? "";
   const url = `ethereum:${eip681.address}@${eip681.chainId}${
-    query != null ? "?" + query.toString() : ""
+    query !== "" ? "?" + query : ""
   }`;
   // Confirm the format is correct
   parseEIP681(url, skipAddressCheck);

--- a/portal/src/util/eip681.ts
+++ b/portal/src/util/eip681.ts
@@ -3,13 +3,15 @@ const ETHEREUM_ADDRESS_REGEX = /^0x[a-fA-F0-9]{40}$/;
 export interface EIP681 {
   chainId: number;
   address: string;
+  query?: URLSearchParams;
 }
 
 export function parseEIP681(
   url: string,
   skipAddressCheck: boolean = false
 ): EIP681 {
-  const protocolURI = url.split(":");
+  const queryURI = url.split("?");
+  const protocolURI = queryURI[0].split(":");
 
   if (protocolURI.length !== 2) {
     throw new Error(`Invalid URI: ${url}`);
@@ -35,9 +37,13 @@ export function parseEIP681(
     throw new Error(`Chain ID cannot be negative: ${chainId}`);
   }
 
+  const query =
+    queryURI.length > 1 ? new URLSearchParams(queryURI[1]) : undefined;
+
   return {
     chainId,
     address,
+    query,
   };
 }
 
@@ -45,7 +51,10 @@ export function createEIP681URL(
   eip681: EIP681,
   skipAddressCheck: boolean = false
 ): string {
-  const url = `ethereum:${eip681.address}@${eip681.chainId}`;
+  const query = eip681.query?.toString();
+  const url = `ethereum:${eip681.address}@${eip681.chainId}${
+    query != null ? "?" + query.toString() : ""
+  }`;
   // Confirm the format is correct
   parseEIP681(url, skipAddressCheck);
   return url;


### PR DESCRIPTION
- Apparently we have to keep the leading zeroes for the contract addresses
- Added query params for contractID to handle putting token id information into the url, this respects the `parameters` field for the eip681 [spec](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-681.md)