### PR TITLE
Fix signup rate limit

### DIFF
--- a/pkg/lib/interaction/nodes/do_create_user.go
+++ b/pkg/lib/interaction/nodes/do_create_user.go
@@ -86,7 +86,7 @@ func (n *NodeDoCreateUser) GetEffects() ([]interaction.Effect, error) {
 				// check the rate limit only before running the effects
 				bucket := interaction.SignupPerIPRateLimitBucketSpec(ctx.Config.Authentication, isAnonymous, ip)
 				reservation = ctx.RateLimiter.Reserve(bucket)
-				if reservation.Error() != nil {
+				if err := reservation.Error(); err != nil {
 					return err
 				}
 			}


### PR DESCRIPTION
When rate limited, the nil err is always returned.