### PR TITLE
Redesign Admin API to avoid identities and authenticators ambiguity

### DIFF
--- a/pkg/admin/facade/authenticator.go
+++ b/pkg/admin/facade/authenticator.go
@@ -3,6 +3,7 @@ package facade
 import (
 	"sort"
 
+	apimodel "github.com/authgear/authgear-server/pkg/api/model"
 	"github.com/authgear/authgear-server/pkg/lib/authn/authenticator"
 	interactionintents "github.com/authgear/authgear-server/pkg/lib/interaction/intents"
 )
@@ -10,7 +11,7 @@ import (
 type AuthenticatorService interface {
 	Get(id string) (*authenticator.Info, error)
 	Count(userID string) (uint64, error)
-	ListRefsByUsers(userIDs []string) ([]*authenticator.Ref, error)
+	ListRefsByUsers(userIDs []string, authenticatorType *apimodel.AuthenticatorType, authenticatorKind *authenticator.Kind) ([]*authenticator.Ref, error)
 }
 
 type AuthenticatorFacade struct {
@@ -22,8 +23,8 @@ func (f *AuthenticatorFacade) Get(id string) (*authenticator.Info, error) {
 	return f.Authenticators.Get(id)
 }
 
-func (f *AuthenticatorFacade) List(userID string) ([]*authenticator.Ref, error) {
-	refs, err := f.Authenticators.ListRefsByUsers([]string{userID})
+func (f *AuthenticatorFacade) List(userID string, authenticatorType *apimodel.AuthenticatorType, authenticatorKind *authenticator.Kind) ([]*authenticator.Ref, error) {
+	refs, err := f.Authenticators.ListRefsByUsers([]string{userID}, authenticatorType, authenticatorKind)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/admin/facade/identity.go
+++ b/pkg/admin/facade/identity.go
@@ -14,7 +14,7 @@ import (
 
 type IdentityService interface {
 	Get(id string) (*identity.Info, error)
-	ListRefsByUsers(userIDs []string) ([]*apimodel.IdentityRef, error)
+	ListRefsByUsers(userIDs []string, identityType *apimodel.IdentityType) ([]*apimodel.IdentityRef, error)
 }
 
 type IdentityFacade struct {
@@ -26,8 +26,8 @@ func (f *IdentityFacade) Get(id string) (*identity.Info, error) {
 	return f.Identities.Get(id)
 }
 
-func (f *IdentityFacade) List(userID string) ([]*apimodel.IdentityRef, error) {
-	refs, err := f.Identities.ListRefsByUsers([]string{userID})
+func (f *IdentityFacade) List(userID string, identityType *apimodel.IdentityType) ([]*apimodel.IdentityRef, error) {
+	refs, err := f.Identities.ListRefsByUsers([]string{userID}, identityType)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/admin/graphql/context.go
+++ b/pkg/admin/graphql/context.go
@@ -51,7 +51,7 @@ type UserFacade interface {
 
 type IdentityFacade interface {
 	Get(id string) (*identity.Info, error)
-	List(userID string) ([]*apimodel.IdentityRef, error)
+	List(userID string, identityType *apimodel.IdentityType) ([]*apimodel.IdentityRef, error)
 	Remove(identityInfo *identity.Info) error
 	Create(userID string, identityDef model.IdentityDef, password string) (*apimodel.IdentityRef, error)
 }

--- a/pkg/admin/graphql/context.go
+++ b/pkg/admin/graphql/context.go
@@ -58,7 +58,7 @@ type IdentityFacade interface {
 
 type AuthenticatorFacade interface {
 	Get(id string) (*authenticator.Info, error)
-	List(userID string) ([]*authenticator.Ref, error)
+	List(userID string, authenticatorType *apimodel.AuthenticatorType, authenticatorKind *authenticator.Kind) ([]*authenticator.Ref, error)
 	Remove(authenticatorInfo *authenticator.Info) error
 }
 

--- a/pkg/admin/graphql/user.go
+++ b/pkg/admin/graphql/user.go
@@ -80,13 +80,13 @@ var nodeUser = node(
 				Type:    nodeAuthenticator,
 				Resolve: authenticatorResolverByTypeAndKind(model.AuthenticatorTypePassword, authenticator.KindPrimary),
 			},
-			"primaryOOBOTPEmailAuthenticators": &graphql.Field{
-				Type:    graphql.NewList(graphql.NewNonNull(nodeAuthenticator)),
-				Resolve: authenticatorsResolverByTypeAndKind(model.AuthenticatorTypeOOBEmail, authenticator.KindPrimary),
+			"primaryOOBOTPEmailAuthenticator": &graphql.Field{
+				Type:    nodeAuthenticator,
+				Resolve: authenticatorResolverByTypeAndKind(model.AuthenticatorTypeOOBEmail, authenticator.KindPrimary),
 			},
-			"primaryOOBOTPSMSAuthenticators": &graphql.Field{
-				Type:    graphql.NewList(graphql.NewNonNull(nodeAuthenticator)),
-				Resolve: authenticatorsResolverByTypeAndKind(model.AuthenticatorTypeOOBSMS, authenticator.KindPrimary),
+			"primaryOOBOTPSMSAuthenticator": &graphql.Field{
+				Type:    nodeAuthenticator,
+				Resolve: authenticatorResolverByTypeAndKind(model.AuthenticatorTypeOOBSMS, authenticator.KindPrimary),
 			},
 			"secondaryTOTPAuthenticators": &graphql.Field{
 				Type:    graphql.NewList(graphql.NewNonNull(nodeAuthenticator)),

--- a/pkg/admin/graphql/user.go
+++ b/pkg/admin/graphql/user.go
@@ -31,19 +31,19 @@ var nodeUser = node(
 				Description: "The last login time of user",
 			},
 			"loginIDs": &graphql.Field{
-				Type:    graphql.NewList(graphql.NewNonNull(nodeIdentity)),
+				Type:    graphql.NewNonNull(graphql.NewList(graphql.NewNonNull(nodeIdentity))),
 				Resolve: identitiesResolverByType(model.IdentityTypeLoginID),
 			},
 			"oauthConnections": &graphql.Field{
-				Type:    graphql.NewList(graphql.NewNonNull(nodeIdentity)),
+				Type:    graphql.NewNonNull(graphql.NewList(graphql.NewNonNull(nodeIdentity))),
 				Resolve: identitiesResolverByType(model.IdentityTypeOAuth),
 			},
 			"biometricRegistrations": &graphql.Field{
-				Type:    graphql.NewList(graphql.NewNonNull(nodeIdentity)),
+				Type:    graphql.NewNonNull(graphql.NewList(graphql.NewNonNull(nodeIdentity))),
 				Resolve: identitiesResolverByType(model.IdentityTypeBiometric),
 			},
 			"passkeys": &graphql.Field{
-				Type:    graphql.NewList(graphql.NewNonNull(nodeIdentity)),
+				Type:    graphql.NewNonNull(graphql.NewList(graphql.NewNonNull(nodeIdentity))),
 				Resolve: identitiesResolverByType(model.IdentityTypePasskey),
 			},
 			"identities": &graphql.Field{
@@ -89,15 +89,15 @@ var nodeUser = node(
 				Resolve: authenticatorResolverByTypeAndKind(model.AuthenticatorTypeOOBSMS, authenticator.KindPrimary),
 			},
 			"secondaryTOTPAuthenticators": &graphql.Field{
-				Type:    graphql.NewList(graphql.NewNonNull(nodeAuthenticator)),
+				Type:    graphql.NewNonNull(graphql.NewList(graphql.NewNonNull(nodeAuthenticator))),
 				Resolve: authenticatorsResolverByTypeAndKind(model.AuthenticatorTypeTOTP, authenticator.KindSecondary),
 			},
 			"secondaryOOBOTPEmailAuthenticators": &graphql.Field{
-				Type:    graphql.NewList(graphql.NewNonNull(nodeAuthenticator)),
+				Type:    graphql.NewNonNull(graphql.NewList(graphql.NewNonNull(nodeAuthenticator))),
 				Resolve: authenticatorsResolverByTypeAndKind(model.AuthenticatorTypeOOBEmail, authenticator.KindSecondary),
 			},
 			"secondaryOOBOTPSMSAuthenticators": &graphql.Field{
-				Type:    graphql.NewList(graphql.NewNonNull(nodeAuthenticator)),
+				Type:    graphql.NewNonNull(graphql.NewList(graphql.NewNonNull(nodeAuthenticator))),
 				Resolve: authenticatorsResolverByTypeAndKind(model.AuthenticatorTypeOOBSMS, authenticator.KindSecondary),
 			},
 			"secondaryPassword": &graphql.Field{

--- a/pkg/admin/graphql/user.go
+++ b/pkg/admin/graphql/user.go
@@ -30,11 +30,22 @@ var nodeUser = node(
 			},
 			"identities": &graphql.Field{
 				Type: connIdentity.ConnectionType,
-				Args: relay.ConnectionArgs,
+				Args: relay.NewConnectionArgs(graphql.FieldConfigArgument{
+					"identityType": &graphql.ArgumentConfig{
+						Type: identityType,
+					},
+				}),
 				Resolve: func(p graphql.ResolveParams) (interface{}, error) {
 					source := p.Source.(*model.User)
 					gqlCtx := GQLContext(p.Context)
-					refs, err := gqlCtx.IdentityFacade.List(source.ID)
+					identityTypeStr, _ := p.Args["identityType"].(string)
+					var identityTypePtr *model.IdentityType
+					if identityTypeStr != "" {
+						identityType := model.IdentityType(identityTypeStr)
+						identityTypePtr = &identityType
+					}
+
+					refs, err := gqlCtx.IdentityFacade.List(source.ID, identityTypePtr)
 					if err != nil {
 						return nil, err
 					}

--- a/pkg/admin/graphql/user.go
+++ b/pkg/admin/graphql/user.go
@@ -5,6 +5,7 @@ import (
 	"github.com/graphql-go/graphql"
 
 	"github.com/authgear/authgear-server/pkg/api/model"
+	apimodel "github.com/authgear/authgear-server/pkg/api/model"
 	"github.com/authgear/authgear-server/pkg/lib/authn/authenticator"
 	"github.com/authgear/authgear-server/pkg/lib/authn/stdattrs"
 	"github.com/authgear/authgear-server/pkg/lib/oauth"
@@ -74,6 +75,34 @@ var nodeUser = node(
 					args := relay.NewConnectionArguments(p.Args)
 					return graphqlutil.NewConnectionFromArray(identities, args), nil
 				},
+			},
+			"primaryPassword": &graphql.Field{
+				Type:    nodeAuthenticator,
+				Resolve: authenticatorResolverByTypeAndKind(model.AuthenticatorTypePassword, authenticator.KindPrimary),
+			},
+			"primaryOOBOTPEmailAuthenticators": &graphql.Field{
+				Type:    graphql.NewList(graphql.NewNonNull(nodeAuthenticator)),
+				Resolve: authenticatorsResolverByTypeAndKind(model.AuthenticatorTypeOOBEmail, authenticator.KindPrimary),
+			},
+			"primaryOOBOTPSMSAuthenticators": &graphql.Field{
+				Type:    graphql.NewList(graphql.NewNonNull(nodeAuthenticator)),
+				Resolve: authenticatorsResolverByTypeAndKind(model.AuthenticatorTypeOOBSMS, authenticator.KindPrimary),
+			},
+			"secondaryTOTPAuthenticators": &graphql.Field{
+				Type:    graphql.NewList(graphql.NewNonNull(nodeAuthenticator)),
+				Resolve: authenticatorsResolverByTypeAndKind(model.AuthenticatorTypeTOTP, authenticator.KindSecondary),
+			},
+			"secondaryOOBOTPEmailAuthenticators": &graphql.Field{
+				Type:    graphql.NewList(graphql.NewNonNull(nodeAuthenticator)),
+				Resolve: authenticatorsResolverByTypeAndKind(model.AuthenticatorTypeOOBEmail, authenticator.KindSecondary),
+			},
+			"secondaryOOBOTPSMSAuthenticators": &graphql.Field{
+				Type:    graphql.NewList(graphql.NewNonNull(nodeAuthenticator)),
+				Resolve: authenticatorsResolverByTypeAndKind(model.AuthenticatorTypeOOBSMS, authenticator.KindSecondary),
+			},
+			"secondaryPassword": &graphql.Field{
+				Type:    nodeAuthenticator,
+				Resolve: authenticatorResolverByTypeAndKind(model.AuthenticatorTypePassword, authenticator.KindSecondary),
 			},
 			"authenticators": &graphql.Field{
 				Type: connAuthenticator.ConnectionType,

--- a/pkg/lib/authn/authenticator/service/service.go
+++ b/pkg/lib/authn/authenticator/service/service.go
@@ -239,8 +239,8 @@ func (s *Service) Count(userID string) (uint64, error) {
 	return s.Store.Count(userID)
 }
 
-func (s *Service) ListRefsByUsers(userIDs []string) ([]*authenticator.Ref, error) {
-	return s.Store.ListRefsByUsers(userIDs)
+func (s *Service) ListRefsByUsers(userIDs []string, authenticatorType *model.AuthenticatorType, authenticatorKind *authenticator.Kind) ([]*authenticator.Ref, error) {
+	return s.Store.ListRefsByUsers(userIDs, authenticatorType, authenticatorKind)
 }
 
 func (s *Service) New(spec *authenticator.Spec) (*authenticator.Info, error) {

--- a/pkg/lib/authn/identity/service/service.go
+++ b/pkg/lib/authn/identity/service/service.go
@@ -425,8 +425,8 @@ func (s *Service) Count(userID string) (uint64, error) {
 	return s.Store.Count(userID)
 }
 
-func (s *Service) ListRefsByUsers(userIDs []string) ([]*model.IdentityRef, error) {
-	return s.Store.ListRefsByUsers(userIDs)
+func (s *Service) ListRefsByUsers(userIDs []string, identityType *model.IdentityType) ([]*model.IdentityRef, error) {
+	return s.Store.ListRefsByUsers(userIDs, identityType)
 }
 
 func (s *Service) ListByClaim(name string, value string) ([]*identity.Info, error) {

--- a/pkg/lib/authn/identity/service/store.go
+++ b/pkg/lib/authn/identity/service/store.go
@@ -31,14 +31,20 @@ func (s *Store) Count(userID string) (uint64, error) {
 	return count, nil
 }
 
-func (s *Store) ListRefsByUsers(userIDs []string) ([]*model.IdentityRef, error) {
+func (s *Store) ListRefsByUsers(userIDs []string, identityType *model.IdentityType) ([]*model.IdentityRef, error) {
 	builder := s.SQLBuilder.
 		Select("id", "type", "user_id", "created_at", "updated_at").
-		Where("user_id = ANY (?)", pq.Array(userIDs)).
-		From(s.SQLBuilder.TableName("_auth_identity"))
+		Where("user_id = ANY (?)", pq.Array(userIDs))
+
+	if identityType != nil && *identityType != "" {
+		builder = builder.Where("type = ?", *identityType)
+	}
+
+	builder = builder.From(s.SQLBuilder.TableName("_auth_identity"))
 
 	return s.listRefs(builder)
 }
+
 func (s *Store) ListRefsByIDs(ids []string) ([]*model.IdentityRef, error) {
 	builder := s.SQLBuilder.
 		Select("id", "type", "user_id", "created_at", "updated_at").

--- a/pkg/lib/interaction/nodes/do_remove_authenticator.go
+++ b/pkg/lib/interaction/nodes/do_remove_authenticator.go
@@ -1,6 +1,7 @@
 package nodes
 
 import (
+	"github.com/authgear/authgear-server/pkg/api/model"
 	"github.com/authgear/authgear-server/pkg/lib/authn/authenticator"
 	"github.com/authgear/authgear-server/pkg/lib/config"
 	"github.com/authgear/authgear-server/pkg/lib/interaction"
@@ -43,6 +44,14 @@ func (n *NodeDoRemoveAuthenticator) GetEffects() ([]interaction.Effect, error) {
 
 			switch n.Authenticator.Kind {
 			case authenticator.KindPrimary:
+				if n.Authenticator.Type == model.AuthenticatorTypePasskey {
+					return interaction.NewInvariantViolated(
+						"RemovePasskeyAuthenticator",
+						"cannot delete passkey authenticator, should delete passkey identity instead",
+						nil,
+					)
+				}
+
 				// Ensure all identities have matching primary authenticator.
 				is, err := ctx.Identities.ListByUser(userID)
 				if err != nil {

--- a/portal/src/graphql/adminapi/globalTypes.generated.ts
+++ b/portal/src/graphql/adminapi/globalTypes.generated.ts
@@ -637,7 +637,7 @@ export type User = Entity & Node & {
   __typename?: 'User';
   authenticators?: Maybe<AuthenticatorConnection>;
   authorizations?: Maybe<AuthorizationConnection>;
-  biometricRegistrations?: Maybe<Array<Identity>>;
+  biometricRegistrations: Array<Identity>;
   /** The creation time of entity */
   createdAt: Scalars['DateTime'];
   customAttributes: Scalars['UserCustomAttributes'];
@@ -654,16 +654,16 @@ export type User = Entity & Node & {
   isDisabled: Scalars['Boolean'];
   /** The last login time of user */
   lastLoginAt?: Maybe<Scalars['DateTime']>;
-  loginIDs?: Maybe<Array<Identity>>;
-  oauthConnections?: Maybe<Array<Identity>>;
-  passkeys?: Maybe<Array<Identity>>;
+  loginIDs: Array<Identity>;
+  oauthConnections: Array<Identity>;
+  passkeys: Array<Identity>;
   primaryOOBOTPEmailAuthenticator?: Maybe<Authenticator>;
   primaryOOBOTPSMSAuthenticator?: Maybe<Authenticator>;
   primaryPassword?: Maybe<Authenticator>;
-  secondaryOOBOTPEmailAuthenticators?: Maybe<Array<Authenticator>>;
-  secondaryOOBOTPSMSAuthenticators?: Maybe<Array<Authenticator>>;
+  secondaryOOBOTPEmailAuthenticators: Array<Authenticator>;
+  secondaryOOBOTPSMSAuthenticators: Array<Authenticator>;
   secondaryPassword?: Maybe<Authenticator>;
-  secondaryTOTPAuthenticators?: Maybe<Array<Authenticator>>;
+  secondaryTOTPAuthenticators: Array<Authenticator>;
   sessions?: Maybe<SessionConnection>;
   standardAttributes: Scalars['UserStandardAttributes'];
   /** The update time of entity */

--- a/portal/src/graphql/adminapi/globalTypes.generated.ts
+++ b/portal/src/graphql/adminapi/globalTypes.generated.ts
@@ -657,6 +657,13 @@ export type User = Entity & Node & {
   loginIDs?: Maybe<Array<Identity>>;
   oauthConnections?: Maybe<Array<Identity>>;
   passkeys?: Maybe<Array<Identity>>;
+  primaryOOBOTPEmailAuthenticators?: Maybe<Array<Authenticator>>;
+  primaryOOBOTPSMSAuthenticators?: Maybe<Array<Authenticator>>;
+  primaryPassword?: Maybe<Authenticator>;
+  secondaryOOBOTPEmailAuthenticators?: Maybe<Array<Authenticator>>;
+  secondaryOOBOTPSMSAuthenticators?: Maybe<Array<Authenticator>>;
+  secondaryPassword?: Maybe<Authenticator>;
+  secondaryTOTPAuthenticators?: Maybe<Array<Authenticator>>;
   sessions?: Maybe<SessionConnection>;
   standardAttributes: Scalars['UserStandardAttributes'];
   /** The update time of entity */

--- a/portal/src/graphql/adminapi/globalTypes.generated.ts
+++ b/portal/src/graphql/adminapi/globalTypes.generated.ts
@@ -637,6 +637,7 @@ export type User = Entity & Node & {
   __typename?: 'User';
   authenticators?: Maybe<AuthenticatorConnection>;
   authorizations?: Maybe<AuthorizationConnection>;
+  biometricRegistrations?: Maybe<Array<Identity>>;
   /** The creation time of entity */
   createdAt: Scalars['DateTime'];
   customAttributes: Scalars['UserCustomAttributes'];
@@ -653,6 +654,9 @@ export type User = Entity & Node & {
   isDisabled: Scalars['Boolean'];
   /** The last login time of user */
   lastLoginAt?: Maybe<Scalars['DateTime']>;
+  loginIDs?: Maybe<Array<Identity>>;
+  oauthConnections?: Maybe<Array<Identity>>;
+  passkeys?: Maybe<Array<Identity>>;
   sessions?: Maybe<SessionConnection>;
   standardAttributes: Scalars['UserStandardAttributes'];
   /** The update time of entity */

--- a/portal/src/graphql/adminapi/globalTypes.generated.ts
+++ b/portal/src/graphql/adminapi/globalTypes.generated.ts
@@ -665,6 +665,8 @@ export type User = Entity & Node & {
 /** Authgear user */
 export type UserAuthenticatorsArgs = {
   after?: InputMaybe<Scalars['String']>;
+  authenticatorKind?: InputMaybe<AuthenticatorKind>;
+  authenticatorType?: InputMaybe<AuthenticatorType>;
   before?: InputMaybe<Scalars['String']>;
   first?: InputMaybe<Scalars['Int']>;
   last?: InputMaybe<Scalars['Int']>;

--- a/portal/src/graphql/adminapi/globalTypes.generated.ts
+++ b/portal/src/graphql/adminapi/globalTypes.generated.ts
@@ -685,6 +685,7 @@ export type UserIdentitiesArgs = {
   after?: InputMaybe<Scalars['String']>;
   before?: InputMaybe<Scalars['String']>;
   first?: InputMaybe<Scalars['Int']>;
+  identityType?: InputMaybe<IdentityType>;
   last?: InputMaybe<Scalars['Int']>;
 };
 

--- a/portal/src/graphql/adminapi/globalTypes.generated.ts
+++ b/portal/src/graphql/adminapi/globalTypes.generated.ts
@@ -657,8 +657,8 @@ export type User = Entity & Node & {
   loginIDs?: Maybe<Array<Identity>>;
   oauthConnections?: Maybe<Array<Identity>>;
   passkeys?: Maybe<Array<Identity>>;
-  primaryOOBOTPEmailAuthenticators?: Maybe<Array<Authenticator>>;
-  primaryOOBOTPSMSAuthenticators?: Maybe<Array<Authenticator>>;
+  primaryOOBOTPEmailAuthenticator?: Maybe<Authenticator>;
+  primaryOOBOTPSMSAuthenticator?: Maybe<Authenticator>;
   primaryPassword?: Maybe<Authenticator>;
   secondaryOOBOTPEmailAuthenticators?: Maybe<Array<Authenticator>>;
   secondaryOOBOTPSMSAuthenticators?: Maybe<Array<Authenticator>>;

--- a/portal/src/graphql/adminapi/schema.graphql
+++ b/portal/src/graphql/adminapi/schema.graphql
@@ -803,6 +803,27 @@ type User implements Entity & Node {
   passkeys: [Identity!]
 
   """"""
+  primaryOOBOTPEmailAuthenticators: [Authenticator!]
+
+  """"""
+  primaryOOBOTPSMSAuthenticators: [Authenticator!]
+
+  """"""
+  primaryPassword: Authenticator
+
+  """"""
+  secondaryOOBOTPEmailAuthenticators: [Authenticator!]
+
+  """"""
+  secondaryOOBOTPSMSAuthenticators: [Authenticator!]
+
+  """"""
+  secondaryPassword: Authenticator
+
+  """"""
+  secondaryTOTPAuthenticators: [Authenticator!]
+
+  """"""
   sessions(after: String, before: String, first: Int, last: Int): SessionConnection
 
   """"""

--- a/portal/src/graphql/adminapi/schema.graphql
+++ b/portal/src/graphql/adminapi/schema.graphql
@@ -755,7 +755,7 @@ type User implements Entity & Node {
   authorizations(after: String, before: String, first: Int, last: Int): AuthorizationConnection
 
   """"""
-  biometricRegistrations: [Identity!]
+  biometricRegistrations: [Identity!]!
 
   """The creation time of entity"""
   createdAt: DateTime!
@@ -794,13 +794,13 @@ type User implements Entity & Node {
   lastLoginAt: DateTime
 
   """"""
-  loginIDs: [Identity!]
+  loginIDs: [Identity!]!
 
   """"""
-  oauthConnections: [Identity!]
+  oauthConnections: [Identity!]!
 
   """"""
-  passkeys: [Identity!]
+  passkeys: [Identity!]!
 
   """"""
   primaryOOBOTPEmailAuthenticator: Authenticator
@@ -812,16 +812,16 @@ type User implements Entity & Node {
   primaryPassword: Authenticator
 
   """"""
-  secondaryOOBOTPEmailAuthenticators: [Authenticator!]
+  secondaryOOBOTPEmailAuthenticators: [Authenticator!]!
 
   """"""
-  secondaryOOBOTPSMSAuthenticators: [Authenticator!]
+  secondaryOOBOTPSMSAuthenticators: [Authenticator!]!
 
   """"""
   secondaryPassword: Authenticator
 
   """"""
-  secondaryTOTPAuthenticators: [Authenticator!]
+  secondaryTOTPAuthenticators: [Authenticator!]!
 
   """"""
   sessions(after: String, before: String, first: Int, last: Int): SessionConnection

--- a/portal/src/graphql/adminapi/schema.graphql
+++ b/portal/src/graphql/adminapi/schema.graphql
@@ -754,6 +754,9 @@ type User implements Entity & Node {
   """"""
   authorizations(after: String, before: String, first: Int, last: Int): AuthorizationConnection
 
+  """"""
+  biometricRegistrations: [Identity!]
+
   """The creation time of entity"""
   createdAt: DateTime!
 
@@ -789,6 +792,15 @@ type User implements Entity & Node {
 
   """The last login time of user"""
   lastLoginAt: DateTime
+
+  """"""
+  loginIDs: [Identity!]
+
+  """"""
+  oauthConnections: [Identity!]
+
+  """"""
+  passkeys: [Identity!]
 
   """"""
   sessions(after: String, before: String, first: Int, last: Int): SessionConnection

--- a/portal/src/graphql/adminapi/schema.graphql
+++ b/portal/src/graphql/adminapi/schema.graphql
@@ -749,7 +749,7 @@ type UpdateUserPayload {
 """Authgear user"""
 type User implements Entity & Node {
   """"""
-  authenticators(after: String, before: String, first: Int, last: Int): AuthenticatorConnection
+  authenticators(after: String, authenticatorKind: AuthenticatorKind, authenticatorType: AuthenticatorType, before: String, first: Int, last: Int): AuthenticatorConnection
 
   """"""
   authorizations(after: String, before: String, first: Int, last: Int): AuthorizationConnection

--- a/portal/src/graphql/adminapi/schema.graphql
+++ b/portal/src/graphql/adminapi/schema.graphql
@@ -803,10 +803,10 @@ type User implements Entity & Node {
   passkeys: [Identity!]
 
   """"""
-  primaryOOBOTPEmailAuthenticators: [Authenticator!]
+  primaryOOBOTPEmailAuthenticator: Authenticator
 
   """"""
-  primaryOOBOTPSMSAuthenticators: [Authenticator!]
+  primaryOOBOTPSMSAuthenticator: Authenticator
 
   """"""
   primaryPassword: Authenticator

--- a/portal/src/graphql/adminapi/schema.graphql
+++ b/portal/src/graphql/adminapi/schema.graphql
@@ -776,7 +776,7 @@ type User implements Entity & Node {
   id: ID!
 
   """"""
-  identities(after: String, before: String, first: Int, last: Int): IdentityConnection
+  identities(after: String, before: String, first: Int, identityType: IdentityType, last: Int): IdentityConnection
 
   """"""
   isAnonymous: Boolean!


### PR DESCRIPTION
refs #2328 

Some notes and questions:

1. I think it is protected already?
    > Deleting a primary OOB OTP authenticator DOES NOT delete the login ID identity. But deletion is possible only if the login ID identity still have a usable primary authenticator.

    refs: https://github.com/authgear/authgear-server/blob/7f46b8e6422a33c0ed7db3a4ce841943e71d6317/pkg/lib/interaction/nodes/do_remove_authenticator.go#L55
1. I revised `primaryOOBOTPAuthenticators` and `secondaryOOBOTPAuthenticators` to have `Email` and `SMS`. Do you think `primaryOOBOTP(Email|SMS)Authenticators` should be a single item or a list? In the PR, they are lists but it seems using a single item is more accurate? thought?