### PR TITLE
Handle ui implementation in sso callback

### DIFF
--- a/pkg/auth/deps.go
+++ b/pkg/auth/deps.go
@@ -347,11 +347,14 @@ func RequestMiddleware(p *deps.RootProvider, configSource *configsource.ConfigSo
 
 var AuthflowUIHandlerDependencySet = wire.NewSet(
 	wire.Struct(new(webapp.AuthflowNavigator), "*"),
+	wire.Struct(new(handlerwebappauthflowv2.AuthflowV2Navigator), "*"),
 	wire.Bind(new(handlerwebapp.AuthflowNavigator), new(*webapp.AuthflowNavigator)),
+	wire.Bind(new(handlerwebapp.AuthflowNavigatorV2), new(*handlerwebappauthflowv2.AuthflowV2Navigator)),
 )
 
 var AuthflowV2UIHandlerDependencySet = wire.NewSet(
 	wire.Struct(new(handlerwebappauthflowv2.AuthflowV2Navigator), "*"),
 	wire.Bind(new(handlerwebapp.AuthflowNavigator), new(*handlerwebappauthflowv2.AuthflowV2Navigator)),
+	wire.Bind(new(handlerwebapp.AuthflowNavigatorV2), new(*handlerwebappauthflowv2.AuthflowV2Navigator)),
 	wire.Bind(new(handlerwebappauthflowv2.AuthflowV2ChangePasswordNavigator), new(*handlerwebappauthflowv2.AuthflowV2Navigator)),
 )

--- a/pkg/auth/handler/webapp/authflow_controller_mock_test.go
+++ b/pkg/auth/handler/webapp/authflow_controller_mock_test.go
@@ -419,3 +419,76 @@ func (mr *MockAuthflowNavigatorMockRecorder) NavigateSelectAccount(result interf
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NavigateSelectAccount", reflect.TypeOf((*MockAuthflowNavigator)(nil).NavigateSelectAccount), result)
 }
+
+// MockAuthflowNavigatorV2 is a mock of AuthflowNavigatorV2 interface.
+type MockAuthflowNavigatorV2 struct {
+	ctrl     *gomock.Controller
+	recorder *MockAuthflowNavigatorV2MockRecorder
+}
+
+// MockAuthflowNavigatorV2MockRecorder is the mock recorder for MockAuthflowNavigatorV2.
+type MockAuthflowNavigatorV2MockRecorder struct {
+	mock *MockAuthflowNavigatorV2
+}
+
+// NewMockAuthflowNavigatorV2 creates a new mock instance.
+func NewMockAuthflowNavigatorV2(ctrl *gomock.Controller) *MockAuthflowNavigatorV2 {
+	mock := &MockAuthflowNavigatorV2{ctrl: ctrl}
+	mock.recorder = &MockAuthflowNavigatorV2MockRecorder{mock}
+	return mock
+}
+
+// EXPECT returns an object that allows the caller to indicate expected use.
+func (m *MockAuthflowNavigatorV2) EXPECT() *MockAuthflowNavigatorV2MockRecorder {
+	return m.recorder
+}
+
+// Navigate mocks base method.
+func (m *MockAuthflowNavigatorV2) Navigate(screen *webapp.AuthflowScreenWithFlowResponse, r *http.Request, webSessionID string, result *webapp.Result) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "Navigate", screen, r, webSessionID, result)
+}
+
+// Navigate indicates an expected call of Navigate.
+func (mr *MockAuthflowNavigatorV2MockRecorder) Navigate(screen, r, webSessionID, result interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Navigate", reflect.TypeOf((*MockAuthflowNavigatorV2)(nil).Navigate), screen, r, webSessionID, result)
+}
+
+// NavigateNonRecoverableError mocks base method.
+func (m *MockAuthflowNavigatorV2) NavigateNonRecoverableError(r *http.Request, u *url.URL, e error) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "NavigateNonRecoverableError", r, u, e)
+}
+
+// NavigateNonRecoverableError indicates an expected call of NavigateNonRecoverableError.
+func (mr *MockAuthflowNavigatorV2MockRecorder) NavigateNonRecoverableError(r, u, e interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NavigateNonRecoverableError", reflect.TypeOf((*MockAuthflowNavigatorV2)(nil).NavigateNonRecoverableError), r, u, e)
+}
+
+// NavigateResetPasswordSuccessPage mocks base method.
+func (m *MockAuthflowNavigatorV2) NavigateResetPasswordSuccessPage() string {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "NavigateResetPasswordSuccessPage")
+	ret0, _ := ret[0].(string)
+	return ret0
+}
+
+// NavigateResetPasswordSuccessPage indicates an expected call of NavigateResetPasswordSuccessPage.
+func (mr *MockAuthflowNavigatorV2MockRecorder) NavigateResetPasswordSuccessPage() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NavigateResetPasswordSuccessPage", reflect.TypeOf((*MockAuthflowNavigatorV2)(nil).NavigateResetPasswordSuccessPage))
+}
+
+// NavigateSelectAccount mocks base method.
+func (m *MockAuthflowNavigatorV2) NavigateSelectAccount(result *webapp.Result) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "NavigateSelectAccount", result)
+}
+
+// NavigateSelectAccount indicates an expected call of NavigateSelectAccount.
+func (mr *MockAuthflowNavigatorV2MockRecorder) NavigateSelectAccount(result interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NavigateSelectAccount", reflect.TypeOf((*MockAuthflowNavigatorV2)(nil).NavigateSelectAccount), result)
+}

