### PR TITLE
Fix if only username is enabled, user cannot login with username

### DIFF
--- a/pkg/auth/handler/webapp/authflow_login.go
+++ b/pkg/auth/handler/webapp/authflow_login.go
@@ -26,9 +26,10 @@ var AuthflowLoginLoginIDSchema = validation.NewSimpleSchema(`
 	{
 		"type": "object",
 		"properties": {
-			"q_login_id": { "type": "string" }
+			"x_login_id": { "type": "string" },
+			"x_login_id_input_type": { "type": "string" }
 		},
-		"required": ["q_login_id"]
+		"required": ["x_login_id", "x_login_id_input_type"]
 	}
 `)
 
@@ -148,8 +149,9 @@ func (h *AuthflowLoginHandler) ServeHTTP(w http.ResponseWriter, r *http.Request)
 			return err
 		}
 
-		loginID := r.Form.Get("q_login_id")
-		identification := webapp.GetMostAppropriateIdentification(screen.StateTokenFlowResponse, loginID)
+		loginID := r.Form.Get("x_login_id")
+		loginIDInputType := r.Form.Get("x_login_id_input_type")
+		identification := webapp.GetMostAppropriateIdentification(screen.StateTokenFlowResponse, loginID, loginIDInputType)
 		input := map[string]interface{}{
 			"identification": identification,
 			"login_id":       loginID,

--- a/resources/authgear/templates/en/web/authflow_login.html
+++ b/resources/authgear/templates/en/web/authflow_login.html
@@ -38,6 +38,7 @@
 					{{ template "log-in-to-continue" (dict "AppOrClientName" $appName) }}
 					{{ end }}
 				</h1>
+				<input type="hidden" name="x_login_id_input_type" value="{{ $.LoginIDInputType }}"/>
 
 				{{ if $.LoginIDInputType }}{{ if eq $.LoginIDInputType "phone" }}{{ if $.PhoneLoginIDEnabled }}
 				<input
@@ -50,7 +51,7 @@
 					inputmode="tel"
 					autocomplete="tel-national username webauthn"
 					autocapitalize="none"
-					name="q_login_id"
+					name="x_login_id"
 					placeholder="{{ template "phone-number-placeholder" }}"
 					data-controller="intl-tel-input"
 					data-action="input->intl-tel-input#input countrychange->intl-tel-input#input intl-tel-input:input->retain-form-form#input"
@@ -67,7 +68,7 @@
 					type="{{ $.NonPhoneLoginIDInputType }}"
 					autocomplete="username webauthn"
 					autocapitalize="none"
-					name="q_login_id"
+					name="x_login_id"
 					placeholder="{{ template "login-id-placeholder" (dict "variant" $.NonPhoneLoginIDType) }}"
 					data-controller="retain-form-input"
 					data-action="input->retain-form-input#input retain-form-input:input->retain-form-form#input"


### PR DESCRIPTION
The cause is it passed "identification": "email" to authflow.

ref #3631