### PR TITLE
Add basic layout & widget styles

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 /var/authgear.features.yaml
 /var/deno
 /var/templates
+/var/static
 /tls-cert.pem
 /tls-key.pem
 .parcel-cache/

--- a/authui/src/authflowv2/base.css
+++ b/authui/src/authflowv2/base.css
@@ -3,7 +3,7 @@
 @layer base {
   html,
   body {
-    @apply h-full min-h-min flex flex-col;
+    @apply h-full min-h-min flex flex-col flex-1-0-auto;
     /* Reference font size */
     font-size: 16px;
     font-family: "Inter", sans-serif;

--- a/authui/src/authflowv2/base.css
+++ b/authui/src/authflowv2/base.css
@@ -49,6 +49,7 @@
     --border-radius-full: 9999px;
     --border-radius-sqaure: 0px;
     --border-radius-rounded-square: 0.875em;
+    --border-radius-large: 1.25rem;
   }
 
   /* Typography */

--- a/authui/src/authflowv2/base.css
+++ b/authui/src/authflowv2/base.css
@@ -47,7 +47,7 @@
   /* Border Radius */
   :root {
     --border-radius-full: 9999px;
-    --border-radius-sqaure: 0px;
+    --border-radius-square: 0px;
     --border-radius-rounded-square: 0.875em;
     --border-radius-large: 1.25rem;
   }

--- a/authui/src/authflowv2/components.css
+++ b/authui/src/authflowv2/components.css
@@ -1,3 +1,5 @@
+@import "./components/layout.css";
+@import "./components/widget.css";
 @import "./components/screen-title.css";
 @import "./components/screen-description.css";
 @import "./components/primary-button.css";

--- a/authui/src/authflowv2/components/layout.css
+++ b/authui/src/authflowv2/components/layout.css
@@ -4,9 +4,17 @@
     @apply items-center justify-start;
   }
 
+  .layout--default .widget {
+    @apply flex-1-0-auto;
+  }
+
   @media (min-width: theme("screens.tablet")) {
     .layout--default {
       @apply justify-center;
+    }
+
+    .layout--default .widget {
+      @apply flex-none;
     }
   }
 }

--- a/authui/src/authflowv2/components/layout.css
+++ b/authui/src/authflowv2/components/layout.css
@@ -1,0 +1,12 @@
+@layer components {
+  .layout--default {
+    @apply flex flex-col flex-1-0-auto;
+    @apply items-center justify-start;
+  }
+
+  @media (min-width: theme("screens.tablet")) {
+    .layout--default {
+      @apply justify-center;
+    }
+  }
+}

--- a/authui/src/authflowv2/components/widget.css
+++ b/authui/src/authflowv2/components/widget.css
@@ -1,0 +1,34 @@
+@layer components {
+  :root {
+    --widget__bg-color: var(--color-white);
+    --widget__width: 100%;
+    --widget__max-width: 480px;
+    --widget__border-radius: var(--border-radius-sqaure);
+    --widget__box-shadow: none;
+    --widget__border: none;
+
+    @media (min-width: theme("screens.tablet")) {
+      --widget__border-radius: 0px;
+      --widget__box-shadow: none;
+      --widget__border: none;
+    }
+  }
+
+  .widget {
+    width: var(--widget__width);
+    max-width: var(--widget__max-width);
+    border-radius: var(--widget__border-radius);
+    border: var(--widget__border);
+    box-shadow: var(--widget__box-shadow);
+    background-color: var(--widget__bg-color);
+    @apply block;
+
+    @apply px-6 py-8 flex-1-0-auto;
+  }
+
+  @media (min-width: theme("screens.tablet")) {
+    .widget {
+      @apply px-6 py-6 flex-none;
+    }
+  }
+}

--- a/authui/src/authflowv2/components/widget.css
+++ b/authui/src/authflowv2/components/widget.css
@@ -23,12 +23,12 @@
     background-color: var(--widget__bg-color);
     @apply block;
 
-    @apply px-6 py-8 flex-1-0-auto;
+    @apply px-6 py-8;
   }
 
   @media (min-width: theme("screens.tablet")) {
     .widget {
-      @apply px-6 py-6 flex-none;
+      @apply px-6 py-6;
     }
   }
 }