--- a/pkg/auth/handler/webapp/authflow_controller_test.go
+++ b/pkg/auth/handler/webapp/authflow_controller_test.go
@@ -54,13 +54,16 @@ func TestAuthflowControllerGetOrCreateWebSession(t *testing.T) {
 		mockSessionStore := NewMockAuthflowControllerSessionStore(ctrl)
 		mockCookieManager := NewMockAuthflowControllerCookieManager(ctrl)
 		mockNavigator := NewNoopAuthflowNavigator()
+		mockNavigatorV2 := NewMockAuthflowNavigatorV2(ctrl)
 
 		c := &AuthflowController{
 			Clock:         clock.NewMockClockAt("2006-01-02T03:04:05Z"),
 			Cookies:       mockCookieManager,
 			Sessions:      mockSessionStore,
 			SessionCookie: webapp.NewSessionCookieDef(),
-			Navigator:     mockNavigator,
+			NavigatorV1:   mockNavigator,
+			NavigatorV2:   mockNavigatorV2,
+			UIConfig:      &config.UIConfig{},
 		}
 
 		Convey("Create new if not in context", func() {
@@ -105,10 +108,13 @@ func TestAuthflowControllerGetScreen(t *testing.T) {
 
 		mockAuthflows := NewMockAuthflowControllerAuthflowService(ctrl)
 		mockNavigator := NewNoopAuthflowNavigator()
+		mockNavigatorV2 := NewNoopAuthflowNavigator()
 
 		c := &AuthflowController{
-			Authflows: mockAuthflows,
-			Navigator: mockNavigator,
+			Authflows:   mockAuthflows,
+			NavigatorV1: mockNavigator,
+			NavigatorV2: mockNavigatorV2,
+			UIConfig:    &config.UIConfig{},
 		}
 
 		Convey("return ErrFlowNotFound if session has no authflow", func() {
@@ -206,12 +212,15 @@ func TestAuthflowControllerCreateScreen(t *testing.T) {
 		mockSessionStore := NewMockAuthflowControllerSessionStore(ctrl)
 		mockClock := clock.NewMockClockAt("2006-01-02T03:04:05Z")
 		mockNavigator := NewNoopAuthflowNavigator()
+		mockNavigatorV2 := NewNoopAuthflowNavigator()
 
 		c := &AuthflowController{
-			Clock:     mockClock,
-			Authflows: mockAuthflows,
-			Sessions:  mockSessionStore,
-			Navigator: mockNavigator,
+			Clock:       mockClock,
+			Authflows:   mockAuthflows,
+			Sessions:    mockSessionStore,
+			NavigatorV1: mockNavigator,
+			NavigatorV2: mockNavigatorV2,
+			UIConfig:    &config.UIConfig{},
 		}
 
 		Convey("create screen", func() {
@@ -255,12 +264,15 @@ func TestAuthflowControllerFeedInput(t *testing.T) {
 		mockSessionStore := NewMockAuthflowControllerSessionStore(ctrl)
 		mockClock := clock.NewMockClockAt("2006-01-02T03:04:05Z")
 		mockNavigator := &webapp.AuthflowNavigator{}
+		mockNavigatorV2 := &webapp.AuthflowNavigator{}
 
 		c := AuthflowController{
-			Clock:     mockClock,
-			Authflows: mockAuthflows,
-			Sessions:  mockSessionStore,
-			Navigator: mockNavigator,
+			Clock:       mockClock,
+			Authflows:   mockAuthflows,
+			Sessions:    mockSessionStore,
+			NavigatorV1: mockNavigator,
+			NavigatorV2: mockNavigatorV2,
+			UIConfig:    &config.UIConfig{},
 		}
 
 		Convey("the branch does not require input to take", func() {

--- a/pkg/auth/wire_gen.go
+++ b/pkg/auth/wire_gen.go
@@ -11934,6 +11934,11 @@ func newWebAppSSOCallbackHandler(p *deps.RequestProvider) http.Handler {
 		UIConfig:    uiConfig,
 		ErrorCookie: errorCookie,
 	}
+	authflowV2Navigator := &authflowv2.AuthflowV2Navigator{
+		Endpoints:   endpointsEndpoints,
+		UIConfig:    uiConfig,
+		ErrorCookie: errorCookie,
+	}
 	authflowController := &webapp.AuthflowController{
 		Logger:                  authflowControllerLogger,
 		TesterEndpointsProvider: endpointsEndpoints,
@@ -11949,7 +11954,8 @@ func newWebAppSSOCallbackHandler(p *deps.RequestProvider) http.Handler {
 		UIInfoResolver:          uiInfoResolver,
 		UIConfig:                uiConfig,
 		OAuthClientResolver:     oauthclientResolver,
-		Navigator:               authflowNavigator,
+		NavigatorV1:             authflowNavigator,
+		NavigatorV2:             authflowV2Navigator,
 	}
 	webappServiceLogger := webapp2.NewServiceLogger(factory)
 	interactionLogger := interaction.NewLogger(factory)
@@ -54550,7 +54556,8 @@ func newWebAppAuthflowV2ErrorHandler(p *deps.RequestProvider) http.Handler {
 		UIInfoResolver:          uiInfoResolver,
 		UIConfig:                uiConfig,
 		OAuthClientResolver:     oauthclientResolver,
-		Navigator:               authflowV2Navigator,
+		NavigatorV1:             authflowV2Navigator,
+		NavigatorV2:             authflowV2Navigator,
 	}
 	uiFeatureConfig := featureConfig.UI
 	forgotPasswordConfig := appConfig.ForgotPassword
@@ -68178,6 +68185,11 @@ func newWebAppAuthflowLoginHandler(p *deps.RequestProvider) http.Handler {
 		UIConfig:    uiConfig,
 		ErrorCookie: errorCookie,
 	}
+	authflowV2Navigator := &authflowv2.AuthflowV2Navigator{
+		Endpoints:   endpointsEndpoints,
+		UIConfig:    uiConfig,
+		ErrorCookie: errorCookie,
+	}
 	authflowController := &webapp.AuthflowController{
 		Logger:                  authflowControllerLogger,
 		TesterEndpointsProvider: endpointsEndpoints,
@@ -68193,7 +68205,8 @@ func newWebAppAuthflowLoginHandler(p *deps.RequestProvider) http.Handler {
 		UIInfoResolver:          uiInfoResolver,
 		UIConfig:                uiConfig,
 		OAuthClientResolver:     oauthclientResolver,
-		Navigator:               authflowNavigator,
+		NavigatorV1:             authflowNavigator,
+		NavigatorV2:             authflowV2Navigator,
 	}
 	uiFeatureConfig := featureConfig.UI
 	forgotPasswordConfig := appConfig.ForgotPassword
@@ -69117,7 +69130,8 @@ func newWebAppAuthflowV2LoginHandler(p *deps.RequestProvider) http.Handler {
 		UIInfoResolver:          uiInfoResolver,
 		UIConfig:                uiConfig,
 		OAuthClientResolver:     oauthclientResolver,
-		Navigator:               authflowV2Navigator,
+		NavigatorV1:             authflowV2Navigator,
+		NavigatorV2:             authflowV2Navigator,
 	}
 	uiFeatureConfig := featureConfig.UI
 	forgotPasswordConfig := appConfig.ForgotPassword
@@ -70038,6 +70052,11 @@ func newWebAppAuthflowSignupHandler(p *deps.RequestProvider) http.Handler {
 		UIConfig:    uiConfig,
 		ErrorCookie: errorCookie,
 	}
+	authflowV2Navigator := &authflowv2.AuthflowV2Navigator{
+		Endpoints:   endpointsEndpoints,
+		UIConfig:    uiConfig,
+		ErrorCookie: errorCookie,
+	}
 	authflowController := &webapp.AuthflowController{
 		Logger:                  authflowControllerLogger,
 		TesterEndpointsProvider: endpointsEndpoints,
@@ -70053,7 +70072,8 @@ func newWebAppAuthflowSignupHandler(p *deps.RequestProvider) http.Handler {
 		UIInfoResolver:          uiInfoResolver,
 		UIConfig:                uiConfig,
 		OAuthClientResolver:     oauthclientResolver,
-		Navigator:               authflowNavigator,
+		NavigatorV1:             authflowNavigator,
+		NavigatorV2:             authflowV2Navigator,
 	}
 	uiFeatureConfig := featureConfig.UI
 	forgotPasswordConfig := appConfig.ForgotPassword
@@ -70976,7 +70996,8 @@ func newWebAppAuthflowV2SignupHandler(p *deps.RequestProvider) http.Handler {
 		UIInfoResolver:          uiInfoResolver,
 		UIConfig:                uiConfig,
 		OAuthClientResolver:     oauthclientResolver,
-		Navigator:               authflowV2Navigator,
+		NavigatorV1:             authflowV2Navigator,
+		NavigatorV2:             authflowV2Navigator,
 	}
 	uiFeatureConfig := featureConfig.UI
 	forgotPasswordConfig := appConfig.ForgotPassword
@@ -71888,6 +71909,11 @@ func newWebAppAuthflowPromoteHandler(p *deps.RequestProvider) http.Handler {
 		UIConfig:    uiConfig,
 		ErrorCookie: errorCookie,
 	}
+	authflowV2Navigator := &authflowv2.AuthflowV2Navigator{
+		Endpoints:   endpointsEndpoints,
+		UIConfig:    uiConfig,
+		ErrorCookie: errorCookie,
+	}
 	authflowController := &webapp.AuthflowController{
 		Logger:                  authflowControllerLogger,
 		TesterEndpointsProvider: endpointsEndpoints,
@@ -71903,7 +71929,8 @@ func newWebAppAuthflowPromoteHandler(p *deps.RequestProvider) http.Handler {
 		UIInfoResolver:          uiInfoResolver,
 		UIConfig:                uiConfig,
 		OAuthClientResolver:     oauthclientResolver,
-		Navigator:               authflowNavigator,
+		NavigatorV1:             authflowNavigator,
+		NavigatorV2:             authflowV2Navigator,
 	}
 	uiFeatureConfig := featureConfig.UI
 	forgotPasswordConfig := appConfig.ForgotPassword
@@ -72809,7 +72836,8 @@ func newWebAppAuthflowV2PromoteHandler(p *deps.RequestProvider) http.Handler {
 		UIInfoResolver:          uiInfoResolver,
 		UIConfig:                uiConfig,
 		OAuthClientResolver:     oauthclientResolver,
-		Navigator:               authflowV2Navigator,
+		NavigatorV1:             authflowV2Navigator,
+		NavigatorV2:             authflowV2Navigator,
 	}
 	uiFeatureConfig := featureConfig.UI
 	forgotPasswordConfig := appConfig.ForgotPassword
@@ -73700,6 +73728,11 @@ func newWebAppAuthflowEnterPasswordHandler(p *deps.RequestProvider) http.Handler
 		UIConfig:    uiConfig,
 		ErrorCookie: errorCookie,
 	}
+	authflowV2Navigator := &authflowv2.AuthflowV2Navigator{
+		Endpoints:   endpointsEndpoints,
+		UIConfig:    uiConfig,
+		ErrorCookie: errorCookie,
+	}
 	authflowController := &webapp.AuthflowController{
 		Logger:                  authflowControllerLogger,
 		TesterEndpointsProvider: endpointsEndpoints,
@@ -73715,7 +73748,8 @@ func newWebAppAuthflowEnterPasswordHandler(p *deps.RequestProvider) http.Handler
 		UIInfoResolver:          uiInfoResolver,
 		UIConfig:                uiConfig,
 		OAuthClientResolver:     oauthclientResolver,
-		Navigator:               authflowNavigator,
+		NavigatorV1:             authflowNavigator,
+		NavigatorV2:             authflowV2Navigator,
 	}
 	uiFeatureConfig := featureConfig.UI
 	forgotPasswordConfig := appConfig.ForgotPassword
@@ -74615,7 +74649,8 @@ func newWebAppAuthflowV2EnterPasswordHandler(p *deps.RequestProvider) http.Handl
 		UIInfoResolver:          uiInfoResolver,
 		UIConfig:                uiConfig,
 		OAuthClientResolver:     oauthclientResolver,
-		Navigator:               authflowV2Navigator,
+		NavigatorV1:             authflowV2Navigator,
+		NavigatorV2:             authflowV2Navigator,
 	}
 	uiFeatureConfig := featureConfig.UI
 	forgotPasswordConfig := appConfig.ForgotPassword
@@ -75500,6 +75535,11 @@ func newWebAppAuthflowEnterOOBOTPHandler(p *deps.RequestProvider) http.Handler {
 		UIConfig:    uiConfig,
 		ErrorCookie: errorCookie,
 	}
+	authflowV2Navigator := &authflowv2.AuthflowV2Navigator{
+		Endpoints:   endpointsEndpoints,
+		UIConfig:    uiConfig,
+		ErrorCookie: errorCookie,
+	}
 	authflowController := &webapp.AuthflowController{
 		Logger:                  authflowControllerLogger,
 		TesterEndpointsProvider: endpointsEndpoints,
@@ -75515,7 +75555,8 @@ func newWebAppAuthflowEnterOOBOTPHandler(p *deps.RequestProvider) http.Handler {
 		UIInfoResolver:          uiInfoResolver,
 		UIConfig:                uiConfig,
 		OAuthClientResolver:     oauthclientResolver,
-		Navigator:               authflowNavigator,
+		NavigatorV1:             authflowNavigator,
+		NavigatorV2:             authflowV2Navigator,
 	}
 	uiFeatureConfig := featureConfig.UI
 	forgotPasswordConfig := appConfig.ForgotPassword
@@ -76417,7 +76458,8 @@ func newWebAppAuthflowV2EnterOOBOTPHandler(p *deps.RequestProvider) http.Handler
 		UIInfoResolver:          uiInfoResolver,
 		UIConfig:                uiConfig,
 		OAuthClientResolver:     oauthclientResolver,
-		Navigator:               authflowV2Navigator,
+		NavigatorV1:             authflowV2Navigator,
+		NavigatorV2:             authflowV2Navigator,
 	}
 	uiFeatureConfig := featureConfig.UI
 	forgotPasswordConfig := appConfig.ForgotPassword
@@ -77304,6 +77346,11 @@ func newWebAppAuthflowCreatePasswordHandler(p *deps.RequestProvider) http.Handle
 		UIConfig:    uiConfig,
 		ErrorCookie: errorCookie,
 	}
+	authflowV2Navigator := &authflowv2.AuthflowV2Navigator{
+		Endpoints:   endpointsEndpoints,
+		UIConfig:    uiConfig,
+		ErrorCookie: errorCookie,
+	}
 	authflowController := &webapp.AuthflowController{
 		Logger:                  authflowControllerLogger,
 		TesterEndpointsProvider: endpointsEndpoints,
@@ -77319,7 +77366,8 @@ func newWebAppAuthflowCreatePasswordHandler(p *deps.RequestProvider) http.Handle
 		UIInfoResolver:          uiInfoResolver,
 		UIConfig:                uiConfig,
 		OAuthClientResolver:     oauthclientResolver,
-		Navigator:               authflowNavigator,
+		NavigatorV1:             authflowNavigator,
+		NavigatorV2:             authflowV2Navigator,
 	}
 	uiFeatureConfig := featureConfig.UI
 	forgotPasswordConfig := appConfig.ForgotPassword
@@ -78219,7 +78267,8 @@ func newWebAppAuthflowV2CreatePasswordHandler(p *deps.RequestProvider) http.Hand
 		UIInfoResolver:          uiInfoResolver,
 		UIConfig:                uiConfig,
 		OAuthClientResolver:     oauthclientResolver,
-		Navigator:               authflowV2Navigator,
+		NavigatorV1:             authflowV2Navigator,
+		NavigatorV2:             authflowV2Navigator,
 	}
 	uiFeatureConfig := featureConfig.UI
 	forgotPasswordConfig := appConfig.ForgotPassword
@@ -79104,6 +79153,11 @@ func newWebAppAuthflowEnterTOTPHandler(p *deps.RequestProvider) http.Handler {
 		UIConfig:    uiConfig,
 		ErrorCookie: errorCookie,
 	}
+	authflowV2Navigator := &authflowv2.AuthflowV2Navigator{
+		Endpoints:   endpointsEndpoints,
+		UIConfig:    uiConfig,
+		ErrorCookie: errorCookie,
+	}
 	authflowController := &webapp.AuthflowController{
 		Logger:                  authflowControllerLogger,
 		TesterEndpointsProvider: endpointsEndpoints,
@@ -79119,7 +79173,8 @@ func newWebAppAuthflowEnterTOTPHandler(p *deps.RequestProvider) http.Handler {
 		UIInfoResolver:          uiInfoResolver,
 		UIConfig:                uiConfig,
 		OAuthClientResolver:     oauthclientResolver,
-		Navigator:               authflowNavigator,
+		NavigatorV1:             authflowNavigator,
+		NavigatorV2:             authflowV2Navigator,
 	}
 	uiFeatureConfig := featureConfig.UI
 	forgotPasswordConfig := appConfig.ForgotPassword
@@ -80019,7 +80074,8 @@ func newWebAppAuthflowV2EnterTOTPHandler(p *deps.RequestProvider) http.Handler {
 		UIInfoResolver:          uiInfoResolver,
 		UIConfig:                uiConfig,
 		OAuthClientResolver:     oauthclientResolver,
-		Navigator:               authflowV2Navigator,
+		NavigatorV1:             authflowV2Navigator,
+		NavigatorV2:             authflowV2Navigator,
 	}
 	uiFeatureConfig := featureConfig.UI
 	forgotPasswordConfig := appConfig.ForgotPassword
@@ -80904,6 +80960,11 @@ func newWebAppAuthflowSetupTOTPHandler(p *deps.RequestProvider) http.Handler {
 		UIConfig:    uiConfig,
 		ErrorCookie: errorCookie,
 	}
+	authflowV2Navigator := &authflowv2.AuthflowV2Navigator{
+		Endpoints:   endpointsEndpoints,
+		UIConfig:    uiConfig,
+		ErrorCookie: errorCookie,
+	}
 	authflowController := &webapp.AuthflowController{
 		Logger:                  authflowControllerLogger,
 		TesterEndpointsProvider: endpointsEndpoints,
@@ -80919,7 +80980,8 @@ func newWebAppAuthflowSetupTOTPHandler(p *deps.RequestProvider) http.Handler {
 		UIInfoResolver:          uiInfoResolver,
 		UIConfig:                uiConfig,
 		OAuthClientResolver:     oauthclientResolver,
-		Navigator:               authflowNavigator,
+		NavigatorV1:             authflowNavigator,
+		NavigatorV2:             authflowV2Navigator,
 	}
 	uiFeatureConfig := featureConfig.UI
 	forgotPasswordConfig := appConfig.ForgotPassword
@@ -81819,7 +81881,8 @@ func newWebAppAuthflowV2SetupTOTPHandler(p *deps.RequestProvider) http.Handler {
 		UIInfoResolver:          uiInfoResolver,
 		UIConfig:                uiConfig,
 		OAuthClientResolver:     oauthclientResolver,
-		Navigator:               authflowV2Navigator,
+		NavigatorV1:             authflowV2Navigator,
+		NavigatorV2:             authflowV2Navigator,
 	}
 	uiFeatureConfig := featureConfig.UI
 	forgotPasswordConfig := appConfig.ForgotPassword
@@ -82704,6 +82767,11 @@ func newWebAppAuthflowViewRecoveryCodeHandler(p *deps.RequestProvider) http.Hand
 		UIConfig:    uiConfig,
 		ErrorCookie: errorCookie,
 	}
+	authflowV2Navigator := &authflowv2.AuthflowV2Navigator{
+		Endpoints:   endpointsEndpoints,
+		UIConfig:    uiConfig,
+		ErrorCookie: errorCookie,
+	}
 	authflowController := &webapp.AuthflowController{
 		Logger:                  authflowControllerLogger,
 		TesterEndpointsProvider: endpointsEndpoints,
@@ -82719,7 +82787,8 @@ func newWebAppAuthflowViewRecoveryCodeHandler(p *deps.RequestProvider) http.Hand
 		UIInfoResolver:          uiInfoResolver,
 		UIConfig:                uiConfig,
 		OAuthClientResolver:     oauthclientResolver,
-		Navigator:               authflowNavigator,
+		NavigatorV1:             authflowNavigator,
+		NavigatorV2:             authflowV2Navigator,
 	}
 	uiFeatureConfig := featureConfig.UI
 	forgotPasswordConfig := appConfig.ForgotPassword
@@ -83619,7 +83688,8 @@ func newWebAppAuthflowV2ViewRecoveryCodeHandler(p *deps.RequestProvider) http.Ha
 		UIInfoResolver:          uiInfoResolver,
 		UIConfig:                uiConfig,
 		OAuthClientResolver:     oauthclientResolver,
-		Navigator:               authflowV2Navigator,
+		NavigatorV1:             authflowV2Navigator,
+		NavigatorV2:             authflowV2Navigator,
 	}
 	uiFeatureConfig := featureConfig.UI
 	forgotPasswordConfig := appConfig.ForgotPassword
@@ -84504,6 +84574,11 @@ func newWebAppAuthflowWhatsappOTPHandler(p *deps.RequestProvider) http.Handler {
 		UIConfig:    uiConfig,
 		ErrorCookie: errorCookie,
 	}
+	authflowV2Navigator := &authflowv2.AuthflowV2Navigator{
+		Endpoints:   endpointsEndpoints,
+		UIConfig:    uiConfig,
+		ErrorCookie: errorCookie,
+	}
 	authflowController := &webapp.AuthflowController{
 		Logger:                  authflowControllerLogger,
 		TesterEndpointsProvider: endpointsEndpoints,
@@ -84519,7 +84594,8 @@ func newWebAppAuthflowWhatsappOTPHandler(p *deps.RequestProvider) http.Handler {
 		UIInfoResolver:          uiInfoResolver,
 		UIConfig:                uiConfig,
 		OAuthClientResolver:     oauthclientResolver,
-		Navigator:               authflowNavigator,
+		NavigatorV1:             authflowNavigator,
+		NavigatorV2:             authflowV2Navigator,
 	}
 	uiFeatureConfig := featureConfig.UI
 	forgotPasswordConfig := appConfig.ForgotPassword
@@ -85406,6 +85482,11 @@ func newWebAppAuthflowOOBOTPLinkHandler(p *deps.RequestProvider) http.Handler {
 		UIConfig:    uiConfig,
 		ErrorCookie: errorCookie,
 	}
+	authflowV2Navigator := &authflowv2.AuthflowV2Navigator{
+		Endpoints:   endpointsEndpoints,
+		UIConfig:    uiConfig,
+		ErrorCookie: errorCookie,
+	}
 	authflowController := &webapp.AuthflowController{
 		Logger:                  authflowControllerLogger,
 		TesterEndpointsProvider: endpointsEndpoints,
@@ -85421,7 +85502,8 @@ func newWebAppAuthflowOOBOTPLinkHandler(p *deps.RequestProvider) http.Handler {
 		UIInfoResolver:          uiInfoResolver,
 		UIConfig:                uiConfig,
 		OAuthClientResolver:     oauthclientResolver,
-		Navigator:               authflowNavigator,
+		NavigatorV1:             authflowNavigator,
+		NavigatorV2:             authflowV2Navigator,
 	}
 	uiFeatureConfig := featureConfig.UI
 	forgotPasswordConfig := appConfig.ForgotPassword
@@ -86323,7 +86405,8 @@ func newWebAppAuthflowV2OOBOTPLinkHandler(p *deps.RequestProvider) http.Handler 
 		UIInfoResolver:          uiInfoResolver,
 		UIConfig:                uiConfig,
 		OAuthClientResolver:     oauthclientResolver,
-		Navigator:               authflowV2Navigator,
+		NavigatorV1:             authflowV2Navigator,
+		NavigatorV2:             authflowV2Navigator,
 	}
 	uiFeatureConfig := featureConfig.UI
 	forgotPasswordConfig := appConfig.ForgotPassword
@@ -87209,6 +87292,11 @@ func newWebAppAuthflowChangePasswordHandler(p *deps.RequestProvider) http.Handle
 		UIConfig:    uiConfig,
 		ErrorCookie: errorCookie,
 	}
+	authflowV2Navigator := &authflowv2.AuthflowV2Navigator{
+		Endpoints:   endpointsEndpoints,
+		UIConfig:    uiConfig,
+		ErrorCookie: errorCookie,
+	}
 	authflowController := &webapp.AuthflowController{
 		Logger:                  authflowControllerLogger,
 		TesterEndpointsProvider: endpointsEndpoints,
@@ -87224,7 +87312,8 @@ func newWebAppAuthflowChangePasswordHandler(p *deps.RequestProvider) http.Handle
 		UIInfoResolver:          uiInfoResolver,
 		UIConfig:                uiConfig,
 		OAuthClientResolver:     oauthclientResolver,
-		Navigator:               authflowNavigator,
+		NavigatorV1:             authflowNavigator,
+		NavigatorV2:             authflowV2Navigator,
 	}
 	uiFeatureConfig := featureConfig.UI
 	forgotPasswordConfig := appConfig.ForgotPassword
@@ -88124,7 +88213,8 @@ func newWebAppAuthflowV2ChangePasswordHandler(p *deps.RequestProvider) http.Hand
 		UIInfoResolver:          uiInfoResolver,
 		UIConfig:                uiConfig,
 		OAuthClientResolver:     oauthclientResolver,
-		Navigator:               authflowV2Navigator,
+		NavigatorV1:             authflowV2Navigator,
+		NavigatorV2:             authflowV2Navigator,
 	}
 	uiFeatureConfig := featureConfig.UI
 	forgotPasswordConfig := appConfig.ForgotPassword
@@ -89025,7 +89115,8 @@ func newWebAppAuthflowV2ChangePasswordSuccessHandler(p *deps.RequestProvider) ht
 		UIInfoResolver:          uiInfoResolver,
 		UIConfig:                uiConfig,
 		OAuthClientResolver:     oauthclientResolver,
-		Navigator:               authflowV2Navigator,
+		NavigatorV1:             authflowV2Navigator,
+		NavigatorV2:             authflowV2Navigator,
 	}
 	uiFeatureConfig := featureConfig.UI
 	forgotPasswordConfig := appConfig.ForgotPassword
@@ -89910,6 +90001,11 @@ func newWebAppAuthflowUsePasskeyHandler(p *deps.RequestProvider) http.Handler {
 		UIConfig:    uiConfig,
 		ErrorCookie: errorCookie,
 	}
+	authflowV2Navigator := &authflowv2.AuthflowV2Navigator{
+		Endpoints:   endpointsEndpoints,
+		UIConfig:    uiConfig,
+		ErrorCookie: errorCookie,
+	}
 	authflowController := &webapp.AuthflowController{
 		Logger:                  authflowControllerLogger,
 		TesterEndpointsProvider: endpointsEndpoints,
@@ -89925,7 +90021,8 @@ func newWebAppAuthflowUsePasskeyHandler(p *deps.RequestProvider) http.Handler {
 		UIInfoResolver:          uiInfoResolver,
 		UIConfig:                uiConfig,
 		OAuthClientResolver:     oauthclientResolver,
-		Navigator:               authflowNavigator,
+		NavigatorV1:             authflowNavigator,
+		NavigatorV2:             authflowV2Navigator,
 	}
 	uiFeatureConfig := featureConfig.UI
 	forgotPasswordConfig := appConfig.ForgotPassword
@@ -90825,7 +90922,8 @@ func newWebAppAuthflowV2UsePasskeyHandler(p *deps.RequestProvider) http.Handler 
 		UIInfoResolver:          uiInfoResolver,
 		UIConfig:                uiConfig,
 		OAuthClientResolver:     oauthclientResolver,
-		Navigator:               authflowV2Navigator,
+		NavigatorV1:             authflowV2Navigator,
+		NavigatorV2:             authflowV2Navigator,
 	}
 	uiFeatureConfig := featureConfig.UI
 	forgotPasswordConfig := appConfig.ForgotPassword
@@ -91710,6 +91808,11 @@ func newWebAppAuthflowPromptCreatePasskeyHandler(p *deps.RequestProvider) http.H
 		UIConfig:    uiConfig,
 		ErrorCookie: errorCookie,
 	}
+	authflowV2Navigator := &authflowv2.AuthflowV2Navigator{
+		Endpoints:   endpointsEndpoints,
+		UIConfig:    uiConfig,
+		ErrorCookie: errorCookie,
+	}
 	authflowController := &webapp.AuthflowController{
 		Logger:                  authflowControllerLogger,
 		TesterEndpointsProvider: endpointsEndpoints,
@@ -91725,7 +91828,8 @@ func newWebAppAuthflowPromptCreatePasskeyHandler(p *deps.RequestProvider) http.H
 		UIInfoResolver:          uiInfoResolver,
 		UIConfig:                uiConfig,
 		OAuthClientResolver:     oauthclientResolver,
-		Navigator:               authflowNavigator,
+		NavigatorV1:             authflowNavigator,
+		NavigatorV2:             authflowV2Navigator,
 	}
 	uiFeatureConfig := featureConfig.UI
 	forgotPasswordConfig := appConfig.ForgotPassword
@@ -92625,7 +92729,8 @@ func newWebAppAuthflowV2PromptCreatePasskeyHandler(p *deps.RequestProvider) http
 		UIInfoResolver:          uiInfoResolver,
 		UIConfig:                uiConfig,
 		OAuthClientResolver:     oauthclientResolver,
-		Navigator:               authflowV2Navigator,
+		NavigatorV1:             authflowV2Navigator,
+		NavigatorV2:             authflowV2Navigator,
 	}
 	uiFeatureConfig := featureConfig.UI
 	forgotPasswordConfig := appConfig.ForgotPassword
@@ -93510,6 +93615,11 @@ func newWebAppAuthflowEnterRecoveryCodeHandler(p *deps.RequestProvider) http.Han
 		UIConfig:    uiConfig,
 		ErrorCookie: errorCookie,
 	}
+	authflowV2Navigator := &authflowv2.AuthflowV2Navigator{
+		Endpoints:   endpointsEndpoints,
+		UIConfig:    uiConfig,
+		ErrorCookie: errorCookie,
+	}
 	authflowController := &webapp.AuthflowController{
 		Logger:                  authflowControllerLogger,
 		TesterEndpointsProvider: endpointsEndpoints,
@@ -93525,7 +93635,8 @@ func newWebAppAuthflowEnterRecoveryCodeHandler(p *deps.RequestProvider) http.Han
 		UIInfoResolver:          uiInfoResolver,
 		UIConfig:                uiConfig,
 		OAuthClientResolver:     oauthclientResolver,
-		Navigator:               authflowNavigator,
+		NavigatorV1:             authflowNavigator,
+		NavigatorV2:             authflowV2Navigator,
 	}
 	uiFeatureConfig := featureConfig.UI
 	forgotPasswordConfig := appConfig.ForgotPassword
@@ -94425,7 +94536,8 @@ func newWebAppAuthflowV2EnterRecoveryCodeHandler(p *deps.RequestProvider) http.H
 		UIInfoResolver:          uiInfoResolver,
 		UIConfig:                uiConfig,
 		OAuthClientResolver:     oauthclientResolver,
-		Navigator:               authflowV2Navigator,
+		NavigatorV1:             authflowV2Navigator,
+		NavigatorV2:             authflowV2Navigator,
 	}
 	uiFeatureConfig := featureConfig.UI
 	forgotPasswordConfig := appConfig.ForgotPassword
@@ -95310,6 +95422,11 @@ func newWebAppAuthflowSetupOOBOTPHandler(p *deps.RequestProvider) http.Handler {
 		UIConfig:    uiConfig,
 		ErrorCookie: errorCookie,
 	}
+	authflowV2Navigator := &authflowv2.AuthflowV2Navigator{
+		Endpoints:   endpointsEndpoints,
+		UIConfig:    uiConfig,
+		ErrorCookie: errorCookie,
+	}
 	authflowController := &webapp.AuthflowController{
 		Logger:                  authflowControllerLogger,
 		TesterEndpointsProvider: endpointsEndpoints,
@@ -95325,7 +95442,8 @@ func newWebAppAuthflowSetupOOBOTPHandler(p *deps.RequestProvider) http.Handler {
 		UIInfoResolver:          uiInfoResolver,
 		UIConfig:                uiConfig,
 		OAuthClientResolver:     oauthclientResolver,
-		Navigator:               authflowNavigator,
+		NavigatorV1:             authflowNavigator,
+		NavigatorV2:             authflowV2Navigator,
 	}
 	uiFeatureConfig := featureConfig.UI
 	forgotPasswordConfig := appConfig.ForgotPassword
@@ -96225,7 +96343,8 @@ func newWebAppAuthflowV2SetupOOBOTPHandler(p *deps.RequestProvider) http.Handler
 		UIInfoResolver:          uiInfoResolver,
 		UIConfig:                uiConfig,
 		OAuthClientResolver:     oauthclientResolver,
-		Navigator:               authflowV2Navigator,
+		NavigatorV1:             authflowV2Navigator,
+		NavigatorV2:             authflowV2Navigator,
 	}
 	uiFeatureConfig := featureConfig.UI
 	forgotPasswordConfig := appConfig.ForgotPassword
@@ -97110,6 +97229,11 @@ func newWebAppAuthflowTerminateOtherSessionsHandler(p *deps.RequestProvider) htt
 		UIConfig:    uiConfig,
 		ErrorCookie: errorCookie,
 	}
+	authflowV2Navigator := &authflowv2.AuthflowV2Navigator{
+		Endpoints:   endpointsEndpoints,
+		UIConfig:    uiConfig,
+		ErrorCookie: errorCookie,
+	}
 	authflowController := &webapp.AuthflowController{
 		Logger:                  authflowControllerLogger,
 		TesterEndpointsProvider: endpointsEndpoints,
@@ -97125,7 +97249,8 @@ func newWebAppAuthflowTerminateOtherSessionsHandler(p *deps.RequestProvider) htt
 		UIInfoResolver:          uiInfoResolver,
 		UIConfig:                uiConfig,
 		OAuthClientResolver:     oauthclientResolver,
-		Navigator:               authflowNavigator,
+		NavigatorV1:             authflowNavigator,
+		NavigatorV2:             authflowV2Navigator,
 	}
 	uiFeatureConfig := featureConfig.UI
 	forgotPasswordConfig := appConfig.ForgotPassword
@@ -98025,7 +98150,8 @@ func newWebAppAuthflowV2TerminateOtherSessionsHandler(p *deps.RequestProvider) h
 		UIInfoResolver:          uiInfoResolver,
 		UIConfig:                uiConfig,
 		OAuthClientResolver:     oauthclientResolver,
-		Navigator:               authflowV2Navigator,
+		NavigatorV1:             authflowV2Navigator,
+		NavigatorV2:             authflowV2Navigator,
 	}
 	uiFeatureConfig := featureConfig.UI
 	forgotPasswordConfig := appConfig.ForgotPassword
@@ -98910,6 +99036,11 @@ func newWebAppAuthflowWechatHandler(p *deps.RequestProvider) http.Handler {
 		UIConfig:    uiConfig,
 		ErrorCookie: errorCookie,
 	}
+	authflowV2Navigator := &authflowv2.AuthflowV2Navigator{
+		Endpoints:   endpointsEndpoints,
+		UIConfig:    uiConfig,
+		ErrorCookie: errorCookie,
+	}
 	authflowController := &webapp.AuthflowController{
 		Logger:                  authflowControllerLogger,
 		TesterEndpointsProvider: endpointsEndpoints,
@@ -98925,7 +99056,8 @@ func newWebAppAuthflowWechatHandler(p *deps.RequestProvider) http.Handler {
 		UIInfoResolver:          uiInfoResolver,
 		UIConfig:                uiConfig,
 		OAuthClientResolver:     oauthclientResolver,
-		Navigator:               authflowNavigator,
+		NavigatorV1:             authflowNavigator,
+		NavigatorV2:             authflowV2Navigator,
 	}
 	uiFeatureConfig := featureConfig.UI
 	forgotPasswordConfig := appConfig.ForgotPassword
@@ -99810,6 +99942,11 @@ func newWebAppAuthflowForgotPasswordHandler(p *deps.RequestProvider) http.Handle
 		UIConfig:    uiConfig,
 		ErrorCookie: errorCookie,
 	}
+	authflowV2Navigator := &authflowv2.AuthflowV2Navigator{
+		Endpoints:   endpointsEndpoints,
+		UIConfig:    uiConfig,
+		ErrorCookie: errorCookie,
+	}
 	authflowController := &webapp.AuthflowController{
 		Logger:                  authflowControllerLogger,
 		TesterEndpointsProvider: endpointsEndpoints,
@@ -99825,7 +99962,8 @@ func newWebAppAuthflowForgotPasswordHandler(p *deps.RequestProvider) http.Handle
 		UIInfoResolver:          uiInfoResolver,
 		UIConfig:                uiConfig,
 		OAuthClientResolver:     oauthclientResolver,
-		Navigator:               authflowNavigator,
+		NavigatorV1:             authflowNavigator,
+		NavigatorV2:             authflowV2Navigator,
 	}
 	uiFeatureConfig := featureConfig.UI
 	forgotPasswordConfig := appConfig.ForgotPassword
@@ -100725,7 +100863,8 @@ func newWebAppAuthflowV2ForgotPasswordHandler(p *deps.RequestProvider) http.Hand
 		UIInfoResolver:          uiInfoResolver,
 		UIConfig:                uiConfig,
 		OAuthClientResolver:     oauthclientResolver,
-		Navigator:               authflowV2Navigator,
+		NavigatorV1:             authflowV2Navigator,
+		NavigatorV2:             authflowV2Navigator,
 	}
 	uiFeatureConfig := featureConfig.UI
 	forgotPasswordConfig := appConfig.ForgotPassword
@@ -101610,6 +101749,11 @@ func newWebAppAuthflowForgotPasswordOTPHandler(p *deps.RequestProvider) http.Han
 		UIConfig:    uiConfig,
 		ErrorCookie: errorCookie,
 	}
+	authflowV2Navigator := &authflowv2.AuthflowV2Navigator{
+		Endpoints:   endpointsEndpoints,
+		UIConfig:    uiConfig,
+		ErrorCookie: errorCookie,
+	}
 	authflowController := &webapp.AuthflowController{
 		Logger:                  authflowControllerLogger,
 		TesterEndpointsProvider: endpointsEndpoints,
@@ -101625,7 +101769,8 @@ func newWebAppAuthflowForgotPasswordOTPHandler(p *deps.RequestProvider) http.Han
 		UIInfoResolver:          uiInfoResolver,
 		UIConfig:                uiConfig,
 		OAuthClientResolver:     oauthclientResolver,
-		Navigator:               authflowNavigator,
+		NavigatorV1:             authflowNavigator,
+		NavigatorV2:             authflowV2Navigator,
 	}
 	uiFeatureConfig := featureConfig.UI
 	forgotPasswordConfig := appConfig.ForgotPassword
@@ -102527,7 +102672,8 @@ func newWebAppAuthflowV2ForgotPasswordOTPHandler(p *deps.RequestProvider) http.H
 		UIInfoResolver:          uiInfoResolver,
 		UIConfig:                uiConfig,
 		OAuthClientResolver:     oauthclientResolver,
-		Navigator:               authflowV2Navigator,
+		NavigatorV1:             authflowV2Navigator,
+		NavigatorV2:             authflowV2Navigator,
 	}
 	uiFeatureConfig := featureConfig.UI
 	forgotPasswordConfig := appConfig.ForgotPassword
@@ -103414,6 +103560,11 @@ func newWebAppAuthflowForgotPasswordSuccessHandler(p *deps.RequestProvider) http
 		UIConfig:    uiConfig,
 		ErrorCookie: errorCookie,
 	}
