### PR TITLE
Update password strength meter to use role meter

### DIFF
--- a/authui/src/authflowv2/components/password-strength-meter.css
+++ b/authui/src/authflowv2/components/password-strength-meter.css
@@ -31,35 +31,35 @@
     & > .password-strength-meter__icon::after {
       content: "sentiment_very_dissatisfied";
     }
-    &[value="1"] {
+    &[aria-valuenow="1"] {
       color: var(--password-strength-meter__color--zxcvbn-score-1);
       & > .password-strength-meter__icon::after {
         content: "sentiment_very_dissatisfied";
       }
     }
 
-    &[value="2"] {
+    &[aria-valuenow="2"] {
       color: var(--password-strength-meter__color--zxcvbn-score-2);
       & > .password-strength-meter__icon::after {
         content: "sentiment_dissatisfied";
       }
     }
 
-    &[value="3"] {
+    &[aria-valuenow="3"] {
       color: var(--password-strength-meter__color--zxcvbn-score-3);
       & > .password-strength-meter__icon::after {
         content: "sentiment_neutral";
       }
     }
 
-    &[value="4"] {
+    &[aria-valuenow="4"] {
       color: var(--password-strength-meter__color--zxcvbn-score-4);
       & > .password-strength-meter__icon::after {
         content: "sentiment_satisfied";
       }
     }
 
-    &[value="5"] {
+    &[aria-valuenow="5"] {
       color: var(--password-strength-meter__color--zxcvbn-score-5);
       & > .password-strength-meter__icon::after {
         content: "sentiment_very_satisfied";

--- a/authui/src/authflowv2/password-policy.ts
+++ b/authui/src/authflowv2/password-policy.ts
@@ -64,12 +64,12 @@ function checkPasswordSymbol(value: string, el: HTMLElement) {
 function checkPasswordStrength(
   value: string,
   el: HTMLElement,
-  currentMeter: HTMLMeterElement
+  currentMeter: HTMLElement
 ) {
   const minLevel = Number(el.getAttribute("data-min-level"));
   const result = zxcvbn(value);
   const score = Math.min(5, Math.max(1, result.score + 1));
-  currentMeter.value = score;
+  currentMeter.setAttribute("aria-valuenow", String(score));
   if (score >= minLevel) {
     el.setAttribute("data-state", "pass");
   } else {
@@ -82,7 +82,7 @@ export class PasswordPolicyController extends Controller {
 
   declare inputTarget: HTMLInputElement;
   declare hasCurrentMeterTarget: boolean;
-  declare currentMeterTarget: HTMLMeterElement;
+  declare currentMeterTarget: HTMLElement;
   declare policyTargets: HTMLElement[];
 
   connect() {
@@ -93,7 +93,7 @@ export class PasswordPolicyController extends Controller {
     const value = this.inputTarget.value;
     if (value === "") {
       if (this.hasCurrentMeterTarget) {
-        this.currentMeterTarget.value = -1;
+        this.currentMeterTarget.setAttribute("aria-valuenow", "0");
       }
       this.policyTargets.forEach((e) => {
         e.setAttribute("data-state", "");

--- a/authui/src/authflowv2/password-strength-meter.ts
+++ b/authui/src/authflowv2/password-strength-meter.ts
@@ -1,11 +1,11 @@
 import { Controller } from "@hotwired/stimulus";
 
 function updateMeterDescription(
-  currentMeter: HTMLMeterElement,
+  currentMeter: HTMLElement,
   currentMeterDescription: HTMLElement
 ) {
   currentMeterDescription.textContent = currentMeter.getAttribute(
-    "data-desc-" + currentMeter.value
+    "data-desc-" + currentMeter.getAttribute("aria-valuenow")
   );
 }
 
@@ -18,7 +18,7 @@ export class PasswordStrengthMeterController extends Controller {
 
   connect() {
     const callback = () => {
-      this.display();
+      this.update();
     };
     this.observer = new MutationObserver(callback);
     this.observer.observe(this.element, {
@@ -30,9 +30,9 @@ export class PasswordStrengthMeterController extends Controller {
     this.observer = null;
   }
 
-  display() {
+  update() {
     updateMeterDescription(
-      this.element as HTMLMeterElement,
+      this.element as HTMLElement,
       this.currentMeterDescriptionTarget
     );
   }

--- a/resources/authgear/templates/en/web/authflowv2/__password_strength_meter.html
+++ b/resources/authgear/templates/en/web/authflowv2/__password_strength_meter.html
@@ -1,11 +1,12 @@
 {{ define "authflowv2/__password_strength_meter.html" }}
-<meter
+<div
+  role="meter"
   class="{{ $.Classname }} password-strength-meter"
-  min="1"
-  max="5"
+  aria-valuemin="0"
+  aria-valuemax="5"
   data-controller="password-strength-meter"
   data-password-policy-target="currentMeter"
-  data-action="password-strength-meter#display"
+  data-desc-0="{{ template "v2-password-policy-password-strength-meter-1" }}"
   data-desc-1="{{ template "v2-password-policy-password-strength-meter-1" }}"
   data-desc-2="{{ template "v2-password-policy-password-strength-meter-2" }}"
   data-desc-3="{{ template "v2-password-policy-password-strength-meter-3" }}"
@@ -14,5 +15,5 @@
 >
   <span class="password-strength-meter__icon material-icons"></span>
   <span class="password-strength-meter__description" data-password-strength-meter-target="currentMeterDescription">{{ template "v2-password-policy-password-strength-meter-1" }}</span>
-</meter>
+</div>
 {{ end }}


### PR DESCRIPTION
ref #3734

Seems safari won't display element inside `<meter>` element, so update to use `role="meter"` instead
https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/meter_role


https://github.com/authgear/authgear-server/assets/63200569/bd06f367-b96c-4b98-a748-43ed20c6e39a

