### PR TITLE
Accepts IDP session only for authz endpoint, continue and consent page

### DIFF
--- a/pkg/auth/routes.go
+++ b/pkg/auth/routes.go
@@ -22,6 +22,10 @@ func newSafeDynamicCSPMiddleware(deps *deps.RequestProvider) httproute.Middlewar
 	return newDynamicCSPMiddleware(deps, false)
 }
 
+func newAllSessionMiddleware(deps *deps.RequestProvider) httproute.Middleware {
+	return newSessionMiddleware(deps, false)
+}
+
 func NewRouter(p *deps.RootProvider, configSource *configsource.ConfigSource) *httproute.Router {
 	router := httproute.NewRouter()
 
@@ -64,7 +68,7 @@ func NewRouter(p *deps.RootProvider, configSource *configsource.ConfigSource) *h
 		rootChain,
 		p.Middleware(newCORSMiddleware),
 		p.Middleware(newPublicOriginMiddleware),
-		p.Middleware(newSessionMiddleware),
+		p.Middleware(newAllSessionMiddleware),
 		httproute.MiddlewareFunc(httputil.NoStore),
 		p.Middleware(newWebAppWeChatRedirectURIMiddleware),
 	)
@@ -80,7 +84,7 @@ func NewRouter(p *deps.RootProvider, configSource *configsource.ConfigSource) *h
 		rootChain,
 		p.Middleware(newCORSMiddleware),
 		p.Middleware(newPublicOriginMiddleware),
-		p.Middleware(newSessionMiddleware),
+		p.Middleware(newAllSessionMiddleware),
 		httproute.MiddlewareFunc(httputil.NoStore),
 	)
 
@@ -93,7 +97,7 @@ func NewRouter(p *deps.RootProvider, configSource *configsource.ConfigSource) *h
 		rootChain,
 		p.Middleware(newCORSMiddleware),
 		p.Middleware(newPublicOriginMiddleware),
-		p.Middleware(newSessionMiddleware),
+		p.Middleware(newAllSessionMiddleware),
 		httproute.MiddlewareFunc(httputil.NoStore),
 		// Current we only require valid session and do not require any scope.
 		httproute.MiddlewareFunc(oauth.RequireScope()),
@@ -103,7 +107,7 @@ func NewRouter(p *deps.RootProvider, configSource *configsource.ConfigSource) *h
 		rootChain,
 		p.Middleware(newPublicOriginMiddleware),
 		p.Middleware(newPanicWebAppMiddleware),
-		p.Middleware(newSessionMiddleware),
+		p.Middleware(newAllSessionMiddleware),
 		httproute.MiddlewareFunc(httputil.NoStore),
 		httproute.MiddlewareFunc(webapp.IntlMiddleware),
 		p.Middleware(newWebAppSessionMiddleware),

--- a/pkg/auth/routes.go
+++ b/pkg/auth/routes.go
@@ -26,7 +26,19 @@ func newAllSessionMiddleware(deps *deps.RequestProvider) httproute.Middleware {
 	return newSessionMiddleware(deps, false)
 }
 