+	authflowV2Navigator := &authflowv2.AuthflowV2Navigator{
+		Endpoints:   endpointsEndpoints,
+		UIConfig:    uiConfig,
+		ErrorCookie: errorCookie,
+	}
 	authflowController := &webapp.AuthflowController{
 		Logger:                  authflowControllerLogger,
 		TesterEndpointsProvider: endpointsEndpoints,
@@ -103429,7 +103580,8 @@ func newWebAppAuthflowForgotPasswordSuccessHandler(p *deps.RequestProvider) http
 		UIInfoResolver:          uiInfoResolver,
 		UIConfig:                uiConfig,
 		OAuthClientResolver:     oauthclientResolver,
-		Navigator:               authflowNavigator,
+		NavigatorV1:             authflowNavigator,
+		NavigatorV2:             authflowV2Navigator,
 	}
 	uiFeatureConfig := featureConfig.UI
 	forgotPasswordConfig := appConfig.ForgotPassword
@@ -104329,7 +104481,8 @@ func newWebAppAuthflowV2ForgotPasswordLinkSentHandler(p *deps.RequestProvider) h
 		UIInfoResolver:          uiInfoResolver,
 		UIConfig:                uiConfig,
 		OAuthClientResolver:     oauthclientResolver,
-		Navigator:               authflowV2Navigator,
+		NavigatorV1:             authflowV2Navigator,
+		NavigatorV2:             authflowV2Navigator,
 	}
 	uiFeatureConfig := featureConfig.UI
 	forgotPasswordConfig := appConfig.ForgotPassword
