### PR TITLE
Fix setup secondary oob otp crashing in auth ui

### DIFF
--- a/pkg/auth/handler/webapp/authflow_change_password.go
+++ b/pkg/auth/handler/webapp/authflow_change_password.go
@@ -81,7 +81,7 @@ func (h *AuthflowChangePasswordHandler) ServeHTTP(w http.ResponseWriter, r *http
 			"new_password": newPlainPassword,
 		}
 
-		result, err := h.Controller.AdvanceWithInput(r, s, screen, input)
+		result, err := h.Controller.AdvanceWithInput(r, s, screen, input, nil)
 		if err != nil {
 			return err
 		}

--- a/pkg/auth/handler/webapp/authflow_controller_test.go
+++ b/pkg/auth/handler/webapp/authflow_controller_test.go
@@ -287,7 +287,7 @@ func TestAuthflowControllerFeedInput(t *testing.T) {
 			}, nil)
 			mockSessionStore.EXPECT().Update(s).Times(1).Return(nil)
 
-			result, err := c.AdvanceWithInput(r, s, screen, input)
+			result, err := c.AdvanceWithInput(r, s, screen, input, nil)
 			So(err, ShouldBeNil)
 			So(strings.HasPrefix(result.RedirectURI, "/authflow/enter_password?x_step="), ShouldBeTrue)
 		})
@@ -369,7 +369,7 @@ func TestAuthflowControllerFeedInput(t *testing.T) {
 				},
 			}, nil)
 
-			result, err := c.AdvanceWithInput(r, s, screen, input)
+			result, err := c.AdvanceWithInput(r, s, screen, input, nil)
 			So(err, ShouldBeNil)
 			So(strings.HasPrefix(result.RedirectURI, "/authflow/enter_oob_otp?x_step="), ShouldBeTrue)
 		})

--- a/pkg/auth/handler/webapp/authflow_create_password.go
+++ b/pkg/auth/handler/webapp/authflow_create_password.go
@@ -113,7 +113,7 @@ func (h *AuthflowCreatePasswordHandler) ServeHTTP(w http.ResponseWriter, r *http
 			"new_password":   newPlainPassword,
 		}
 
-		result, err := h.Controller.AdvanceWithInput(r, s, screen, input)
+		result, err := h.Controller.AdvanceWithInput(r, s, screen, input, nil)
 		if err != nil {
 			return err
 		}

--- a/pkg/auth/handler/webapp/authflow_enter_oob_otp.go
+++ b/pkg/auth/handler/webapp/authflow_enter_oob_otp.go
@@ -132,7 +132,7 @@ func (h *AuthflowEnterOOBOTPHandler) ServeHTTP(w http.ResponseWriter, r *http.Re
 			"request_device_token": requestDeviceToken,
 		}
 
-		result, err := h.Controller.AdvanceWithInput(r, s, screen, input)
+		result, err := h.Controller.AdvanceWithInput(r, s, screen, input, nil)
 		if err != nil {
 			return err
 		}

--- a/pkg/auth/handler/webapp/authflow_enter_password.go
+++ b/pkg/auth/handler/webapp/authflow_enter_password.go
@@ -126,7 +126,7 @@ func (h *AuthflowEnterPasswordHandler) ServeHTTP(w http.ResponseWriter, r *http.
 			"request_device_token": requestDeviceToken,
 		}
 
-		result, err := h.Controller.AdvanceWithInput(r, s, screen, input)
+		result, err := h.Controller.AdvanceWithInput(r, s, screen, input, nil)
 		if err != nil {
 			return err
 		}

--- a/pkg/auth/handler/webapp/authflow_enter_recovery_code.go
+++ b/pkg/auth/handler/webapp/authflow_enter_recovery_code.go
@@ -78,7 +78,7 @@ func (h *AuthflowEnterRecoveryCodeHandler) ServeHTTP(w http.ResponseWriter, r *h
 			"request_device_token": requestDeviceToken,
 		}
 
-		result, err := h.Controller.AdvanceWithInput(r, s, screen, input)
+		result, err := h.Controller.AdvanceWithInput(r, s, screen, input, nil)
 		if err != nil {
 			return err
 		}

--- a/pkg/auth/handler/webapp/authflow_enter_totp.go
+++ b/pkg/auth/handler/webapp/authflow_enter_totp.go
@@ -76,7 +76,7 @@ func (h *AuthflowEnterTOTPHandler) ServeHTTP(w http.ResponseWriter, r *http.Requ
 			"request_device_token": requestDeviceToken,
 		}
 
