### PR TITLE
Redirect the user based on query after authentication

### DIFF
--- a/pkg/auth/endpoints.go
+++ b/pkg/auth/endpoints.go
@@ -44,8 +44,17 @@ func (p *EndpointsProvider) RevokeEndpointURL() *url.URL     { return p.urlOf("o
 func (p *EndpointsProvider) JWKSEndpointURL() *url.URL       { return p.urlOf("oauth2/jwks") }
 func (p *EndpointsProvider) UserInfoEndpointURL() *url.URL   { return p.urlOf("oauth2/userinfo") }
 func (p *EndpointsProvider) EndSessionEndpointURL() *url.URL { return p.urlOf("oauth2/end_session") }
-func (p *EndpointsProvider) OAuthEntrypointURL() *url.URL {
-	return p.urlOf("_internals/oauth_entrypoint")
+func (p *EndpointsProvider) OAuthEntrypointURL(clientID string, redirectURI string) *url.URL {
+	u := p.urlOf("_internals/oauth_entrypoint")
+	q := u.Query()
+	if clientID != "" {
+		q.Set("client_id", clientID)
+	}
+	if redirectURI != "" {
+		q.Set("redirect_uri", redirectURI)
+	}
+	u.RawQuery = q.Encode()
+	return u
 }
 func (p *EndpointsProvider) LoginEndpointURL() *url.URL       { return p.urlOf("./login") }
 func (p *EndpointsProvider) SignupEndpointURL() *url.URL      { return p.urlOf("./signup") }

--- a/pkg/auth/handler/webapp/controller.go
+++ b/pkg/auth/handler/webapp/controller.go
@@ -197,10 +197,6 @@ func (c *Controller) EntryPointSession(opts webapp.SessionOptions) *webapp.Sessi
 			o.RedirectURI = opts.RedirectURI
 		}
 		o.KeepAfterFinish = opts.KeepAfterFinish
-	} else {
-		if o.RedirectURI == "" {
-			o.RedirectURI = webapp.DefaultPostLoginRedirectURI(c.UIConfig)
-		}
 	}
 	o.UpdatedAt = now
 	s = webapp.NewSession(o)

--- a/pkg/auth/handler/webapp/oauth_entrypoint.go
+++ b/pkg/auth/handler/webapp/oauth_entrypoint.go
@@ -3,6 +3,7 @@ package webapp
 import (
 	"net/http"
 
+	"github.com/authgear/authgear-server/pkg/auth/webapp"
 	"github.com/authgear/authgear-server/pkg/util/httproute"
 )
 
@@ -15,5 +16,6 @@ func ConfigureOAuthEntrypointRoute(route httproute.Route) httproute.Route {
 type OAuthEntrypointHandler struct{}
 
 func (h *OAuthEntrypointHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	http.Redirect(w, r, "/flows/select_account", http.StatusFound)
+	u := webapp.MakeRelativeURL("/flows/select_account", webapp.PreserveQuery(r.URL.Query()))
+	http.Redirect(w, r, u.String(), http.StatusFound)
 }

--- a/pkg/auth/handler/webapp/root.go
+++ b/pkg/auth/handler/webapp/root.go
@@ -29,5 +29,6 @@ func (h *RootHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		path = "/login"
 	}
 
-	http.Redirect(w, r, path, http.StatusFound)
+	u := webapp.MakeRelativeURL(path, webapp.PreserveQuery(r.URL.Query()))
+	http.Redirect(w, r, u.String(), http.StatusFound)
 }

--- a/pkg/auth/handler/webapp/select_account.go
+++ b/pkg/auth/handler/webapp/select_account.go
@@ -56,6 +56,8 @@ type SelectAccountHandler struct {
 	Identities                SelectAccountIdentityService
 	AuthenticationInfoService SelectAccountAuthenticationInfoService
 	Cookies                   CookieManager
+	OAuthConfig               *config.OAuthConfig
+	UIConfig                  *config.UIConfig
 }
 
 func (h *SelectAccountHandler) GetData(r *http.Request, rw http.ResponseWriter, userID string) (map[string]interface{}, error) {
@@ -111,7 +113,7 @@ func (h *SelectAccountHandler) ServeHTTP(w http.ResponseWriter, r *http.Request)
 	}
 
 	continueWithCurrentAccount := func() error {
-		redirectURI := "/settings"
+		redirectURI := ""
 
 		// Complete the web session and redirect to web session's RedirectURI
 		if webSession != nil {
@@ -119,6 +121,10 @@ func (h *SelectAccountHandler) ServeHTTP(w http.ResponseWriter, r *http.Request)
 			if err := ctrl.DeleteSession(webSession.ID); err != nil {
 				return err
 			}
+		}
+
+		if redirectURI == "" {
+			redirectURI = webapp.DerivePostLoginRedirectURIFromRequest(r, h.OAuthConfig, h.UIConfig)
 		}
 
 		// Write authentication info cookie

--- a/pkg/auth/handler/webapp/select_account.go
+++ b/pkg/auth/handler/webapp/select_account.go
@@ -154,7 +154,7 @@ func (h *SelectAccountHandler) ServeHTTP(w http.ResponseWriter, r *http.Request)
 				path = "/login"
 			}
 			if path != "" {
-				http.Redirect(w, r, path, http.StatusFound)
+				h.continueLoginFlow(w, r, path)
 				return
 			}
 		}
@@ -168,10 +168,10 @@ func (h *SelectAccountHandler) ServeHTTP(w http.ResponseWriter, r *http.Request)
 			path = "/login"
 		}
 
-		http.Redirect(w, r, path, http.StatusFound)
+		h.continueLoginFlow(w, r, path)
 	}
 	gotoLogin := func() {
-		http.Redirect(w, r, "/login", http.StatusFound)
+		h.continueLoginFlow(w, r, "/login")
 	}
 
 	// ctrl.Serve() always write response.
@@ -264,4 +264,10 @@ func (h *SelectAccountHandler) ServeHTTP(w http.ResponseWriter, r *http.Request)
 		gotoSignupOrLogin()
 		return nil
 	})
+}
+
+func (h *SelectAccountHandler) continueLoginFlow(w http.ResponseWriter, r *http.Request, path string) {
+	// preserve query only when continuing the login flow
+	u := webapp.MakeRelativeURL(path, webapp.PreserveQuery(r.URL.Query()))
+	http.Redirect(w, r, u.String(), http.StatusFound)
 }