@@ -106074,6 +106227,11 @@ func newWebAppAuthflowReauthHandler(p *deps.RequestProvider) http.Handler {
 		UIConfig:    uiConfig,
 		ErrorCookie: errorCookie,
 	}
+	authflowV2Navigator := &authflowv2.AuthflowV2Navigator{
+		Endpoints:   endpointsEndpoints,
+		UIConfig:    uiConfig,
+		ErrorCookie: errorCookie,
+	}
 	authflowController := &webapp.AuthflowController{
 		Logger:                  authflowControllerLogger,
 		TesterEndpointsProvider: endpointsEndpoints,
@@ -106089,7 +106247,8 @@ func newWebAppAuthflowReauthHandler(p *deps.RequestProvider) http.Handler {
 		UIInfoResolver:          uiInfoResolver,
 		UIConfig:                uiConfig,
 		OAuthClientResolver:     oauthclientResolver,
-		Navigator:               authflowNavigator,
+		NavigatorV1:             authflowNavigator,
+		NavigatorV2:             authflowV2Navigator,
 	}
 	authflowReauthHandler := &webapp.AuthflowReauthHandler{
 		Controller:        authflowController,
@@ -106960,7 +107119,8 @@ func newWebAppAuthflowV2ReauthHandler(p *deps.RequestProvider) http.Handler {
 		UIInfoResolver:          uiInfoResolver,
 		UIConfig:                uiConfig,
 		OAuthClientResolver:     oauthclientResolver,
-		Navigator:               authflowV2Navigator,
+		NavigatorV1:             authflowV2Navigator,
+		NavigatorV2:             authflowV2Navigator,
 	}
 	authflowV2ReauthHandler := &authflowv2.AuthflowV2ReauthHandler{
 		Controller:        authflowController,
@@ -107816,6 +107976,11 @@ func newWebAppAuthflowResetPasswordHandler(p *deps.RequestProvider) http.Handler
 		UIConfig:    uiConfig,
 		ErrorCookie: errorCookie,
 	}
+	authflowV2Navigator := &authflowv2.AuthflowV2Navigator{
+		Endpoints:   endpointsEndpoints,
+		UIConfig:    uiConfig,
+		ErrorCookie: errorCookie,
+	}
 	authflowController := &webapp.AuthflowController{
 		Logger:                  authflowControllerLogger,
 		TesterEndpointsProvider: endpointsEndpoints,
@@ -107831,7 +107996,8 @@ func newWebAppAuthflowResetPasswordHandler(p *deps.RequestProvider) http.Handler
 		UIInfoResolver:          uiInfoResolver,
 		UIConfig:                uiConfig,
 		OAuthClientResolver:     oauthclientResolver,
-		Navigator:               authflowNavigator,
+		NavigatorV1:             authflowNavigator,
+		NavigatorV2:             authflowV2Navigator,
 	}
 	uiFeatureConfig := featureConfig.UI
 	forgotPasswordConfig := appConfig.ForgotPassword
@@ -108731,7 +108897,8 @@ func newWebAppAuthflowV2ResetPasswordHandler(p *deps.RequestProvider) http.Handl
 		UIInfoResolver:          uiInfoResolver,
 		UIConfig:                uiConfig,
 		OAuthClientResolver:     oauthclientResolver,
-		Navigator:               authflowV2Navigator,
+		NavigatorV1:             authflowV2Navigator,
+		NavigatorV2:             authflowV2Navigator,
 	}
 	uiFeatureConfig := featureConfig.UI
 	forgotPasswordConfig := appConfig.ForgotPassword
@@ -109616,6 +109783,11 @@ func newWebAppAuthflowResetPasswordSuccessHandler(p *deps.RequestProvider) http.
 		UIConfig:    uiConfig,
 		ErrorCookie: errorCookie,
 	}