-		result, err := h.Controller.AdvanceWithInput(r, s, screen, input)
+		result, err := h.Controller.AdvanceWithInput(r, s, screen, input, nil)
 		if err != nil {
 			return err
 		}

--- a/pkg/auth/handler/webapp/authflow_fallback.go
+++ b/pkg/auth/handler/webapp/authflow_fallback.go
@@ -1,0 +1,5 @@
+package webapp
+
+import "fmt"
+
+var ErrNoFallbackAvailable = fmt.Errorf("webapp: no fallback is available")

--- a/pkg/auth/handler/webapp/authflow_forgot_password.go
+++ b/pkg/auth/handler/webapp/authflow_forgot_password.go
@@ -193,7 +193,7 @@ func (h *AuthflowForgotPasswordHandler) ServeHTTP(w http.ResponseWriter, r *http
 
 		inputs := h.makeInputs(screen, identification, loginID, 0)
 
-		result, err := h.Controller.AdvanceWithInputs(r, s, screen, inputs)
+		result, err := h.Controller.AdvanceWithInputs(r, s, screen, inputs, nil)
 		if errors.Is(err, otp.ErrInvalidWhatsappUser) {
 			// The code failed to send because it is not a valid whatsapp user
 			// Try again with sms if possible
@@ -271,7 +271,7 @@ func (h *AuthflowForgotPasswordHandler) fallbackToSMS(
 	}
 
 	inputs := h.makeInputs(screen, identification, loginID, smsOptionIdx)
-	return h.Controller.AdvanceWithInputs(r, s, screen, inputs)
+	return h.Controller.AdvanceWithInputs(r, s, screen, inputs, nil)
 }
 
 func (h *AuthflowForgotPasswordHandler) makeInputs(

--- a/pkg/auth/handler/webapp/authflow_forgot_password.go
+++ b/pkg/auth/handler/webapp/authflow_forgot_password.go
@@ -2,7 +2,6 @@ package webapp
 
 import (
 	"errors"
-	"fmt"
 	"net/http"
 
 	"github.com/authgear/authgear-server/pkg/auth/handler/webapp/viewmodels"
@@ -200,7 +199,9 @@ func (h *AuthflowForgotPasswordHandler) ServeHTTP(w http.ResponseWriter, r *http
 			// Try again with sms if possible
 			var fallbackErr error
 			result, fallbackErr = h.fallbackToSMS(r, s, screen, identification, loginID)
-			if fallbackErr != nil {
+			if errors.Is(fallbackErr, ErrNoFallbackAvailable) {
+				return err
+			} else if fallbackErr != nil {
 				return fallbackErr
 			}
 		} else if err != nil {
@@ -266,7 +267,7 @@ func (h *AuthflowForgotPasswordHandler) fallbackToSMS(
 	}
 	if smsOptionIdx == -1 {
 		// No sms option is available, failing
-		return nil, fmt.Errorf("webapp: whatsapp is unavailable and no sms option is available")
+		return nil, ErrNoFallbackAvailable
 	}
 
 	inputs := h.makeInputs(screen, identification, loginID, smsOptionIdx)

--- a/pkg/auth/handler/webapp/authflow_forgot_password_otp.go
+++ b/pkg/auth/handler/webapp/authflow_forgot_password_otp.go
@@ -179,7 +179,7 @@ func (h *AuthflowForgotPasswordOTPHandler) ServeHTTP(w http.ResponseWriter, r *h
 			return fmt.Errorf("authflow webapp: unexpected previous step")
 		}
 
-		result, err := h.Controller.AdvanceWithInput(r, s, prevScreen, input)
+		result, err := h.Controller.AdvanceWithInput(r, s, prevScreen, input, nil)
 		if err != nil {
 			return err
 		}
@@ -199,7 +199,7 @@ func (h *AuthflowForgotPasswordOTPHandler) ServeHTTP(w http.ResponseWriter, r *h
 			"account_recovery_code": code,
 		}
 
-		result, err := h.Controller.AdvanceWithInput(r, s, screen, input)
+		result, err := h.Controller.AdvanceWithInput(r, s, screen, input, nil)
 		if err != nil {
 			return err
 		}

--- a/pkg/auth/handler/webapp/authflow_login.go
+++ b/pkg/auth/handler/webapp/authflow_login.go
@@ -155,7 +155,7 @@ func (h *AuthflowLoginHandler) ServeHTTP(w http.ResponseWriter, r *http.Request)
 			"login_id":       loginID,
 		}
 
-		result, err := h.Controller.AdvanceWithInput(r, s, screen, input)
+		result, err := h.Controller.AdvanceWithInput(r, s, screen, input, nil)
 		if err != nil {
 			return err
 		}
@@ -178,7 +178,7 @@ func (h *AuthflowLoginHandler) ServeHTTP(w http.ResponseWriter, r *http.Request)
 			"assertion_response": assertionResponseJSON,
 		}
 
-		result, err := h.Controller.AdvanceWithInput(r, s, screen, input)
+		result, err := h.Controller.AdvanceWithInput(r, s, screen, input, nil)
 		if err != nil {
 			return err
 		}

--- a/pkg/auth/handler/webapp/authflow_oob_otp_link.go
+++ b/pkg/auth/handler/webapp/authflow_oob_otp_link.go
@@ -112,7 +112,7 @@ func (h *AuthflowOOBOTPLinkHandler) ServeHTTP(w http.ResponseWriter, r *http.Req
 			"request_device_token": requestDeviceToken,
 		}
 
-		result, err := h.Controller.AdvanceWithInput(r, s, screen, input)
+		result, err := h.Controller.AdvanceWithInput(r, s, screen, input, nil)
 		if err != nil {
 			return err
 		}

--- a/pkg/auth/handler/webapp/authflow_promote.go
+++ b/pkg/auth/handler/webapp/authflow_promote.go
@@ -86,7 +86,7 @@ func (h *AuthflowPromoteHandler) ServeHTTP(w http.ResponseWriter, r *http.Reques
 			"response_mode":  string(sso.ResponseModeFormPost),
 		}
 
-		result, err := h.Controller.AdvanceWithInput(r, s, screen, input)
+		result, err := h.Controller.AdvanceWithInput(r, s, screen, input, nil)
 		if err != nil {
 			return err
 		}
@@ -109,7 +109,7 @@ func (h *AuthflowPromoteHandler) ServeHTTP(w http.ResponseWriter, r *http.Reques
 			"login_id":       loginID,
 		}
 
-		result, err := h.Controller.AdvanceWithInput(r, s, screen, input)
+		result, err := h.Controller.AdvanceWithInput(r, s, screen, input, nil)
 		if err != nil {
 			return err
 		}

--- a/pkg/auth/handler/webapp/authflow_prompt_create_passkey.go
+++ b/pkg/auth/handler/webapp/authflow_prompt_create_passkey.go
@@ -69,7 +69,7 @@ func (h *AuthflowPromptCreatePasskeyHandler) ServeHTTP(w http.ResponseWriter, r 
 			"skip": true,
 		}
 
-		result, err := h.Controller.AdvanceWithInput(r, s, screen, input)
+		result, err := h.Controller.AdvanceWithInput(r, s, screen, input, nil)
 		if err != nil {
 			return err
 		}
@@ -90,7 +90,7 @@ func (h *AuthflowPromptCreatePasskeyHandler) ServeHTTP(w http.ResponseWriter, r 
 			"creation_response": creationResponseJSON,
 		}
 
-		result, err := h.Controller.AdvanceWithInput(r, s, screen, input)
+		result, err := h.Controller.AdvanceWithInput(r, s, screen, input, nil)
 		if err != nil {
 			return err
 		}

--- a/pkg/auth/handler/webapp/authflow_reset_password.go
+++ b/pkg/auth/handler/webapp/authflow_reset_password.go
@@ -99,7 +99,7 @@ func (h *AuthflowResetPasswordHandler) ServeHTTP(w http.ResponseWriter, r *http.
 
 		result, err := h.Controller.AdvanceWithInput(r, s, screen, map[string]interface{}{
 			"new_password": newPassword,
-		})
+		}, nil)
 
 		if err != nil {
 			return err

--- a/pkg/auth/handler/webapp/authflow_setup_oob_otp.go
+++ b/pkg/auth/handler/webapp/authflow_setup_oob_otp.go
@@ -116,7 +116,9 @@ func (h *AuthflowSetupOOBOTPHandler) ServeHTTP(w http.ResponseWriter, r *http.Re
 			"channel":        channel,
 		}
 
-		result, err := h.Controller.AdvanceWithInput(r, s, screen, input)
+		result, err := h.Controller.AdvanceWithInput(r, s, screen, input, &AdvanceOptions{
+			InheritTakenBranchState: true,
+		})
 		if errors.Is(err, otp.ErrInvalidWhatsappUser) {
 			// The code failed to send because it is not a valid whatsapp user
 			// Try again with sms if possible
@@ -163,5 +165,7 @@ func (h *AuthflowSetupOOBOTPHandler) tryFallbackToSMS(
 		"target":         target,
 		"channel":        channels[smsOptionIdx],
 	}
-	return h.Controller.AdvanceWithInput(r, s, screen, input)
+	return h.Controller.AdvanceWithInput(r, s, screen, input, &AdvanceOptions{
+		InheritTakenBranchState: true,
+	})
 }

--- a/pkg/auth/handler/webapp/authflow_setup_oob_otp.go
+++ b/pkg/auth/handler/webapp/authflow_setup_oob_otp.go
@@ -100,12 +100,18 @@ func (h *AuthflowSetupOOBOTPHandler) ServeHTTP(w http.ResponseWriter, r *http.Re
 		screenData := screen.StateTokenFlowResponse.Action.Data.(declarative.IntentSignupFlowStepCreateAuthenticatorData)
 		option := screenData.Options[index]
 		authentication := option.Authentication
+		channel := screen.Screen.TakenChannel
 
 		target := r.Form.Get("x_target")
+
+		if channel == "" {
+			channel = option.Channels[0]
+		}
 
 		input := map[string]interface{}{
 			"authentication": authentication,
 			"target":         target,
+			"channel":        channel,
 		}
 
 		result, err := h.Controller.AdvanceWithInput(r, s, screen, input)

--- a/pkg/auth/handler/webapp/authflow_setup_totp.go
+++ b/pkg/auth/handler/webapp/authflow_setup_totp.go
@@ -99,7 +99,7 @@ func (h *AuthflowSetupTOTPHandler) ServeHTTP(w http.ResponseWriter, r *http.Requ
 			"code": code,
 		}
 
-		result, err := h.Controller.AdvanceWithInput(r, s, screen, input)
+		result, err := h.Controller.AdvanceWithInput(r, s, screen, input, nil)
 		if err != nil {
 			return err
 		}

--- a/pkg/auth/handler/webapp/authflow_signup.go
+++ b/pkg/auth/handler/webapp/authflow_signup.go
@@ -127,7 +127,7 @@ func (h *AuthflowSignupHandler) ServeHTTP(w http.ResponseWriter, r *http.Request
 			"login_id":       loginID,
 		}
 
-		result, err := h.Controller.AdvanceWithInput(r, s, screen, input)
+		result, err := h.Controller.AdvanceWithInput(r, s, screen, input, nil)
 		if err != nil {
 			return err
 		}

--- a/pkg/auth/handler/webapp/authflow_terminate_other_sessions.go
+++ b/pkg/auth/handler/webapp/authflow_terminate_other_sessions.go
@@ -51,7 +51,7 @@ func (h *AuthflowTerminateOtherSessionsHandler) ServeHTTP(w http.ResponseWriter,
 			"confirm_terminate_other_sessions": true,
 		}
 
-		result, err := h.Controller.AdvanceWithInput(r, s, screen, input)
+		result, err := h.Controller.AdvanceWithInput(r, s, screen, input, nil)
 		if err != nil {
 			return err
 		}

--- a/pkg/auth/handler/webapp/authflow_use_passkey.go
+++ b/pkg/auth/handler/webapp/authflow_use_passkey.go
@@ -96,7 +96,7 @@ func (h *AuthflowUsePasskeyHandler) ServeHTTP(w http.ResponseWriter, r *http.Req
 			"assertion_response": assertionResponseJSON,
 		}
 
-		result, err := h.Controller.AdvanceWithInput(r, s, screen, input)
+		result, err := h.Controller.AdvanceWithInput(r, s, screen, input, nil)
 		if err != nil {
 			return err
 		}

--- a/pkg/auth/handler/webapp/authflow_view_recovery_code.go
+++ b/pkg/auth/handler/webapp/authflow_view_recovery_code.go
@@ -73,7 +73,7 @@ func (h *AuthflowViewRecoveryCodeHandler) ServeHTTP(w http.ResponseWriter, r *ht
 			"confirm_recovery_code": true,
 		}
 
-		result, err := h.Controller.AdvanceWithInput(r, s, screen, input)
+		result, err := h.Controller.AdvanceWithInput(r, s, screen, input, nil)
 		if err != nil {
 			return err
 		}

--- a/pkg/auth/handler/webapp/authflow_wechat.go
+++ b/pkg/auth/handler/webapp/authflow_wechat.go
@@ -105,7 +105,7 @@ func (h *AuthflowWechatHandler) ServeHTTP(w http.ResponseWriter, r *http.Request
 			input["error_description"] = data.ErrorDescription
 		}
 
-		result, err := h.Controller.AdvanceWithInput(r, s, screen, input)
+		result, err := h.Controller.AdvanceWithInput(r, s, screen, input, nil)
 		if err != nil {
 			return err
 		}

--- a/pkg/auth/handler/webapp/authflow_whatsapp_otp.go
+++ b/pkg/auth/handler/webapp/authflow_whatsapp_otp.go
@@ -126,7 +126,7 @@ func (h *AuthflowWhatsappOTPHandler) ServeHTTP(w http.ResponseWriter, r *http.Re
 			"request_device_token": requestDeviceToken,
 		}
 
-		result, err := h.Controller.AdvanceWithInput(r, s, screen, input)
+		result, err := h.Controller.AdvanceWithInput(r, s, screen, input, nil)
 		if err != nil {
 			return err
 		}

--- a/pkg/auth/webapp/session_authflow.go
+++ b/pkg/auth/webapp/session_authflow.go
@@ -361,6 +361,15 @@ type TakeBranchOptions struct {
 	DisableFallbackToSMS bool
 }
 
+func (s *AuthflowScreenWithFlowResponse) InheritTakenBranchState(from *AuthflowScreenWithFlowResponse) {
+	if from.BranchStateTokenFlowResponse != nil {
+		s.BranchStateTokenFlowResponse = from.BranchStateTokenFlowResponse
+		s.Screen.BranchStateToken = from.Screen.BranchStateToken
+		s.Screen.TakenBranchIndex = from.Screen.TakenBranchIndex
+		s.Screen.TakenChannel = from.Screen.TakenChannel
+	}
+}
+
 func (s *AuthflowScreenWithFlowResponse) TakeBranch(index int, channel model.AuthenticatorOOBChannel, options *TakeBranchOptions) TakeBranchResult {
 	switch s.StateTokenFlowResponse.Type {
 	case authflow.FlowTypeSignup:

--- a/resources/authgear/templates/en/translation.json
+++ b/resources/authgear/templates/en/translation.json
@@ -471,6 +471,7 @@
   "phone-otp-verify-with-whatsapp-instead": "Verify via WhatsApp instead",
 
   "setup-oob-otp-title--sms": "Set up SMS 2-step verification",
+  "setup-oob-otp-title--whatsapp": "Set up WhatsApp 2-step verification",
   "setup-oob-otp-title--email": "Set up email 2-step verification",
 
   "setup-whatsapp-otp-title": "Set up phone 2-step verification",

--- a/resources/authgear/templates/en/web/authflow_setup_oob_otp.html
+++ b/resources/authgear/templates/en/web/authflow_setup_oob_otp.html
@@ -5,7 +5,11 @@
 
 <h1 class="m-0 primary-txt text-center text-xl font-bold">
 {{- if eq $.OOBAuthenticatorType "oob_otp_sms" }}
-	{{ template "setup-oob-otp-title--sms" }}
+	{{- if eq .Channel "whatsapp" }}
+		{{ template "setup-oob-otp-title--whatsapp" }}
+	{{ else }}
+		{{ template "setup-oob-otp-title--sms" }}
+	{{- end }}
 {{- end }}
 {{- if eq $.OOBAuthenticatorType "oob_otp_email" }}
 	{{ template "setup-oob-otp-title--email" }}

--- a/resources/authgear/templates/zh-HK/translation.json
+++ b/resources/authgear/templates/zh-HK/translation.json
@@ -471,6 +471,7 @@
   "phone-otp-verify-with-whatsapp-instead": "改為通過 WhatsApp 驗證",
 
   "setup-oob-otp-title--sms": "設置短訊雙重驗證",
+  "setup-oob-otp-title--whatsapp": "設置WhatsApp雙重驗證",
   "setup-oob-otp-title--email": "設置電郵雙重驗證",
 
   "setup-whatsapp-otp-title": "設置手機兩步驗證",

--- a/resources/authgear/templates/zh-TW/translation.json
+++ b/resources/authgear/templates/zh-TW/translation.json
@@ -471,6 +471,7 @@
   "phone-otp-verify-with-whatsapp-instead": "改為通過 WhatsApp 驗證",
 
   "setup-oob-otp-title--sms": "設置短訊雙重驗證",
+  "setup-oob-otp-title--whatsapp": "設置WhatsApp雙重驗證",
   "setup-oob-otp-title--email": "設置電郵雙重驗證",
 
   "setup-whatsapp-otp-title": "設置手機兩步驗證",


### PR DESCRIPTION
ref #3549 

@fungc-io I removed the fallback to sms logic in this step, because the ux seems confusing. I guess displaying an error is better. Maybe you can test it out in staging later.