--- a/pkg/auth/handler/webapp/select_account.go
+++ b/pkg/auth/handler/webapp/select_account.go
@@ -98,7 +98,7 @@ func (h *SelectAccountHandler) ServeHTTP(w http.ResponseWriter, r *http.Request)
 
 	if webSession != nil {
 		loginPrompt = slice.ContainsString(webSession.Prompt, "login")
-		fromAuthzEndpoint = webSession.ClientID != ""
+		fromAuthzEndpoint = webSession.FromAuthzEndpoint
 		userIDHint = webSession.UserIDHint
 		canUseIntentReauthenticate = webSession.CanUseIntentReauthenticate
 		suppressIDPSessionCookie = webSession.SuppressIDPSessionCookie

--- a/pkg/auth/webapp/auth_entry_point_middleware.go
+++ b/pkg/auth/webapp/auth_entry_point_middleware.go
@@ -8,8 +8,9 @@ import (
 )
 
 type AuthEntryPointMiddleware struct {
-	TrustProxy config.TrustProxy
-	UIConfig   *config.UIConfig
+	TrustProxy  config.TrustProxy
+	OAuthConfig *config.OAuthConfig
+	UIConfig    *config.UIConfig
 }
 
 func (m AuthEntryPointMiddleware) Handle(next http.Handler) http.Handler {
@@ -24,7 +25,7 @@ func (m AuthEntryPointMiddleware) Handle(next http.Handler) http.Handler {
 		}
 
 		if userID != nil && !fromAuthzEndpoint {
-			defaultRedirectURI := DefaultPostLoginRedirectURI(m.UIConfig)
+			defaultRedirectURI := DerivePostLoginRedirectURIFromRequest(r, m.OAuthConfig, m.UIConfig)
 			redirectURI := GetRedirectURI(r, bool(m.TrustProxy), defaultRedirectURI)
 
 			http.Redirect(w, r, redirectURI, http.StatusFound)

--- a/pkg/auth/webapp/auth_entry_point_middleware.go
+++ b/pkg/auth/webapp/auth_entry_point_middleware.go
@@ -20,7 +20,7 @@ func (m AuthEntryPointMiddleware) Handle(next http.Handler) http.Handler {
 		fromAuthzEndpoint := false
 		if webSession != nil {
 			// stay in the auth entry point if login is triggered by authz endpoint
-			fromAuthzEndpoint = webSession.ClientID != ""
+			fromAuthzEndpoint = webSession.FromAuthzEndpoint
 		}
 
 		if userID != nil && !fromAuthzEndpoint {

--- a/pkg/auth/webapp/client_id.go
+++ b/pkg/auth/webapp/client_id.go
@@ -38,21 +38,12 @@ func (m *ClientIDMiddleware) Handle(next http.Handler) http.Handler {
 func (m *ClientIDMiddleware) ReadClientID(r *http.Request) (clientID string, ok bool) {
 	// Read client_id in the following order.
 	// 1. From query
-	// 2. From web session cookie
-	// 3. From client ID cookie
+	// 2. From client ID cookie
 	q := r.URL.Query()
 	clientID = q.Get("client_id")
 	if clientID != "" {
 		ok = true
 		return
-	}
-
-	if cookie, err := m.Cookies.GetCookie(r, m.SessionCookieDef.Def); err == nil {
-		if s, err := m.States.Get(cookie.Value); err == nil && s.ClientID != "" {
-			clientID = s.ClientID
-			ok = true
-			return
-		}
 	}
 
 	if cookie, err := m.Cookies.GetCookie(r, m.ClientIDCookieDef.Def); err == nil {

--- a/pkg/auth/webapp/redirect.go
+++ b/pkg/auth/webapp/redirect.go
@@ -15,10 +15,51 @@ func GetRedirectURI(r *http.Request, trustProxy bool, defaultURI string) string 
 	return redirectURI
 }
 
-func DefaultPostLoginRedirectURI(uiConfig *config.UIConfig) string {
+func DerivePostLoginRedirectURIFromRequest(r *http.Request, oauthConfig *config.OAuthConfig, uiConfig *config.UIConfig) string {
+	// 1. Redirect URL in query param (must be whitelisted)
+	// 2. Default redirect URL of the client
+	// 3. Post-login URL
+	// 4. `/settings`
+	redirectURIFromQuery := func() string {
+		clientID := r.URL.Query().Get("client_id")
+		redirectURI := r.URL.Query().Get("redirect_uri")
+		if clientID == "" {
+			return ""
+		}
+		client, found := oauthConfig.GetClient(clientID)
+		if !found {
+			return ""
+		}
+
+		allowedURIs := client.RedirectURIs
+		allowed := false
+
+		for _, u := range allowedURIs {
+			if u == redirectURI {
+				allowed = true
+				break
+			}
+		}
+
+		// 1. Redirect URL in query param (must be whitelisted)
+		if allowed && redirectURI != "" {
+			return redirectURI
+		}
+
+		// 2. Default redirect URL of the client
+		return client.DefaultRedirectURI()
+	}()
+
+	if redirectURIFromQuery != "" {
+		return redirectURIFromQuery
+	}
+
+	// 3. Post-login URL
 	if uiConfig != nil && uiConfig.DefaultRedirectURI != "" {
 		return uiConfig.DefaultRedirectURI
 	}
+
+	// 4. `/settings`
 	return "/settings"
 }
 

--- a/pkg/auth/webapp/result.go
+++ b/pkg/auth/webapp/result.go
@@ -6,6 +6,7 @@ import (
 	"net/url"
 
 	"github.com/authgear/authgear-server/pkg/util/httputil"
+	"github.com/authgear/authgear-server/pkg/util/setutil"
 )
 
 type Result struct {
@@ -15,6 +16,7 @@ type Result struct {
 	NavigationAction string
 	Cookies          []*http.Cookie
 	IsInteractionErr bool
+	RemoveQueries    setutil.Set[string]
 }
 
 func (r *Result) WriteResponse(w http.ResponseWriter, req *http.Request) {
@@ -35,8 +37,9 @@ func (r *Result) WriteResponse(w http.ResponseWriter, req *http.Request) {
 	if redirectURI.Host == "" {
 		original := PreserveQuery(req.URL.Query())
 		for key := range original {
+			_, ignoreKey := r.RemoveQueries[key]
 			// preserve the query only if it doesn't exist in the new query
-			if q.Get(key) == "" {
+			if q.Get(key) == "" && !ignoreKey {
 				q.Set(key, original.Get(key))
 			}
 		}

--- a/pkg/auth/webapp/service2.go
+++ b/pkg/auth/webapp/service2.go
@@ -53,6 +53,7 @@ type Service2 struct {
 	Cookies              CookieManager
 	OAuthConfig          *config.OAuthConfig
 	UIConfig             *config.UIConfig
+	TrustProxy           config.TrustProxy
 
 	Graph GraphService
 }
@@ -499,12 +500,15 @@ func (s *Service2) deriveFinishRedirectURI(session *Session, graph *interaction.
 	}
 
 	// 1. WebSession's Redirect URL (e.g. authorization endpoint, settings page)
-	// 2. DerivePostLoginRedirectURIFromRequest
+	// 2. Obtain redirect_uri which is from the same origin by calling GetRedirectURI
+	// 3. DerivePostLoginRedirectURIFromRequest
 	if session.RedirectURI != "" {
 		return session.RedirectURI
 	}
 
-	return DerivePostLoginRedirectURIFromRequest(s.Request, s.OAuthConfig, s.UIConfig)
+	postLoginRedirectURI := DerivePostLoginRedirectURIFromRequest(s.Request, s.OAuthConfig, s.UIConfig)
+	redirectURI := GetRedirectURI(s.Request, bool(s.TrustProxy), postLoginRedirectURI)
+	return redirectURI
 }
 
 // nolint:gocyclo

--- a/pkg/auth/webapp/service2.go
+++ b/pkg/auth/webapp/service2.go
@@ -15,6 +15,7 @@ import (
 	"github.com/authgear/authgear-server/pkg/lib/interaction/intents"
 	"github.com/authgear/authgear-server/pkg/lib/interaction/nodes"
 	"github.com/authgear/authgear-server/pkg/util/log"
+	"github.com/authgear/authgear-server/pkg/util/setutil"
 )
 
 type SessionStore interface {
@@ -426,6 +427,9 @@ func (s *Service2) afterPost(
 
 	// Transition to redirect URI
 	if isFinished {
+		result.RemoveQueries = setutil.Set[string]{
+			"x_step": struct{}{},
+		}
 		result.RedirectURI = s.deriveFinishRedirectURI(session, graph)
 		switch graph.Intent.(type) {
 		case *intents.IntentAuthenticate:

--- a/pkg/auth/webapp/session.go
+++ b/pkg/auth/webapp/session.go
@@ -32,6 +32,7 @@ type SessionOptions struct {
 	CanUseIntentReauthenticate bool
 	SuppressIDPSessionCookie   bool
 	OAuthProviderAlias         string
+	FromAuthzEndpoint          bool
 }
 
 func NewSessionOptionsFromSession(s *Session) SessionOptions {
@@ -47,6 +48,7 @@ func NewSessionOptionsFromSession(s *Session) SessionOptions {
 		CanUseIntentReauthenticate: s.CanUseIntentReauthenticate,
 		SuppressIDPSessionCookie:   s.SuppressIDPSessionCookie,
 		OAuthProviderAlias:         s.OAuthProviderAlias,
+		FromAuthzEndpoint:          s.FromAuthzEndpoint,
 	}
 }
 
@@ -96,6 +98,9 @@ type Session struct {
 
 	// OAuthProviderAlias is used to auto redirect user to the given oauth provider in the login page
 	OAuthProviderAlias string `json:"oauth_provider_alias,omitempty"`
+
+	// FromAuthzEndpoint indicates whether the web session is created from the authorization endpoint
+	FromAuthzEndpoint bool `json:"from_authz_endpoint,omitempty"`
 }
 
 func newSessionID() string {
@@ -121,6 +126,7 @@ func NewSession(options SessionOptions) *Session {
 		CanUseIntentReauthenticate: options.CanUseIntentReauthenticate,
 		SuppressIDPSessionCookie:   options.SuppressIDPSessionCookie,
 		OAuthProviderAlias:         options.OAuthProviderAlias,
+		FromAuthzEndpoint:          options.FromAuthzEndpoint,
 	}
 	for k, v := range options.Extra {
 		s.Extra[k] = v

--- a/pkg/auth/webapp/session.go
+++ b/pkg/auth/webapp/session.go
@@ -21,7 +21,6 @@ func WithSession(ctx context.Context, session *Session) context.Context {
 
 type SessionOptions struct {
 	RedirectURI                string
-	ClientID                   string
 	KeepAfterFinish            bool
 	Prompt                     []string
 	Extra                      map[string]interface{}
@@ -38,7 +37,6 @@ type SessionOptions struct {
 func NewSessionOptionsFromSession(s *Session) SessionOptions {
 	return SessionOptions{
 		RedirectURI:                s.RedirectURI,
-		ClientID:                   s.ClientID,
 		KeepAfterFinish:            s.KeepAfterFinish,
 		Prompt:                     s.Prompt,
 		Extra:                      nil, // Omit extra by default
@@ -64,9 +62,6 @@ type Session struct {
 	// KeepAfterFinish indicates the session would not be deleted after the
 	// completion of interaction graph.
 	KeepAfterFinish bool `json:"keep_after_finish,omitempty"`
-
-	// ClientID is the client ID associated with this session.
-	ClientID string `json:"client_id,omitempty"`
 
 	// Extra is used to store extra information for use of webapp.
 	Extra map[string]interface{} `json:"extra"`
@@ -116,7 +111,6 @@ func NewSession(options SessionOptions) *Session {
 		ID:                         newSessionID(),
 		RedirectURI:                options.RedirectURI,
 		KeepAfterFinish:            options.KeepAfterFinish,
-		ClientID:                   options.ClientID,
 		Extra:                      make(map[string]interface{}),
 		Prompt:                     options.Prompt,
 		Page:                       options.Page,

--- a/pkg/auth/webapp/session.go
+++ b/pkg/auth/webapp/session.go
@@ -131,9 +131,6 @@ func NewSession(options SessionOptions) *Session {
 	for k, v := range options.Extra {
 		s.Extra[k] = v
 	}
-	if s.RedirectURI == "" {
-		s.RedirectURI = "/"
-	}
 	return s
 }
 

--- a/pkg/auth/webapp/url.go
+++ b/pkg/auth/webapp/url.go
@@ -16,6 +16,13 @@ func MakeURL(u *url.URL, path string, inQuery url.Values) *url.URL {
 	return uu
 }
 
+func MakeRelativeURL(path string, inQuery url.Values) *url.URL {
+	u := &url.URL{}
+	u.RawQuery = inQuery.Encode()
+	u.Path = path
+	return u
+}
+
 func PreserveQuery(q url.Values) url.Values {
 	outQuery := url.Values{}
 	for key := range q {

--- a/pkg/auth/webapp/url_provider.go
+++ b/pkg/auth/webapp/url_provider.go
@@ -13,7 +13,7 @@ import (
 
 type EndpointsProvider interface {
 	BaseURL() *url.URL
-	OAuthEntrypointURL() *url.URL
+	OAuthEntrypointURL(clientID string, redirectURI string) *url.URL
 	LoginEndpointURL() *url.URL
 	SignupEndpointURL() *url.URL
 	LogoutEndpointURL() *url.URL
@@ -67,10 +67,16 @@ type AuthenticateURLOptions struct {
 	UILocales      string
 	ColorScheme    string
 	Cookies        []*http.Cookie
+	ClientID       string
+	// RedirectURL will be used only when the WebSession doesn't have the redirect URI
+	// When the WebSession has a redirect URI, it usually starts from the authorization endpoint
+	// User will be redirected back to the authorization endpoint after authentication
+	// Authorization endpoint will use the redirect URI in the OAuthSession
+	RedirectURL string
 }
 
 func (p *AuthenticateURLProvider) AuthenticateURL(options AuthenticateURLOptions) (httputil.Result, error) {
-	endpoint := p.Endpoints.OAuthEntrypointURL().String()
+	endpoint := p.Endpoints.OAuthEntrypointURL(options.ClientID, options.RedirectURL).String()
 	now := p.Clock.NowUTC()
 	sessionOpts := options.SessionOptions
 	sessionOpts.UpdatedAt = now

--- a/pkg/auth/wire_gen.go
+++ b/pkg/auth/wire_gen.go
@@ -203,6 +203,7 @@ func newOAuthAuthorizeHandler(p *deps.RequestProvider) http.Handler {
 		Cookie:  errorCookieDef,
 		Cookies: cookieManager,
 	}
+	uiConfig := appConfig.UI
 	interactionLogger := interaction.NewLogger(factory)
 	featureConfig := config.FeatureConfig
 	eventLogger := event.NewLogger(factory)
@@ -810,6 +811,8 @@ func newOAuthAuthorizeHandler(p *deps.RequestProvider) http.Handler {
 		MFADeviceTokenCookie: cookieDef,
 		ErrorCookie:          errorCookie,
 		Cookies:              cookieManager,
+		OAuthConfig:          oAuthConfig,
+		UIConfig:             uiConfig,
 		Graph:                interactionService,
 	}
 	authenticateURLProvider := &webapp2.AuthenticateURLProvider{
@@ -978,6 +981,7 @@ func newOAuthConsentHandler(p *deps.RequestProvider) http.Handler {
 		Cookie:  errorCookieDef,
 		Cookies: cookieManager,
 	}
+	uiConfig := appConfig.UI
 	interactionLogger := interaction.NewLogger(factory)
 	featureConfig := config.FeatureConfig
 	eventLogger := event.NewLogger(factory)
@@ -1585,6 +1589,8 @@ func newOAuthConsentHandler(p *deps.RequestProvider) http.Handler {
 		MFADeviceTokenCookie: cookieDef,
 		ErrorCookie:          errorCookie,
 		Cookies:              cookieManager,
+		OAuthConfig:          oAuthConfig,
+		UIConfig:             uiConfig,
 		Graph:                interactionService,
 	}
 	authenticateURLProvider := &webapp2.AuthenticateURLProvider{
@@ -1644,7 +1650,6 @@ func newOAuthConsentHandler(p *deps.RequestProvider) http.Handler {
 		Cookies:                   cookieManager,
 		OAuthSessionService:       oauthsessionStoreRedis,
 	}
-	uiConfig := appConfig.UI
 	uiFeatureConfig := featureConfig.UI
 	googleTagManagerConfig := appConfig.GoogleTagManager
 	flashMessage := &httputil.FlashMessage{
@@ -6459,6 +6464,8 @@ func newWebAppLoginHandler(p *deps.RequestProvider) http.Handler {
 		Cookie:  errorCookieDef,
 		Cookies: cookieManager,
 	}
+	oAuthConfig := appConfig.OAuth
+	uiConfig := appConfig.UI
 	logger := interaction.NewLogger(factory)
 	remoteIP := deps.ProvideRemoteIP(request, trustProxy)
 	contextContext := deps.ProvideRequestContext(request)
@@ -6923,7 +6930,6 @@ func newWebAppLoginHandler(p *deps.RequestProvider) http.Handler {
 		SQLExecutor: sqlExecutor,
 		Clock:       clockClock,
 	}
-	oAuthConfig := appConfig.OAuth
 	sessionManager := &oauth2.SessionManager{
 		Store:  redisStore,
 		Clock:  clockClock,
@@ -7127,9 +7133,10 @@ func newWebAppLoginHandler(p *deps.RequestProvider) http.Handler {
 		MFADeviceTokenCookie: cookieDef,
 		ErrorCookie:          errorCookie,
 		Cookies:              cookieManager,
+		OAuthConfig:          oAuthConfig,
+		UIConfig:             uiConfig,
 		Graph:                interactionService,
 	}
-	uiConfig := appConfig.UI
 	uiFeatureConfig := featureConfig.UI
 	googleTagManagerConfig := appConfig.GoogleTagManager
 	flashMessage := &httputil.FlashMessage{
@@ -7238,6 +7245,8 @@ func newWebAppSignupHandler(p *deps.RequestProvider) http.Handler {
 		Cookie:  errorCookieDef,
 		Cookies: cookieManager,
 	}
+	oAuthConfig := appConfig.OAuth
+	uiConfig := appConfig.UI
 	logger := interaction.NewLogger(factory)
 	remoteIP := deps.ProvideRemoteIP(request, trustProxy)
 	contextContext := deps.ProvideRequestContext(request)
@@ -7702,7 +7711,6 @@ func newWebAppSignupHandler(p *deps.RequestProvider) http.Handler {
 		SQLExecutor: sqlExecutor,
 		Clock:       clockClock,
 	}
-	oAuthConfig := appConfig.OAuth
 	sessionManager := &oauth2.SessionManager{
 		Store:  redisStore,
 		Clock:  clockClock,
@@ -7906,9 +7914,10 @@ func newWebAppSignupHandler(p *deps.RequestProvider) http.Handler {
 		MFADeviceTokenCookie: cookieDef,
 		ErrorCookie:          errorCookie,
 		Cookies:              cookieManager,
+		OAuthConfig:          oAuthConfig,
+		UIConfig:             uiConfig,
 		Graph:                interactionService,
 	}
-	uiConfig := appConfig.UI
 	uiFeatureConfig := featureConfig.UI
 	googleTagManagerConfig := appConfig.GoogleTagManager
 	flashMessage := &httputil.FlashMessage{
@@ -8016,6 +8025,8 @@ func newWebAppPromoteHandler(p *deps.RequestProvider) http.Handler {
 		Cookie:  errorCookieDef,
 		Cookies: cookieManager,
 	}
+	oAuthConfig := appConfig.OAuth
+	uiConfig := appConfig.UI
 	logger := interaction.NewLogger(factory)
 	remoteIP := deps.ProvideRemoteIP(request, trustProxy)
 	contextContext := deps.ProvideRequestContext(request)
@@ -8480,7 +8491,6 @@ func newWebAppPromoteHandler(p *deps.RequestProvider) http.Handler {
 		SQLExecutor: sqlExecutor,
 		Clock:       clockClock,
 	}
-	oAuthConfig := appConfig.OAuth
 	sessionManager := &oauth2.SessionManager{
 		Store:  redisStore,
 		Clock:  clockClock,
@@ -8684,9 +8694,10 @@ func newWebAppPromoteHandler(p *deps.RequestProvider) http.Handler {
 		MFADeviceTokenCookie: cookieDef,
 		ErrorCookie:          errorCookie,
 		Cookies:              cookieManager,
+		OAuthConfig:          oAuthConfig,
+		UIConfig:             uiConfig,
 		Graph:                interactionService,
 	}
-	uiConfig := appConfig.UI
 	uiFeatureConfig := featureConfig.UI
 	googleTagManagerConfig := appConfig.GoogleTagManager
 	flashMessage := &httputil.FlashMessage{
@@ -8777,6 +8788,8 @@ func newWebAppSelectAccountHandler(p *deps.RequestProvider) http.Handler {
 		Cookie:  errorCookieDef,
 		Cookies: cookieManager,
 	}
+	oAuthConfig := appConfig.OAuth
+	uiConfig := appConfig.UI
 	logger := interaction.NewLogger(factory)
 	remoteIP := deps.ProvideRemoteIP(request, trustProxy)
 	contextContext := deps.ProvideRequestContext(request)
@@ -9241,7 +9254,6 @@ func newWebAppSelectAccountHandler(p *deps.RequestProvider) http.Handler {
 		SQLExecutor: sqlExecutor,
 		Clock:       clockClock,
 	}
-	oAuthConfig := appConfig.OAuth
 	sessionManager := &oauth2.SessionManager{
 		Store:  redisStore,
 		Clock:  clockClock,
@@ -9445,9 +9457,10 @@ func newWebAppSelectAccountHandler(p *deps.RequestProvider) http.Handler {
 		MFADeviceTokenCookie: cookieDef,
 		ErrorCookie:          errorCookie,
 		Cookies:              cookieManager,
+		OAuthConfig:          oAuthConfig,
+		UIConfig:             uiConfig,
 		Graph:                interactionService,
 	}
-	uiConfig := appConfig.UI
 	uiFeatureConfig := featureConfig.UI
 	googleTagManagerConfig := appConfig.GoogleTagManager
 	flashMessage := &httputil.FlashMessage{
@@ -9534,6 +9547,8 @@ func newWebAppSSOCallbackHandler(p *deps.RequestProvider) http.Handler {
 		Cookie:  errorCookieDef,
 		Cookies: cookieManager,
 	}
+	oAuthConfig := appConfig.OAuth
+	uiConfig := appConfig.UI
 	logger := interaction.NewLogger(factory)
 	remoteIP := deps.ProvideRemoteIP(request, trustProxy)
 	contextContext := deps.ProvideRequestContext(request)
@@ -9998,7 +10013,6 @@ func newWebAppSSOCallbackHandler(p *deps.RequestProvider) http.Handler {
 		SQLExecutor: sqlExecutor,
 		Clock:       clockClock,
 	}
-	oAuthConfig := appConfig.OAuth
 	sessionManager := &oauth2.SessionManager{
 		Store:  redisStore,
 		Clock:  clockClock,
@@ -10202,9 +10216,10 @@ func newWebAppSSOCallbackHandler(p *deps.RequestProvider) http.Handler {
 		MFADeviceTokenCookie: cookieDef,
 		ErrorCookie:          errorCookie,
 		Cookies:              cookieManager,
+		OAuthConfig:          oAuthConfig,
+		UIConfig:             uiConfig,
 		Graph:                interactionService,
 	}
-	uiConfig := appConfig.UI
 	uiFeatureConfig := featureConfig.UI
 	googleTagManagerConfig := appConfig.GoogleTagManager
 	flashMessage := &httputil.FlashMessage{
@@ -10283,6 +10298,8 @@ func newWechatAuthHandler(p *deps.RequestProvider) http.Handler {
 		Cookie:  errorCookieDef,
 		Cookies: cookieManager,
 	}
+	oAuthConfig := appConfig.OAuth
+	uiConfig := appConfig.UI
 	logger := interaction.NewLogger(factory)
 	remoteIP := deps.ProvideRemoteIP(request, trustProxy)
 	contextContext := deps.ProvideRequestContext(request)
@@ -10747,7 +10764,6 @@ func newWechatAuthHandler(p *deps.RequestProvider) http.Handler {
 		SQLExecutor: sqlExecutor,
 		Clock:       clockClock,
 	}
-	oAuthConfig := appConfig.OAuth
 	sessionManager := &oauth2.SessionManager{
 		Store:  redisStore,
 		Clock:  clockClock,
@@ -10951,9 +10967,10 @@ func newWechatAuthHandler(p *deps.RequestProvider) http.Handler {
 		MFADeviceTokenCookie: cookieDef,
 		ErrorCookie:          errorCookie,
 		Cookies:              cookieManager,
+		OAuthConfig:          oAuthConfig,
+		UIConfig:             uiConfig,
 		Graph:                interactionService,
 	}
-	uiConfig := appConfig.UI
 	uiFeatureConfig := featureConfig.UI
 	googleTagManagerConfig := appConfig.GoogleTagManager
 	flashMessage := &httputil.FlashMessage{
@@ -11035,6 +11052,8 @@ func newWechatCallbackHandler(p *deps.RequestProvider) http.Handler {
 		Cookie:  errorCookieDef,
 		Cookies: cookieManager,
 	}
+	oAuthConfig := appConfig.OAuth
+	uiConfig := appConfig.UI
 	logger := interaction.NewLogger(factory)
 	remoteIP := deps.ProvideRemoteIP(request, trustProxy)
 	contextContext := deps.ProvideRequestContext(request)
@@ -11499,7 +11518,6 @@ func newWechatCallbackHandler(p *deps.RequestProvider) http.Handler {
 		SQLExecutor: sqlExecutor,
 		Clock:       clockClock,
 	}
-	oAuthConfig := appConfig.OAuth
 	sessionManager := &oauth2.SessionManager{
 		Store:  redisStore,
 		Clock:  clockClock,
@@ -11703,9 +11721,10 @@ func newWechatCallbackHandler(p *deps.RequestProvider) http.Handler {
 		MFADeviceTokenCookie: cookieDef,
 		ErrorCookie:          errorCookie,
 		Cookies:              cookieManager,
+		OAuthConfig:          oAuthConfig,
+		UIConfig:             uiConfig,
 		Graph:                interactionService,
 	}
-	uiConfig := appConfig.UI
 	uiFeatureConfig := featureConfig.UI
 	googleTagManagerConfig := appConfig.GoogleTagManager
 	flashMessage := &httputil.FlashMessage{
@@ -11790,6 +11809,8 @@ func newWebAppEnterLoginIDHandler(p *deps.RequestProvider) http.Handler {
 		Cookie:  errorCookieDef,
 		Cookies: cookieManager,
 	}
+	oAuthConfig := appConfig.OAuth
+	uiConfig := appConfig.UI
 	logger := interaction.NewLogger(factory)
 	remoteIP := deps.ProvideRemoteIP(request, trustProxy)
 	contextContext := deps.ProvideRequestContext(request)
@@ -12254,7 +12275,6 @@ func newWebAppEnterLoginIDHandler(p *deps.RequestProvider) http.Handler {
 		SQLExecutor: sqlExecutor,
 		Clock:       clockClock,
 	}
-	oAuthConfig := appConfig.OAuth
 	sessionManager := &oauth2.SessionManager{
 		Store:  redisStore,
 		Clock:  clockClock,
@@ -12458,9 +12478,10 @@ func newWebAppEnterLoginIDHandler(p *deps.RequestProvider) http.Handler {
 		MFADeviceTokenCookie: cookieDef,
 		ErrorCookie:          errorCookie,
 		Cookies:              cookieManager,
+		OAuthConfig:          oAuthConfig,
+		UIConfig:             uiConfig,
 		Graph:                interactionService,
 	}
-	uiConfig := appConfig.UI
 	uiFeatureConfig := featureConfig.UI
 	googleTagManagerConfig := appConfig.GoogleTagManager
 	flashMessage := &httputil.FlashMessage{
@@ -12547,6 +12568,8 @@ func newWebAppEnterPasswordHandler(p *deps.RequestProvider) http.Handler {
 		Cookie:  errorCookieDef,
 		Cookies: cookieManager,
 	}
+	oAuthConfig := appConfig.OAuth
+	uiConfig := appConfig.UI
 	logger := interaction.NewLogger(factory)
 	remoteIP := deps.ProvideRemoteIP(request, trustProxy)
 	contextContext := deps.ProvideRequestContext(request)
@@ -13011,7 +13034,6 @@ func newWebAppEnterPasswordHandler(p *deps.RequestProvider) http.Handler {
 		SQLExecutor: sqlExecutor,
 		Clock:       clockClock,
 	}
-	oAuthConfig := appConfig.OAuth
 	sessionManager := &oauth2.SessionManager{
 		Store:  redisStore,
 		Clock:  clockClock,
@@ -13215,9 +13237,10 @@ func newWebAppEnterPasswordHandler(p *deps.RequestProvider) http.Handler {
 		MFADeviceTokenCookie: cookieDef,
 		ErrorCookie:          errorCookie,
 		Cookies:              cookieManager,
+		OAuthConfig:          oAuthConfig,
+		UIConfig:             uiConfig,
 		Graph:                interactionService,
 	}
-	uiConfig := appConfig.UI
 	uiFeatureConfig := featureConfig.UI
 	googleTagManagerConfig := appConfig.GoogleTagManager
 	flashMessage := &httputil.FlashMessage{
@@ -13302,6 +13325,8 @@ func newWebAppUsePasskeyHandler(p *deps.RequestProvider) http.Handler {
 		Cookie:  errorCookieDef,
 		Cookies: cookieManager,
 	}
+	oAuthConfig := appConfig.OAuth
+	uiConfig := appConfig.UI
 	logger := interaction.NewLogger(factory)
 	remoteIP := deps.ProvideRemoteIP(request, trustProxy)
 	contextContext := deps.ProvideRequestContext(request)
@@ -13766,7 +13791,6 @@ func newWebAppUsePasskeyHandler(p *deps.RequestProvider) http.Handler {
 		SQLExecutor: sqlExecutor,
 		Clock:       clockClock,
 	}
-	oAuthConfig := appConfig.OAuth
 	sessionManager := &oauth2.SessionManager{
 		Store:  redisStore,
 		Clock:  clockClock,
@@ -13970,9 +13994,10 @@ func newWebAppUsePasskeyHandler(p *deps.RequestProvider) http.Handler {
 		MFADeviceTokenCookie: cookieDef,
 		ErrorCookie:          errorCookie,
 		Cookies:              cookieManager,
+		OAuthConfig:          oAuthConfig,
+		UIConfig:             uiConfig,
 		Graph:                interactionService,
 	}
-	uiConfig := appConfig.UI
 	uiFeatureConfig := featureConfig.UI
 	googleTagManagerConfig := appConfig.GoogleTagManager
 	flashMessage := &httputil.FlashMessage{
@@ -14057,6 +14082,8 @@ func newWebAppCreatePasswordHandler(p *deps.RequestProvider) http.Handler {
 		Cookie:  errorCookieDef,
 		Cookies: cookieManager,
 	}
+	oAuthConfig := appConfig.OAuth
+	uiConfig := appConfig.UI
 	logger := interaction.NewLogger(factory)
 	remoteIP := deps.ProvideRemoteIP(request, trustProxy)
 	contextContext := deps.ProvideRequestContext(request)
@@ -14521,7 +14548,6 @@ func newWebAppCreatePasswordHandler(p *deps.RequestProvider) http.Handler {
 		SQLExecutor: sqlExecutor,
 		Clock:       clockClock,
 	}
-	oAuthConfig := appConfig.OAuth
 	sessionManager := &oauth2.SessionManager{
 		Store:  redisStore,
 		Clock:  clockClock,
@@ -14725,9 +14751,10 @@ func newWebAppCreatePasswordHandler(p *deps.RequestProvider) http.Handler {
 		MFADeviceTokenCookie: cookieDef,
 		ErrorCookie:          errorCookie,
 		Cookies:              cookieManager,
+		OAuthConfig:          oAuthConfig,
+		UIConfig:             uiConfig,
 		Graph:                interactionService,
 	}
-	uiConfig := appConfig.UI
 	uiFeatureConfig := featureConfig.UI
 	googleTagManagerConfig := appConfig.GoogleTagManager
 	flashMessage := &httputil.FlashMessage{
@@ -14813,6 +14840,8 @@ func newWebAppCreatePasskeyHandler(p *deps.RequestProvider) http.Handler {
 		Cookie:  errorCookieDef,
 		Cookies: cookieManager,
 	}
+	oAuthConfig := appConfig.OAuth
+	uiConfig := appConfig.UI
 	logger := interaction.NewLogger(factory)
 	remoteIP := deps.ProvideRemoteIP(request, trustProxy)
 	contextContext := deps.ProvideRequestContext(request)
@@ -15277,7 +15306,6 @@ func newWebAppCreatePasskeyHandler(p *deps.RequestProvider) http.Handler {
 		SQLExecutor: sqlExecutor,
 		Clock:       clockClock,
 	}
-	oAuthConfig := appConfig.OAuth
 	sessionManager := &oauth2.SessionManager{
 		Store:  redisStore,
 		Clock:  clockClock,
@@ -15481,9 +15509,10 @@ func newWebAppCreatePasskeyHandler(p *deps.RequestProvider) http.Handler {
 		MFADeviceTokenCookie: cookieDef,
 		ErrorCookie:          errorCookie,
 		Cookies:              cookieManager,
+		OAuthConfig:          oAuthConfig,
+		UIConfig:             uiConfig,
 		Graph:                interactionService,
 	}
-	uiConfig := appConfig.UI
 	uiFeatureConfig := featureConfig.UI
 	googleTagManagerConfig := appConfig.GoogleTagManager
 	flashMessage := &httputil.FlashMessage{
@@ -15568,6 +15597,8 @@ func newWebAppPromptCreatePasskeyHandler(p *deps.RequestProvider) http.Handler {
 		Cookie:  errorCookieDef,
 		Cookies: cookieManager,
 	}
+	oAuthConfig := appConfig.OAuth
+	uiConfig := appConfig.UI
 	logger := interaction.NewLogger(factory)
 	remoteIP := deps.ProvideRemoteIP(request, trustProxy)
 	contextContext := deps.ProvideRequestContext(request)
@@ -16032,7 +16063,6 @@ func newWebAppPromptCreatePasskeyHandler(p *deps.RequestProvider) http.Handler {
 		SQLExecutor: sqlExecutor,
 		Clock:       clockClock,
 	}
-	oAuthConfig := appConfig.OAuth
 	sessionManager := &oauth2.SessionManager{
 		Store:  redisStore,
 		Clock:  clockClock,
@@ -16236,9 +16266,10 @@ func newWebAppPromptCreatePasskeyHandler(p *deps.RequestProvider) http.Handler {
 		MFADeviceTokenCookie: cookieDef,
 		ErrorCookie:          errorCookie,
 		Cookies:              cookieManager,
+		OAuthConfig:          oAuthConfig,
+		UIConfig:             uiConfig,
 		Graph:                interactionService,
 	}
-	uiConfig := appConfig.UI
 	uiFeatureConfig := featureConfig.UI
 	googleTagManagerConfig := appConfig.GoogleTagManager
 	flashMessage := &httputil.FlashMessage{
@@ -16323,6 +16354,8 @@ func newWebAppSetupTOTPHandler(p *deps.RequestProvider) http.Handler {
 		Cookie:  errorCookieDef,
 		Cookies: cookieManager,
 	}
+	oAuthConfig := appConfig.OAuth
+	uiConfig := appConfig.UI
 	logger := interaction.NewLogger(factory)
 	remoteIP := deps.ProvideRemoteIP(request, trustProxy)
 	contextContext := deps.ProvideRequestContext(request)
@@ -16787,7 +16820,6 @@ func newWebAppSetupTOTPHandler(p *deps.RequestProvider) http.Handler {
 		SQLExecutor: sqlExecutor,
 		Clock:       clockClock,
 	}
-	oAuthConfig := appConfig.OAuth
 	sessionManager := &oauth2.SessionManager{
 		Store:  redisStore,
 		Clock:  clockClock,
@@ -16991,9 +17023,10 @@ func newWebAppSetupTOTPHandler(p *deps.RequestProvider) http.Handler {
 		MFADeviceTokenCookie: cookieDef,
 		ErrorCookie:          errorCookie,
 		Cookies:              cookieManager,
+		OAuthConfig:          oAuthConfig,
+		UIConfig:             uiConfig,
 		Graph:                interactionService,
 	}
-	uiConfig := appConfig.UI
 	uiFeatureConfig := featureConfig.UI
 	googleTagManagerConfig := appConfig.GoogleTagManager
 	flashMessage := &httputil.FlashMessage{
@@ -17080,6 +17113,8 @@ func newWebAppEnterTOTPHandler(p *deps.RequestProvider) http.Handler {
 		Cookie:  errorCookieDef,
 		Cookies: cookieManager,
 	}
+	oAuthConfig := appConfig.OAuth
+	uiConfig := appConfig.UI
 	logger := interaction.NewLogger(factory)
 	remoteIP := deps.ProvideRemoteIP(request, trustProxy)
 	contextContext := deps.ProvideRequestContext(request)
@@ -17544,7 +17579,6 @@ func newWebAppEnterTOTPHandler(p *deps.RequestProvider) http.Handler {
 		SQLExecutor: sqlExecutor,
 		Clock:       clockClock,
 	}
-	oAuthConfig := appConfig.OAuth
 	sessionManager := &oauth2.SessionManager{
 		Store:  redisStore,
 		Clock:  clockClock,
@@ -17748,9 +17782,10 @@ func newWebAppEnterTOTPHandler(p *deps.RequestProvider) http.Handler {
 		MFADeviceTokenCookie: cookieDef,
 		ErrorCookie:          errorCookie,
 		Cookies:              cookieManager,
+		OAuthConfig:          oAuthConfig,
+		UIConfig:             uiConfig,
 		Graph:                interactionService,
 	}
-	uiConfig := appConfig.UI
 	uiFeatureConfig := featureConfig.UI
 	googleTagManagerConfig := appConfig.GoogleTagManager
 	flashMessage := &httputil.FlashMessage{
@@ -17835,6 +17870,8 @@ func newWebAppSetupOOBOTPHandler(p *deps.RequestProvider) http.Handler {
 		Cookie:  errorCookieDef,
 		Cookies: cookieManager,
 	}
+	oAuthConfig := appConfig.OAuth
+	uiConfig := appConfig.UI
 	logger := interaction.NewLogger(factory)
 	remoteIP := deps.ProvideRemoteIP(request, trustProxy)
 	contextContext := deps.ProvideRequestContext(request)
@@ -18299,7 +18336,6 @@ func newWebAppSetupOOBOTPHandler(p *deps.RequestProvider) http.Handler {
 		SQLExecutor: sqlExecutor,
 		Clock:       clockClock,
 	}
-	oAuthConfig := appConfig.OAuth
 	sessionManager := &oauth2.SessionManager{
 		Store:  redisStore,
 		Clock:  clockClock,
@@ -18503,9 +18539,10 @@ func newWebAppSetupOOBOTPHandler(p *deps.RequestProvider) http.Handler {
 		MFADeviceTokenCookie: cookieDef,
 		ErrorCookie:          errorCookie,
 		Cookies:              cookieManager,
+		OAuthConfig:          oAuthConfig,
+		UIConfig:             uiConfig,
 		Graph:                interactionService,
 	}
-	uiConfig := appConfig.UI
 	uiFeatureConfig := featureConfig.UI
 	googleTagManagerConfig := appConfig.GoogleTagManager
 	flashMessage := &httputil.FlashMessage{
@@ -18590,6 +18627,8 @@ func newWebAppEnterOOBOTPHandler(p *deps.RequestProvider) http.Handler {
 		Cookie:  errorCookieDef,
 		Cookies: cookieManager,
 	}
+	oAuthConfig := appConfig.OAuth
+	uiConfig := appConfig.UI
 	logger := interaction.NewLogger(factory)
 	remoteIP := deps.ProvideRemoteIP(request, trustProxy)
 	contextContext := deps.ProvideRequestContext(request)
@@ -19054,7 +19093,6 @@ func newWebAppEnterOOBOTPHandler(p *deps.RequestProvider) http.Handler {
 		SQLExecutor: sqlExecutor,
 		Clock:       clockClock,
 	}
-	oAuthConfig := appConfig.OAuth
 	sessionManager := &oauth2.SessionManager{
 		Store:  redisStore,
 		Clock:  clockClock,
@@ -19258,9 +19296,10 @@ func newWebAppEnterOOBOTPHandler(p *deps.RequestProvider) http.Handler {
 		MFADeviceTokenCookie: cookieDef,
 		ErrorCookie:          errorCookie,
 		Cookies:              cookieManager,
+		OAuthConfig:          oAuthConfig,
+		UIConfig:             uiConfig,
 		Graph:                interactionService,
 	}
-	uiConfig := appConfig.UI
 	uiFeatureConfig := featureConfig.UI
 	googleTagManagerConfig := appConfig.GoogleTagManager
 	flashMessage := &httputil.FlashMessage{
@@ -19347,6 +19386,8 @@ func newWebAppSetupWhatsappOTPHandler(p *deps.RequestProvider) http.Handler {
 		Cookie:  errorCookieDef,
 		Cookies: cookieManager,
 	}
+	oAuthConfig := appConfig.OAuth
+	uiConfig := appConfig.UI
 	logger := interaction.NewLogger(factory)
 	remoteIP := deps.ProvideRemoteIP(request, trustProxy)
 	contextContext := deps.ProvideRequestContext(request)
@@ -19811,7 +19852,6 @@ func newWebAppSetupWhatsappOTPHandler(p *deps.RequestProvider) http.Handler {
 		SQLExecutor: sqlExecutor,
 		Clock:       clockClock,
 	}
-	oAuthConfig := appConfig.OAuth
 	sessionManager := &oauth2.SessionManager{
 		Store:  redisStore,
 		Clock:  clockClock,
@@ -20015,9 +20055,10 @@ func newWebAppSetupWhatsappOTPHandler(p *deps.RequestProvider) http.Handler {
 		MFADeviceTokenCookie: cookieDef,
 		ErrorCookie:          errorCookie,
 		Cookies:              cookieManager,
+		OAuthConfig:          oAuthConfig,
+		UIConfig:             uiConfig,
 		Graph:                interactionService,
 	}
-	uiConfig := appConfig.UI
 	uiFeatureConfig := featureConfig.UI
 	googleTagManagerConfig := appConfig.GoogleTagManager
 	flashMessage := &httputil.FlashMessage{
@@ -20102,6 +20143,8 @@ func newWebAppWhatsappOTPHandler(p *deps.RequestProvider) http.Handler {
 		Cookie:  errorCookieDef,
 		Cookies: cookieManager,
 	}
+	oAuthConfig := appConfig.OAuth
+	uiConfig := appConfig.UI
 	logger := interaction.NewLogger(factory)
 	remoteIP := deps.ProvideRemoteIP(request, trustProxy)
 	contextContext := deps.ProvideRequestContext(request)
@@ -20566,7 +20609,6 @@ func newWebAppWhatsappOTPHandler(p *deps.RequestProvider) http.Handler {
 		SQLExecutor: sqlExecutor,
 		Clock:       clockClock,
 	}
-	oAuthConfig := appConfig.OAuth
 	sessionManager := &oauth2.SessionManager{
 		Store:  redisStore,
 		Clock:  clockClock,
@@ -20770,9 +20812,10 @@ func newWebAppWhatsappOTPHandler(p *deps.RequestProvider) http.Handler {
 		MFADeviceTokenCookie: cookieDef,
 		ErrorCookie:          errorCookie,
 		Cookies:              cookieManager,
+		OAuthConfig:          oAuthConfig,
+		UIConfig:             uiConfig,
 		Graph:                interactionService,
 	}
-	uiConfig := appConfig.UI
 	uiFeatureConfig := featureConfig.UI
 	googleTagManagerConfig := appConfig.GoogleTagManager
 	flashMessage := &httputil.FlashMessage{
@@ -21286,6 +21329,8 @@ func newWebAppEnterRecoveryCodeHandler(p *deps.RequestProvider) http.Handler {
 		Cookie:  errorCookieDef,
 		Cookies: cookieManager,
 	}
+	oAuthConfig := appConfig.OAuth
+	uiConfig := appConfig.UI
 	logger := interaction.NewLogger(factory)
 	remoteIP := deps.ProvideRemoteIP(request, trustProxy)
 	contextContext := deps.ProvideRequestContext(request)
@@ -21750,7 +21795,6 @@ func newWebAppEnterRecoveryCodeHandler(p *deps.RequestProvider) http.Handler {
 		SQLExecutor: sqlExecutor,
 		Clock:       clockClock,
 	}
-	oAuthConfig := appConfig.OAuth
 	sessionManager := &oauth2.SessionManager{
 		Store:  redisStore,
 		Clock:  clockClock,
@@ -21954,9 +21998,10 @@ func newWebAppEnterRecoveryCodeHandler(p *deps.RequestProvider) http.Handler {
 		MFADeviceTokenCookie: cookieDef,
 		ErrorCookie:          errorCookie,
 		Cookies:              cookieManager,
+		OAuthConfig:          oAuthConfig,
+		UIConfig:             uiConfig,
 		Graph:                interactionService,
 	}
-	uiConfig := appConfig.UI
 	uiFeatureConfig := featureConfig.UI
 	googleTagManagerConfig := appConfig.GoogleTagManager
 	flashMessage := &httputil.FlashMessage{
@@ -22041,6 +22086,8 @@ func newWebAppSetupRecoveryCodeHandler(p *deps.RequestProvider) http.Handler {
 		Cookie:  errorCookieDef,
 		Cookies: cookieManager,
 	}
+	oAuthConfig := appConfig.OAuth
+	uiConfig := appConfig.UI
 	logger := interaction.NewLogger(factory)
 	remoteIP := deps.ProvideRemoteIP(request, trustProxy)
 	contextContext := deps.ProvideRequestContext(request)
@@ -22505,7 +22552,6 @@ func newWebAppSetupRecoveryCodeHandler(p *deps.RequestProvider) http.Handler {
 		SQLExecutor: sqlExecutor,
 		Clock:       clockClock,
 	}
-	oAuthConfig := appConfig.OAuth
 	sessionManager := &oauth2.SessionManager{
 		Store:  redisStore,
 		Clock:  clockClock,
@@ -22709,9 +22755,10 @@ func newWebAppSetupRecoveryCodeHandler(p *deps.RequestProvider) http.Handler {
 		MFADeviceTokenCookie: cookieDef,
 		ErrorCookie:          errorCookie,
 		Cookies:              cookieManager,
+		OAuthConfig:          oAuthConfig,
+		UIConfig:             uiConfig,
 		Graph:                interactionService,
 	}
-	uiConfig := appConfig.UI
 	uiFeatureConfig := featureConfig.UI
 	googleTagManagerConfig := appConfig.GoogleTagManager
 	flashMessage := &httputil.FlashMessage{
@@ -22792,6 +22839,8 @@ func newWebAppVerifyIdentityHandler(p *deps.RequestProvider) http.Handler {
 		Cookie:  errorCookieDef,
 		Cookies: cookieManager,
 	}
+	oAuthConfig := appConfig.OAuth
+	uiConfig := appConfig.UI
 	logger := interaction.NewLogger(factory)
 	remoteIP := deps.ProvideRemoteIP(request, trustProxy)
 	contextContext := deps.ProvideRequestContext(request)
@@ -23256,7 +23305,6 @@ func newWebAppVerifyIdentityHandler(p *deps.RequestProvider) http.Handler {
 		SQLExecutor: sqlExecutor,
 		Clock:       clockClock,
 	}
-	oAuthConfig := appConfig.OAuth
 	sessionManager := &oauth2.SessionManager{
 		Store:  redisStore,
 		Clock:  clockClock,
@@ -23460,9 +23508,10 @@ func newWebAppVerifyIdentityHandler(p *deps.RequestProvider) http.Handler {
 		MFADeviceTokenCookie: cookieDef,
 		ErrorCookie:          errorCookie,
 		Cookies:              cookieManager,
+		OAuthConfig:          oAuthConfig,
+		UIConfig:             uiConfig,
 		Graph:                interactionService,
 	}
-	uiConfig := appConfig.UI
 	uiFeatureConfig := featureConfig.UI
 	googleTagManagerConfig := appConfig.GoogleTagManager
 	flashMessage := &httputil.FlashMessage{
@@ -23545,6 +23594,8 @@ func newWebAppVerifyIdentitySuccessHandler(p *deps.RequestProvider) http.Handler
 		Cookie:  errorCookieDef,
 		Cookies: cookieManager,
 	}
+	oAuthConfig := appConfig.OAuth
+	uiConfig := appConfig.UI
 	logger := interaction.NewLogger(factory)
 	remoteIP := deps.ProvideRemoteIP(request, trustProxy)
 	contextContext := deps.ProvideRequestContext(request)
@@ -24009,7 +24060,6 @@ func newWebAppVerifyIdentitySuccessHandler(p *deps.RequestProvider) http.Handler
 		SQLExecutor: sqlExecutor,
 		Clock:       clockClock,
 	}
-	oAuthConfig := appConfig.OAuth
 	sessionManager := &oauth2.SessionManager{
 		Store:  redisStore,
 		Clock:  clockClock,
@@ -24213,9 +24263,10 @@ func newWebAppVerifyIdentitySuccessHandler(p *deps.RequestProvider) http.Handler
 		MFADeviceTokenCookie: cookieDef,
 		ErrorCookie:          errorCookie,
 		Cookies:              cookieManager,
+		OAuthConfig:          oAuthConfig,
+		UIConfig:             uiConfig,
 		Graph:                interactionService,
 	}
-	uiConfig := appConfig.UI
 	uiFeatureConfig := featureConfig.UI
 	googleTagManagerConfig := appConfig.GoogleTagManager
 	flashMessage := &httputil.FlashMessage{
@@ -24296,6 +24347,8 @@ func newWebAppForgotPasswordHandler(p *deps.RequestProvider) http.Handler {
 		Cookie:  errorCookieDef,
 		Cookies: cookieManager,
 	}
+	oAuthConfig := appConfig.OAuth
+	uiConfig := appConfig.UI
 	logger := interaction.NewLogger(factory)
 	remoteIP := deps.ProvideRemoteIP(request, trustProxy)
 	contextContext := deps.ProvideRequestContext(request)
@@ -24760,7 +24813,6 @@ func newWebAppForgotPasswordHandler(p *deps.RequestProvider) http.Handler {
 		SQLExecutor: sqlExecutor,
 		Clock:       clockClock,
 	}
-	oAuthConfig := appConfig.OAuth
 	sessionManager := &oauth2.SessionManager{
 		Store:  redisStore,
 		Clock:  clockClock,
@@ -24964,9 +25016,10 @@ func newWebAppForgotPasswordHandler(p *deps.RequestProvider) http.Handler {
 		MFADeviceTokenCookie: cookieDef,
 		ErrorCookie:          errorCookie,
 		Cookies:              cookieManager,
+		OAuthConfig:          oAuthConfig,
+		UIConfig:             uiConfig,
 		Graph:                interactionService,
 	}
-	uiConfig := appConfig.UI
 	uiFeatureConfig := featureConfig.UI
 	googleTagManagerConfig := appConfig.GoogleTagManager
 	flashMessage := &httputil.FlashMessage{
@@ -25057,6 +25110,8 @@ func newWebAppForgotPasswordSuccessHandler(p *deps.RequestProvider) http.Handler
 		Cookie:  errorCookieDef,
 		Cookies: cookieManager,
 	}
+	oAuthConfig := appConfig.OAuth
+	uiConfig := appConfig.UI
 	logger := interaction.NewLogger(factory)
 	remoteIP := deps.ProvideRemoteIP(request, trustProxy)
 	contextContext := deps.ProvideRequestContext(request)
@@ -25521,7 +25576,6 @@ func newWebAppForgotPasswordSuccessHandler(p *deps.RequestProvider) http.Handler
 		SQLExecutor: sqlExecutor,
 		Clock:       clockClock,
 	}
-	oAuthConfig := appConfig.OAuth
 	sessionManager := &oauth2.SessionManager{
 		Store:  redisStore,
 		Clock:  clockClock,
@@ -25725,9 +25779,10 @@ func newWebAppForgotPasswordSuccessHandler(p *deps.RequestProvider) http.Handler
 		MFADeviceTokenCookie: cookieDef,
 		ErrorCookie:          errorCookie,
 		Cookies:              cookieManager,
+		OAuthConfig:          oAuthConfig,
+		UIConfig:             uiConfig,
 		Graph:                interactionService,
 	}
-	uiConfig := appConfig.UI
 	uiFeatureConfig := featureConfig.UI
 	googleTagManagerConfig := appConfig.GoogleTagManager
 	flashMessage := &httputil.FlashMessage{
@@ -25808,6 +25863,8 @@ func newWebAppResetPasswordHandler(p *deps.RequestProvider) http.Handler {
 		Cookie:  errorCookieDef,
 		Cookies: cookieManager,
 	}
+	oAuthConfig := appConfig.OAuth
+	uiConfig := appConfig.UI
 	logger := interaction.NewLogger(factory)
 	remoteIP := deps.ProvideRemoteIP(request, trustProxy)
 	contextContext := deps.ProvideRequestContext(request)
@@ -26272,7 +26329,6 @@ func newWebAppResetPasswordHandler(p *deps.RequestProvider) http.Handler {
 		SQLExecutor: sqlExecutor,
 		Clock:       clockClock,
 	}
-	oAuthConfig := appConfig.OAuth
 	sessionManager := &oauth2.SessionManager{
 		Store:  redisStore,
 		Clock:  clockClock,
@@ -26476,9 +26532,10 @@ func newWebAppResetPasswordHandler(p *deps.RequestProvider) http.Handler {
 		MFADeviceTokenCookie: cookieDef,
 		ErrorCookie:          errorCookie,
 		Cookies:              cookieManager,
+		OAuthConfig:          oAuthConfig,
+		UIConfig:             uiConfig,
 		Graph:                interactionService,
 	}
-	uiConfig := appConfig.UI
 	uiFeatureConfig := featureConfig.UI
 	googleTagManagerConfig := appConfig.GoogleTagManager
 	flashMessage := &httputil.FlashMessage{
@@ -26560,6 +26617,8 @@ func newWebAppResetPasswordSuccessHandler(p *deps.RequestProvider) http.Handler 
 		Cookie:  errorCookieDef,
 		Cookies: cookieManager,
 	}
+	oAuthConfig := appConfig.OAuth
+	uiConfig := appConfig.UI
 	logger := interaction.NewLogger(factory)
 	remoteIP := deps.ProvideRemoteIP(request, trustProxy)
 	contextContext := deps.ProvideRequestContext(request)
@@ -27024,7 +27083,6 @@ func newWebAppResetPasswordSuccessHandler(p *deps.RequestProvider) http.Handler 
 		SQLExecutor: sqlExecutor,
 		Clock:       clockClock,
 	}
-	oAuthConfig := appConfig.OAuth
 	sessionManager := &oauth2.SessionManager{
 		Store:  redisStore,
 		Clock:  clockClock,
@@ -27228,9 +27286,10 @@ func newWebAppResetPasswordSuccessHandler(p *deps.RequestProvider) http.Handler 
 		MFADeviceTokenCookie: cookieDef,
 		ErrorCookie:          errorCookie,
 		Cookies:              cookieManager,
+		OAuthConfig:          oAuthConfig,
+		UIConfig:             uiConfig,
 		Graph:                interactionService,
 	}
-	uiConfig := appConfig.UI
 	uiFeatureConfig := featureConfig.UI
 	googleTagManagerConfig := appConfig.GoogleTagManager
 	flashMessage := &httputil.FlashMessage{
@@ -27311,6 +27370,8 @@ func newWebAppSettingsHandler(p *deps.RequestProvider) http.Handler {
 		Cookie:  errorCookieDef,
 		Cookies: cookieManager,
 	}
+	oAuthConfig := appConfig.OAuth
+	uiConfig := appConfig.UI
 	logger := interaction.NewLogger(factory)
 	remoteIP := deps.ProvideRemoteIP(request, trustProxy)
 	contextContext := deps.ProvideRequestContext(request)
@@ -27775,7 +27836,6 @@ func newWebAppSettingsHandler(p *deps.RequestProvider) http.Handler {
 		SQLExecutor: sqlExecutor,
 		Clock:       clockClock,
 	}
-	oAuthConfig := appConfig.OAuth
 	sessionManager := &oauth2.SessionManager{
 		Store:  redisStore,
 		Clock:  clockClock,
@@ -27979,9 +28039,10 @@ func newWebAppSettingsHandler(p *deps.RequestProvider) http.Handler {
 		MFADeviceTokenCookie: cookieDef,
 		ErrorCookie:          errorCookie,
 		Cookies:              cookieManager,
+		OAuthConfig:          oAuthConfig,
+		UIConfig:             uiConfig,
 		Graph:                interactionService,
 	}
-	uiConfig := appConfig.UI
 	uiFeatureConfig := featureConfig.UI
 	googleTagManagerConfig := appConfig.GoogleTagManager
 	flashMessage := &httputil.FlashMessage{
@@ -28093,6 +28154,8 @@ func newWebAppSettingsProfileHandler(p *deps.RequestProvider) http.Handler {
 		Cookie:  errorCookieDef,
 		Cookies: cookieManager,
 	}
+	oAuthConfig := appConfig.OAuth
+	uiConfig := appConfig.UI
 	logger := interaction.NewLogger(factory)
 	remoteIP := deps.ProvideRemoteIP(request, trustProxy)
 	contextContext := deps.ProvideRequestContext(request)
@@ -28557,7 +28620,6 @@ func newWebAppSettingsProfileHandler(p *deps.RequestProvider) http.Handler {
 		SQLExecutor: sqlExecutor,
 		Clock:       clockClock,
 	}
-	oAuthConfig := appConfig.OAuth
 	sessionManager := &oauth2.SessionManager{
 		Store:  redisStore,
 		Clock:  clockClock,
@@ -28761,9 +28823,10 @@ func newWebAppSettingsProfileHandler(p *deps.RequestProvider) http.Handler {
 		MFADeviceTokenCookie: cookieDef,
 		ErrorCookie:          errorCookie,
 		Cookies:              cookieManager,
+		OAuthConfig:          oAuthConfig,
+		UIConfig:             uiConfig,
 		Graph:                interactionService,
 	}
-	uiConfig := appConfig.UI
 	uiFeatureConfig := featureConfig.UI
 	googleTagManagerConfig := appConfig.GoogleTagManager
 	flashMessage := &httputil.FlashMessage{
@@ -28855,6 +28918,8 @@ func newWebAppSettingsProfileEditHandler(p *deps.RequestProvider) http.Handler {
 		Cookie:  errorCookieDef,
 		Cookies: cookieManager,
 	}
+	oAuthConfig := appConfig.OAuth
+	uiConfig := appConfig.UI
 	logger := interaction.NewLogger(factory)
 	remoteIP := deps.ProvideRemoteIP(request, trustProxy)
 	contextContext := deps.ProvideRequestContext(request)
@@ -29319,7 +29384,6 @@ func newWebAppSettingsProfileEditHandler(p *deps.RequestProvider) http.Handler {
 		SQLExecutor: sqlExecutor,
 		Clock:       clockClock,
 	}
-	oAuthConfig := appConfig.OAuth
 	sessionManager := &oauth2.SessionManager{
 		Store:  redisStore,
 		Clock:  clockClock,
@@ -29523,9 +29587,10 @@ func newWebAppSettingsProfileEditHandler(p *deps.RequestProvider) http.Handler {
 		MFADeviceTokenCookie: cookieDef,
 		ErrorCookie:          errorCookie,
 		Cookies:              cookieManager,
+		OAuthConfig:          oAuthConfig,
+		UIConfig:             uiConfig,
 		Graph:                interactionService,
 	}
-	uiConfig := appConfig.UI
 	uiFeatureConfig := featureConfig.UI
 	googleTagManagerConfig := appConfig.GoogleTagManager
 	flashMessage := &httputil.FlashMessage{
@@ -29630,6 +29695,8 @@ func newWebAppSettingsIdentityHandler(p *deps.RequestProvider) http.Handler {
 		Cookie:  errorCookieDef,
 		Cookies: cookieManager,
 	}
+	oAuthConfig := appConfig.OAuth
+	uiConfig := appConfig.UI
 	logger := interaction.NewLogger(factory)
 	remoteIP := deps.ProvideRemoteIP(request, trustProxy)
 	contextContext := deps.ProvideRequestContext(request)
@@ -30094,7 +30161,6 @@ func newWebAppSettingsIdentityHandler(p *deps.RequestProvider) http.Handler {
 		SQLExecutor: sqlExecutor,
 		Clock:       clockClock,
 	}
-	oAuthConfig := appConfig.OAuth
 	sessionManager := &oauth2.SessionManager{
 		Store:  redisStore,
 		Clock:  clockClock,
@@ -30298,9 +30364,10 @@ func newWebAppSettingsIdentityHandler(p *deps.RequestProvider) http.Handler {
 		MFADeviceTokenCookie: cookieDef,
 		ErrorCookie:          errorCookie,
 		Cookies:              cookieManager,
+		OAuthConfig:          oAuthConfig,
+		UIConfig:             uiConfig,
 		Graph:                interactionService,
 	}
-	uiConfig := appConfig.UI
 	uiFeatureConfig := featureConfig.UI
 	googleTagManagerConfig := appConfig.GoogleTagManager
 	flashMessage := &httputil.FlashMessage{
@@ -30389,6 +30456,8 @@ func newWebAppSettingsBiometricHandler(p *deps.RequestProvider) http.Handler {
 		Cookie:  errorCookieDef,
 		Cookies: cookieManager,
 	}
+	oAuthConfig := appConfig.OAuth
+	uiConfig := appConfig.UI
 	logger := interaction.NewLogger(factory)
 	remoteIP := deps.ProvideRemoteIP(request, trustProxy)
 	contextContext := deps.ProvideRequestContext(request)
@@ -30853,7 +30922,6 @@ func newWebAppSettingsBiometricHandler(p *deps.RequestProvider) http.Handler {
 		SQLExecutor: sqlExecutor,
 		Clock:       clockClock,
 	}
-	oAuthConfig := appConfig.OAuth
 	sessionManager := &oauth2.SessionManager{
 		Store:  redisStore,
 		Clock:  clockClock,
@@ -31057,9 +31125,10 @@ func newWebAppSettingsBiometricHandler(p *deps.RequestProvider) http.Handler {
 		MFADeviceTokenCookie: cookieDef,
 		ErrorCookie:          errorCookie,
 		Cookies:              cookieManager,
+		OAuthConfig:          oAuthConfig,
+		UIConfig:             uiConfig,
 		Graph:                interactionService,
 	}
-	uiConfig := appConfig.UI
 	uiFeatureConfig := featureConfig.UI
 	googleTagManagerConfig := appConfig.GoogleTagManager
 	flashMessage := &httputil.FlashMessage{
@@ -31141,6 +31210,8 @@ func newWebAppSettingsMFAHandler(p *deps.RequestProvider) http.Handler {
 		Cookie:  errorCookieDef,
 		Cookies: cookieManager,
 	}
+	oAuthConfig := appConfig.OAuth
+	uiConfig := appConfig.UI
 	logger := interaction.NewLogger(factory)
 	remoteIP := deps.ProvideRemoteIP(request, trustProxy)
 	contextContext := deps.ProvideRequestContext(request)
@@ -31605,7 +31676,6 @@ func newWebAppSettingsMFAHandler(p *deps.RequestProvider) http.Handler {
 		SQLExecutor: sqlExecutor,
 		Clock:       clockClock,
 	}
-	oAuthConfig := appConfig.OAuth
 	sessionManager := &oauth2.SessionManager{
 		Store:  redisStore,
 		Clock:  clockClock,
@@ -31809,9 +31879,10 @@ func newWebAppSettingsMFAHandler(p *deps.RequestProvider) http.Handler {
 		MFADeviceTokenCookie: cookieDef,
 		ErrorCookie:          errorCookie,
 		Cookies:              cookieManager,
+		OAuthConfig:          oAuthConfig,
+		UIConfig:             uiConfig,
 		Graph:                interactionService,
 	}
-	uiConfig := appConfig.UI
 	uiFeatureConfig := featureConfig.UI
 	googleTagManagerConfig := appConfig.GoogleTagManager
 	flashMessage := &httputil.FlashMessage{
@@ -31901,6 +31972,8 @@ func newWebAppSettingsTOTPHandler(p *deps.RequestProvider) http.Handler {
 		Cookie:  errorCookieDef,
 		Cookies: cookieManager,
 	}
+	oAuthConfig := appConfig.OAuth
+	uiConfig := appConfig.UI
 	logger := interaction.NewLogger(factory)
 	remoteIP := deps.ProvideRemoteIP(request, trustProxy)
 	contextContext := deps.ProvideRequestContext(request)
@@ -32365,7 +32438,6 @@ func newWebAppSettingsTOTPHandler(p *deps.RequestProvider) http.Handler {
 		SQLExecutor: sqlExecutor,
 		Clock:       clockClock,
 	}
-	oAuthConfig := appConfig.OAuth
 	sessionManager := &oauth2.SessionManager{
 		Store:  redisStore,
 		Clock:  clockClock,
@@ -32569,9 +32641,10 @@ func newWebAppSettingsTOTPHandler(p *deps.RequestProvider) http.Handler {
 		MFADeviceTokenCookie: cookieDef,
 		ErrorCookie:          errorCookie,
 		Cookies:              cookieManager,
+		OAuthConfig:          oAuthConfig,
+		UIConfig:             uiConfig,
 		Graph:                interactionService,
 	}
-	uiConfig := appConfig.UI
 	uiFeatureConfig := featureConfig.UI
 	googleTagManagerConfig := appConfig.GoogleTagManager
 	flashMessage := &httputil.FlashMessage{
@@ -32653,6 +32726,8 @@ func newWebAppSettingsPasskeyHandler(p *deps.RequestProvider) http.Handler {
 		Cookie:  errorCookieDef,
 		Cookies: cookieManager,
 	}
+	oAuthConfig := appConfig.OAuth
+	uiConfig := appConfig.UI
 	logger := interaction.NewLogger(factory)
 	remoteIP := deps.ProvideRemoteIP(request, trustProxy)
 	contextContext := deps.ProvideRequestContext(request)
@@ -33117,7 +33192,6 @@ func newWebAppSettingsPasskeyHandler(p *deps.RequestProvider) http.Handler {
 		SQLExecutor: sqlExecutor,
 		Clock:       clockClock,
 	}
-	oAuthConfig := appConfig.OAuth
 	sessionManager := &oauth2.SessionManager{
 		Store:  redisStore,
 		Clock:  clockClock,
@@ -33321,9 +33395,10 @@ func newWebAppSettingsPasskeyHandler(p *deps.RequestProvider) http.Handler {
 		MFADeviceTokenCookie: cookieDef,
 		ErrorCookie:          errorCookie,
 		Cookies:              cookieManager,
+		OAuthConfig:          oAuthConfig,
+		UIConfig:             uiConfig,
 		Graph:                interactionService,
 	}
-	uiConfig := appConfig.UI
 	uiFeatureConfig := featureConfig.UI
 	googleTagManagerConfig := appConfig.GoogleTagManager
 	flashMessage := &httputil.FlashMessage{
@@ -33405,6 +33480,8 @@ func newWebAppSettingsOOBOTPHandler(p *deps.RequestProvider) http.Handler {
 		Cookie:  errorCookieDef,
 		Cookies: cookieManager,
 	}
+	oAuthConfig := appConfig.OAuth
+	uiConfig := appConfig.UI
 	logger := interaction.NewLogger(factory)
 	remoteIP := deps.ProvideRemoteIP(request, trustProxy)
 	contextContext := deps.ProvideRequestContext(request)
@@ -33869,7 +33946,6 @@ func newWebAppSettingsOOBOTPHandler(p *deps.RequestProvider) http.Handler {
 		SQLExecutor: sqlExecutor,
 		Clock:       clockClock,
 	}
-	oAuthConfig := appConfig.OAuth
 	sessionManager := &oauth2.SessionManager{
 		Store:  redisStore,
 		Clock:  clockClock,
@@ -34073,9 +34149,10 @@ func newWebAppSettingsOOBOTPHandler(p *deps.RequestProvider) http.Handler {
 		MFADeviceTokenCookie: cookieDef,
 		ErrorCookie:          errorCookie,
 		Cookies:              cookieManager,
+		OAuthConfig:          oAuthConfig,
+		UIConfig:             uiConfig,
 		Graph:                interactionService,
 	}
-	uiConfig := appConfig.UI
 	uiFeatureConfig := featureConfig.UI
 	googleTagManagerConfig := appConfig.GoogleTagManager
 	flashMessage := &httputil.FlashMessage{
@@ -34157,6 +34234,8 @@ func newWebAppSettingsRecoveryCodeHandler(p *deps.RequestProvider) http.Handler 
 		Cookie:  errorCookieDef,
 		Cookies: cookieManager,
 	}
+	oAuthConfig := appConfig.OAuth
+	uiConfig := appConfig.UI
 	logger := interaction.NewLogger(factory)
 	remoteIP := deps.ProvideRemoteIP(request, trustProxy)
 	contextContext := deps.ProvideRequestContext(request)
@@ -34621,7 +34700,6 @@ func newWebAppSettingsRecoveryCodeHandler(p *deps.RequestProvider) http.Handler 
 		SQLExecutor: sqlExecutor,
 		Clock:       clockClock,
 	}
-	oAuthConfig := appConfig.OAuth
 	sessionManager := &oauth2.SessionManager{
 		Store:  redisStore,
 		Clock:  clockClock,
@@ -34825,9 +34903,10 @@ func newWebAppSettingsRecoveryCodeHandler(p *deps.RequestProvider) http.Handler 
 		MFADeviceTokenCookie: cookieDef,
 		ErrorCookie:          errorCookie,
 		Cookies:              cookieManager,
+		OAuthConfig:          oAuthConfig,
+		UIConfig:             uiConfig,
 		Graph:                interactionService,
 	}
-	uiConfig := appConfig.UI
 	uiFeatureConfig := featureConfig.UI
 	googleTagManagerConfig := appConfig.GoogleTagManager
 	flashMessage := &httputil.FlashMessage{
@@ -34910,6 +34989,8 @@ func newWebAppSettingsSessionsHandler(p *deps.RequestProvider) http.Handler {
 		Cookie:  errorCookieDef,
 		Cookies: cookieManager,
 	}
+	oAuthConfig := appConfig.OAuth
+	uiConfig := appConfig.UI
 	logger := interaction.NewLogger(factory)
 	remoteIP := deps.ProvideRemoteIP(request, trustProxy)
 	contextContext := deps.ProvideRequestContext(request)
@@ -35374,7 +35455,6 @@ func newWebAppSettingsSessionsHandler(p *deps.RequestProvider) http.Handler {
 		SQLExecutor: sqlExecutor,
 		Clock:       clockClock,
 	}
-	oAuthConfig := appConfig.OAuth
 	sessionManager := &oauth2.SessionManager{
 		Store:  redisStore,
 		Clock:  clockClock,
@@ -35578,9 +35658,10 @@ func newWebAppSettingsSessionsHandler(p *deps.RequestProvider) http.Handler {
 		MFADeviceTokenCookie: cookieDef,
 		ErrorCookie:          errorCookie,
 		Cookies:              cookieManager,
+		OAuthConfig:          oAuthConfig,
+		UIConfig:             uiConfig,
 		Graph:                interactionService,
 	}
-	uiConfig := appConfig.UI
 	uiFeatureConfig := featureConfig.UI
 	googleTagManagerConfig := appConfig.GoogleTagManager
 	flashMessage := &httputil.FlashMessage{
@@ -35673,6 +35754,8 @@ func newWebAppForceChangePasswordHandler(p *deps.RequestProvider) http.Handler {
 		Cookie:  errorCookieDef,
 		Cookies: cookieManager,
 	}
+	oAuthConfig := appConfig.OAuth
+	uiConfig := appConfig.UI
 	logger := interaction.NewLogger(factory)
 	remoteIP := deps.ProvideRemoteIP(request, trustProxy)
 	contextContext := deps.ProvideRequestContext(request)
@@ -36137,7 +36220,6 @@ func newWebAppForceChangePasswordHandler(p *deps.RequestProvider) http.Handler {
 		SQLExecutor: sqlExecutor,
 		Clock:       clockClock,
 	}
-	oAuthConfig := appConfig.OAuth
 	sessionManager := &oauth2.SessionManager{
 		Store:  redisStore,
 		Clock:  clockClock,
@@ -36341,9 +36423,10 @@ func newWebAppForceChangePasswordHandler(p *deps.RequestProvider) http.Handler {
 		MFADeviceTokenCookie: cookieDef,
 		ErrorCookie:          errorCookie,
 		Cookies:              cookieManager,
+		OAuthConfig:          oAuthConfig,
+		UIConfig:             uiConfig,
 		Graph:                interactionService,
 	}
-	uiConfig := appConfig.UI
 	uiFeatureConfig := featureConfig.UI
 	googleTagManagerConfig := appConfig.GoogleTagManager
 	flashMessage := &httputil.FlashMessage{
@@ -36425,6 +36508,8 @@ func newWebAppSettingsChangePasswordHandler(p *deps.RequestProvider) http.Handle
 		Cookie:  errorCookieDef,
 		Cookies: cookieManager,
 	}
+	oAuthConfig := appConfig.OAuth
+	uiConfig := appConfig.UI
 	logger := interaction.NewLogger(factory)
 	remoteIP := deps.ProvideRemoteIP(request, trustProxy)
 	contextContext := deps.ProvideRequestContext(request)
@@ -36889,7 +36974,6 @@ func newWebAppSettingsChangePasswordHandler(p *deps.RequestProvider) http.Handle
 		SQLExecutor: sqlExecutor,
 		Clock:       clockClock,
 	}
-	oAuthConfig := appConfig.OAuth
 	sessionManager := &oauth2.SessionManager{
 		Store:  redisStore,
 		Clock:  clockClock,
@@ -37093,9 +37177,10 @@ func newWebAppSettingsChangePasswordHandler(p *deps.RequestProvider) http.Handle
 		MFADeviceTokenCookie: cookieDef,
 		ErrorCookie:          errorCookie,
 		Cookies:              cookieManager,
+		OAuthConfig:          oAuthConfig,
+		UIConfig:             uiConfig,
 		Graph:                interactionService,
 	}
-	uiConfig := appConfig.UI
 	uiFeatureConfig := featureConfig.UI
 	googleTagManagerConfig := appConfig.GoogleTagManager
 	flashMessage := &httputil.FlashMessage{
@@ -37177,6 +37262,8 @@ func newWebAppForceChangeSecondaryPasswordHandler(p *deps.RequestProvider) http.
 		Cookie:  errorCookieDef,
 		Cookies: cookieManager,
 	}
+	oAuthConfig := appConfig.OAuth
+	uiConfig := appConfig.UI
 	logger := interaction.NewLogger(factory)
 	remoteIP := deps.ProvideRemoteIP(request, trustProxy)
 	contextContext := deps.ProvideRequestContext(request)
@@ -37641,7 +37728,6 @@ func newWebAppForceChangeSecondaryPasswordHandler(p *deps.RequestProvider) http.
 		SQLExecutor: sqlExecutor,
 		Clock:       clockClock,
 	}
-	oAuthConfig := appConfig.OAuth
 	sessionManager := &oauth2.SessionManager{
 		Store:  redisStore,
 		Clock:  clockClock,
@@ -37845,9 +37931,10 @@ func newWebAppForceChangeSecondaryPasswordHandler(p *deps.RequestProvider) http.
 		MFADeviceTokenCookie: cookieDef,
 		ErrorCookie:          errorCookie,
 		Cookies:              cookieManager,
+		OAuthConfig:          oAuthConfig,
+		UIConfig:             uiConfig,
 		Graph:                interactionService,
 	}
-	uiConfig := appConfig.UI
 	uiFeatureConfig := featureConfig.UI
 	googleTagManagerConfig := appConfig.GoogleTagManager
 	flashMessage := &httputil.FlashMessage{
@@ -37929,6 +38016,8 @@ func newWebAppSettingsChangeSecondaryPasswordHandler(p *deps.RequestProvider) ht
 		Cookie:  errorCookieDef,
 		Cookies: cookieManager,
 	}
+	oAuthConfig := appConfig.OAuth
+	uiConfig := appConfig.UI
 	logger := interaction.NewLogger(factory)
 	remoteIP := deps.ProvideRemoteIP(request, trustProxy)
 	contextContext := deps.ProvideRequestContext(request)
@@ -38393,7 +38482,6 @@ func newWebAppSettingsChangeSecondaryPasswordHandler(p *deps.RequestProvider) ht
 		SQLExecutor: sqlExecutor,
 		Clock:       clockClock,
 	}
-	oAuthConfig := appConfig.OAuth
 	sessionManager := &oauth2.SessionManager{
 		Store:  redisStore,
 		Clock:  clockClock,
@@ -38597,9 +38685,10 @@ func newWebAppSettingsChangeSecondaryPasswordHandler(p *deps.RequestProvider) ht
 		MFADeviceTokenCookie: cookieDef,
 		ErrorCookie:          errorCookie,
 		Cookies:              cookieManager,
+		OAuthConfig:          oAuthConfig,
+		UIConfig:             uiConfig,
 		Graph:                interactionService,
 	}
-	uiConfig := appConfig.UI
 	uiFeatureConfig := featureConfig.UI
 	googleTagManagerConfig := appConfig.GoogleTagManager
 	flashMessage := &httputil.FlashMessage{
@@ -38681,6 +38770,8 @@ func newWebAppSettingsDeleteAccountHandler(p *deps.RequestProvider) http.Handler
 		Cookie:  errorCookieDef,
 		Cookies: cookieManager,
 	}
+	oAuthConfig := appConfig.OAuth
+	uiConfig := appConfig.UI
 	logger := interaction.NewLogger(factory)
 	remoteIP := deps.ProvideRemoteIP(request, trustProxy)
 	contextContext := deps.ProvideRequestContext(request)
@@ -39145,7 +39236,6 @@ func newWebAppSettingsDeleteAccountHandler(p *deps.RequestProvider) http.Handler
 		SQLExecutor: sqlExecutor,
 		Clock:       clockClock,
 	}
-	oAuthConfig := appConfig.OAuth
 	sessionManager := &oauth2.SessionManager{
 		Store:  redisStore,
 		Clock:  clockClock,
@@ -39349,9 +39439,10 @@ func newWebAppSettingsDeleteAccountHandler(p *deps.RequestProvider) http.Handler
 		MFADeviceTokenCookie: cookieDef,
 		ErrorCookie:          errorCookie,
 		Cookies:              cookieManager,
+		OAuthConfig:          oAuthConfig,
+		UIConfig:             uiConfig,
 		Graph:                interactionService,
 	}
-	uiConfig := appConfig.UI
 	uiFeatureConfig := featureConfig.UI
 	googleTagManagerConfig := appConfig.GoogleTagManager
 	flashMessage := &httputil.FlashMessage{
@@ -39440,6 +39531,8 @@ func newWebAppSettingsDeleteAccountSuccessHandler(p *deps.RequestProvider) http.
 		Cookie:  errorCookieDef,
 		Cookies: cookieManager,
 	}
+	oAuthConfig := appConfig.OAuth
+	uiConfig := appConfig.UI
 	logger := interaction.NewLogger(factory)
 	remoteIP := deps.ProvideRemoteIP(request, trustProxy)
 	contextContext := deps.ProvideRequestContext(request)
@@ -39904,7 +39997,6 @@ func newWebAppSettingsDeleteAccountSuccessHandler(p *deps.RequestProvider) http.
 		SQLExecutor: sqlExecutor,
 		Clock:       clockClock,
 	}
-	oAuthConfig := appConfig.OAuth
 	sessionManager := &oauth2.SessionManager{
 		Store:  redisStore,
 		Clock:  clockClock,
@@ -40108,9 +40200,10 @@ func newWebAppSettingsDeleteAccountSuccessHandler(p *deps.RequestProvider) http.
 		MFADeviceTokenCookie: cookieDef,
 		ErrorCookie:          errorCookie,
 		Cookies:              cookieManager,
+		OAuthConfig:          oAuthConfig,
+		UIConfig:             uiConfig,
 		Graph:                interactionService,
 	}
-	uiConfig := appConfig.UI
 	uiFeatureConfig := featureConfig.UI
 	googleTagManagerConfig := appConfig.GoogleTagManager
 	flashMessage := &httputil.FlashMessage{
@@ -40193,6 +40286,8 @@ func newWebAppAccountStatusHandler(p *deps.RequestProvider) http.Handler {
 		Cookie:  errorCookieDef,
 		Cookies: cookieManager,
 	}
+	oAuthConfig := appConfig.OAuth
+	uiConfig := appConfig.UI
 	logger := interaction.NewLogger(factory)
 	remoteIP := deps.ProvideRemoteIP(request, trustProxy)
 	contextContext := deps.ProvideRequestContext(request)
@@ -40657,7 +40752,6 @@ func newWebAppAccountStatusHandler(p *deps.RequestProvider) http.Handler {
 		SQLExecutor: sqlExecutor,
 		Clock:       clockClock,
 	}
-	oAuthConfig := appConfig.OAuth
 	sessionManager := &oauth2.SessionManager{
 		Store:  redisStore,
 		Clock:  clockClock,
@@ -40861,9 +40955,10 @@ func newWebAppAccountStatusHandler(p *deps.RequestProvider) http.Handler {
 		MFADeviceTokenCookie: cookieDef,
 		ErrorCookie:          errorCookie,
 		Cookies:              cookieManager,
+		OAuthConfig:          oAuthConfig,
+		UIConfig:             uiConfig,
 		Graph:                interactionService,
 	}
-	uiConfig := appConfig.UI
 	uiFeatureConfig := featureConfig.UI
 	googleTagManagerConfig := appConfig.GoogleTagManager
 	flashMessage := &httputil.FlashMessage{
@@ -40944,6 +41039,8 @@ func newWebAppLogoutHandler(p *deps.RequestProvider) http.Handler {
 		Cookie:  errorCookieDef,
 		Cookies: cookieManager,
 	}
+	oAuthConfig := appConfig.OAuth
+	uiConfig := appConfig.UI
 	logger := interaction.NewLogger(factory)
 	remoteIP := deps.ProvideRemoteIP(request, trustProxy)
 	contextContext := deps.ProvideRequestContext(request)
@@ -41408,7 +41505,6 @@ func newWebAppLogoutHandler(p *deps.RequestProvider) http.Handler {
 		SQLExecutor: sqlExecutor,
 		Clock:       clockClock,
 	}
-	oAuthConfig := appConfig.OAuth
 	sessionManager := &oauth2.SessionManager{
 		Store:  redisStore,
 		Clock:  clockClock,
@@ -41612,9 +41708,10 @@ func newWebAppLogoutHandler(p *deps.RequestProvider) http.Handler {
 		MFADeviceTokenCookie: cookieDef,
 		ErrorCookie:          errorCookie,
 		Cookies:              cookieManager,
+		OAuthConfig:          oAuthConfig,
+		UIConfig:             uiConfig,
 		Graph:                interactionService,
 	}
-	uiConfig := appConfig.UI
 	uiFeatureConfig := featureConfig.UI
 	googleTagManagerConfig := appConfig.GoogleTagManager
 	flashMessage := &httputil.FlashMessage{
@@ -41714,6 +41811,8 @@ func newWebAppReturnHandler(p *deps.RequestProvider) http.Handler {
 		Cookie:  errorCookieDef,
 		Cookies: cookieManager,
 	}
+	oAuthConfig := appConfig.OAuth
+	uiConfig := appConfig.UI
 	logger := interaction.NewLogger(factory)
 	remoteIP := deps.ProvideRemoteIP(request, trustProxy)
 	contextContext := deps.ProvideRequestContext(request)
@@ -42178,7 +42277,6 @@ func newWebAppReturnHandler(p *deps.RequestProvider) http.Handler {
 		SQLExecutor: sqlExecutor,
 		Clock:       clockClock,
 	}
-	oAuthConfig := appConfig.OAuth
 	sessionManager := &oauth2.SessionManager{
 		Store:  redisStore,
 		Clock:  clockClock,
@@ -42382,9 +42480,10 @@ func newWebAppReturnHandler(p *deps.RequestProvider) http.Handler {
 		MFADeviceTokenCookie: cookieDef,
 		ErrorCookie:          errorCookie,
 		Cookies:              cookieManager,
+		OAuthConfig:          oAuthConfig,
+		UIConfig:             uiConfig,
 		Graph:                interactionService,
 	}
-	uiConfig := appConfig.UI
 	uiFeatureConfig := featureConfig.UI
 	googleTagManagerConfig := appConfig.GoogleTagManager
 	flashMessage := &httputil.FlashMessage{
@@ -42465,6 +42564,8 @@ func newWebAppErrorHandler(p *deps.RequestProvider) http.Handler {
 		Cookie:  errorCookieDef,
 		Cookies: cookieManager,
 	}
+	oAuthConfig := appConfig.OAuth
+	uiConfig := appConfig.UI
 	logger := interaction.NewLogger(factory)
 	remoteIP := deps.ProvideRemoteIP(request, trustProxy)
 	contextContext := deps.ProvideRequestContext(request)
@@ -42929,7 +43030,6 @@ func newWebAppErrorHandler(p *deps.RequestProvider) http.Handler {
 		SQLExecutor: sqlExecutor,
 		Clock:       clockClock,
 	}
-	oAuthConfig := appConfig.OAuth
 	sessionManager := &oauth2.SessionManager{
 		Store:  redisStore,
 		Clock:  clockClock,
@@ -43133,9 +43233,10 @@ func newWebAppErrorHandler(p *deps.RequestProvider) http.Handler {
 		MFADeviceTokenCookie: cookieDef,
 		ErrorCookie:          errorCookie,
 		Cookies:              cookieManager,
+		OAuthConfig:          oAuthConfig,
+		UIConfig:             uiConfig,
 		Graph:                interactionService,
 	}
-	uiConfig := appConfig.UI
 	uiFeatureConfig := featureConfig.UI
 	googleTagManagerConfig := appConfig.GoogleTagManager
 	flashMessage := &httputil.FlashMessage{
@@ -43216,6 +43317,8 @@ func newWebAppNotFoundHandler(p *deps.RequestProvider) http.Handler {
 		Cookie:  errorCookieDef,
 		Cookies: cookieManager,
 	}
+	oAuthConfig := appConfig.OAuth
+	uiConfig := appConfig.UI
 	logger := interaction.NewLogger(factory)
 	remoteIP := deps.ProvideRemoteIP(request, trustProxy)
 	contextContext := deps.ProvideRequestContext(request)
@@ -43680,7 +43783,6 @@ func newWebAppNotFoundHandler(p *deps.RequestProvider) http.Handler {
 		SQLExecutor: sqlExecutor,
 		Clock:       clockClock,
 	}
-	oAuthConfig := appConfig.OAuth
 	sessionManager := &oauth2.SessionManager{
 		Store:  redisStore,
 		Clock:  clockClock,
@@ -43884,9 +43986,10 @@ func newWebAppNotFoundHandler(p *deps.RequestProvider) http.Handler {
 		MFADeviceTokenCookie: cookieDef,
 		ErrorCookie:          errorCookie,
 		Cookies:              cookieManager,
+		OAuthConfig:          oAuthConfig,
+		UIConfig:             uiConfig,
 		Graph:                interactionService,
 	}
-	uiConfig := appConfig.UI
 	uiFeatureConfig := featureConfig.UI
 	googleTagManagerConfig := appConfig.GoogleTagManager
 	flashMessage := &httputil.FlashMessage{
@@ -43983,6 +44086,8 @@ func newWebAppPasskeyCreationOptionsHandler(p *deps.RequestProvider) http.Handle
 		Cookie:  errorCookieDef,
 		Cookies: cookieManager,
 	}
+	oAuthConfig := appConfig.OAuth
+	uiConfig := appConfig.UI
 	logger := interaction.NewLogger(factory)
 	remoteIP := deps.ProvideRemoteIP(request, trustProxy)
 	contextContext := deps.ProvideRequestContext(request)
@@ -44448,7 +44553,6 @@ func newWebAppPasskeyCreationOptionsHandler(p *deps.RequestProvider) http.Handle
 		SQLExecutor: sqlExecutor,
 		Clock:       clockClock,
 	}
-	oAuthConfig := appConfig.OAuth
 	sessionManager := &oauth2.SessionManager{
 		Store:  redisStore,
 		Clock:  clockClock,
@@ -44652,6 +44756,8 @@ func newWebAppPasskeyCreationOptionsHandler(p *deps.RequestProvider) http.Handle
 		MFADeviceTokenCookie: cookieDef,
 		ErrorCookie:          errorCookie,
 		Cookies:              cookieManager,
+		OAuthConfig:          oAuthConfig,
+		UIConfig:             uiConfig,
 		Graph:                interactionService,
 	}
 	jsonResponseWriterLogger := httputil.NewJSONResponseWriterLogger(factory)
@@ -44700,6 +44806,8 @@ func newWebAppPasskeyRequestOptionsHandler(p *deps.RequestProvider) http.Handler
 		Cookie:  errorCookieDef,
 		Cookies: cookieManager,
 	}
+	oAuthConfig := appConfig.OAuth
+	uiConfig := appConfig.UI
 	logger := interaction.NewLogger(factory)
 	remoteIP := deps.ProvideRemoteIP(request, trustProxy)
 	contextContext := deps.ProvideRequestContext(request)
@@ -45165,7 +45273,6 @@ func newWebAppPasskeyRequestOptionsHandler(p *deps.RequestProvider) http.Handler
 		SQLExecutor: sqlExecutor,
 		Clock:       clockClock,
 	}
-	oAuthConfig := appConfig.OAuth
 	sessionManager := &oauth2.SessionManager{
 		Store:  redisStore,
 		Clock:  clockClock,
@@ -45369,6 +45476,8 @@ func newWebAppPasskeyRequestOptionsHandler(p *deps.RequestProvider) http.Handler
 		MFADeviceTokenCookie: cookieDef,
 		ErrorCookie:          errorCookie,
 		Cookies:              cookieManager,
+		OAuthConfig:          oAuthConfig,
+		UIConfig:             uiConfig,
 		Graph:                interactionService,
 	}
 	jsonResponseWriterLogger := httputil.NewJSONResponseWriterLogger(factory)
@@ -45417,6 +45526,8 @@ func newWebAppConnectWeb3AccountHandler(p *deps.RequestProvider) http.Handler {
 		Cookie:  errorCookieDef,
 		Cookies: cookieManager,
 	}
+	oAuthConfig := appConfig.OAuth
+	uiConfig := appConfig.UI
 	logger := interaction.NewLogger(factory)
 	remoteIP := deps.ProvideRemoteIP(request, trustProxy)
 	contextContext := deps.ProvideRequestContext(request)
@@ -45881,7 +45992,6 @@ func newWebAppConnectWeb3AccountHandler(p *deps.RequestProvider) http.Handler {
 		SQLExecutor: sqlExecutor,
 		Clock:       clockClock,
 	}
-	oAuthConfig := appConfig.OAuth
 	sessionManager := &oauth2.SessionManager{
 		Store:  redisStore,
 		Clock:  clockClock,
@@ -46085,9 +46195,10 @@ func newWebAppConnectWeb3AccountHandler(p *deps.RequestProvider) http.Handler {
 		MFADeviceTokenCookie: cookieDef,
 		ErrorCookie:          errorCookie,
 		Cookies:              cookieManager,
+		OAuthConfig:          oAuthConfig,
+		UIConfig:             uiConfig,
 		Graph:                interactionService,
 	}
-	uiConfig := appConfig.UI
 	uiFeatureConfig := featureConfig.UI
 	googleTagManagerConfig := appConfig.GoogleTagManager
 	flashMessage := &httputil.FlashMessage{
@@ -46178,6 +46289,8 @@ func newWebAppMissingWeb3WalletHandler(p *deps.RequestProvider) http.Handler {
 		Cookie:  errorCookieDef,
 		Cookies: cookieManager,
 	}
+	oAuthConfig := appConfig.OAuth
+	uiConfig := appConfig.UI
 	logger := interaction.NewLogger(factory)
 	remoteIP := deps.ProvideRemoteIP(request, trustProxy)
 	contextContext := deps.ProvideRequestContext(request)
@@ -46642,7 +46755,6 @@ func newWebAppMissingWeb3WalletHandler(p *deps.RequestProvider) http.Handler {
 		SQLExecutor: sqlExecutor,
 		Clock:       clockClock,
 	}
-	oAuthConfig := appConfig.OAuth
 	sessionManager := &oauth2.SessionManager{
 		Store:  redisStore,
 		Clock:  clockClock,
@@ -46846,9 +46958,10 @@ func newWebAppMissingWeb3WalletHandler(p *deps.RequestProvider) http.Handler {
 		MFADeviceTokenCookie: cookieDef,
 		ErrorCookie:          errorCookie,
 		Cookies:              cookieManager,
+		OAuthConfig:          oAuthConfig,
+		UIConfig:             uiConfig,
 		Graph:                interactionService,
 	}
-	uiConfig := appConfig.UI
 	uiFeatureConfig := featureConfig.UI
 	googleTagManagerConfig := appConfig.GoogleTagManager
 	flashMessage := &httputil.FlashMessage{
@@ -47100,10 +47213,12 @@ func newAuthEntryPointMiddleware(p *deps.RequestProvider) httproute.Middleware {
 	trustProxy := environmentConfig.TrustProxy
 	config := appProvider.Config
 	appConfig := config.AppConfig
+	oAuthConfig := appConfig.OAuth
 	uiConfig := appConfig.UI
 	authEntryPointMiddleware := &webapp2.AuthEntryPointMiddleware{
-		TrustProxy: trustProxy,
-		UIConfig:   uiConfig,
+		TrustProxy:  trustProxy,
+		OAuthConfig: oAuthConfig,
+		UIConfig:    uiConfig,
 	}
 	return authEntryPointMiddleware
 }

--- a/pkg/auth/wire_gen.go
+++ b/pkg/auth/wire_gen.go
@@ -9515,6 +9515,8 @@ func newWebAppSelectAccountHandler(p *deps.RequestProvider) http.Handler {
 		Identities:                serviceService,
 		AuthenticationInfoService: authenticationinfoStoreRedis,
 		Cookies:                   cookieManager,
+		OAuthConfig:               oAuthConfig,
+		UIConfig:                  uiConfig,
 	}
 	return selectAccountHandler
 }

--- a/pkg/auth/wire_gen.go
+++ b/pkg/auth/wire_gen.go
@@ -813,6 +813,7 @@ func newOAuthAuthorizeHandler(p *deps.RequestProvider) http.Handler {
 		Cookies:              cookieManager,
 		OAuthConfig:          oAuthConfig,
 		UIConfig:             uiConfig,
+		TrustProxy:           trustProxy,
 		Graph:                interactionService,
 	}
 	authenticateURLProvider := &webapp2.AuthenticateURLProvider{
@@ -1591,6 +1592,7 @@ func newOAuthConsentHandler(p *deps.RequestProvider) http.Handler {
 		Cookies:              cookieManager,
 		OAuthConfig:          oAuthConfig,
 		UIConfig:             uiConfig,
+		TrustProxy:           trustProxy,
 		Graph:                interactionService,
 	}
 	authenticateURLProvider := &webapp2.AuthenticateURLProvider{
@@ -7135,6 +7137,7 @@ func newWebAppLoginHandler(p *deps.RequestProvider) http.Handler {
 		Cookies:              cookieManager,
 		OAuthConfig:          oAuthConfig,
 		UIConfig:             uiConfig,
+		TrustProxy:           trustProxy,
 		Graph:                interactionService,
 	}
 	uiFeatureConfig := featureConfig.UI
@@ -7916,6 +7919,7 @@ func newWebAppSignupHandler(p *deps.RequestProvider) http.Handler {
 		Cookies:              cookieManager,
 		OAuthConfig:          oAuthConfig,
 		UIConfig:             uiConfig,
+		TrustProxy:           trustProxy,
 		Graph:                interactionService,
 	}
 	uiFeatureConfig := featureConfig.UI
@@ -8696,6 +8700,7 @@ func newWebAppPromoteHandler(p *deps.RequestProvider) http.Handler {
 		Cookies:              cookieManager,
 		OAuthConfig:          oAuthConfig,
 		UIConfig:             uiConfig,
+		TrustProxy:           trustProxy,
 		Graph:                interactionService,
 	}
 	uiFeatureConfig := featureConfig.UI
@@ -9459,6 +9464,7 @@ func newWebAppSelectAccountHandler(p *deps.RequestProvider) http.Handler {
 		Cookies:              cookieManager,
 		OAuthConfig:          oAuthConfig,
 		UIConfig:             uiConfig,
+		TrustProxy:           trustProxy,
 		Graph:                interactionService,
 	}
 	uiFeatureConfig := featureConfig.UI
@@ -10220,6 +10226,7 @@ func newWebAppSSOCallbackHandler(p *deps.RequestProvider) http.Handler {
 		Cookies:              cookieManager,
 		OAuthConfig:          oAuthConfig,
 		UIConfig:             uiConfig,
+		TrustProxy:           trustProxy,
 		Graph:                interactionService,
 	}
 	uiFeatureConfig := featureConfig.UI
@@ -10971,6 +10978,7 @@ func newWechatAuthHandler(p *deps.RequestProvider) http.Handler {
 		Cookies:              cookieManager,
 		OAuthConfig:          oAuthConfig,
 		UIConfig:             uiConfig,
+		TrustProxy:           trustProxy,
 		Graph:                interactionService,
 	}
 	uiFeatureConfig := featureConfig.UI
@@ -11725,6 +11733,7 @@ func newWechatCallbackHandler(p *deps.RequestProvider) http.Handler {
 		Cookies:              cookieManager,
 		OAuthConfig:          oAuthConfig,
 		UIConfig:             uiConfig,
+		TrustProxy:           trustProxy,
 		Graph:                interactionService,
 	}
 	uiFeatureConfig := featureConfig.UI
@@ -12482,6 +12491,7 @@ func newWebAppEnterLoginIDHandler(p *deps.RequestProvider) http.Handler {
 		Cookies:              cookieManager,
 		OAuthConfig:          oAuthConfig,
 		UIConfig:             uiConfig,
+		TrustProxy:           trustProxy,
 		Graph:                interactionService,
 	}
 	uiFeatureConfig := featureConfig.UI
@@ -13241,6 +13251,7 @@ func newWebAppEnterPasswordHandler(p *deps.RequestProvider) http.Handler {
 		Cookies:              cookieManager,
 		OAuthConfig:          oAuthConfig,
 		UIConfig:             uiConfig,
+		TrustProxy:           trustProxy,
 		Graph:                interactionService,
 	}
 	uiFeatureConfig := featureConfig.UI
@@ -13998,6 +14009,7 @@ func newWebAppUsePasskeyHandler(p *deps.RequestProvider) http.Handler {
 		Cookies:              cookieManager,
 		OAuthConfig:          oAuthConfig,
 		UIConfig:             uiConfig,
+		TrustProxy:           trustProxy,
 		Graph:                interactionService,
 	}
 	uiFeatureConfig := featureConfig.UI
@@ -14755,6 +14767,7 @@ func newWebAppCreatePasswordHandler(p *deps.RequestProvider) http.Handler {
 		Cookies:              cookieManager,
 		OAuthConfig:          oAuthConfig,
 		UIConfig:             uiConfig,
+		TrustProxy:           trustProxy,
 		Graph:                interactionService,
 	}
 	uiFeatureConfig := featureConfig.UI
@@ -15513,6 +15526,7 @@ func newWebAppCreatePasskeyHandler(p *deps.RequestProvider) http.Handler {
 		Cookies:              cookieManager,
 		OAuthConfig:          oAuthConfig,
 		UIConfig:             uiConfig,
+		TrustProxy:           trustProxy,
 		Graph:                interactionService,
 	}
 	uiFeatureConfig := featureConfig.UI
@@ -16270,6 +16284,7 @@ func newWebAppPromptCreatePasskeyHandler(p *deps.RequestProvider) http.Handler {
 		Cookies:              cookieManager,
 		OAuthConfig:          oAuthConfig,
 		UIConfig:             uiConfig,
+		TrustProxy:           trustProxy,
 		Graph:                interactionService,
 	}
 	uiFeatureConfig := featureConfig.UI
@@ -17027,6 +17042,7 @@ func newWebAppSetupTOTPHandler(p *deps.RequestProvider) http.Handler {
 		Cookies:              cookieManager,
 		OAuthConfig:          oAuthConfig,
 		UIConfig:             uiConfig,
+		TrustProxy:           trustProxy,
 		Graph:                interactionService,
 	}
 	uiFeatureConfig := featureConfig.UI
@@ -17786,6 +17802,7 @@ func newWebAppEnterTOTPHandler(p *deps.RequestProvider) http.Handler {
 		Cookies:              cookieManager,
 		OAuthConfig:          oAuthConfig,
 		UIConfig:             uiConfig,
+		TrustProxy:           trustProxy,
 		Graph:                interactionService,
 	}
 	uiFeatureConfig := featureConfig.UI
@@ -18543,6 +18560,7 @@ func newWebAppSetupOOBOTPHandler(p *deps.RequestProvider) http.Handler {
 		Cookies:              cookieManager,
 		OAuthConfig:          oAuthConfig,
 		UIConfig:             uiConfig,
+		TrustProxy:           trustProxy,
 		Graph:                interactionService,
 	}
 	uiFeatureConfig := featureConfig.UI
@@ -19300,6 +19318,7 @@ func newWebAppEnterOOBOTPHandler(p *deps.RequestProvider) http.Handler {
 		Cookies:              cookieManager,
 		OAuthConfig:          oAuthConfig,
 		UIConfig:             uiConfig,
+		TrustProxy:           trustProxy,
 		Graph:                interactionService,
 	}
 	uiFeatureConfig := featureConfig.UI
@@ -20059,6 +20078,7 @@ func newWebAppSetupWhatsappOTPHandler(p *deps.RequestProvider) http.Handler {
 		Cookies:              cookieManager,
 		OAuthConfig:          oAuthConfig,
 		UIConfig:             uiConfig,
+		TrustProxy:           trustProxy,
 		Graph:                interactionService,
 	}
 	uiFeatureConfig := featureConfig.UI
@@ -20816,6 +20836,7 @@ func newWebAppWhatsappOTPHandler(p *deps.RequestProvider) http.Handler {
 		Cookies:              cookieManager,
 		OAuthConfig:          oAuthConfig,
 		UIConfig:             uiConfig,
+		TrustProxy:           trustProxy,
 		Graph:                interactionService,
 	}
 	uiFeatureConfig := featureConfig.UI
@@ -22002,6 +22023,7 @@ func newWebAppEnterRecoveryCodeHandler(p *deps.RequestProvider) http.Handler {
 		Cookies:              cookieManager,
 		OAuthConfig:          oAuthConfig,
 		UIConfig:             uiConfig,
+		TrustProxy:           trustProxy,
 		Graph:                interactionService,
 	}
 	uiFeatureConfig := featureConfig.UI
@@ -22759,6 +22781,7 @@ func newWebAppSetupRecoveryCodeHandler(p *deps.RequestProvider) http.Handler {
 		Cookies:              cookieManager,
 		OAuthConfig:          oAuthConfig,
 		UIConfig:             uiConfig,
+		TrustProxy:           trustProxy,
 		Graph:                interactionService,
 	}
 	uiFeatureConfig := featureConfig.UI
@@ -23512,6 +23535,7 @@ func newWebAppVerifyIdentityHandler(p *deps.RequestProvider) http.Handler {
 		Cookies:              cookieManager,
 		OAuthConfig:          oAuthConfig,
 		UIConfig:             uiConfig,
+		TrustProxy:           trustProxy,
 		Graph:                interactionService,
 	}
 	uiFeatureConfig := featureConfig.UI
@@ -24267,6 +24291,7 @@ func newWebAppVerifyIdentitySuccessHandler(p *deps.RequestProvider) http.Handler
 		Cookies:              cookieManager,
 		OAuthConfig:          oAuthConfig,
 		UIConfig:             uiConfig,
+		TrustProxy:           trustProxy,
 		Graph:                interactionService,
 	}
 	uiFeatureConfig := featureConfig.UI
@@ -25020,6 +25045,7 @@ func newWebAppForgotPasswordHandler(p *deps.RequestProvider) http.Handler {
 		Cookies:              cookieManager,
 		OAuthConfig:          oAuthConfig,
 		UIConfig:             uiConfig,
+		TrustProxy:           trustProxy,
 		Graph:                interactionService,
 	}
 	uiFeatureConfig := featureConfig.UI
@@ -25783,6 +25809,7 @@ func newWebAppForgotPasswordSuccessHandler(p *deps.RequestProvider) http.Handler
 		Cookies:              cookieManager,
 		OAuthConfig:          oAuthConfig,
 		UIConfig:             uiConfig,
+		TrustProxy:           trustProxy,
 		Graph:                interactionService,
 	}
 	uiFeatureConfig := featureConfig.UI
@@ -26536,6 +26563,7 @@ func newWebAppResetPasswordHandler(p *deps.RequestProvider) http.Handler {
 		Cookies:              cookieManager,
 		OAuthConfig:          oAuthConfig,
 		UIConfig:             uiConfig,
+		TrustProxy:           trustProxy,
 		Graph:                interactionService,
 	}
 	uiFeatureConfig := featureConfig.UI
@@ -27290,6 +27318,7 @@ func newWebAppResetPasswordSuccessHandler(p *deps.RequestProvider) http.Handler 
 		Cookies:              cookieManager,
 		OAuthConfig:          oAuthConfig,
 		UIConfig:             uiConfig,
+		TrustProxy:           trustProxy,
 		Graph:                interactionService,
 	}
 	uiFeatureConfig := featureConfig.UI
@@ -28043,6 +28072,7 @@ func newWebAppSettingsHandler(p *deps.RequestProvider) http.Handler {
 		Cookies:              cookieManager,
 		OAuthConfig:          oAuthConfig,
 		UIConfig:             uiConfig,
+		TrustProxy:           trustProxy,
 		Graph:                interactionService,
 	}
 	uiFeatureConfig := featureConfig.UI
@@ -28827,6 +28857,7 @@ func newWebAppSettingsProfileHandler(p *deps.RequestProvider) http.Handler {
 		Cookies:              cookieManager,
 		OAuthConfig:          oAuthConfig,
 		UIConfig:             uiConfig,
+		TrustProxy:           trustProxy,
 		Graph:                interactionService,
 	}
 	uiFeatureConfig := featureConfig.UI
@@ -29591,6 +29622,7 @@ func newWebAppSettingsProfileEditHandler(p *deps.RequestProvider) http.Handler {
 		Cookies:              cookieManager,
 		OAuthConfig:          oAuthConfig,
 		UIConfig:             uiConfig,
+		TrustProxy:           trustProxy,
 		Graph:                interactionService,
 	}
 	uiFeatureConfig := featureConfig.UI
@@ -30368,6 +30400,7 @@ func newWebAppSettingsIdentityHandler(p *deps.RequestProvider) http.Handler {
 		Cookies:              cookieManager,
 		OAuthConfig:          oAuthConfig,
 		UIConfig:             uiConfig,
+		TrustProxy:           trustProxy,
 		Graph:                interactionService,
 	}
 	uiFeatureConfig := featureConfig.UI
@@ -31129,6 +31162,7 @@ func newWebAppSettingsBiometricHandler(p *deps.RequestProvider) http.Handler {
 		Cookies:              cookieManager,
 		OAuthConfig:          oAuthConfig,
 		UIConfig:             uiConfig,
+		TrustProxy:           trustProxy,
 		Graph:                interactionService,
 	}
 	uiFeatureConfig := featureConfig.UI
@@ -31883,6 +31917,7 @@ func newWebAppSettingsMFAHandler(p *deps.RequestProvider) http.Handler {
 		Cookies:              cookieManager,
 		OAuthConfig:          oAuthConfig,
 		UIConfig:             uiConfig,
+		TrustProxy:           trustProxy,
 		Graph:                interactionService,
 	}
 	uiFeatureConfig := featureConfig.UI
@@ -32645,6 +32680,7 @@ func newWebAppSettingsTOTPHandler(p *deps.RequestProvider) http.Handler {
 		Cookies:              cookieManager,
 		OAuthConfig:          oAuthConfig,
 		UIConfig:             uiConfig,
+		TrustProxy:           trustProxy,
 		Graph:                interactionService,
 	}
 	uiFeatureConfig := featureConfig.UI
@@ -33399,6 +33435,7 @@ func newWebAppSettingsPasskeyHandler(p *deps.RequestProvider) http.Handler {
 		Cookies:              cookieManager,
 		OAuthConfig:          oAuthConfig,
 		UIConfig:             uiConfig,
+		TrustProxy:           trustProxy,
 		Graph:                interactionService,
 	}
 	uiFeatureConfig := featureConfig.UI
@@ -34153,6 +34190,7 @@ func newWebAppSettingsOOBOTPHandler(p *deps.RequestProvider) http.Handler {
 		Cookies:              cookieManager,
 		OAuthConfig:          oAuthConfig,
 		UIConfig:             uiConfig,
+		TrustProxy:           trustProxy,
 		Graph:                interactionService,
 	}
 	uiFeatureConfig := featureConfig.UI
@@ -34907,6 +34945,7 @@ func newWebAppSettingsRecoveryCodeHandler(p *deps.RequestProvider) http.Handler 
 		Cookies:              cookieManager,
 		OAuthConfig:          oAuthConfig,
 		UIConfig:             uiConfig,
+		TrustProxy:           trustProxy,
 		Graph:                interactionService,
 	}
 	uiFeatureConfig := featureConfig.UI
@@ -35662,6 +35701,7 @@ func newWebAppSettingsSessionsHandler(p *deps.RequestProvider) http.Handler {
 		Cookies:              cookieManager,
 		OAuthConfig:          oAuthConfig,
 		UIConfig:             uiConfig,
+		TrustProxy:           trustProxy,
 		Graph:                interactionService,
 	}
 	uiFeatureConfig := featureConfig.UI
@@ -36427,6 +36467,7 @@ func newWebAppForceChangePasswordHandler(p *deps.RequestProvider) http.Handler {
 		Cookies:              cookieManager,
 		OAuthConfig:          oAuthConfig,
 		UIConfig:             uiConfig,
+		TrustProxy:           trustProxy,
 		Graph:                interactionService,
 	}
 	uiFeatureConfig := featureConfig.UI
@@ -37181,6 +37222,7 @@ func newWebAppSettingsChangePasswordHandler(p *deps.RequestProvider) http.Handle
 		Cookies:              cookieManager,
 		OAuthConfig:          oAuthConfig,
 		UIConfig:             uiConfig,
+		TrustProxy:           trustProxy,
 		Graph:                interactionService,
 	}
 	uiFeatureConfig := featureConfig.UI
@@ -37935,6 +37977,7 @@ func newWebAppForceChangeSecondaryPasswordHandler(p *deps.RequestProvider) http.
 		Cookies:              cookieManager,
 		OAuthConfig:          oAuthConfig,
 		UIConfig:             uiConfig,
+		TrustProxy:           trustProxy,
 		Graph:                interactionService,
 	}
 	uiFeatureConfig := featureConfig.UI
@@ -38689,6 +38732,7 @@ func newWebAppSettingsChangeSecondaryPasswordHandler(p *deps.RequestProvider) ht
 		Cookies:              cookieManager,
 		OAuthConfig:          oAuthConfig,
 		UIConfig:             uiConfig,
+		TrustProxy:           trustProxy,
 		Graph:                interactionService,
 	}
 	uiFeatureConfig := featureConfig.UI
@@ -39443,6 +39487,7 @@ func newWebAppSettingsDeleteAccountHandler(p *deps.RequestProvider) http.Handler
 		Cookies:              cookieManager,
 		OAuthConfig:          oAuthConfig,
 		UIConfig:             uiConfig,
+		TrustProxy:           trustProxy,
 		Graph:                interactionService,
 	}
 	uiFeatureConfig := featureConfig.UI
@@ -40204,6 +40249,7 @@ func newWebAppSettingsDeleteAccountSuccessHandler(p *deps.RequestProvider) http.
 		Cookies:              cookieManager,
 		OAuthConfig:          oAuthConfig,
 		UIConfig:             uiConfig,
+		TrustProxy:           trustProxy,
 		Graph:                interactionService,
 	}
 	uiFeatureConfig := featureConfig.UI
@@ -40959,6 +41005,7 @@ func newWebAppAccountStatusHandler(p *deps.RequestProvider) http.Handler {
 		Cookies:              cookieManager,
 		OAuthConfig:          oAuthConfig,
 		UIConfig:             uiConfig,
+		TrustProxy:           trustProxy,
 		Graph:                interactionService,
 	}
 	uiFeatureConfig := featureConfig.UI
@@ -41712,6 +41759,7 @@ func newWebAppLogoutHandler(p *deps.RequestProvider) http.Handler {
 		Cookies:              cookieManager,
 		OAuthConfig:          oAuthConfig,
 		UIConfig:             uiConfig,
+		TrustProxy:           trustProxy,
 		Graph:                interactionService,
 	}
 	uiFeatureConfig := featureConfig.UI
@@ -42484,6 +42532,7 @@ func newWebAppReturnHandler(p *deps.RequestProvider) http.Handler {
 		Cookies:              cookieManager,
 		OAuthConfig:          oAuthConfig,
 		UIConfig:             uiConfig,
+		TrustProxy:           trustProxy,
 		Graph:                interactionService,
 	}
 	uiFeatureConfig := featureConfig.UI
@@ -43237,6 +43286,7 @@ func newWebAppErrorHandler(p *deps.RequestProvider) http.Handler {
 		Cookies:              cookieManager,
 		OAuthConfig:          oAuthConfig,
 		UIConfig:             uiConfig,
+		TrustProxy:           trustProxy,
 		Graph:                interactionService,
 	}
 	uiFeatureConfig := featureConfig.UI
@@ -43990,6 +44040,7 @@ func newWebAppNotFoundHandler(p *deps.RequestProvider) http.Handler {
 		Cookies:              cookieManager,
 		OAuthConfig:          oAuthConfig,
 		UIConfig:             uiConfig,
+		TrustProxy:           trustProxy,
 		Graph:                interactionService,
 	}
 	uiFeatureConfig := featureConfig.UI
@@ -44760,6 +44811,7 @@ func newWebAppPasskeyCreationOptionsHandler(p *deps.RequestProvider) http.Handle
 		Cookies:              cookieManager,
 		OAuthConfig:          oAuthConfig,
 		UIConfig:             uiConfig,
+		TrustProxy:           trustProxy,
 		Graph:                interactionService,
 	}
 	jsonResponseWriterLogger := httputil.NewJSONResponseWriterLogger(factory)
@@ -45480,6 +45532,7 @@ func newWebAppPasskeyRequestOptionsHandler(p *deps.RequestProvider) http.Handler
 		Cookies:              cookieManager,
 		OAuthConfig:          oAuthConfig,
 		UIConfig:             uiConfig,
+		TrustProxy:           trustProxy,
 		Graph:                interactionService,
 	}
 	jsonResponseWriterLogger := httputil.NewJSONResponseWriterLogger(factory)
@@ -46199,6 +46252,7 @@ func newWebAppConnectWeb3AccountHandler(p *deps.RequestProvider) http.Handler {
 		Cookies:              cookieManager,
 		OAuthConfig:          oAuthConfig,
 		UIConfig:             uiConfig,
+		TrustProxy:           trustProxy,
 		Graph:                interactionService,
 	}
 	uiFeatureConfig := featureConfig.UI
@@ -46962,6 +47016,7 @@ func newWebAppMissingWeb3WalletHandler(p *deps.RequestProvider) http.Handler {
 		Cookies:              cookieManager,
 		OAuthConfig:          oAuthConfig,
 		UIConfig:             uiConfig,
+		TrustProxy:           trustProxy,
 		Graph:                interactionService,
 	}
 	uiFeatureConfig := featureConfig.UI

--- a/pkg/lib/config/oauth.go
+++ b/pkg/lib/config/oauth.go
@@ -120,6 +120,14 @@ type OAuthClientConfig struct {
 	TOSURI                         string                     `json:"tos_uri,omitempty"`
 }
 
+func (c *OAuthClientConfig) DefaultRedirectURI() string {
+	if len(c.RedirectURIs) > 0 {
+		return c.RedirectURIs[0]
+	}
+
+	return ""
+}
+
 func (c *OAuthClientConfig) ClientParty() ClientParty {
 	if c.ApplicationType == OAuthClientApplicationTypeThirdPartyApp {
 		return ClientPartyThird

--- a/pkg/lib/oauth/handler/handler_authz.go
+++ b/pkg/lib/oauth/handler/handler_authz.go
@@ -367,7 +367,6 @@ func (h *AuthorizationHandler) doHandle(
 	}
 
 	sessionOptions := webapp.SessionOptions{
-		ClientID:                 r.ClientID(),
 		WebhookState:             r.State(),
 		Page:                     r.Page(),
 		RedirectURI:              h.OAuthURLs.ConsentURL(r).String(),

--- a/pkg/lib/oauth/handler/handler_authz.go
+++ b/pkg/lib/oauth/handler/handler_authz.go
@@ -374,6 +374,7 @@ func (h *AuthorizationHandler) doHandle(
 		Prompt:                   h.handleMaxAgeAndPrompt(r, sidSession),
 		SuppressIDPSessionCookie: r.SuppressIDPSessionCookie(),
 		OAuthProviderAlias:       r.OAuthProviderAlias(),
+		FromAuthzEndpoint:        true,
 	}
 	uiLocales := strings.Join(r.UILocales(), " ")
 	colorScheme := r.ColorScheme()

--- a/pkg/lib/oauth/handler/handler_authz.go
+++ b/pkg/lib/oauth/handler/handler_authz.go
@@ -440,6 +440,8 @@ func (h *AuthorizationHandler) doHandle(
 			UILocales:      uiLocales,
 			ColorScheme:    colorScheme,
 			Cookies:        oauthSessionEntryCookies,
+			ClientID:       r.ClientID(),
+			RedirectURL:    r.RedirectURI(),
 		})
 		if apierrors.IsKind(err, interaction.InvalidCredentials) {
 			return nil, protocol.NewError("invalid_request", err.Error())


### PR DESCRIPTION
ref #2628 

----

**Some cases to test**

1. When the unauthenticated user visits an auth required path (e.g. "/settings/identity"),
they should be redirected back to the original path after login. (This was broken and it is fixed in this PR)
1. When the unauthenticated user visits "/", they should be redirected to "/settings" after login.
1. Start authentication via SDK, the enduser should be redirected back to the client app.
1. The enduser visits login link with `client_id` and `redirect_uri`, they should be redirected back to `redirect_uri`.
1. The enduser visits login link with `client_id` only, they should be redirected back to default redirect uri.
1. The enduser visits login link with `redirect_uri` only, they should be redirected back to "/settings".

More cases are welcome!!