### PR TITLE
Determine the country selected before complete phone number is entered

### DIFF
--- a/authui/src/phoneInput.ts
+++ b/authui/src/phoneInput.ts
@@ -8,6 +8,38 @@ import defaultTerritories from "cldr-localenames-full/main/en/territories.json";
 import territoriesMap from "cldr-localenames-full/main/*/territories.json";
 import { getEmojiFlag } from "./getEmojiFlag";
 import { CustomSelectController } from "./customSelect";
+import metadata from "libphonenumber-js/metadata.min.json";
+const CountryCodes = metadata.country_calling_codes;
+// Duplicated country codes
+// {
+//     "1": [ "US", "AG", "AI", "AS", "BB", "BM", "BS", "CA", "DM", "DO", "GD", "GU", "JM", "KN", "KY", "LC", "MP", "MS", "PR", "SX", "TC", "TT", "VC", "VG", "VI" ],
+//     "7": [ "RU", "KZ" ],
+//     "39": [ "IT", "VA" ],
+//     "44": [ "GB", "GG", "IM", "JE" ],
+//     "47": [ "NO", "SJ" ],
+//     "61": [ "AU", "CC", "CX" ],
+//     "212": [ "MA", "EH" ],
+//     "262": [ "RE", "YT" ],
+//     "290": [ "SH", "TA" ],
+//     "358": [ "FI", "AX" ],
+//     "590": [ "GP", "BL", "MF" ],
+//     "599": [ "CW", "BQ" ]
+// }
+
+const defaultCountryForDuplicatedCountryCodes: Record<string, CountryCode> = {
+  "1": "US",
+  "7": "RU",
+  "39": "IT",
+  "44": "GB",
+  "47": "NO",
+  "61": "AU",
+  "212": "MA",
+  "262": "RE",
+  "290": "SH",
+  "358": "FI",
+  "590": "GP",
+  "599": "CW",
+};
 
 interface PhoneInputCountry {
   flagEmoji: string;
@@ -146,9 +178,17 @@ export class PhoneInputController extends Controller {
     let value = target.value;
     const asYouType = new AsYouType();
     asYouType.input(value);
+
+    let countryCodeFromPartialNumber: CountryCode | undefined = undefined;
+    const callingCode = asYouType.getCallingCode();
+    if (callingCode != null) {
+      countryCodeFromPartialNumber =
+        defaultCountryForDuplicatedCountryCodes[callingCode] ??
+        CountryCodes[callingCode][0];
+    }
     const maybeCountry = asYouType.getCountry();
-    if (maybeCountry) {
-      this.countrySelect!.select(maybeCountry);
+    if (maybeCountry || countryCodeFromPartialNumber) {
+      this.countrySelect!.select(maybeCountry ?? countryCodeFromPartialNumber);
     }
     this.updateValue();
   }


### PR DESCRIPTION
ref #3765

Can not completely duplicate the behaviour of `intl-tel-input`.

----------------

`intl-tel-input` is referencing a custom dataset  and it will combine the country calling code and area code to determine the country before the complete phone number is entered

 https://github.com/authgear/intl-tel-input/blob/master/src/js/data.js
https://github.com/authgear/intl-tel-input/blob/3e25f91f1ab5af622caf878b971d9e87b4d770d9/src/js/intlTelInput.js#L289


`libphonenumber.js`  has similar mechanism called `leading_digits` but only some of the countries are defined so it doesn't work for all phone number (e.g. US and Canada) and complete phone number is required to determine the country for these countries. It's using regex to do the matching for those case 

https://gitlab.com/catamphetamine/libphonenumber-js/blob/master/METADATA.md#leading_digits
https://gitlab.com/catamphetamine/libphonenumber-js/-/blob/master/PhoneNumberMetadata.xml#L5321

---------------------------

There are also another issue.  `intl-tel-input` has defined common countries to be the first one when duplicate country calling code are encountered (e.g. US and UK) https://github.com/authgear/intl-tel-input/blob/3e25f91f1ab5af622caf878b971d9e87b4d770d9/src/js/data.js#L1246

But `libphonenumber.js` doesn't have such mechanism and hence when we type `+1` (US's code),  `Antigua and Barbuda`'s option is the first one to be selected.






https://github.com/authgear/authgear-server/assets/63200569/ab88f589-b774-4f92-ba1b-3a48d2fbdeec





