### PR TITLE
Default is_anonymized to false

### DIFF
--- a/migrations/authgear/20230130154554-is_anonymized_default_false.sql
+++ b/migrations/authgear/20230130154554-is_anonymized_default_false.sql
@@ -1,0 +1,7 @@
+-- +migrate Up
+
+ALTER TABLE _auth_user ALTER COLUMN is_anonymized SET DEFAULT FALSE;
+
+-- +migrate Down
+
+ALTER TABLE _auth_user ALTER COLUMN is_anonymized DROP DEFAULT;


### PR DESCRIPTION
ref: #2731

Current production deployment may have significant delay between database schema and code deployment. 

Without default value for `is_anonymized`, user signup will fail until code is deployed also.

#### How to test

1. Apply migration up to before this PR
2. Checkout cb6d9f82ae9e
3. Try signup, should error after submit password
4. Apply migration of this PR
5. Try signup again, should create user successfully