+func newIDPSessionOnlySessionMiddleware(deps *deps.RequestProvider) httproute.Middleware {
+	return newSessionMiddleware(deps, true)
+}
+
 func NewRouter(p *deps.RootProvider, configSource *configsource.ConfigSource) *httproute.Router {
+
+	newSessionMiddleware := func(idpSessionOnly bool) httproute.Middleware {
+		if idpSessionOnly {
+			return p.Middleware(newIDPSessionOnlySessionMiddleware)
+		}
+		return p.Middleware(newAllSessionMiddleware)
+	}
+
 	router := httproute.NewRouter()
 
 	router.Add(httproute.Route{
@@ -64,15 +76,20 @@ func NewRouter(p *deps.RootProvider, configSource *configsource.ConfigSource) *h
 		p.Middleware(newPublicOriginMiddleware),
 	)
 
-	oauthAPIChain := httproute.Chain(
-		rootChain,
-		p.Middleware(newCORSMiddleware),
-		p.Middleware(newPublicOriginMiddleware),
-		p.Middleware(newAllSessionMiddleware),
-		httproute.MiddlewareFunc(httputil.NoStore),
-		p.Middleware(newWebAppWeChatRedirectURIMiddleware),
-	)
+	newOAuthAPIChain := func(idpSessionOnly bool) httproute.Middleware {
+		return httproute.Chain(
+			rootChain,
+			p.Middleware(newCORSMiddleware),
+			p.Middleware(newPublicOriginMiddleware),
+			newSessionMiddleware(idpSessionOnly),
+			httproute.MiddlewareFunc(httputil.NoStore),
+			p.Middleware(newWebAppWeChatRedirectURIMiddleware),
+		)
+	}
 
+	oauthAPIChain := newOAuthAPIChain(false)
+	// authz endpoint only accepts idp session
+	oauthAuthzAPIChain := newOAuthAPIChain(true)
 	siweAPIChain := httproute.Chain(
 		rootChain,
 		p.Middleware(newCORSMiddleware),
@@ -103,20 +120,23 @@ func NewRouter(p *deps.RootProvider, configSource *configsource.ConfigSource) *h
 		httproute.MiddlewareFunc(oauth.RequireScope()),
 	)
 
-	webappChain := httproute.Chain(
-		rootChain,
-		p.Middleware(newPublicOriginMiddleware),
-		p.Middleware(newPanicWebAppMiddleware),
-		p.Middleware(newAllSessionMiddleware),
-		httproute.MiddlewareFunc(httputil.NoStore),
-		httproute.MiddlewareFunc(webapp.IntlMiddleware),
-		p.Middleware(newWebAppSessionMiddleware),
-		p.Middleware(newWebAppUILocalesMiddleware),
-		p.Middleware(newWebAppColorSchemeMiddleware),
-		p.Middleware(newWebAppWeChatRedirectURIMiddleware),
-		p.Middleware(newWebAppClientIDMiddleware),
-		p.Middleware(newTutorialMiddleware),
-	)
+	newWebappChain := func(idpSessionOnly bool) httproute.Middleware {
+		return httproute.Chain(
+			rootChain,
+			p.Middleware(newPublicOriginMiddleware),
+			p.Middleware(newPanicWebAppMiddleware),
+			newSessionMiddleware(idpSessionOnly),
+			httproute.MiddlewareFunc(httputil.NoStore),
+			httproute.MiddlewareFunc(webapp.IntlMiddleware),
+			p.Middleware(newWebAppSessionMiddleware),
+			p.Middleware(newWebAppUILocalesMiddleware),
+			p.Middleware(newWebAppColorSchemeMiddleware),
+			p.Middleware(newWebAppWeChatRedirectURIMiddleware),
+			p.Middleware(newWebAppClientIDMiddleware),
+			p.Middleware(newTutorialMiddleware),
+		)
+	}
+	webappChain := newWebappChain(false)
 	webappSSOCallbackChain := httproute.Chain(
 		webappChain,
 	)
@@ -129,14 +149,18 @@ func NewRouter(p *deps.RootProvider, configSource *configsource.ConfigSource) *h
 	webappAPIChain := httproute.Chain(
 		webappChain,
 	)
-	webappPageChain := httproute.Chain(
-		webappChain,
-		p.Middleware(newCSRFMiddleware),
-		// Turbo no longer requires us to tell the redirected location.
-		// It can now determine redirection from the response.
-		// https://github.com/hotwired/turbo/blob/daabebb0575fffbae1b2582dc458967cd638e899/src/core/drive/visit.ts#L316
-		p.Middleware(newSafeDynamicCSPMiddleware),
-	)
+
+	newWebappPageChain := func(idpSessionOnly bool) httproute.Middleware {
+		return httproute.Chain(
+			newWebappChain(idpSessionOnly),
+			p.Middleware(newCSRFMiddleware),
+			// Turbo no longer requires us to tell the redirected location.
+			// It can now determine redirection from the response.
+			// https://github.com/hotwired/turbo/blob/daabebb0575fffbae1b2582dc458967cd638e899/src/core/drive/visit.ts#L316
+			p.Middleware(newSafeDynamicCSPMiddleware),
+		)
+	}
+	webappPageChain := newWebappPageChain(false)
 	webappSIWEChain := httproute.Chain(
 		webappChain,
 		p.Middleware(newCSRFMiddleware),
@@ -148,6 +172,13 @@ func NewRouter(p *deps.RootProvider, configSource *configsource.ConfigSource) *h
 		// A unique visit is started when the user visit auth entry point
 		p.Middleware(newWebAppVisitorIDMiddleware),
 	)
+	// select account page only accepts idp session
+	webappSelectAccountChain := httproute.Chain(
+		newWebappPageChain(true),
+		p.Middleware(newAuthEntryPointMiddleware),
+	)
+	// consent page only accepts idp session
+	webappConsentPageChain := newWebappPageChain(true)
 	webappAuthenticatedChain := httproute.Chain(
 		webappPageChain,
 		webapp.RequireAuthenticatedMiddleware{},
@@ -171,6 +202,7 @@ func NewRouter(p *deps.RootProvider, configSource *configsource.ConfigSource) *h
 	generatedStaticRoute := httproute.Route{Middleware: generatedStaticChain}
 	oauthStaticRoute := httproute.Route{Middleware: oauthStaticChain}
 	oauthAPIRoute := httproute.Route{Middleware: oauthAPIChain}
+	oauthAuthzAPIRoute := httproute.Route{Middleware: oauthAuthzAPIChain}
 	siweAPIRoute := httproute.Route{Middleware: siweAPIChain}
 	apiRoute := httproute.Route{Middleware: apiChain}
 	apiAuthenticatedRoute := httproute.Route{Middleware: apiAuthenticatedChain}
@@ -178,6 +210,8 @@ func NewRouter(p *deps.RootProvider, configSource *configsource.ConfigSource) *h
 	webappPageRoute := httproute.Route{Middleware: webappPageChain}
 	webappSIWERoute := httproute.Route{Middleware: webappSIWEChain}
 	webappAuthEntrypointRoute := httproute.Route{Middleware: webappAuthEntrypointChain}
+	webappSelectAccountRoute := httproute.Route{Middleware: webappSelectAccountChain}
+	webappConsentPageRoute := httproute.Route{Middleware: webappConsentPageChain}
 	webappAuthenticatedRoute := httproute.Route{Middleware: webappAuthenticatedChain}
 	webappSuccessPageRoute := httproute.Route{Middleware: webappSuccessPageChain}
 	webappSettingsSubRoutesRoute := httproute.Route{Middleware: webappSettingsSubRoutesChain}
@@ -190,7 +224,7 @@ func NewRouter(p *deps.RootProvider, configSource *configsource.ConfigSource) *h
 	router.Add(webapphandler.ConfigureOAuthEntrypointRoute(webappAuthEntrypointRoute), p.Handler(newWebAppOAuthEntrypointHandler))
 	router.Add(webapphandler.ConfigureLoginRoute(webappAuthEntrypointRoute), p.Handler(newWebAppLoginHandler))
 	router.Add(webapphandler.ConfigureSignupRoute(webappAuthEntrypointRoute), p.Handler(newWebAppSignupHandler))
-	router.Add(webapphandler.ConfigureSelectAccountRoute(webappAuthEntrypointRoute), p.Handler(newWebAppSelectAccountHandler))
+	router.Add(webapphandler.ConfigureSelectAccountRoute(webappSelectAccountRoute), p.Handler(newWebAppSelectAccountHandler))
 
 	router.Add(webapphandler.ConfigurePromoteRoute(webappPageRoute), p.Handler(newWebAppPromoteHandler))
 	router.Add(webapphandler.ConfigureEnterPasswordRoute(webappPageRoute), p.Handler(newWebAppEnterPasswordHandler))
@@ -254,7 +288,7 @@ func NewRouter(p *deps.RootProvider, configSource *configsource.ConfigSource) *h
 	router.Add(oauthhandler.ConfigureOAuthMetadataRoute(oauthStaticRoute), p.Handler(newOAuthMetadataHandler))
 	router.Add(oauthhandler.ConfigureJWKSRoute(oauthStaticRoute), p.Handler(newOAuthJWKSHandler))
 
-	router.Add(oauthhandler.ConfigureAuthorizeRoute(oauthAPIRoute), p.Handler(newOAuthAuthorizeHandler))
+	router.Add(oauthhandler.ConfigureAuthorizeRoute(oauthAuthzAPIRoute), p.Handler(newOAuthAuthorizeHandler))
 	router.Add(oauthhandler.ConfigureTokenRoute(oauthAPIRoute), p.Handler(newOAuthTokenHandler))
 	router.Add(oauthhandler.ConfigureRevokeRoute(oauthAPIRoute), p.Handler(newOAuthRevokeHandler))
 	router.Add(oauthhandler.ConfigureEndSessionRoute(oauthAPIRoute), p.Handler(newOAuthEndSessionHandler))
@@ -264,7 +298,7 @@ func NewRouter(p *deps.RootProvider, configSource *configsource.ConfigSource) *h
 
 	router.Add(oauthhandler.ConfigureUserInfoRoute(scopedRoute), p.Handler(newOAuthUserInfoHandler))
 
-	router.Add(oauthhandler.ConfigureConsentRoute(webappPageRoute), p.Handler(newOAuthConsentHandler))
+	router.Add(oauthhandler.ConfigureConsentRoute(webappConsentPageRoute), p.Handler(newOAuthConsentHandler))
 
 	router.Add(siwehandler.ConfigureNonceRoute(siweAPIRoute), p.Handler(newSIWENonceHandler))
 

--- a/pkg/auth/wire_gen.go
+++ b/pkg/auth/wire_gen.go
@@ -47921,7 +47921,7 @@ func newAuthEntryPointMiddleware(p *deps.RequestProvider) httproute.Middleware {
 	return authEntryPointMiddleware
 }
 
-func newSessionMiddleware(p *deps.RequestProvider) httproute.Middleware {
+func newSessionMiddleware(p *deps.RequestProvider, idpSessionOnly bool) httproute.Middleware {
 	appProvider := p.AppProvider
 	config := appProvider.Config
 	appConfig := config.AppConfig
@@ -48361,6 +48361,7 @@ func newSessionMiddleware(p *deps.RequestProvider) httproute.Middleware {
 		Database:                   appdbHandle,
 		Logger:                     middlewareLogger,
 		MeterService:               meterService,
+		IDPSessionOnly:             idpSessionOnly,
 	}
 	return sessionMiddleware
 }

--- a/pkg/auth/wire_middleware.go
+++ b/pkg/auth/wire_middleware.go
@@ -80,7 +80,7 @@ func newAuthEntryPointMiddleware(p *deps.RequestProvider) httproute.Middleware {
 	))
 }
 
-func newSessionMiddleware(p *deps.RequestProvider) httproute.Middleware {
+func newSessionMiddleware(p *deps.RequestProvider, idpSessionOnly bool) httproute.Middleware {
 	panic(wire.Build(
 		DependencySet,
 		wire.Bind(new(httproute.Middleware), new(*session.Middleware)),

--- a/pkg/lib/session/middleware.go
+++ b/pkg/lib/session/middleware.go
@@ -40,6 +40,7 @@ type Middleware struct {
 	Database                   *appdb.Handle
 	Logger                     MiddlewareLogger
 	MeterService               MeterService
+	IDPSessionOnly             bool
 }
 
 func (m *Middleware) Handle(next http.Handler) http.Handler {
@@ -108,10 +109,18 @@ func (m *Middleware) resolve(rw http.ResponseWriter, r *http.Request) (s Session
 func (m *Middleware) resolveSession(rw http.ResponseWriter, r *http.Request) (Session, error) {
 	isInvalid := false
 
-	// Access token in header/App session token in cookie takes priority over IDP session in cookie
-	// If both the app session and IDP session exist in the cookie
-	// Middleware will read the app session first, so SDK will always open the correct settings page
-	for _, resolver := range []Resolver{m.AccessTokenSessionResolver, m.IDPSessionResolver} {
+	var resolvers []Resolver
+	if m.IDPSessionOnly {
+		// For some routes, only idp session is accepted. e.g. authz endpoint, continue screen, consent screen...
+		resolvers = []Resolver{m.IDPSessionResolver}
+	} else {
+		// Access token in header/App session token in cookie takes priority over IDP session in cookie
+		// If both the app session and IDP session exist in the cookie
+		// Middleware will read the app session first, so SDK will always open the correct settings page
+		resolvers = []Resolver{m.AccessTokenSessionResolver, m.IDPSessionResolver}
+	}
+
+	for _, resolver := range resolvers {
 		session, err := resolver.Resolve(rw, r)
 		if errors.Is(err, ErrInvalidSession) {
 			// Continue to attempt resolving session, even if one of the resolver reported invalid.

--- a/pkg/resolver/routes.go
+++ b/pkg/resolver/routes.go
@@ -8,6 +8,10 @@ import (
 	"github.com/authgear/authgear-server/pkg/util/httputil"
 )
 
+func newAllSessionMiddleware(p *deps.RequestProvider) httproute.Middleware {
+	return newSessionMiddleware(p, false)
+}
+
 func NewRouter(p *deps.RootProvider, configSource *configsource.ConfigSource) *httproute.Router {
 	router := httproute.NewRouter()
 
@@ -25,7 +29,7 @@ func NewRouter(p *deps.RootProvider, configSource *configsource.ConfigSource) *h
 			RootProvider: p,
 			ConfigSource: configSource,
 		},
-		p.Middleware(newSessionMiddleware),
+		p.Middleware(newAllSessionMiddleware),
 	)
 
 	route := httproute.Route{Middleware: chain}

--- a/pkg/resolver/wire.go
+++ b/pkg/resolver/wire.go
@@ -48,7 +48,7 @@ func newBodyLimitMiddleware(p *deps.RootProvider) httproute.Middleware {
 	))
 }
 
-func newSessionMiddleware(p *deps.RequestProvider) httproute.Middleware {
+func newSessionMiddleware(p *deps.RequestProvider, idpSessionOnly bool) httproute.Middleware {
 	panic(wire.Build(
 		DependencySet,
 		wire.Bind(new(httproute.Middleware), new(*session.Middleware)),

--- a/pkg/resolver/wire_gen.go
+++ b/pkg/resolver/wire_gen.go
@@ -96,7 +96,7 @@ func newBodyLimitMiddleware(p *deps.RootProvider) httproute.Middleware {
 	return bodyLimitMiddleware
 }
 
-func newSessionMiddleware(p *deps.RequestProvider) httproute.Middleware {
+func newSessionMiddleware(p *deps.RequestProvider, idpSessionOnly bool) httproute.Middleware {
 	appProvider := p.AppProvider
 	config := appProvider.Config
 	appConfig := config.AppConfig
@@ -532,6 +532,7 @@ func newSessionMiddleware(p *deps.RequestProvider) httproute.Middleware {
 		Database:                   appdbHandle,
 		Logger:                     middlewareLogger,
 		MeterService:               meterService,
+		IDPSessionOnly:             idpSessionOnly,
 	}
 	return sessionMiddleware
 }


### PR DESCRIPTION
ref #2713 

The problem happened after commit fc8c1aee79c513894b99326b04179811ad13c405. Actually, some endpoints only accept IDP sessions. After we change the priority in the middleware, the app session is resolved when both the app session and IDP session exist. Those endpoints don't expect an app session is resolved and cause the problem.

In this PR, I updated the middleware to resolve the IDP session for those endpoints.