### PR TITLE
Add "include" for executing template as a string

### DIFF
--- a/pkg/util/template/engine.go
+++ b/pkg/util/template/engine.go
@@ -2,13 +2,14 @@ package template
 
 import (
 	"fmt"
-	"golang.org/x/text/language"
 	htmltemplate "html/template"
 	"net/http"
 	"strconv"
 	"strings"
 	texttemplate "text/template"
 	"text/template/parse"
+
+	"golang.org/x/text/language"
 
 	"github.com/authgear/authgear-server/pkg/util/intl"
 	"github.com/authgear/authgear-server/pkg/util/messageformat"
@@ -59,7 +60,8 @@ func (e *Engine) Render(resource Resource, preferredLanguages []string, data int
 
 func (e *Engine) renderHTML(desc *HTML, preferredLanguages []string, data interface{}) (string, error) {
 	t := htmltemplate.New("")
-	t.Funcs(DefaultFuncMap)
+	funcMap := MakeTemplateFuncMap(t)
+	t.Funcs(funcMap)
 
 	var loadTemplate func(desc *HTML) error
 	loadTemplate = func(desc *HTML) error {
@@ -123,7 +125,8 @@ func (e *Engine) renderHTML(desc *HTML, preferredLanguages []string, data interf
 
 func (e *Engine) renderPlainText(desc *PlainText, preferredLanguages []string, data interface{}) (string, error) {
 	t := texttemplate.New("")
-	t.Funcs(DefaultFuncMap)
+	funcMap := MakeTemplateFuncMap(t)
+	t.Funcs(funcMap)
 
 	var loadTemplate func(desc *PlainText) error
 	loadTemplate = func(desc *PlainText) error {

--- a/pkg/util/template/func.go
+++ b/pkg/util/template/func.go
@@ -104,7 +104,7 @@ func makeInclude(t tpl) func(tplName string, data any) (template.HTML, error) {
 	) (template.HTML, error) {
 		buf := &bytes.Buffer{}
 		err := t.ExecuteTemplate(buf, tplName, data)
-		html := template.HTML(buf.String())
+		html := template.HTML(buf.String()) // nolint:gosec
 		return html, err
 	}
 }

--- a/pkg/util/template/func.go
+++ b/pkg/util/template/func.go
@@ -3,6 +3,7 @@ package template
 import (
 	"bytes"
 	"fmt"
+	"html/template"
 	"io"
 	"reflect"
 	"strconv"
@@ -96,13 +97,14 @@ func ShowAttributeValue(v interface{}) string {
 	}
 }
 
-func makeInclude(t tpl) func(tplName string, data any) (string, error) {
+func makeInclude(t tpl) func(tplName string, data any) (template.HTML, error) {
 	return func(
 		tplName string,
 		data any,
-	) (string, error) {
+	) (template.HTML, error) {
 		buf := &bytes.Buffer{}
 		err := t.ExecuteTemplate(buf, tplName, data)
-		return buf.String(), err
+		html := template.HTML(buf.String())
+		return html, err
 	}
 }

--- a/pkg/util/template/resource.go
+++ b/pkg/util/template/resource.go
@@ -288,7 +288,8 @@ func viewHTMLTemplates(name string, resources []resource.ResourceFile, view reso
 			return nil, err
 		}
 		tpl := htmltemplate.New(name)
-		tpl.Funcs(DefaultFuncMap)
+		funcMap := MakeTemplateFuncMap(tpl)
+		tpl.Funcs(funcMap)
 		_, err = tpl.Parse(string(bytes.([]byte)))
 		if err != nil {
 			return nil, fmt.Errorf("invalid HTML template: %w", err)
@@ -297,7 +298,8 @@ func viewHTMLTemplates(name string, resources []resource.ResourceFile, view reso
 	case resource.ValidateResourceView:
 		for _, resrc := range resources {
 			tpl := htmltemplate.New(name)
-			tpl.Funcs(DefaultFuncMap)
+			funcMap := MakeTemplateFuncMap(tpl)
+			tpl.Funcs(funcMap)
 			_, err := tpl.Parse(string(resrc.Data))
 			if err != nil {
 				return nil, fmt.Errorf("invalid HTML template: %w", err)
@@ -331,7 +333,8 @@ func viewTextTemplates(name string, resources []resource.ResourceFile, view reso
 			return nil, err
 		}
 		tpl := texttemplate.New(name)
-		tpl.Funcs(DefaultFuncMap)
+		funcMap := MakeTemplateFuncMap(tpl)
+		tpl.Funcs(funcMap)
 		_, err = tpl.Parse(string(bytes.([]byte)))
 		if err != nil {
 			return nil, fmt.Errorf("invalid text template: %w", err)
@@ -340,7 +343,8 @@ func viewTextTemplates(name string, resources []resource.ResourceFile, view reso
 	case resource.ValidateResourceView:
 		for _, resrc := range resources {
 			tpl := texttemplate.New(name)
-			tpl.Funcs(DefaultFuncMap)
+			funcMap := MakeTemplateFuncMap(tpl)
+			tpl.Funcs(funcMap)
 			_, err := tpl.Parse(string(resrc.Data))
 			if err != nil {
 				return nil, fmt.Errorf("invalid text template: %w", err)

--- a/pkg/util/template/translation_map.go
+++ b/pkg/util/template/translation_map.go
@@ -27,7 +27,8 @@ func (t *TranslationMap) RenderText(key string, args interface{}) (string, error
 	}
 
 	tpl := texttemplate.New("")
-	tpl.Funcs(DefaultFuncMap)
+	funcMap := MakeTemplateFuncMap(tpl)
+	tpl.Funcs(funcMap)
 	_, err := tpl.AddParseTree("translation", tree)
 	if err != nil {
 		return "", fmt.Errorf("template: failed to construct template: %w", err)
@@ -55,7 +56,8 @@ func (t *TranslationMap) RenderHTML(key string, args interface{}) (string, error
 	}
 
 	tpl := htmltemplate.New("")
-	tpl.Funcs(DefaultFuncMap)
+	funcMap := MakeTemplateFuncMap(tpl)
+	tpl.Funcs(funcMap)
 	_, err := tpl.AddParseTree("translation", tree)
 	if err != nil {
 		return "", fmt.Errorf("template: failed to construct template: %w", err)


### PR DESCRIPTION
ref #3644 

Usage

```
{{ $errorMessage := include "authflowv2/__error.html" . }}
```