### PR TITLE
Fix login crashing if login id is having same email with oauth id

### DIFF
--- a/pkg/lib/authn/authenticator/info.go
+++ b/pkg/lib/authn/authenticator/info.go
@@ -196,7 +196,7 @@ func (i *Info) IsDependentOf(iden *identity.Info) bool {
 	if i.Kind == KindPrimary && (i.Type == model.AuthenticatorTypeOOBEmail || i.Type == model.AuthenticatorTypeOOBSMS) {
 		identityClaims := iden.IdentityAwareStandardClaims()
 		for k, v := range i.StandardClaims() {
-			if identityClaims[k] == v {
+			if iden.Type == model.IdentityTypeLoginID && identityClaims[k] == v {
 				return true
 			}
 		}


### PR DESCRIPTION
ref #3334 

Conditions to reproduce the bug:

1. Email link login & sso login is enabled in the project.
2. Create an account using email link as primary authenticator.
3. In settings, link to google oauth. The google account must have the same email address as the registered login id in previous step.
4. Logout, and login again. Crash.