### PR TITLE
Resolve authgear event type hints for deno hook editor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 /var/authgear.yaml
 /var/authgear.secrets.yaml
 /var/authgear.features.yaml
+/var/deno
 /tls-cert.pem
 /tls-key.pem
 .parcel-cache/

--- a/portal/src/CodeEditor.tsx
+++ b/portal/src/CodeEditor.tsx
@@ -1,16 +1,124 @@
-import React from "react";
-import ControlledEditor, { EditorProps } from "@monaco-editor/react";
+import React, { useCallback, useRef } from "react";
+import ControlledEditor, {
+  EditorProps,
+  Monaco,
+  OnChange,
+  OnMount,
+} from "@monaco-editor/react";
 
 export interface CodeEditorProps extends EditorProps {
   className?: string;
+  packages?: string[];
+}
+
+const DEFAULT_WHITELISTED_PACKAGES = [
+  "https://deno.land/std",
+  "https://deno.land/x/authgear_deno_hook",
+];
+
+const REGEX_DETECT_IMPORT =
+  /(?:^|\r|\n|\r\n)(?:(?:(?:import)|(?:export))(?:.|\n)*?from\s+["']([^"']+)["'])|(?:require(?:\s+)?\(["']([^"']+)["']\))|(?:\/+\s+<reference\s+path=["']([^"']+)["']\s+\/>)/g;
+
+function parseDependencies(source: string): string[] {
+  return [...source.matchAll(REGEX_DETECT_IMPORT)]
+    .map((x) => x[1] || x[2] || x[3])
+    .filter((x) => !!x);
 }
 
 const CodeEditor: React.VFC<CodeEditorProps> = function CodeEditor(props) {
-  const { className, ...rest } = props;
+  const {
+    className,
+    packages: whitelistedPackages = DEFAULT_WHITELISTED_PACKAGES,
+    onMount,
+    onChange,
+    ...rest
+  } = props;
+
+  const monacoRef = useRef<Monaco>();
+  const resolveImports = useCallback(
+    async (value: string | undefined) => {
+      if (!value) {
+        return;
+      }
+
+      const monaco = monacoRef.current;
+      if (!monaco) {
+        return;
+      }
+
+      function isWhitelistedPackage(pkg: string): boolean {
+        return whitelistedPackages.some(
+          (allowedPkg) =>
+            pkg === allowedPkg ||
+            pkg.startsWith(allowedPkg + "@") || // versioned
+            pkg.startsWith(allowedPkg + "/") // latest
+        );
+      }
+
+      // We only resolve first-level imports to avoid performance issue
+      for (const pkg of parseDependencies(value)) {
+        const path = `inmemory://model/${pkg}`;
+        const uri = monaco.Uri.file(path);
+
+        if (!monaco.editor.getModel(uri)) {
+          // Here we only use best-effort to import external script using `declare module` due to following limitations:
+          // - `monaco-editor` cannot use vscode extensions e.g. "vscode-deno", so cannot use official solution for url imports
+          // -`--moduleResolution: bundle` in Typescript allows `.ts` extension but not yet supported in monaco-editor, thus path alis won't work.
+          const code = isWhitelistedPackage(pkg)
+            ? await fetch(pkg).then(async (r) => r.text())
+            : "";
+          const dts =
+            `declare module '${pkg}'` +
+            (code && parseDependencies(code).length === 0 ? `{${code}}` : "");
+          monaco.languages.typescript.typescriptDefaults.addExtraLib(dts, path);
+          monaco.editor.createModel(dts, "typescript", uri);
+        }
+      }
+    },
+    [whitelistedPackages]
+  );
+
+  const handleEditorMount = useCallback<OnMount>(
+    async (editor, monaco) => {
+      monacoRef.current = monaco;
+
+      const options =
+        monaco.languages.typescript.typescriptDefaults.getCompilerOptions();
+      options.strict = true;
+      options.strictNullChecks = true;
+      options.strictBindCallApply = true;
+      options.moduleResolution =
+        monaco.languages.typescript.ModuleResolutionKind.NodeJs;
+      monaco.languages.typescript.typescriptDefaults.setCompilerOptions(
+        options
+      );
+
+      // eslint-disable-next-line no-void
+      void resolveImports(editor.getValue());
+
+      onMount?.(editor, monaco);
+    },
+    [resolveImports, onMount]
+  );
+
+  const handleEditorChange = useCallback<OnChange>(
+    async (value, ev) => {
+      // eslint-disable-next-line no-void
+      void resolveImports(value);
+
+      onChange?.(value, ev);
+    },
+    [onChange, resolveImports]
+  );
 
   return (
     <div className={className}>
-      <ControlledEditor height="100%" {...rest} />
+      <ControlledEditor
+        height="100%"
+        onMount={handleEditorMount}
+        onChange={handleEditorChange}
+        {...rest}
+      />
     </div>
   );
 };


### PR DESCRIPTION
Demo: https://codesandbox.io/s/focused-kalam-8jxnfl

### Intent

Currently Deno hook editor cannot resolve external dependencies, so user only know if types are correct on save.

This PR downloads imports and include them in monaco-editor, providing better type-hint for users.

### Limitations and Reasons

1. Assumes downloaded file does not have relative imports, falls back to `any` otherwise

	- Typescript ignores path alias if the imported path has `.ts` extension
		- `"moduleResolution": "bundler"`([related pr](https://github.com/microsoft/TypeScript/pull/51669)) might help fix `.ts` extension handling, however monaco-editor's `monaco.languages.typescript.ModuleResolutionKind` does not support it yet
	- monaco-editor cannot install vscode extension e.g. https://marketplace.visualstudio.com/items?itemName=denoland.vscode-deno so need to fake with nodejs module resolution

2. Does not support recursive import

	- Deno does not provide a reliable way to know all imported modules. Therefore recursive import has to be done linearly, which is too expensive in this use case.