### PR TITLE
Support per IP rate limit to send any SMS

### DIFF
--- a/pkg/admin/wire_gen.go
+++ b/pkg/admin/wire_gen.go
@@ -767,6 +767,7 @@ func newGraphQLHandler(p *deps.RequestProvider) http.Handler {
 		Config: smsConfig,
 	}
 	messageSender := &otp.MessageSender{
+		RemoteIP:          remoteIP,
 		Translation:       translationService,
 		Endpoints:         endpointsEndpoints,
 		TaskQueue:         queue,

--- a/pkg/auth/wire_gen.go
+++ b/pkg/auth/wire_gen.go
@@ -1693,6 +1693,7 @@ func newOAuthTokenHandler(p *deps.RequestProvider) http.Handler {
 		Config: smsConfig,
 	}
 	messageSender := &otp.MessageSender{
+		RemoteIP:          remoteIP,
 		Translation:       translationService,
 		Endpoints:         endpointsEndpoints,
 		TaskQueue:         queue,
@@ -4233,6 +4234,7 @@ func newOAuthAppSessionTokenHandler(p *deps.RequestProvider) http.Handler {
 		Config: smsConfig,
 	}
 	messageSender := &otp.MessageSender{
+		RemoteIP:          remoteIP,
 		Translation:       translationService,
 		Endpoints:         endpointsEndpoints,
 		TaskQueue:         queue,
@@ -5064,6 +5066,7 @@ func newAPIAnonymousUserSignupHandler(p *deps.RequestProvider) http.Handler {
 		Config: smsConfig,
 	}
 	messageSender := &otp.MessageSender{
+		RemoteIP:          remoteIP,
 		Translation:       translationService,
 		Endpoints:         endpointsEndpoints,
 		TaskQueue:         queue,
@@ -5837,6 +5840,7 @@ func newAPIAnonymousUserPromotionCodeHandler(p *deps.RequestProvider) http.Handl
 		Config: smsConfig,
 	}
 	messageSender := &otp.MessageSender{
+		RemoteIP:          remoteIP,
 		Translation:       translationService,
 		Endpoints:         endpointsEndpoints,
 		TaskQueue:         queue,
@@ -6716,6 +6720,7 @@ func newWebAppLoginHandler(p *deps.RequestProvider) http.Handler {
 		Config: smsConfig,
 	}
 	messageSender := &otp.MessageSender{
+		RemoteIP:          remoteIP,
 		Translation:       translationService,
 		Endpoints:         endpointsEndpoints,
 		TaskQueue:         queue,
@@ -7533,6 +7538,7 @@ func newWebAppSignupHandler(p *deps.RequestProvider) http.Handler {
 		Config: smsConfig,
 	}
 	messageSender := &otp.MessageSender{
+		RemoteIP:          remoteIP,
 		Translation:       translationService,
 		Endpoints:         endpointsEndpoints,
 		TaskQueue:         queue,
@@ -8349,6 +8355,7 @@ func newWebAppPromoteHandler(p *deps.RequestProvider) http.Handler {
 		Config: smsConfig,
 	}
 	messageSender := &otp.MessageSender{
+		RemoteIP:          remoteIP,
 		Translation:       translationService,
 		Endpoints:         endpointsEndpoints,
 		TaskQueue:         queue,
@@ -9153,6 +9160,7 @@ func newWebAppSelectAccountHandler(p *deps.RequestProvider) http.Handler {
 		Config: smsConfig,
 	}
 	messageSender := &otp.MessageSender{
+		RemoteIP:          remoteIP,
 		Translation:       translationService,
 		Endpoints:         endpointsEndpoints,
 		TaskQueue:         queue,
@@ -9950,6 +9958,7 @@ func newWebAppSSOCallbackHandler(p *deps.RequestProvider) http.Handler {
 		Config: smsConfig,
 	}
 	messageSender := &otp.MessageSender{
+		RemoteIP:          remoteIP,
 		Translation:       translationService,
 		Endpoints:         endpointsEndpoints,
 		TaskQueue:         queue,
@@ -10737,6 +10746,7 @@ func newWechatAuthHandler(p *deps.RequestProvider) http.Handler {
 		Config: smsConfig,
 	}
 	messageSender := &otp.MessageSender{
+		RemoteIP:          remoteIP,
 		Translation:       translationService,
 		Endpoints:         endpointsEndpoints,
 		TaskQueue:         queue,
@@ -11527,6 +11537,7 @@ func newWechatCallbackHandler(p *deps.RequestProvider) http.Handler {
 		Config: smsConfig,
 	}
 	messageSender := &otp.MessageSender{
+		RemoteIP:          remoteIP,
 		Translation:       translationService,
 		Endpoints:         endpointsEndpoints,
 		TaskQueue:         queue,
@@ -12320,6 +12331,7 @@ func newWebAppEnterLoginIDHandler(p *deps.RequestProvider) http.Handler {
 		Config: smsConfig,
 	}
 	messageSender := &otp.MessageSender{
+		RemoteIP:          remoteIP,
 		Translation:       translationService,
 		Endpoints:         endpointsEndpoints,
 		TaskQueue:         queue,
@@ -13115,6 +13127,7 @@ func newWebAppEnterPasswordHandler(p *deps.RequestProvider) http.Handler {
 		Config: smsConfig,
 	}
 	messageSender := &otp.MessageSender{
+		RemoteIP:          remoteIP,
 		Translation:       translationService,
 		Endpoints:         endpointsEndpoints,
 		TaskQueue:         queue,
@@ -13908,6 +13921,7 @@ func newWebConfirmTerminateOtherSessionsHandler(p *deps.RequestProvider) http.Ha
 		Config: smsConfig,
 	}
 	messageSender := &otp.MessageSender{
+		RemoteIP:          remoteIP,
 		Translation:       translationService,
 		Endpoints:         endpointsEndpoints,
 		TaskQueue:         queue,
@@ -14697,6 +14711,7 @@ func newWebAppUsePasskeyHandler(p *deps.RequestProvider) http.Handler {
 		Config: smsConfig,
 	}
 	messageSender := &otp.MessageSender{
+		RemoteIP:          remoteIP,
 		Translation:       translationService,
 		Endpoints:         endpointsEndpoints,
 		TaskQueue:         queue,
@@ -15490,6 +15505,7 @@ func newWebAppCreatePasswordHandler(p *deps.RequestProvider) http.Handler {
 		Config: smsConfig,
 	}
 	messageSender := &otp.MessageSender{
+		RemoteIP:          remoteIP,
 		Translation:       translationService,
 		Endpoints:         endpointsEndpoints,
 		TaskQueue:         queue,
@@ -16284,6 +16300,7 @@ func newWebAppCreatePasskeyHandler(p *deps.RequestProvider) http.Handler {
 		Config: smsConfig,
 	}
 	messageSender := &otp.MessageSender{
+		RemoteIP:          remoteIP,
 		Translation:       translationService,
 		Endpoints:         endpointsEndpoints,
 		TaskQueue:         queue,
@@ -17077,6 +17094,7 @@ func newWebAppPromptCreatePasskeyHandler(p *deps.RequestProvider) http.Handler {
 		Config: smsConfig,
 	}
 	messageSender := &otp.MessageSender{
+		RemoteIP:          remoteIP,
 		Translation:       translationService,
 		Endpoints:         endpointsEndpoints,
 		TaskQueue:         queue,
@@ -17870,6 +17888,7 @@ func newWebAppSetupTOTPHandler(p *deps.RequestProvider) http.Handler {
 		Config: smsConfig,
 	}
 	messageSender := &otp.MessageSender{
+		RemoteIP:          remoteIP,
 		Translation:       translationService,
 		Endpoints:         endpointsEndpoints,
 		TaskQueue:         queue,
@@ -18665,6 +18684,7 @@ func newWebAppEnterTOTPHandler(p *deps.RequestProvider) http.Handler {
 		Config: smsConfig,
 	}
 	messageSender := &otp.MessageSender{
+		RemoteIP:          remoteIP,
 		Translation:       translationService,
 		Endpoints:         endpointsEndpoints,
 		TaskQueue:         queue,
@@ -19458,6 +19478,7 @@ func newWebAppSetupOOBOTPHandler(p *deps.RequestProvider) http.Handler {
 		Config: smsConfig,
 	}
 	messageSender := &otp.MessageSender{
+		RemoteIP:          remoteIP,
 		Translation:       translationService,
 		Endpoints:         endpointsEndpoints,
 		TaskQueue:         queue,
@@ -20251,6 +20272,7 @@ func newWebAppEnterOOBOTPHandler(p *deps.RequestProvider) http.Handler {
 		Config: smsConfig,
 	}
 	messageSender := &otp.MessageSender{
+		RemoteIP:          remoteIP,
 		Translation:       translationService,
 		Endpoints:         endpointsEndpoints,
 		TaskQueue:         queue,
@@ -21048,6 +21070,7 @@ func newWebAppSetupWhatsappOTPHandler(p *deps.RequestProvider) http.Handler {
 		Config: smsConfig,
 	}
 	messageSender := &otp.MessageSender{
+		RemoteIP:          remoteIP,
 		Translation:       translationService,
 		Endpoints:         endpointsEndpoints,
 		TaskQueue:         queue,
@@ -21841,6 +21864,7 @@ func newWebAppWhatsappOTPHandler(p *deps.RequestProvider) http.Handler {
 		Config: smsConfig,
 	}
 	messageSender := &otp.MessageSender{
+		RemoteIP:          remoteIP,
 		Translation:       translationService,
 		Endpoints:         endpointsEndpoints,
 		TaskQueue:         queue,
@@ -22696,6 +22720,7 @@ func newWebAppSetupLoginLinkOTPHandler(p *deps.RequestProvider) http.Handler {
 		Config: smsConfig,
 	}
 	messageSender := &otp.MessageSender{
+		RemoteIP:          remoteIP,
 		Translation:       translationService,
 		Endpoints:         endpointsEndpoints,
 		TaskQueue:         queue,
@@ -23499,6 +23524,7 @@ func newWebAppLoginLinkOTPHandler(p *deps.RequestProvider) http.Handler {
 		Config: smsConfig,
 	}
 	messageSender := &otp.MessageSender{
+		RemoteIP:          remoteIP,
 		Translation:       translationService,
 		Endpoints:         endpointsEndpoints,
 		TaskQueue:         queue,
@@ -24310,6 +24336,7 @@ func newWebAppVerifyLoginLinkOTPHandler(p *deps.RequestProvider) http.Handler {
 		Config: smsConfig,
 	}
 	messageSender := &otp.MessageSender{
+		RemoteIP:          remoteIP,
 		Translation:       translationService,
 		Endpoints:         endpointsEndpoints,
 		TaskQueue:         queue,
@@ -25113,6 +25140,7 @@ func newWebAppEnterRecoveryCodeHandler(p *deps.RequestProvider) http.Handler {
 		Config: smsConfig,
 	}
 	messageSender := &otp.MessageSender{
+		RemoteIP:          remoteIP,
 		Translation:       translationService,
 		Endpoints:         endpointsEndpoints,
 		TaskQueue:         queue,
@@ -25906,6 +25934,7 @@ func newWebAppSetupRecoveryCodeHandler(p *deps.RequestProvider) http.Handler {
 		Config: smsConfig,
 	}
 	messageSender := &otp.MessageSender{
+		RemoteIP:          remoteIP,
 		Translation:       translationService,
 		Endpoints:         endpointsEndpoints,
 		TaskQueue:         queue,
@@ -26695,6 +26724,7 @@ func newWebAppVerifyIdentityHandler(p *deps.RequestProvider) http.Handler {
 		Config: smsConfig,
 	}
 	messageSender := &otp.MessageSender{
+		RemoteIP:          remoteIP,
 		Translation:       translationService,
 		Endpoints:         endpointsEndpoints,
 		TaskQueue:         queue,
@@ -27488,6 +27518,7 @@ func newWebAppVerifyIdentitySuccessHandler(p *deps.RequestProvider) http.Handler
 		Config: smsConfig,
 	}
 	messageSender := &otp.MessageSender{
+		RemoteIP:          remoteIP,
 		Translation:       translationService,
 		Endpoints:         endpointsEndpoints,
 		TaskQueue:         queue,
@@ -28277,6 +28308,7 @@ func newWebAppForgotPasswordHandler(p *deps.RequestProvider) http.Handler {
 		Config: smsConfig,
 	}
 	messageSender := &otp.MessageSender{
+		RemoteIP:          remoteIP,
 		Translation:       translationService,
 		Endpoints:         endpointsEndpoints,
 		TaskQueue:         queue,
@@ -29076,6 +29108,7 @@ func newWebAppForgotPasswordSuccessHandler(p *deps.RequestProvider) http.Handler
 		Config: smsConfig,
 	}
 	messageSender := &otp.MessageSender{
+		RemoteIP:          remoteIP,
 		Translation:       translationService,
 		Endpoints:         endpointsEndpoints,
 		TaskQueue:         queue,
@@ -29865,6 +29898,7 @@ func newWebAppResetPasswordHandler(p *deps.RequestProvider) http.Handler {
 		Config: smsConfig,
 	}
 	messageSender := &otp.MessageSender{
+		RemoteIP:          remoteIP,
 		Translation:       translationService,
 		Endpoints:         endpointsEndpoints,
 		TaskQueue:         queue,
@@ -30656,6 +30690,7 @@ func newWebAppResetPasswordSuccessHandler(p *deps.RequestProvider) http.Handler 
 		Config: smsConfig,
 	}
 	messageSender := &otp.MessageSender{
+		RemoteIP:          remoteIP,
 		Translation:       translationService,
 		Endpoints:         endpointsEndpoints,
 		TaskQueue:         queue,
@@ -31445,6 +31480,7 @@ func newWebAppSettingsHandler(p *deps.RequestProvider) http.Handler {
 		Config: smsConfig,
 	}
 	messageSender := &otp.MessageSender{
+		RemoteIP:          remoteIP,
 		Translation:       translationService,
 		Endpoints:         endpointsEndpoints,
 		TaskQueue:         queue,
@@ -32266,6 +32302,7 @@ func newWebAppSettingsProfileHandler(p *deps.RequestProvider) http.Handler {
 		Config: smsConfig,
 	}
 	messageSender := &otp.MessageSender{
+		RemoteIP:          remoteIP,
 		Translation:       translationService,
 		Endpoints:         endpointsEndpoints,
 		TaskQueue:         queue,
@@ -33066,6 +33103,7 @@ func newWebAppSettingsProfileEditHandler(p *deps.RequestProvider) http.Handler {
 		Config: smsConfig,
 	}
 	messageSender := &otp.MessageSender{
+		RemoteIP:          remoteIP,
 		Translation:       translationService,
 		Endpoints:         endpointsEndpoints,
 		TaskQueue:         queue,
@@ -33879,6 +33917,7 @@ func newWebAppSettingsIdentityHandler(p *deps.RequestProvider) http.Handler {
 		Config: smsConfig,
 	}
 	messageSender := &otp.MessageSender{
+		RemoteIP:          remoteIP,
 		Translation:       translationService,
 		Endpoints:         endpointsEndpoints,
 		TaskQueue:         queue,
@@ -34676,6 +34715,7 @@ func newWebAppSettingsBiometricHandler(p *deps.RequestProvider) http.Handler {
 		Config: smsConfig,
 	}
 	messageSender := &otp.MessageSender{
+		RemoteIP:          remoteIP,
 		Translation:       translationService,
 		Endpoints:         endpointsEndpoints,
 		TaskQueue:         queue,
@@ -35466,6 +35506,7 @@ func newWebAppSettingsMFAHandler(p *deps.RequestProvider) http.Handler {
 		Config: smsConfig,
 	}
 	messageSender := &otp.MessageSender{
+		RemoteIP:          remoteIP,
 		Translation:       translationService,
 		Endpoints:         endpointsEndpoints,
 		TaskQueue:         queue,
@@ -36264,6 +36305,7 @@ func newWebAppSettingsTOTPHandler(p *deps.RequestProvider) http.Handler {
 		Config: smsConfig,
 	}
 	messageSender := &otp.MessageSender{
+		RemoteIP:          remoteIP,
 		Translation:       translationService,
 		Endpoints:         endpointsEndpoints,
 		TaskQueue:         queue,
@@ -37054,6 +37096,7 @@ func newWebAppSettingsPasskeyHandler(p *deps.RequestProvider) http.Handler {
 		Config: smsConfig,
 	}
 	messageSender := &otp.MessageSender{
+		RemoteIP:          remoteIP,
 		Translation:       translationService,
 		Endpoints:         endpointsEndpoints,
 		TaskQueue:         queue,
@@ -37844,6 +37887,7 @@ func newWebAppSettingsOOBOTPHandler(p *deps.RequestProvider) http.Handler {
 		Config: smsConfig,
 	}
 	messageSender := &otp.MessageSender{
+		RemoteIP:          remoteIP,
 		Translation:       translationService,
 		Endpoints:         endpointsEndpoints,
 		TaskQueue:         queue,
@@ -38634,6 +38678,7 @@ func newWebAppSettingsRecoveryCodeHandler(p *deps.RequestProvider) http.Handler 
 		Config: smsConfig,
 	}
 	messageSender := &otp.MessageSender{
+		RemoteIP:          remoteIP,
 		Translation:       translationService,
 		Endpoints:         endpointsEndpoints,
 		TaskQueue:         queue,
@@ -39425,6 +39470,7 @@ func newWebAppSettingsSessionsHandler(p *deps.RequestProvider) http.Handler {
 		Config: smsConfig,
 	}
 	messageSender := &otp.MessageSender{
+		RemoteIP:          remoteIP,
 		Translation:       translationService,
 		Endpoints:         endpointsEndpoints,
 		TaskQueue:         queue,
@@ -40234,6 +40280,7 @@ func newWebAppForceChangePasswordHandler(p *deps.RequestProvider) http.Handler {
 		Config: smsConfig,
 	}
 	messageSender := &otp.MessageSender{
+		RemoteIP:          remoteIP,
 		Translation:       translationService,
 		Endpoints:         endpointsEndpoints,
 		TaskQueue:         queue,
@@ -41024,6 +41071,7 @@ func newWebAppSettingsChangePasswordHandler(p *deps.RequestProvider) http.Handle
 		Config: smsConfig,
 	}
 	messageSender := &otp.MessageSender{
+		RemoteIP:          remoteIP,
 		Translation:       translationService,
 		Endpoints:         endpointsEndpoints,
 		TaskQueue:         queue,
@@ -41814,6 +41862,7 @@ func newWebAppForceChangeSecondaryPasswordHandler(p *deps.RequestProvider) http.
 		Config: smsConfig,
 	}
 	messageSender := &otp.MessageSender{
+		RemoteIP:          remoteIP,
 		Translation:       translationService,
 		Endpoints:         endpointsEndpoints,
 		TaskQueue:         queue,
@@ -42604,6 +42653,7 @@ func newWebAppSettingsChangeSecondaryPasswordHandler(p *deps.RequestProvider) ht
 		Config: smsConfig,
 	}
 	messageSender := &otp.MessageSender{
+		RemoteIP:          remoteIP,
 		Translation:       translationService,
 		Endpoints:         endpointsEndpoints,
 		TaskQueue:         queue,
@@ -43394,6 +43444,7 @@ func newWebAppSettingsDeleteAccountHandler(p *deps.RequestProvider) http.Handler
 		Config: smsConfig,
 	}
 	messageSender := &otp.MessageSender{
+		RemoteIP:          remoteIP,
 		Translation:       translationService,
 		Endpoints:         endpointsEndpoints,
 		TaskQueue:         queue,
@@ -44191,6 +44242,7 @@ func newWebAppSettingsDeleteAccountSuccessHandler(p *deps.RequestProvider) http.
 		Config: smsConfig,
 	}
 	messageSender := &otp.MessageSender{
+		RemoteIP:          remoteIP,
 		Translation:       translationService,
 		Endpoints:         endpointsEndpoints,
 		TaskQueue:         queue,
@@ -44982,6 +45034,7 @@ func newWebAppAccountStatusHandler(p *deps.RequestProvider) http.Handler {
 		Config: smsConfig,
 	}
 	messageSender := &otp.MessageSender{
+		RemoteIP:          remoteIP,
 		Translation:       translationService,
 		Endpoints:         endpointsEndpoints,
 		TaskQueue:         queue,
@@ -45771,6 +45824,7 @@ func newWebAppLogoutHandler(p *deps.RequestProvider) http.Handler {
 		Config: smsConfig,
 	}
 	messageSender := &otp.MessageSender{
+		RemoteIP:          remoteIP,
 		Translation:       translationService,
 		Endpoints:         endpointsEndpoints,
 		TaskQueue:         queue,
@@ -46575,6 +46629,7 @@ func newWebAppReturnHandler(p *deps.RequestProvider) http.Handler {
 		Config: smsConfig,
 	}
 	messageSender := &otp.MessageSender{
+		RemoteIP:          remoteIP,
 		Translation:       translationService,
 		Endpoints:         endpointsEndpoints,
 		TaskQueue:         queue,
@@ -47364,6 +47419,7 @@ func newWebAppErrorHandler(p *deps.RequestProvider) http.Handler {
 		Config: smsConfig,
 	}
 	messageSender := &otp.MessageSender{
+		RemoteIP:          remoteIP,
 		Translation:       translationService,
 		Endpoints:         endpointsEndpoints,
 		TaskQueue:         queue,
@@ -48153,6 +48209,7 @@ func newWebAppNotFoundHandler(p *deps.RequestProvider) http.Handler {
 		Config: smsConfig,
 	}
 	messageSender := &otp.MessageSender{
+		RemoteIP:          remoteIP,
 		Translation:       translationService,
 		Endpoints:         endpointsEndpoints,
 		TaskQueue:         queue,
@@ -48960,6 +49017,7 @@ func newWebAppPasskeyCreationOptionsHandler(p *deps.RequestProvider) http.Handle
 		Config: smsConfig,
 	}
 	messageSender := &otp.MessageSender{
+		RemoteIP:          remoteIP,
 		Translation:       translationService,
 		Endpoints:         endpointsEndpoints,
 		TaskQueue:         queue,
@@ -49716,6 +49774,7 @@ func newWebAppPasskeyRequestOptionsHandler(p *deps.RequestProvider) http.Handler
 		Config: smsConfig,
 	}
 	messageSender := &otp.MessageSender{
+		RemoteIP:          remoteIP,
 		Translation:       translationService,
 		Endpoints:         endpointsEndpoints,
 		TaskQueue:         queue,
@@ -50471,6 +50530,7 @@ func newWebAppConnectWeb3AccountHandler(p *deps.RequestProvider) http.Handler {
 		Config: smsConfig,
 	}
 	messageSender := &otp.MessageSender{
+		RemoteIP:          remoteIP,
 		Translation:       translationService,
 		Endpoints:         endpointsEndpoints,
 		TaskQueue:         queue,
@@ -51270,6 +51330,7 @@ func newWebAppMissingWeb3WalletHandler(p *deps.RequestProvider) http.Handler {
 		Config: smsConfig,
 	}
 	messageSender := &otp.MessageSender{
+		RemoteIP:          remoteIP,
 		Translation:       translationService,
 		Endpoints:         endpointsEndpoints,
 		TaskQueue:         queue,
@@ -52060,6 +52121,7 @@ func newWebAppFeatureDisabledHandler(p *deps.RequestProvider) http.Handler {
 		Config: smsConfig,
 	}
 	messageSender := &otp.MessageSender{
+		RemoteIP:          remoteIP,
 		Translation:       translationService,
 		Endpoints:         endpointsEndpoints,
 		TaskQueue:         queue,
@@ -52836,6 +52898,7 @@ func newAPIWorkflowNewHandler(p *deps.RequestProvider) http.Handler {
 		Config: smsConfig,
 	}
 	messageSender := &otp.MessageSender{
+		RemoteIP:          remoteIP,
 		Translation:       translationService,
 		Endpoints:         endpointsEndpoints,
 		TaskQueue:         queue,
@@ -53574,6 +53637,7 @@ func newAPIWorkflowGetHandler(p *deps.RequestProvider) http.Handler {
 		Config: smsConfig,
 	}
 	messageSender := &otp.MessageSender{
+		RemoteIP:          remoteIP,
 		Translation:       translationService,
 		Endpoints:         endpointsEndpoints,
 		TaskQueue:         queue,
@@ -54282,6 +54346,7 @@ func newAPIWorkflowInputHandler(p *deps.RequestProvider) http.Handler {
 		Config: smsConfig,
 	}
 	messageSender := &otp.MessageSender{
+		RemoteIP:          remoteIP,
 		Translation:       translationService,
 		Endpoints:         endpointsEndpoints,
 		TaskQueue:         queue,
@@ -55802,6 +55867,7 @@ func newWebAppSessionMiddleware(p *deps.RequestProvider) httproute.Middleware {
 		Config: smsConfig,
 	}
 	messageSender := &otp.MessageSender{
+		RemoteIP:          remoteIP,
 		Translation:       translationService,
 		Endpoints:         endpointsEndpoints,
 		TaskQueue:         queue,

--- a/pkg/latte/intent_authenticate_email_login_link.go
+++ b/pkg/latte/intent_authenticate_email_login_link.go
@@ -3,7 +3,6 @@ package latte
 import (
 	"context"
 
-	"github.com/authgear/authgear-server/pkg/api/apierrors"
 	"github.com/authgear/authgear-server/pkg/lib/authn/authenticator"
 	"github.com/authgear/authgear-server/pkg/lib/authn/otp"
 	"github.com/authgear/authgear-server/pkg/lib/ratelimit"
@@ -49,8 +48,8 @@ func (i *IntentAuthenticateEmailLoginLink) ReactTo(ctx context.Context, deps *wo
 			AuthenticatorInfo: authenticator,
 			OTPMode:           otp.OTPModeLoginLink,
 		}).Do()
-		if apierrors.IsKind(err, ratelimit.RateLimited) {
-			// Ignore rate limit error for initial sending
+		if ratelimit.IsRateLimitErrorWithBucketName(err, "AntiSpamOTPCodeBucket") {
+			// Ignore resend cooldown rate limit error for initial sending
 		} else if err != nil {
 			return nil, err
 		}

--- a/pkg/latte/intent_authenticate_oob_otp_phone.go
+++ b/pkg/latte/intent_authenticate_oob_otp_phone.go
@@ -3,7 +3,6 @@ package latte
 import (
 	"context"
 
-	"github.com/authgear/authgear-server/pkg/api/apierrors"
 	"github.com/authgear/authgear-server/pkg/lib/authn/authenticator"
 	"github.com/authgear/authgear-server/pkg/lib/ratelimit"
 	"github.com/authgear/authgear-server/pkg/lib/workflow"
@@ -47,8 +46,8 @@ func (i *IntentAuthenticateOOBOTPPhone) ReactTo(ctx context.Context, deps *workf
 			IsAuthenticating:  true,
 			AuthenticatorInfo: authenticator,
 		}).Do()
-		if apierrors.IsKind(err, ratelimit.RateLimited) {
-			// Ignore rate limit error for initial sending
+		if ratelimit.IsRateLimitErrorWithBucketName(err, "AntiSpamOTPCodeBucket") {
+			// Ignore resend cooldown rate limit error for initial sending
 		} else if err != nil {
 			return nil, err
 		}

--- a/pkg/latte/intent_verify_identity.go
+++ b/pkg/latte/intent_verify_identity.go
@@ -4,7 +4,6 @@ import (
 	"context"
 
 	"github.com/authgear/authgear-server/pkg/api"
-	"github.com/authgear/authgear-server/pkg/api/apierrors"
 	"github.com/authgear/authgear-server/pkg/api/model"
 	"github.com/authgear/authgear-server/pkg/lib/authn/identity"
 	"github.com/authgear/authgear-server/pkg/lib/feature/verification"
@@ -88,8 +87,8 @@ func (i *IntentVerifyIdentity) ReactTo(ctx context.Context, deps *workflow.Depen
 	}
 
 	err = node.sendCode(ctx, deps, w)
-	if apierrors.IsKind(err, ratelimit.RateLimited) {
-		// Ignore rate limit error; continue the workflow
+	if ratelimit.IsRateLimitErrorWithBucketName(err, "AntiSpamOTPCodeBucket") {
+		// Ignore resend cool down rate limit error; continue the workflow
 	} else if err != nil {
 		return nil, err
 	}

--- a/pkg/latte/node_verify_email.go
+++ b/pkg/latte/node_verify_email.go
@@ -113,7 +113,17 @@ func (n *NodeVerifyEmail) bucket(deps *workflow.Dependencies) ratelimit.Bucket {
 }
 
 func (n *NodeVerifyEmail) sendCode(ctx context.Context, deps *workflow.Dependencies, w *workflow.Workflow) error {
-	err := deps.RateLimiter.TakeToken(n.bucket(deps))
+	// Should check if we can send code to the target first before taking token
+	// from the AntiSpamOTPCodeBucket (resend cooldown)
+	// It may be blocked due to exceeding the per target or per ip rate limit,
+	// and this error should be returned
+	var err error
+	err = deps.OOBCodeSender.CanSendCode(model.AuthenticatorOOBChannelEmail, n.Email)
+	if err != nil {
+		return err
+	}
+
+	err = deps.RateLimiter.TakeToken(n.bucket(deps))
 	if err != nil {
 		return err
 	}

--- a/pkg/lib/authn/authenticator/oob/sender.go
+++ b/pkg/lib/authn/authenticator/oob/sender.go
@@ -6,12 +6,28 @@ import (
 )
 
 type OTPMessageSender interface {
+	CanSendEmail(email string) error
 	SendEmail(email string, opts otp.SendOptions) error
+	CanSendSMS(phone string) error
 	SendSMS(phone string, opts otp.SendOptions) error
 }
 
 type CodeSender struct {
 	OTPMessageSender OTPMessageSender
+}
+
+func (s *CodeSender) CanSendCode(
+	channel model.AuthenticatorOOBChannel,
+	target string,
+) error {
+	switch channel {
+	case model.AuthenticatorOOBChannelEmail:
+		return s.OTPMessageSender.CanSendEmail(target)
+	case model.AuthenticatorOOBChannelSMS:
+		return s.OTPMessageSender.CanSendSMS(target)
+	default:
+		panic("oob: unknown channel type: " + channel)
+	}
 }
 
 func (s *CodeSender) SendCode(

--- a/pkg/lib/authn/otp/sender.go
+++ b/pkg/lib/authn/otp/sender.go
@@ -36,8 +36,8 @@ type HardSMSBucketer interface {
 }
 
 type AntiSpamSMSBucketMaker interface {
-	IsEnabled() bool
-	MakeBucket(phone string) ratelimit.Bucket
+	IsPerPhoneEnabled() bool
+	MakePerPhoneBucket(phone string) ratelimit.Bucket
 }
 
 type RateLimiter interface {
@@ -195,8 +195,8 @@ func (s *MessageSender) SendSMS(phone string, opts SendOptions) (err error) {
 		return err
 	}
 
-	if s.AntiSpamSMSBucket.IsEnabled() {
-		err = s.RateLimiter.TakeToken(s.AntiSpamSMSBucket.MakeBucket(phone))
+	if s.AntiSpamSMSBucket.IsPerPhoneEnabled() {
+		err = s.RateLimiter.TakeToken(s.AntiSpamSMSBucket.MakePerPhoneBucket(phone))
 		if err != nil {
 			return err
 		}

--- a/pkg/lib/config/messaging.go
+++ b/pkg/lib/config/messaging.go
@@ -53,6 +53,7 @@ var _ = Schema.Add("SMSRatelimitConfig", `
 	"additionalProperties": false,
 	"properties": {
 		"per_phone": { "$ref": "#/$defs/SMSRateLimitPerPhoneConfig" },
+		"per_ip": { "$ref": "#/$defs/SMSRateLimitPerIPConfig" },
 		"resend_cooldown_seconds": {
 			"$ref": "#/$defs/DurationSeconds",
 			"enum": [60, 120]
@@ -63,6 +64,7 @@ var _ = Schema.Add("SMSRatelimitConfig", `
 
 type SMSRatelimitConfig struct {
 	PerPhone              *SMSRateLimitPerPhoneConfig `json:"per_phone,omitempty"`
+	PerIP                 *SMSRateLimitPerIPConfig    `json:"per_ip,omitempty"`
 	ResendCooldownSeconds DurationSeconds             `json:"resend_cooldown_seconds,omitempty"`
 }
 
@@ -97,6 +99,35 @@ func (c *SMSRateLimitPerPhoneConfig) SetDefaults() {
 		}
 		if c.ResetPeriod == "" {
 			c.ResetPeriod = "24h"
+		}
+	}
+}
+
+var _ = Schema.Add("SMSRateLimitPerIPConfig", `
+{
+	"type": "object",
+	"additionalProperties": false,
+	"properties": {
+		"enabled": { "type": "boolean" },
+		"size": { "type": "integer", "minimum": 1 },
+		"reset_period": { "$ref": "#/$defs/DurationString" }
+	}
+}
+`)
+
+type SMSRateLimitPerIPConfig struct {
+	Enabled     bool           `json:"enabled,omitempty"`
+	Size        int            `json:"size,omitempty"`
+	ResetPeriod DurationString `json:"reset_period,omitempty"`
+}
+
+func (c *SMSRateLimitPerIPConfig) SetDefaults() {
+	if c.Enabled {
+		if c.Size == 0 {
+			c.Size = 120
+		}
+		if c.ResetPeriod == "" {
+			c.ResetPeriod = "1m"
 		}
 	}
 }

--- a/pkg/lib/config/testdata/default_config.yaml
+++ b/pkg/lib/config/testdata/default_config.yaml
@@ -273,6 +273,10 @@ messaging:
         enabled: false
         reset_period: ""
         size: 0
+      per_ip:
+        enabled: false
+        reset_period: ""
+        size: 0
       resend_cooldown_seconds: 60
   email:
     ratelimit:

--- a/pkg/lib/feature/forgotpassword/provider.go
+++ b/pkg/lib/feature/forgotpassword/provider.go
@@ -72,6 +72,8 @@ type HardSMSBucketer interface {
 type AntiSpamSMSBucketMaker interface {
 	IsPerPhoneEnabled() bool
 	MakePerPhoneBucket(phone string) ratelimit.Bucket
+	IsPerIPEnabled() bool
+	MakePerIPBucket(ip string) ratelimit.Bucket
 }
 
 type Provider struct {
@@ -247,6 +249,13 @@ func (p *Provider) sendSMS(phone string, code string, userID string) (err error)
 
 	if p.AntiSpamSMSBucket.IsPerPhoneEnabled() {
 		err = p.RateLimiter.TakeToken(p.AntiSpamSMSBucket.MakePerPhoneBucket(phone))
+		if err != nil {
+			return err
+		}
+	}
+
+	if p.AntiSpamSMSBucket.IsPerIPEnabled() {
+		err = p.RateLimiter.TakeToken(p.AntiSpamSMSBucket.MakePerIPBucket(string(p.RemoteIP)))
 		if err != nil {
 			return err
 		}

--- a/pkg/lib/feature/forgotpassword/provider.go
+++ b/pkg/lib/feature/forgotpassword/provider.go
@@ -70,8 +70,8 @@ type HardSMSBucketer interface {
 }
 
 type AntiSpamSMSBucketMaker interface {
-	IsEnabled() bool
-	MakeBucket(phone string) ratelimit.Bucket
+	IsPerPhoneEnabled() bool
+	MakePerPhoneBucket(phone string) ratelimit.Bucket
 }
 
 type Provider struct {
@@ -245,8 +245,8 @@ func (p *Provider) sendSMS(phone string, code string, userID string) (err error)
 		return err
 	}
 
-	if p.AntiSpamSMSBucket.IsEnabled() {
-		err = p.RateLimiter.TakeToken(p.AntiSpamSMSBucket.MakeBucket(phone))
+	if p.AntiSpamSMSBucket.IsPerPhoneEnabled() {
+		err = p.RateLimiter.TakeToken(p.AntiSpamSMSBucket.MakePerPhoneBucket(phone))
 		if err != nil {
 			return err
 		}

--- a/pkg/lib/infra/sms/ratelimit.go
+++ b/pkg/lib/infra/sms/ratelimit.go
@@ -15,11 +15,11 @@ type AntiSpamSMSBucketMaker struct {
 	Config *config.SMSConfig
 }
 
-func (m *AntiSpamSMSBucketMaker) IsEnabled() bool {
+func (m *AntiSpamSMSBucketMaker) IsPerPhoneEnabled() bool {
 	return m.Config.Ratelimit.PerPhone.Enabled
 }
 
-func (m *AntiSpamSMSBucketMaker) MakeBucket(phone string) ratelimit.Bucket {
+func (m *AntiSpamSMSBucketMaker) MakePerPhoneBucket(phone string) ratelimit.Bucket {
 	return ratelimit.Bucket{
 		Key:         fmt.Sprintf("sms-message:%s", phone),
 		Name:        "AntiSpamSMSBucket",

--- a/pkg/lib/infra/sms/ratelimit.go
+++ b/pkg/lib/infra/sms/ratelimit.go
@@ -22,7 +22,7 @@ func (m *AntiSpamSMSBucketMaker) IsPerPhoneEnabled() bool {
 func (m *AntiSpamSMSBucketMaker) MakePerPhoneBucket(phone string) ratelimit.Bucket {
 	return ratelimit.Bucket{
 		Key:         fmt.Sprintf("sms-message:%s", phone),
-		Name:        "AntiSpamSMSBucket",
+		Name:        "AntiSpamSMSBucketPerPhone",
 		Size:        m.Config.Ratelimit.PerPhone.Size,
 		ResetPeriod: m.Config.Ratelimit.PerPhone.ResetPeriod.Duration(),
 	}
@@ -35,7 +35,7 @@ func (m *AntiSpamSMSBucketMaker) IsPerIPEnabled() bool {
 func (m *AntiSpamSMSBucketMaker) MakePerIPBucket(ip string) ratelimit.Bucket {
 	return ratelimit.Bucket{
 		Key:         fmt.Sprintf("sms-message-per-ip:%s", ip),
-		Name:        "AntiSpamSMSBucket",
+		Name:        "AntiSpamSMSBucketPerIP",
 		Size:        m.Config.Ratelimit.PerIP.Size,
 		ResetPeriod: m.Config.Ratelimit.PerIP.ResetPeriod.Duration(),
 	}

--- a/pkg/lib/infra/sms/ratelimit.go
+++ b/pkg/lib/infra/sms/ratelimit.go
@@ -27,3 +27,16 @@ func (m *AntiSpamSMSBucketMaker) MakePerPhoneBucket(phone string) ratelimit.Buck
 		ResetPeriod: m.Config.Ratelimit.PerPhone.ResetPeriod.Duration(),
 	}
 }
+
+func (m *AntiSpamSMSBucketMaker) IsPerIPEnabled() bool {
+	return m.Config.Ratelimit.PerIP.Enabled
+}
+
+func (m *AntiSpamSMSBucketMaker) MakePerIPBucket(ip string) ratelimit.Bucket {
+	return ratelimit.Bucket{
+		Key:         fmt.Sprintf("sms-message-per-ip:%s", ip),
+		Name:        "AntiSpamSMSBucket",
+		Size:        m.Config.Ratelimit.PerIP.Size,
+		ResetPeriod: m.Config.Ratelimit.PerIP.ResetPeriod.Duration(),
+	}
+}

--- a/pkg/lib/interaction/ratelimit.go
+++ b/pkg/lib/interaction/ratelimit.go
@@ -68,5 +68,6 @@ func (m *AntiSpamOTPCodeBucketMaker) MakeBucket(channel model.AuthenticatorOOBCh
 		Key:         fmt.Sprintf("otp-code:%s", target),
 		Size:        1,
 		ResetPeriod: resetPeriod,
+		Name:        "AntiSpamOTPCodeBucket",
 	}
 }

--- a/pkg/lib/ratelimit/error.go
+++ b/pkg/lib/ratelimit/error.go
@@ -4,6 +4,8 @@ import (
 	"github.com/authgear/authgear-server/pkg/api/apierrors"
 )
 
+const bucketNameKey = "bucket_name"
+
 var ErrUsageLimitExceeded = apierrors.ServiceUnavailable.WithReason("UsageLimitExceeded").
 	New("usage limit exceeded")
 
@@ -15,7 +17,20 @@ func ErrTooManyRequestsFrom(bucket Bucket) error {
 		return RateLimited.New(errMsg)
 	} else {
 		return RateLimited.NewWithInfo(errMsg, apierrors.Details{
-			"bucket_name": bucket.Name,
+			bucketNameKey: bucket.Name,
 		})
 	}
+}
+
+func IsRateLimitErrorWithBucketName(err error, bucketName string) bool {
+	if !apierrors.IsKind(err, RateLimited) {
+		return false
+	}
+
+	apiError := apierrors.AsAPIError(err)
+	if apiError == nil {
+		return false
+	}
+
+	return apiError.Info[bucketNameKey] == bucketName
 }

--- a/pkg/lib/workflow/dependencies.go
+++ b/pkg/lib/workflow/dependencies.go
@@ -52,6 +52,10 @@ type OTPCodeService interface {
 }
 
 type OOBCodeSender interface {
+	CanSendCode(
+		channel model.AuthenticatorOOBChannel,
+		target string,
+	) error
 	SendCode(
 		channel model.AuthenticatorOOBChannel,
 		target string,

--- a/resources/authgear/templates/en/web/__error.html
+++ b/resources/authgear/templates/en/web/__error.html
@@ -182,7 +182,9 @@ $display_error = true }} {{ if eq .Error.reason "PasswordPolicyViolated" }}
       </a>
     </li>
     {{ else if eq .Error.reason "RateLimited" }}
-      {{ if eq .Error.info.bucket_name "AntiSpamSMSBucket" }}
+      {{ if eq .Error.info.bucket_name "AntiSpamSMSBucketPerPhone" }}
+      <li>{{ template "error-sms-send-limit-exceeded" }}</li>
+      {{ else if eq .Error.info.bucket_name "AntiSpamSMSBucketPerIP" }}
       <li>{{ template "error-sms-send-limit-exceeded" }}</li>
       {{ else }}
       <li>{{ template "error-rate-limited" }}</li>


### PR DESCRIPTION
ref #2986 

Remarks:
- Doesn't support updating via the portal yet
- Question: Currently in the workflow API. When a phone number is submitted and the rate limit is reached (including per phone, per IP, and resend cooldown), we skip sending and no error is returned. Should we show the error to the user if it is per phone or per IP limit?