### PR TITLE
Disable parcel scope hoisting

### DIFF
--- a/portal/package.json
+++ b/portal/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "test": "jest",
     "start": "parcel serve --port 1234 --no-cache './src/*.html'",
-    "build": "PARCEL_BUNDLE_ANALYZER=1 parcel build --no-cache './src/*.html'",
+    "build": "PARCEL_BUNDLE_ANALYZER=1 parcel build --no-cache --no-scope-hoist './src/*.html'",
     "clean": "rm -rf ./dist/ ./parcel-bundle-reports/ && mkdir ./dist/ && touch ./dist/.gitkeep",
     "typecheck": "tsc",
     "fmt": "prettier --list-different --write './src/**/*.{js,ts,jsx,tsx,css,scss,html}'",


### PR DESCRIPTION
ref #3543 

https://parceljs.org/features/scope-hoisting/

It might result in a larger bundle size and some performance impact, but I guess that is not very important for portal.