### PR TITLE
Use monospace font for code block

### DIFF
--- a/authui/src/authflowv2/components/code-block.css
+++ b/authui/src/authflowv2/components/code-block.css
@@ -3,7 +3,8 @@
     --code-block__bg-color: var(--color-neutral-100);
     --code-block__border-radius: var(--border-radius-rounded-square);
     --code-block__text-color: var(--color-neutral-700);
-    --code-block__font-family: var(--typography-body-small__font-family);
+    --code-block__font-family: ui-monospace, sfmono-regular, menlo, monaco,
+      consolas, "Liberation Mono", "Courier New", monospace; /* = tailwind font-mono */
     --code-block__font-size: var(--typography-body-small__font-size);
     --code-block__line-height: var(--typography-body-small__line-height);
     --code-block__letter-spacing: var(--typography-body-small__letter-spacing);


### PR DESCRIPTION
ref #3747

<img width="731" alt="Screenshot 2024-02-22 at 4 43 50 PM" src="https://github.com/authgear/authgear-server/assets/63200569/ea537ed8-a9bc-4f30-a3de-5c25892fd91f">