+	authflowV2Navigator := &authflowv2.AuthflowV2Navigator{
+		Endpoints:   endpointsEndpoints,
+		UIConfig:    uiConfig,
+		ErrorCookie: errorCookie,
+	}
 	authflowController := &webapp.AuthflowController{
 		Logger:                  authflowControllerLogger,
 		TesterEndpointsProvider: endpointsEndpoints,
@@ -109631,7 +109803,8 @@ func newWebAppAuthflowResetPasswordSuccessHandler(p *deps.RequestProvider) http.
 		UIInfoResolver:          uiInfoResolver,
 		UIConfig:                uiConfig,
 		OAuthClientResolver:     oauthclientResolver,
-		Navigator:               authflowNavigator,
+		NavigatorV1:             authflowNavigator,
+		NavigatorV2:             authflowV2Navigator,
 	}
 	uiFeatureConfig := featureConfig.UI
 	forgotPasswordConfig := appConfig.ForgotPassword
@@ -110531,7 +110704,8 @@ func newWebAppAuthflowV2ResetPasswordSuccessHandler(p *deps.RequestProvider) htt
 		UIInfoResolver:          uiInfoResolver,
 		UIConfig:                uiConfig,
 		OAuthClientResolver:     oauthclientResolver,
-		Navigator:               authflowV2Navigator,
+		NavigatorV1:             authflowV2Navigator,
+		NavigatorV2:             authflowV2Navigator,
 	}
 	uiFeatureConfig := featureConfig.UI
 	forgotPasswordConfig := appConfig.ForgotPassword
