### PR TITLE
Fix identity conflict is not checked for OAuth

### DIFF
--- a/pkg/lib/authn/identity/loginid/provider.go
+++ b/pkg/lib/authn/identity/loginid/provider.go
@@ -172,31 +172,8 @@ func (p *Provider) WithValue(iden *identity.LoginID, value string, options Check
 	return &newIden, nil
 }
 
-func (p *Provider) CheckDuplicated(uniqueKey string, standardClaims map[model.ClaimName]string, userID string) (*identity.LoginID, error) {
-	// check duplication with unique key
-	info, err := p.Store.GetByUniqueKey(uniqueKey)
-	if err == nil {
-		return info, identity.ErrIdentityAlreadyExists
-	} else if !errors.Is(err, identity.ErrIdentityNotFound) {
-		return nil, err
-	}
-
-	// check duplication with standard claims
-	for name, value := range standardClaims {
-		ls, err := p.ListByClaim(string(name), value)
-		if err != nil {
-			return nil, err
-		}
-
-		for _, i := range ls {
-			if i.UserID == userID {
-				continue
-			}
-			return i, identity.ErrIdentityAlreadyExists
-		}
-	}
-
-	return nil, nil
+func (p *Provider) GetByUniqueKey(uniqueKey string) (*identity.LoginID, error) {
+	return p.Store.GetByUniqueKey(uniqueKey)
 }
 
 func (p *Provider) Create(i *identity.LoginID) error {

--- a/pkg/lib/authn/identity/oauth/provider.go
+++ b/pkg/lib/authn/identity/oauth/provider.go
@@ -3,7 +3,6 @@ package oauth
 import (
 	"sort"
 
-	"github.com/authgear/authgear-server/pkg/api/model"
 	"github.com/authgear/authgear-server/pkg/lib/authn/identity"
 	"github.com/authgear/authgear-server/pkg/lib/config"
 	"github.com/authgear/authgear-server/pkg/util/clock"
@@ -92,25 +91,6 @@ func (p *Provider) WithUpdate(
 	newIden.Claims = claims
 
 	return &newIden
-}
-
-func (p *Provider) CheckDuplicated(standardClaims map[model.ClaimName]string, userID string) (*identity.OAuth, error) {
-	// check duplication with standard claims
-	for name, value := range standardClaims {
-		ls, err := p.ListByClaim(string(name), value)
-		if err != nil {
-			return nil, err
-		}
-
-		for _, i := range ls {
-			if i.UserID == userID {
-				continue
-			}
-			return i, identity.ErrIdentityAlreadyExists
-		}
-	}
-
-	return nil, nil
 }
 
 func (p *Provider) Create(i *identity.OAuth) error {

--- a/pkg/lib/authn/identity/service/service.go
+++ b/pkg/lib/authn/identity/service/service.go
@@ -17,13 +17,13 @@ type LoginIDIdentityProvider interface {
 	GetMany(ids []string) ([]*identity.LoginID, error)
 	List(userID string) ([]*identity.LoginID, error)
 	GetByValue(loginIDValue string) ([]*identity.LoginID, error)
+	GetByUniqueKey(uniqueKey string) (*identity.LoginID, error)
 	ListByClaim(name string, value string) ([]*identity.LoginID, error)
 	New(userID string, loginID identity.LoginIDSpec, options loginid.CheckerOptions) (*identity.LoginID, error)
 	WithValue(iden *identity.LoginID, value string, options loginid.CheckerOptions) (*identity.LoginID, error)
 	Create(i *identity.LoginID) error
 	Update(i *identity.LoginID) error
 	Delete(i *identity.LoginID) error
-	CheckDuplicated(uniqueKey string, standardClaims map[model.ClaimName]string, userID string) (*identity.LoginID, error)
 }
 
 type OAuthIdentityProvider interface {
@@ -44,7 +44,6 @@ type OAuthIdentityProvider interface {
 	Create(i *identity.OAuth) error
 	Update(i *identity.OAuth) error
 	Delete(i *identity.OAuth) error
-	CheckDuplicated(standardClaims map[model.ClaimName]string, userID string) (*identity.OAuth, error)
 }
 
 type AnonymousIdentityProvider interface {
@@ -643,40 +642,73 @@ func (s *Service) Delete(info *identity.Info) error {
 	return nil
 }
 
-func (s *Service) CheckDuplicated(is *identity.Info) (dupeIdentity *identity.Info, err error) {
-	// extract login id unique key
-	loginIDUniqueKey := ""
-	if is.Type == model.IdentityTypeLoginID {
-		li := is.LoginID
-		loginIDUniqueKey = li.UniqueKey
+func (s *Service) CheckDuplicated(info *identity.Info) (dupeIdentity *identity.Info, err error) {
+	// There are two ways to check duplicate.
+	// 1. Check duplicate by considering standard attributes.
+	// 2. Check duplicate by considering type-specific unique key.
+	// Only LoginID and OAuth has identity aware standard attributes and unique key.
+
+	// 1. Check duplicate by considering standard attributes.
+	claims := info.IdentityAwareStandardClaims()
+	for name, value := range claims {
+		var loginIDs []*identity.LoginID
+		loginIDs, err = s.LoginID.ListByClaim(string(name), value)
+		if err != nil {
+			return nil, err
+		}
+
+		for _, i := range loginIDs {
+			if i.UserID == info.UserID {
+				continue
+			}
+			dupeIdentity = i.ToInfo()
+			err = identity.ErrIdentityAlreadyExists
+			return
+		}
+
+		var oauths []*identity.OAuth
+		oauths, err = s.OAuth.ListByClaim(string(name), value)
+		if err != nil {
+			return nil, err
+		}
+
+		for _, i := range oauths {
+			if i.UserID == info.UserID {
+				continue
+			}
+			dupeIdentity = i.ToInfo()
+			err = identity.ErrIdentityAlreadyExists
+			return
+		}
 	}
 
-	// extract standard claims
-	claims := is.IdentityAwareStandardClaims()
-
-	li, err := s.LoginID.CheckDuplicated(loginIDUniqueKey, claims, is.UserID)
-	if errors.Is(err, identity.ErrIdentityAlreadyExists) {
-		dupeIdentity = li.ToInfo()
-		return
-	} else if err != nil {
-		return
+	// 2. Check duplicate by considering type-specific unique key.
+	switch info.Type {
+	case model.IdentityTypeLoginID:
+		var i *identity.LoginID
+		i, err = s.LoginID.GetByUniqueKey(info.LoginID.UniqueKey)
+		if err != nil {
+			if !errors.Is(err, identity.ErrIdentityNotFound) {
+				return
+			}
+			err = nil
+		} else {
+			dupeIdentity = i.ToInfo()
+			err = identity.ErrIdentityAlreadyExists
+		}
+	case model.IdentityTypeOAuth:
+		var o *identity.OAuth
+		o, err = s.OAuth.GetByProviderSubject(info.OAuth.ProviderID, info.OAuth.ProviderSubjectID)
+		if err != nil {
+			if !errors.Is(err, identity.ErrIdentityNotFound) {
+				return
+			}
+			err = nil
+		} else {
+			dupeIdentity = o.ToInfo()
+			err = identity.ErrIdentityAlreadyExists
+		}
 	}
-
-	oi, err := s.OAuth.CheckDuplicated(claims, is.UserID)
-	if errors.Is(err, identity.ErrIdentityAlreadyExists) {
-		dupeIdentity = oi.ToInfo()
-		return
-	} else if err != nil {
-		return
-	}
-
-	// No need to consider anonymous identity
-
-	// No need to consider biometric identity
-
-	// No need to consider passkey identity
-
-	// No need to consider SIWE identity
 
 	return
 }

--- a/pkg/lib/authn/identity/service/service_mock_test.go
+++ b/pkg/lib/authn/identity/service/service_mock_test.go
@@ -7,7 +7,6 @@ package service
 import (
 	reflect "reflect"
 
-	model "github.com/authgear/authgear-server/pkg/api/model"
 	identity "github.com/authgear/authgear-server/pkg/lib/authn/identity"
 	loginid "github.com/authgear/authgear-server/pkg/lib/authn/identity/loginid"
 	config "github.com/authgear/authgear-server/pkg/lib/config"
@@ -35,21 +34,6 @@ func NewMockLoginIDIdentityProvider(ctrl *gomock.Controller) *MockLoginIDIdentit
 // EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockLoginIDIdentityProvider) EXPECT() *MockLoginIDIdentityProviderMockRecorder {
 	return m.recorder
-}
-
-// CheckDuplicated mocks base method.
-func (m *MockLoginIDIdentityProvider) CheckDuplicated(uniqueKey string, standardClaims map[model.ClaimName]string, userID string) (*identity.LoginID, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "CheckDuplicated", uniqueKey, standardClaims, userID)
-	ret0, _ := ret[0].(*identity.LoginID)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// CheckDuplicated indicates an expected call of CheckDuplicated.
-func (mr *MockLoginIDIdentityProviderMockRecorder) CheckDuplicated(uniqueKey, standardClaims, userID interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CheckDuplicated", reflect.TypeOf((*MockLoginIDIdentityProvider)(nil).CheckDuplicated), uniqueKey, standardClaims, userID)
 }
 
 // Create mocks base method.
@@ -93,6 +77,21 @@ func (m *MockLoginIDIdentityProvider) Get(userID, id string) (*identity.LoginID,
 func (mr *MockLoginIDIdentityProviderMockRecorder) Get(userID, id interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Get", reflect.TypeOf((*MockLoginIDIdentityProvider)(nil).Get), userID, id)
+}
+
+// GetByUniqueKey mocks base method.
+func (m *MockLoginIDIdentityProvider) GetByUniqueKey(uniqueKey string) (*identity.LoginID, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetByUniqueKey", uniqueKey)
+	ret0, _ := ret[0].(*identity.LoginID)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetByUniqueKey indicates an expected call of GetByUniqueKey.
+func (mr *MockLoginIDIdentityProviderMockRecorder) GetByUniqueKey(uniqueKey interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetByUniqueKey", reflect.TypeOf((*MockLoginIDIdentityProvider)(nil).GetByUniqueKey), uniqueKey)
 }
 
 // GetByValue mocks base method.
@@ -220,21 +219,6 @@ func NewMockOAuthIdentityProvider(ctrl *gomock.Controller) *MockOAuthIdentityPro
 // EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockOAuthIdentityProvider) EXPECT() *MockOAuthIdentityProviderMockRecorder {
 	return m.recorder
-}
-
-// CheckDuplicated mocks base method.
-func (m *MockOAuthIdentityProvider) CheckDuplicated(standardClaims map[model.ClaimName]string, userID string) (*identity.OAuth, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "CheckDuplicated", standardClaims, userID)
-	ret0, _ := ret[0].(*identity.OAuth)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// CheckDuplicated indicates an expected call of CheckDuplicated.
-func (mr *MockOAuthIdentityProviderMockRecorder) CheckDuplicated(standardClaims, userID interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CheckDuplicated", reflect.TypeOf((*MockOAuthIdentityProvider)(nil).CheckDuplicated), standardClaims, userID)
 }
 
 // Create mocks base method.


### PR DESCRIPTION
Steps to reproduce the bug:
1. Sign in as anonymous user.
2. Promote with a OAuth account that is already linked to an existing user.

ref #3234