--- a/authui/src/authflowv2/components/widget.css
+++ b/authui/src/authflowv2/components/widget.css
@@ -2,7 +2,7 @@
   :root {
     --widget__bg-color: var(--color-white);
     --widget__width: 100%;
-    --widget__max-width: 480px;
+    --widget__max-width: 400px;
     --widget__border-radius: var(--border-radius-sqaure);
     --widget__box-shadow: none;
     --widget__border: none;

--- a/authui/src/authflowv2/components/widget.css
+++ b/authui/src/authflowv2/components/widget.css
@@ -3,12 +3,12 @@
     --widget__bg-color: var(--color-white);
     --widget__width: 100%;
     --widget__max-width: 400px;
-    --widget__border-radius: var(--border-radius-sqaure);
+    --widget__border-radius: 0px;
     --widget__box-shadow: none;
     --widget__border: none;
 
     @media (min-width: theme("screens.tablet")) {
-      --widget__border-radius: 0px;
+      --widget__border-radius: var(--border-radius-large);
       --widget__box-shadow: none;
       --widget__border: none;
     }

--- a/authui/tailwind.config.js
+++ b/authui/tailwind.config.js
@@ -16,6 +16,9 @@ module.exports = {
   darkMode: "class",
   theme: {
     extend: {
+      flex: {
+        "1-0-auto": "1 0 auto",
+      },
       spacing: {
         18: "4.5rem",
       },

--- a/pkg/lib/web/html.go
+++ b/pkg/lib/web/html.go
@@ -26,6 +26,8 @@ var TemplateWebTermsOfServiceAndPrivacyPolicyFooterHTML = template.RegisterHTML(
 var TemplateWebAuthflowBranchHTML = template.RegisterHTML("web/__authflow_branch.html")
 var TemplateWebAuthflowForgotPasswordAlternativesHTML = template.RegisterHTML("web/__authflow_forgot_password_alternatives.html")
 
+var TemplateWebAuthflowV2LayoutHTML = template.RegisterHTML("web/authflowv2/layout.html")
+
 var TemplateWebAuthflowV2HTMLHeadHTML = template.RegisterHTML("web/authflowv2/__html_head.html")
 var TemplateWebAuthflowV2GeneratedAssetHTML = template.RegisterHTML("web/authflowv2/__generated_asset.html")
 var TemplateWebAuthflowV2PageFrameHTML = template.RegisterHTML("web/authflowv2/__page_frame.html")
@@ -55,6 +57,7 @@ var ComponentsHTML = []*template.HTML{
 	TemplateWebAuthflowBranchHTML,
 	TemplateWebAuthflowForgotPasswordAlternativesHTML,
 
+	TemplateWebAuthflowV2LayoutHTML,
 	TemplateWebAuthflowV2HTMLHeadHTML,
 	TemplateWebAuthflowV2GeneratedAssetHTML,
 	TemplateWebAuthflowV2PageFrameHTML,

--- a/pkg/lib/web/static_asset_resolver.go
+++ b/pkg/lib/web/static_asset_resolver.go
@@ -24,8 +24,10 @@ var StaticAssetResources = map[string]resource.Descriptor{
 	"app-logo-dark": AppLogoDark,
 	"favicon":       Favicon,
 
-	"authgear-light-theme.css": AuthgearLightThemeCSS,
-	"authgear-dark-theme.css":  AuthgearDarkThemeCSS,
+	"authgear-light-theme.css":            AuthgearLightThemeCSS,
+	"authgear-dark-theme.css":             AuthgearDarkThemeCSS,
+	"authgear-authflowv2-light-theme.css": AuthgearAuthflowV2LightThemeCSS,
+	"authgear-authflowv2-dark-theme.css":  AuthgearAuthflowV2DarkThemeCSS,
 }
 
 type ResourceManager interface {

--- a/pkg/lib/web/static_assets.go
+++ b/pkg/lib/web/static_assets.go
@@ -22,3 +22,11 @@ var AuthgearDarkThemeCSS = resource.RegisterResource(CSSDescriptor{
 var AppLogo = resource.RegisterResource(ImageDescriptor{Name: "app_logo"})
 var AppLogoDark = resource.RegisterResource(ImageDescriptor{Name: "app_logo_dark"})
 var Favicon = resource.RegisterResource(ImageDescriptor{Name: "favicon"})
+
+var AuthgearAuthflowV2LightThemeCSS = resource.RegisterResource(CSSDescriptor{
+	Path: path.Join(AppAssetsURLDirname, "authgear-authflowv2-light-theme.css"),
+})
+
+var AuthgearAuthflowV2DarkThemeCSS = resource.RegisterResource(CSSDescriptor{
+	Path: path.Join(AppAssetsURLDirname, "authgear-authflowv2-dark-theme.css"),
+})

--- a/resources/authgear/templates/en/web/authflowv2/__html_head.html
+++ b/resources/authgear/templates/en/web/authflowv2/__html_head.html
@@ -20,15 +20,14 @@
 <!-- Stale page is still available for navigating back -->
 <meta name="turbo-cache-control" content="no-preview">
 
-<!-- Our CSS have to override styles in __generated_asset.html -->
+<!-- Our CSS have to override styles in authflowv2/__generated_asset.html -->
 {{ template "authflowv2/__generated_asset.html" . }}
-<!-- TODO(tung): Use another name for the stylesheets -->
-{{ if call $.HasAppSpecificAsset "authgear-light-theme.css" }}
-<link rel="stylesheet" href="{{ call $.StaticAssetURL "authgear-light-theme.css" }}">
+{{ if call $.HasAppSpecificAsset "authgear-authflowv2-light-theme.css" }}
+<link rel="stylesheet" href="{{ call $.StaticAssetURL "authgear-authflowv2-light-theme.css" }}">
 {{ end }}
-{{ if call $.HasAppSpecificAsset "authgear-dark-theme.css" }}
+{{ if call $.HasAppSpecificAsset "authgear-authflowv2-dark-theme.css" }}
 {{ if $.DarkThemeEnabled }}
-<link rel="stylesheet" href="{{ call $.StaticAssetURL "authgear-dark-theme.css" }}">
+<link rel="stylesheet" href="{{ call $.StaticAssetURL "authgear-authflowv2-dark-theme.css" }}">
 {{ end }}
 {{ end }}
 

--- a/resources/authgear/templates/en/web/authflowv2/__page_frame.html
+++ b/resources/authgear/templates/en/web/authflowv2/__page_frame.html
@@ -29,8 +29,10 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 <div id="loading-progress-bar"></div>
 {{ template "__tutorial.html" . }}
 <!-- TODO(tung): Extract this part to another overridable template -->
-<div class="flex flex-col">
-	{{ template "page-content" . }}
+<div class="layout--default">
+	<div class="widget">
+		{{ template "page-content" . }}
+	</div>
 </div>
 </body>
 </html>

--- a/resources/authgear/templates/en/web/authflowv2/__page_frame.html
+++ b/resources/authgear/templates/en/web/authflowv2/__page_frame.html
@@ -27,13 +27,13 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 <!-- End Google Tag Manager (noscript) -->
 
 <div id="loading-progress-bar"></div>
-{{ template "__tutorial.html" . }}
-<!-- TODO(tung): Extract this part to another overridable template -->
-<div class="layout--default">
+{{ template "web/authflowv2/layout.html" . }}
+</body>
+</html>
+{{ end }}
+
+{{ define "widget" }}
 	<div class="widget">
 		{{ template "page-content" . }}
 	</div>
-</div>
-</body>
-</html>
 {{ end }}

--- a/resources/authgear/templates/en/web/authflowv2/enter_password.html
+++ b/resources/authgear/templates/en/web/authflowv2/enter_password.html
@@ -3,7 +3,7 @@
 
 <h1 class="screen-title">Enter Password</h1>
 
-<div class="w-[400px] p-6 space-y-2">
+<div class="space-y-2">
   {{ template "authflowv2/__header.html" . }}
   <br />
   {{ template "authflowv2/__divider.html" (dict "Classname" "h-20") }}

--- a/resources/authgear/templates/en/web/authflowv2/layout.html
+++ b/resources/authgear/templates/en/web/authflowv2/layout.html
@@ -1,0 +1,5 @@
+<!-- This template can be customized by each app. -->
+<!-- Customized layout.html must be placed in templates/en/web/authflowv2/layout.html of app resources -->
+<div class="layout--default">
+  {{ template "widget" . }}
+</div>


### PR DESCRIPTION
ref #3567 

- The layout can be customized by creating a file in `var/templates/en/web/authflowv2/layout.html`

<img width="1266" alt="Screenshot 2024-01-10 at 6 00 10 PM" src="https://github.com/authgear/authgear-server/assets/34942210/5322bfe6-dfdc-4b24-93ef-dc26da7b1a54">

<img width="1266" alt="Screenshot 2024-01-10 at 6 04 52 PM" src="https://github.com/authgear/authgear-server/assets/34942210/abf6217f-4a4b-4fb6-8dba-2773ff0ec0fa">


Customized border, border radius and box shadow:
<img width="1266" alt="Screenshot 2024-01-10 at 6 05 59 PM" src="https://github.com/authgear/authgear-server/assets/34942210/db1f7012-1425-4182-a66f-7e58277660b5">