@@ -111704,6 +111878,11 @@ func newWebAppAuthflowFinishFlowHandler(p *deps.RequestProvider) http.Handler {
 		UIConfig:    uiConfig,
 		ErrorCookie: errorCookie,
 	}
+	authflowV2Navigator := &authflowv2.AuthflowV2Navigator{
+		Endpoints:   endpointsEndpoints,
+		UIConfig:    uiConfig,
+		ErrorCookie: errorCookie,
+	}
 	authflowController := &webapp.AuthflowController{
 		Logger:                  authflowControllerLogger,
 		TesterEndpointsProvider: endpointsEndpoints,
@@ -111719,7 +111898,8 @@ func newWebAppAuthflowFinishFlowHandler(p *deps.RequestProvider) http.Handler {
 		UIInfoResolver:          uiInfoResolver,
 		UIConfig:                uiConfig,
 		OAuthClientResolver:     oauthclientResolver,
-		Navigator:               authflowNavigator,
+		NavigatorV1:             authflowNavigator,
+		NavigatorV2:             authflowV2Navigator,
 	}
 	uiFeatureConfig := featureConfig.UI
 	forgotPasswordConfig := appConfig.ForgotPassword
@@ -112619,7 +112799,8 @@ func newWebAppAuthflowV2FinishFlowHandler(p *deps.RequestProvider) http.Handler 
 		UIInfoResolver:          uiInfoResolver,
 		UIConfig:                uiConfig,
 		OAuthClientResolver:     oauthclientResolver,
-		Navigator:               authflowV2Navigator,
+		NavigatorV1:             authflowV2Navigator,
+		NavigatorV2:             authflowV2Navigator,
 	}
 	uiFeatureConfig := featureConfig.UI
 	forgotPasswordConfig := appConfig.ForgotPassword


### PR DESCRIPTION
ref #3939

Wanted to make a switcher like implementation_switcher middleware, but seems weird to make navigator aware of current `ui.implementation`