### PR TITLE
Use a better matching algorithm to match languages

### DIFF
--- a/pkg/admin/wire_gen.go
+++ b/pkg/admin/wire_gen.go
@@ -832,7 +832,8 @@ func newGraphQLHandler(p *deps.RequestProvider) http.Handler {
 		DevMode:                           devMode,
 		FeatureTestModeWhatsappSuppressed: featureTestModeWhatsappSuppressed,
 		TestModeWhatsappConfig:            testModeWhatsappConfig,
-		Config:                            whatsappConfig,
+		WhatsappConfig:                    whatsappConfig,
+		LocalizationConfig:                localizationConfig,
 		OnPremisesClient:                  onPremisesClient,
 		TokenStore:                        tokenStore,
 	}

--- a/pkg/auth/wire_gen.go
+++ b/pkg/auth/wire_gen.go
@@ -1898,7 +1898,8 @@ func newOAuthTokenHandler(p *deps.RequestProvider) http.Handler {
 		DevMode:                           devMode,
 		FeatureTestModeWhatsappSuppressed: featureTestModeWhatsappSuppressed,
 		TestModeWhatsappConfig:            testModeWhatsappConfig,
-		Config:                            whatsappConfig,
+		WhatsappConfig:                    whatsappConfig,
+		LocalizationConfig:                localizationConfig,
 		OnPremisesClient:                  onPremisesClient,
 		TokenStore:                        tokenStore,
 	}
@@ -4672,7 +4673,8 @@ func newOAuthAppSessionTokenHandler(p *deps.RequestProvider) http.Handler {
 		DevMode:                           devMode,
 		FeatureTestModeWhatsappSuppressed: featureTestModeWhatsappSuppressed,
 		TestModeWhatsappConfig:            testModeWhatsappConfig,
-		Config:                            whatsappConfig,
+		WhatsappConfig:                    whatsappConfig,
+		LocalizationConfig:                localizationConfig,
 		OnPremisesClient:                  onPremisesClient,
 		TokenStore:                        tokenStore,
 	}
@@ -5617,7 +5619,8 @@ func newAPIAnonymousUserSignupHandler(p *deps.RequestProvider) http.Handler {
 		DevMode:                           devMode,
 		FeatureTestModeWhatsappSuppressed: featureTestModeWhatsappSuppressed,
 		TestModeWhatsappConfig:            testModeWhatsappConfig,
-		Config:                            whatsappConfig,
+		WhatsappConfig:                    whatsappConfig,
+		LocalizationConfig:                localizationConfig,
 		OnPremisesClient:                  onPremisesClient,
 		TokenStore:                        tokenStore,
 	}
@@ -6439,7 +6442,8 @@ func newAPIAnonymousUserPromotionCodeHandler(p *deps.RequestProvider) http.Handl
 		DevMode:                           devMode,
 		FeatureTestModeWhatsappSuppressed: featureTestModeWhatsappSuppressed,
 		TestModeWhatsappConfig:            testModeWhatsappConfig,
-		Config:                            whatsappConfig,
+		WhatsappConfig:                    whatsappConfig,
+		LocalizationConfig:                localizationConfig,
 		OnPremisesClient:                  onPremisesClient,
 		TokenStore:                        tokenStore,
 	}
@@ -7407,7 +7411,8 @@ func newWebAppLoginHandler(p *deps.RequestProvider) http.Handler {
 		DevMode:                           devMode,
 		FeatureTestModeWhatsappSuppressed: featureTestModeWhatsappSuppressed,
 		TestModeWhatsappConfig:            testModeWhatsappConfig,
-		Config:                            whatsappConfig,
+		WhatsappConfig:                    whatsappConfig,
+		LocalizationConfig:                localizationConfig,
 		OnPremisesClient:                  onPremisesClient,
 		TokenStore:                        tokenStore,
 	}
@@ -8302,7 +8307,8 @@ func newWebAppSignupHandler(p *deps.RequestProvider) http.Handler {
 		DevMode:                           devMode,
 		FeatureTestModeWhatsappSuppressed: featureTestModeWhatsappSuppressed,
 		TestModeWhatsappConfig:            testModeWhatsappConfig,
-		Config:                            whatsappConfig,
+		WhatsappConfig:                    whatsappConfig,
+		LocalizationConfig:                localizationConfig,
 		OnPremisesClient:                  onPremisesClient,
 		TokenStore:                        tokenStore,
 	}
@@ -9196,7 +9202,8 @@ func newWebAppPromoteHandler(p *deps.RequestProvider) http.Handler {
 		DevMode:                           devMode,
 		FeatureTestModeWhatsappSuppressed: featureTestModeWhatsappSuppressed,
 		TestModeWhatsappConfig:            testModeWhatsappConfig,
-		Config:                            whatsappConfig,
+		WhatsappConfig:                    whatsappConfig,
+		LocalizationConfig:                localizationConfig,
 		OnPremisesClient:                  onPremisesClient,
 		TokenStore:                        tokenStore,
 	}
@@ -10078,7 +10085,8 @@ func newWebAppSelectAccountHandler(p *deps.RequestProvider) http.Handler {
 		DevMode:                           devMode,
 		FeatureTestModeWhatsappSuppressed: featureTestModeWhatsappSuppressed,
 		TestModeWhatsappConfig:            testModeWhatsappConfig,
-		Config:                            whatsappConfig,
+		WhatsappConfig:                    whatsappConfig,
+		LocalizationConfig:                localizationConfig,
 		OnPremisesClient:                  onPremisesClient,
 		TokenStore:                        tokenStore,
 	}
@@ -10955,7 +10963,8 @@ func newWebAppAuthflowV2SelectAccountHandler(p *deps.RequestProvider) http.Handl
 		DevMode:                           devMode,
 		FeatureTestModeWhatsappSuppressed: featureTestModeWhatsappSuppressed,
 		TestModeWhatsappConfig:            testModeWhatsappConfig,
-		Config:                            whatsappConfig,
+		WhatsappConfig:                    whatsappConfig,
+		LocalizationConfig:                localizationConfig,
 		OnPremisesClient:                  onPremisesClient,
 		TokenStore:                        tokenStore,
 	}
@@ -11816,7 +11825,8 @@ func newWebAppSSOCallbackHandler(p *deps.RequestProvider) http.Handler {
 		DevMode:                           devMode,
 		FeatureTestModeWhatsappSuppressed: featureTestModeWhatsappSuppressed,
 		TestModeWhatsappConfig:            testModeWhatsappConfig,
-		Config:                            whatsappConfig,
+		WhatsappConfig:                    whatsappConfig,
+		LocalizationConfig:                localizationConfig,
 		OnPremisesClient:                  onPremisesClient,
 		TokenStore:                        tokenStore,
 	}
@@ -12810,7 +12820,8 @@ func newWebAppAuthflowSSOCallbackHandler(p *deps.RequestProvider) http.Handler {
 		DevMode:                           devMode,
 		FeatureTestModeWhatsappSuppressed: featureTestModeWhatsappSuppressed,
 		TestModeWhatsappConfig:            testModeWhatsappConfig,
-		Config:                            whatsappConfig,
+		WhatsappConfig:                    whatsappConfig,
+		LocalizationConfig:                localizationConfig,
 		OnPremisesClient:                  onPremisesClient,
 		TokenStore:                        tokenStore,
 	}
@@ -13804,7 +13815,8 @@ func newWebAppAuthflowV2SSOCallbackHandler(p *deps.RequestProvider) http.Handler
 		DevMode:                           devMode,
 		FeatureTestModeWhatsappSuppressed: featureTestModeWhatsappSuppressed,
 		TestModeWhatsappConfig:            testModeWhatsappConfig,
-		Config:                            whatsappConfig,
+		WhatsappConfig:                    whatsappConfig,
+		LocalizationConfig:                localizationConfig,
 		OnPremisesClient:                  onPremisesClient,
 		TokenStore:                        tokenStore,
 	}
@@ -14814,7 +14826,8 @@ func newWechatAuthHandler(p *deps.RequestProvider) http.Handler {
 		DevMode:                           devMode,
 		FeatureTestModeWhatsappSuppressed: featureTestModeWhatsappSuppressed,
 		TestModeWhatsappConfig:            testModeWhatsappConfig,
-		Config:                            whatsappConfig,
+		WhatsappConfig:                    whatsappConfig,
+		LocalizationConfig:                localizationConfig,
 		OnPremisesClient:                  onPremisesClient,
 		TokenStore:                        tokenStore,
 	}
@@ -15681,7 +15694,8 @@ func newWechatCallbackHandler(p *deps.RequestProvider) http.Handler {
 		DevMode:                           devMode,
 		FeatureTestModeWhatsappSuppressed: featureTestModeWhatsappSuppressed,
 		TestModeWhatsappConfig:            testModeWhatsappConfig,
-		Config:                            whatsappConfig,
+		WhatsappConfig:                    whatsappConfig,
+		LocalizationConfig:                localizationConfig,
 		OnPremisesClient:                  onPremisesClient,
 		TokenStore:                        tokenStore,
 	}
@@ -16552,7 +16566,8 @@ func newWebAppEnterLoginIDHandler(p *deps.RequestProvider) http.Handler {
 		DevMode:                           devMode,
 		FeatureTestModeWhatsappSuppressed: featureTestModeWhatsappSuppressed,
 		TestModeWhatsappConfig:            testModeWhatsappConfig,
-		Config:                            whatsappConfig,
+		WhatsappConfig:                    whatsappConfig,
+		LocalizationConfig:                localizationConfig,
 		OnPremisesClient:                  onPremisesClient,
 		TokenStore:                        tokenStore,
 	}
@@ -17425,7 +17440,8 @@ func newWebAppEnterPasswordHandler(p *deps.RequestProvider) http.Handler {
 		DevMode:                           devMode,
 		FeatureTestModeWhatsappSuppressed: featureTestModeWhatsappSuppressed,
 		TestModeWhatsappConfig:            testModeWhatsappConfig,
-		Config:                            whatsappConfig,
+		WhatsappConfig:                    whatsappConfig,
+		LocalizationConfig:                localizationConfig,
 		OnPremisesClient:                  onPremisesClient,
 		TokenStore:                        tokenStore,
 	}
@@ -18296,7 +18312,8 @@ func newWebConfirmTerminateOtherSessionsHandler(p *deps.RequestProvider) http.Ha
 		DevMode:                           devMode,
 		FeatureTestModeWhatsappSuppressed: featureTestModeWhatsappSuppressed,
 		TestModeWhatsappConfig:            testModeWhatsappConfig,
-		Config:                            whatsappConfig,
+		WhatsappConfig:                    whatsappConfig,
+		LocalizationConfig:                localizationConfig,
 		OnPremisesClient:                  onPremisesClient,
 		TokenStore:                        tokenStore,
 	}
@@ -19165,7 +19182,8 @@ func newWebAppUsePasskeyHandler(p *deps.RequestProvider) http.Handler {
 		DevMode:                           devMode,
 		FeatureTestModeWhatsappSuppressed: featureTestModeWhatsappSuppressed,
 		TestModeWhatsappConfig:            testModeWhatsappConfig,
-		Config:                            whatsappConfig,
+		WhatsappConfig:                    whatsappConfig,
+		LocalizationConfig:                localizationConfig,
 		OnPremisesClient:                  onPremisesClient,
 		TokenStore:                        tokenStore,
 	}
@@ -20036,7 +20054,8 @@ func newWebAppCreatePasswordHandler(p *deps.RequestProvider) http.Handler {
 		DevMode:                           devMode,
 		FeatureTestModeWhatsappSuppressed: featureTestModeWhatsappSuppressed,
 		TestModeWhatsappConfig:            testModeWhatsappConfig,
-		Config:                            whatsappConfig,
+		WhatsappConfig:                    whatsappConfig,
+		LocalizationConfig:                localizationConfig,
 		OnPremisesClient:                  onPremisesClient,
 		TokenStore:                        tokenStore,
 	}
@@ -20908,7 +20927,8 @@ func newWebAppCreatePasskeyHandler(p *deps.RequestProvider) http.Handler {
 		DevMode:                           devMode,
 		FeatureTestModeWhatsappSuppressed: featureTestModeWhatsappSuppressed,
 		TestModeWhatsappConfig:            testModeWhatsappConfig,
-		Config:                            whatsappConfig,
+		WhatsappConfig:                    whatsappConfig,
+		LocalizationConfig:                localizationConfig,
 		OnPremisesClient:                  onPremisesClient,
 		TokenStore:                        tokenStore,
 	}
@@ -21779,7 +21799,8 @@ func newWebAppPromptCreatePasskeyHandler(p *deps.RequestProvider) http.Handler {
 		DevMode:                           devMode,
 		FeatureTestModeWhatsappSuppressed: featureTestModeWhatsappSuppressed,
 		TestModeWhatsappConfig:            testModeWhatsappConfig,
-		Config:                            whatsappConfig,
+		WhatsappConfig:                    whatsappConfig,
+		LocalizationConfig:                localizationConfig,
 		OnPremisesClient:                  onPremisesClient,
 		TokenStore:                        tokenStore,
 	}
@@ -22650,7 +22671,8 @@ func newWebAppSetupTOTPHandler(p *deps.RequestProvider) http.Handler {
 		DevMode:                           devMode,
 		FeatureTestModeWhatsappSuppressed: featureTestModeWhatsappSuppressed,
 		TestModeWhatsappConfig:            testModeWhatsappConfig,
-		Config:                            whatsappConfig,
+		WhatsappConfig:                    whatsappConfig,
+		LocalizationConfig:                localizationConfig,
 		OnPremisesClient:                  onPremisesClient,
 		TokenStore:                        tokenStore,
 	}
@@ -23523,7 +23545,8 @@ func newWebAppEnterTOTPHandler(p *deps.RequestProvider) http.Handler {
 		DevMode:                           devMode,
 		FeatureTestModeWhatsappSuppressed: featureTestModeWhatsappSuppressed,
 		TestModeWhatsappConfig:            testModeWhatsappConfig,
-		Config:                            whatsappConfig,
+		WhatsappConfig:                    whatsappConfig,
+		LocalizationConfig:                localizationConfig,
 		OnPremisesClient:                  onPremisesClient,
 		TokenStore:                        tokenStore,
 	}
@@ -24394,7 +24417,8 @@ func newWebAppSetupOOBOTPHandler(p *deps.RequestProvider) http.Handler {
 		DevMode:                           devMode,
 		FeatureTestModeWhatsappSuppressed: featureTestModeWhatsappSuppressed,
 		TestModeWhatsappConfig:            testModeWhatsappConfig,
-		Config:                            whatsappConfig,
+		WhatsappConfig:                    whatsappConfig,
+		LocalizationConfig:                localizationConfig,
 		OnPremisesClient:                  onPremisesClient,
 		TokenStore:                        tokenStore,
 	}
@@ -25265,7 +25289,8 @@ func newWebAppEnterOOBOTPHandler(p *deps.RequestProvider) http.Handler {
 		DevMode:                           devMode,
 		FeatureTestModeWhatsappSuppressed: featureTestModeWhatsappSuppressed,
 		TestModeWhatsappConfig:            testModeWhatsappConfig,
-		Config:                            whatsappConfig,
+		WhatsappConfig:                    whatsappConfig,
+		LocalizationConfig:                localizationConfig,
 		OnPremisesClient:                  onPremisesClient,
 		TokenStore:                        tokenStore,
 	}
@@ -26140,7 +26165,8 @@ func newWebAppSetupWhatsappOTPHandler(p *deps.RequestProvider) http.Handler {
 		DevMode:                           devMode,
 		FeatureTestModeWhatsappSuppressed: featureTestModeWhatsappSuppressed,
 		TestModeWhatsappConfig:            testModeWhatsappConfig,
-		Config:                            whatsappConfig,
+		WhatsappConfig:                    whatsappConfig,
+		LocalizationConfig:                localizationConfig,
 		OnPremisesClient:                  onPremisesClient,
 		TokenStore:                        tokenStore,
 	}
@@ -27011,7 +27037,8 @@ func newWebAppWhatsappOTPHandler(p *deps.RequestProvider) http.Handler {
 		DevMode:                           devMode,
 		FeatureTestModeWhatsappSuppressed: featureTestModeWhatsappSuppressed,
 		TestModeWhatsappConfig:            testModeWhatsappConfig,
-		Config:                            whatsappConfig,
+		WhatsappConfig:                    whatsappConfig,
+		LocalizationConfig:                localizationConfig,
 		OnPremisesClient:                  onPremisesClient,
 		TokenStore:                        tokenStore,
 	}
@@ -27886,7 +27913,8 @@ func newWebAppSetupLoginLinkOTPHandler(p *deps.RequestProvider) http.Handler {
 		DevMode:                           devMode,
 		FeatureTestModeWhatsappSuppressed: featureTestModeWhatsappSuppressed,
 		TestModeWhatsappConfig:            testModeWhatsappConfig,
-		Config:                            whatsappConfig,
+		WhatsappConfig:                    whatsappConfig,
+		LocalizationConfig:                localizationConfig,
 		OnPremisesClient:                  onPremisesClient,
 		TokenStore:                        tokenStore,
 	}
@@ -28757,7 +28785,8 @@ func newWebAppLoginLinkOTPHandler(p *deps.RequestProvider) http.Handler {
 		DevMode:                           devMode,
 		FeatureTestModeWhatsappSuppressed: featureTestModeWhatsappSuppressed,
 		TestModeWhatsappConfig:            testModeWhatsappConfig,
-		Config:                            whatsappConfig,
+		WhatsappConfig:                    whatsappConfig,
+		LocalizationConfig:                localizationConfig,
 		OnPremisesClient:                  onPremisesClient,
 		TokenStore:                        tokenStore,
 	}
@@ -29636,7 +29665,8 @@ func newWebAppVerifyLoginLinkOTPHandler(p *deps.RequestProvider) http.Handler {
 		DevMode:                           devMode,
 		FeatureTestModeWhatsappSuppressed: featureTestModeWhatsappSuppressed,
 		TestModeWhatsappConfig:            testModeWhatsappConfig,
-		Config:                            whatsappConfig,
+		WhatsappConfig:                    whatsappConfig,
+		LocalizationConfig:                localizationConfig,
 		OnPremisesClient:                  onPremisesClient,
 		TokenStore:                        tokenStore,
 	}
@@ -30529,7 +30559,8 @@ func newWebAppAuthflowV2VerifyLoginLinkOTPHandler(p *deps.RequestProvider) http.
 		DevMode:                           devMode,
 		FeatureTestModeWhatsappSuppressed: featureTestModeWhatsappSuppressed,
 		TestModeWhatsappConfig:            testModeWhatsappConfig,
-		Config:                            whatsappConfig,
+		WhatsappConfig:                    whatsappConfig,
+		LocalizationConfig:                localizationConfig,
 		OnPremisesClient:                  onPremisesClient,
 		TokenStore:                        tokenStore,
 	}
@@ -31411,7 +31442,8 @@ func newWebAppEnterRecoveryCodeHandler(p *deps.RequestProvider) http.Handler {
 		DevMode:                           devMode,
 		FeatureTestModeWhatsappSuppressed: featureTestModeWhatsappSuppressed,
 		TestModeWhatsappConfig:            testModeWhatsappConfig,
-		Config:                            whatsappConfig,
+		WhatsappConfig:                    whatsappConfig,
+		LocalizationConfig:                localizationConfig,
 		OnPremisesClient:                  onPremisesClient,
 		TokenStore:                        tokenStore,
 	}
@@ -32282,7 +32314,8 @@ func newWebAppSetupRecoveryCodeHandler(p *deps.RequestProvider) http.Handler {
 		DevMode:                           devMode,
 		FeatureTestModeWhatsappSuppressed: featureTestModeWhatsappSuppressed,
 		TestModeWhatsappConfig:            testModeWhatsappConfig,
-		Config:                            whatsappConfig,
+		WhatsappConfig:                    whatsappConfig,
+		LocalizationConfig:                localizationConfig,
 		OnPremisesClient:                  onPremisesClient,
 		TokenStore:                        tokenStore,
 	}
@@ -33149,7 +33182,8 @@ func newWebAppVerifyIdentityHandler(p *deps.RequestProvider) http.Handler {
 		DevMode:                           devMode,
 		FeatureTestModeWhatsappSuppressed: featureTestModeWhatsappSuppressed,
 		TestModeWhatsappConfig:            testModeWhatsappConfig,
-		Config:                            whatsappConfig,
+		WhatsappConfig:                    whatsappConfig,
+		LocalizationConfig:                localizationConfig,
 		OnPremisesClient:                  onPremisesClient,
 		TokenStore:                        tokenStore,
 	}
@@ -34020,7 +34054,8 @@ func newWebAppVerifyIdentitySuccessHandler(p *deps.RequestProvider) http.Handler
 		DevMode:                           devMode,
 		FeatureTestModeWhatsappSuppressed: featureTestModeWhatsappSuppressed,
 		TestModeWhatsappConfig:            testModeWhatsappConfig,
-		Config:                            whatsappConfig,
+		WhatsappConfig:                    whatsappConfig,
+		LocalizationConfig:                localizationConfig,
 		OnPremisesClient:                  onPremisesClient,
 		TokenStore:                        tokenStore,
 	}
@@ -34887,7 +34922,8 @@ func newWebAppForgotPasswordHandler(p *deps.RequestProvider) http.Handler {
 		DevMode:                           devMode,
 		FeatureTestModeWhatsappSuppressed: featureTestModeWhatsappSuppressed,
 		TestModeWhatsappConfig:            testModeWhatsappConfig,
-		Config:                            whatsappConfig,
+		WhatsappConfig:                    whatsappConfig,
+		LocalizationConfig:                localizationConfig,
 		OnPremisesClient:                  onPremisesClient,
 		TokenStore:                        tokenStore,
 	}
@@ -35764,7 +35800,8 @@ func newWebAppForgotPasswordSuccessHandler(p *deps.RequestProvider) http.Handler
 		DevMode:                           devMode,
 		FeatureTestModeWhatsappSuppressed: featureTestModeWhatsappSuppressed,
 		TestModeWhatsappConfig:            testModeWhatsappConfig,
-		Config:                            whatsappConfig,
+		WhatsappConfig:                    whatsappConfig,
+		LocalizationConfig:                localizationConfig,
 		OnPremisesClient:                  onPremisesClient,
 		TokenStore:                        tokenStore,
 	}
@@ -36631,7 +36668,8 @@ func newWebAppResetPasswordHandler(p *deps.RequestProvider) http.Handler {
 		DevMode:                           devMode,
 		FeatureTestModeWhatsappSuppressed: featureTestModeWhatsappSuppressed,
 		TestModeWhatsappConfig:            testModeWhatsappConfig,
-		Config:                            whatsappConfig,
+		WhatsappConfig:                    whatsappConfig,
+		LocalizationConfig:                localizationConfig,
 		OnPremisesClient:                  onPremisesClient,
 		TokenStore:                        tokenStore,
 	}
@@ -37500,7 +37538,8 @@ func newWebAppResetPasswordSuccessHandler(p *deps.RequestProvider) http.Handler 
 		DevMode:                           devMode,
 		FeatureTestModeWhatsappSuppressed: featureTestModeWhatsappSuppressed,
 		TestModeWhatsappConfig:            testModeWhatsappConfig,
-		Config:                            whatsappConfig,
+		WhatsappConfig:                    whatsappConfig,
+		LocalizationConfig:                localizationConfig,
 		OnPremisesClient:                  onPremisesClient,
 		TokenStore:                        tokenStore,
 	}
@@ -38367,7 +38406,8 @@ func newWebAppSettingsHandler(p *deps.RequestProvider) http.Handler {
 		DevMode:                           devMode,
 		FeatureTestModeWhatsappSuppressed: featureTestModeWhatsappSuppressed,
 		TestModeWhatsappConfig:            testModeWhatsappConfig,
-		Config:                            whatsappConfig,
+		WhatsappConfig:                    whatsappConfig,
+		LocalizationConfig:                localizationConfig,
 		OnPremisesClient:                  onPremisesClient,
 		TokenStore:                        tokenStore,
 	}
@@ -39266,7 +39306,8 @@ func newWebAppSettingsProfileHandler(p *deps.RequestProvider) http.Handler {
 		DevMode:                           devMode,
 		FeatureTestModeWhatsappSuppressed: featureTestModeWhatsappSuppressed,
 		TestModeWhatsappConfig:            testModeWhatsappConfig,
-		Config:                            whatsappConfig,
+		WhatsappConfig:                    whatsappConfig,
+		LocalizationConfig:                localizationConfig,
 		OnPremisesClient:                  onPremisesClient,
 		TokenStore:                        tokenStore,
 	}
@@ -40144,7 +40185,8 @@ func newWebAppSettingsProfileEditHandler(p *deps.RequestProvider) http.Handler {
 		DevMode:                           devMode,
 		FeatureTestModeWhatsappSuppressed: featureTestModeWhatsappSuppressed,
 		TestModeWhatsappConfig:            testModeWhatsappConfig,
-		Config:                            whatsappConfig,
+		WhatsappConfig:                    whatsappConfig,
+		LocalizationConfig:                localizationConfig,
 		OnPremisesClient:                  onPremisesClient,
 		TokenStore:                        tokenStore,
 	}
@@ -41035,7 +41077,8 @@ func newWebAppSettingsIdentityHandler(p *deps.RequestProvider) http.Handler {
 		DevMode:                           devMode,
 		FeatureTestModeWhatsappSuppressed: featureTestModeWhatsappSuppressed,
 		TestModeWhatsappConfig:            testModeWhatsappConfig,
-		Config:                            whatsappConfig,
+		WhatsappConfig:                    whatsappConfig,
+		LocalizationConfig:                localizationConfig,
 		OnPremisesClient:                  onPremisesClient,
 		TokenStore:                        tokenStore,
 	}
@@ -41910,7 +41953,8 @@ func newWebAppSettingsBiometricHandler(p *deps.RequestProvider) http.Handler {
 		DevMode:                           devMode,
 		FeatureTestModeWhatsappSuppressed: featureTestModeWhatsappSuppressed,
 		TestModeWhatsappConfig:            testModeWhatsappConfig,
-		Config:                            whatsappConfig,
+		WhatsappConfig:                    whatsappConfig,
+		LocalizationConfig:                localizationConfig,
 		OnPremisesClient:                  onPremisesClient,
 		TokenStore:                        tokenStore,
 	}
@@ -42778,7 +42822,8 @@ func newWebAppSettingsMFAHandler(p *deps.RequestProvider) http.Handler {
 		DevMode:                           devMode,
 		FeatureTestModeWhatsappSuppressed: featureTestModeWhatsappSuppressed,
 		TestModeWhatsappConfig:            testModeWhatsappConfig,
-		Config:                            whatsappConfig,
+		WhatsappConfig:                    whatsappConfig,
+		LocalizationConfig:                localizationConfig,
 		OnPremisesClient:                  onPremisesClient,
 		TokenStore:                        tokenStore,
 	}
@@ -43654,7 +43699,8 @@ func newWebAppSettingsTOTPHandler(p *deps.RequestProvider) http.Handler {
 		DevMode:                           devMode,
 		FeatureTestModeWhatsappSuppressed: featureTestModeWhatsappSuppressed,
 		TestModeWhatsappConfig:            testModeWhatsappConfig,
-		Config:                            whatsappConfig,
+		WhatsappConfig:                    whatsappConfig,
+		LocalizationConfig:                localizationConfig,
 		OnPremisesClient:                  onPremisesClient,
 		TokenStore:                        tokenStore,
 	}
@@ -44522,7 +44568,8 @@ func newWebAppSettingsPasskeyHandler(p *deps.RequestProvider) http.Handler {
 		DevMode:                           devMode,
 		FeatureTestModeWhatsappSuppressed: featureTestModeWhatsappSuppressed,
 		TestModeWhatsappConfig:            testModeWhatsappConfig,
-		Config:                            whatsappConfig,
+		WhatsappConfig:                    whatsappConfig,
+		LocalizationConfig:                localizationConfig,
 		OnPremisesClient:                  onPremisesClient,
 		TokenStore:                        tokenStore,
 	}
@@ -45390,7 +45437,8 @@ func newWebAppSettingsOOBOTPHandler(p *deps.RequestProvider) http.Handler {
 		DevMode:                           devMode,
 		FeatureTestModeWhatsappSuppressed: featureTestModeWhatsappSuppressed,
 		TestModeWhatsappConfig:            testModeWhatsappConfig,
-		Config:                            whatsappConfig,
+		WhatsappConfig:                    whatsappConfig,
+		LocalizationConfig:                localizationConfig,
 		OnPremisesClient:                  onPremisesClient,
 		TokenStore:                        tokenStore,
 	}
@@ -46258,7 +46306,8 @@ func newWebAppSettingsRecoveryCodeHandler(p *deps.RequestProvider) http.Handler 
 		DevMode:                           devMode,
 		FeatureTestModeWhatsappSuppressed: featureTestModeWhatsappSuppressed,
 		TestModeWhatsappConfig:            testModeWhatsappConfig,
-		Config:                            whatsappConfig,
+		WhatsappConfig:                    whatsappConfig,
+		LocalizationConfig:                localizationConfig,
 		OnPremisesClient:                  onPremisesClient,
 		TokenStore:                        tokenStore,
 	}
@@ -47127,7 +47176,8 @@ func newWebAppSettingsSessionsHandler(p *deps.RequestProvider) http.Handler {
 		DevMode:                           devMode,
 		FeatureTestModeWhatsappSuppressed: featureTestModeWhatsappSuppressed,
 		TestModeWhatsappConfig:            testModeWhatsappConfig,
-		Config:                            whatsappConfig,
+		WhatsappConfig:                    whatsappConfig,
+		LocalizationConfig:                localizationConfig,
 		OnPremisesClient:                  onPremisesClient,
 		TokenStore:                        tokenStore,
 	}
@@ -48015,7 +48065,8 @@ func newWebAppForceChangePasswordHandler(p *deps.RequestProvider) http.Handler {
 		DevMode:                           devMode,
 		FeatureTestModeWhatsappSuppressed: featureTestModeWhatsappSuppressed,
 		TestModeWhatsappConfig:            testModeWhatsappConfig,
-		Config:                            whatsappConfig,
+		WhatsappConfig:                    whatsappConfig,
+		LocalizationConfig:                localizationConfig,
 		OnPremisesClient:                  onPremisesClient,
 		TokenStore:                        tokenStore,
 	}
@@ -48888,7 +48939,8 @@ func newWebAppSettingsChangePasswordHandler(p *deps.RequestProvider) http.Handle
 		DevMode:                           devMode,
 		FeatureTestModeWhatsappSuppressed: featureTestModeWhatsappSuppressed,
 		TestModeWhatsappConfig:            testModeWhatsappConfig,
-		Config:                            whatsappConfig,
+		WhatsappConfig:                    whatsappConfig,
+		LocalizationConfig:                localizationConfig,
 		OnPremisesClient:                  onPremisesClient,
 		TokenStore:                        tokenStore,
 	}
@@ -49756,7 +49808,8 @@ func newWebAppForceChangeSecondaryPasswordHandler(p *deps.RequestProvider) http.
 		DevMode:                           devMode,
 		FeatureTestModeWhatsappSuppressed: featureTestModeWhatsappSuppressed,
 		TestModeWhatsappConfig:            testModeWhatsappConfig,
-		Config:                            whatsappConfig,
+		WhatsappConfig:                    whatsappConfig,
+		LocalizationConfig:                localizationConfig,
 		OnPremisesClient:                  onPremisesClient,
 		TokenStore:                        tokenStore,
 	}
@@ -50629,7 +50682,8 @@ func newWebAppSettingsChangeSecondaryPasswordHandler(p *deps.RequestProvider) ht
 		DevMode:                           devMode,
 		FeatureTestModeWhatsappSuppressed: featureTestModeWhatsappSuppressed,
 		TestModeWhatsappConfig:            testModeWhatsappConfig,
-		Config:                            whatsappConfig,
+		WhatsappConfig:                    whatsappConfig,
+		LocalizationConfig:                localizationConfig,
 		OnPremisesClient:                  onPremisesClient,
 		TokenStore:                        tokenStore,
 	}
@@ -51497,7 +51551,8 @@ func newWebAppSettingsDeleteAccountHandler(p *deps.RequestProvider) http.Handler
 		DevMode:                           devMode,
 		FeatureTestModeWhatsappSuppressed: featureTestModeWhatsappSuppressed,
 		TestModeWhatsappConfig:            testModeWhatsappConfig,
-		Config:                            whatsappConfig,
+		WhatsappConfig:                    whatsappConfig,
+		LocalizationConfig:                localizationConfig,
 		OnPremisesClient:                  onPremisesClient,
 		TokenStore:                        tokenStore,
 	}
@@ -52372,7 +52427,8 @@ func newWebAppSettingsDeleteAccountSuccessHandler(p *deps.RequestProvider) http.
 		DevMode:                           devMode,
 		FeatureTestModeWhatsappSuppressed: featureTestModeWhatsappSuppressed,
 		TestModeWhatsappConfig:            testModeWhatsappConfig,
-		Config:                            whatsappConfig,
+		WhatsappConfig:                    whatsappConfig,
+		LocalizationConfig:                localizationConfig,
 		OnPremisesClient:                  onPremisesClient,
 		TokenStore:                        tokenStore,
 	}
@@ -53241,7 +53297,8 @@ func newWebAppAccountStatusHandler(p *deps.RequestProvider) http.Handler {
 		DevMode:                           devMode,
 		FeatureTestModeWhatsappSuppressed: featureTestModeWhatsappSuppressed,
 		TestModeWhatsappConfig:            testModeWhatsappConfig,
-		Config:                            whatsappConfig,
+		WhatsappConfig:                    whatsappConfig,
+		LocalizationConfig:                localizationConfig,
 		OnPremisesClient:                  onPremisesClient,
 		TokenStore:                        tokenStore,
 	}
@@ -54108,7 +54165,8 @@ func newWebAppLogoutHandler(p *deps.RequestProvider) http.Handler {
 		DevMode:                           devMode,
 		FeatureTestModeWhatsappSuppressed: featureTestModeWhatsappSuppressed,
 		TestModeWhatsappConfig:            testModeWhatsappConfig,
-		Config:                            whatsappConfig,
+		WhatsappConfig:                    whatsappConfig,
+		LocalizationConfig:                localizationConfig,
 		OnPremisesClient:                  onPremisesClient,
 		TokenStore:                        tokenStore,
 	}
@@ -54991,7 +55049,8 @@ func newWebAppReturnHandler(p *deps.RequestProvider) http.Handler {
 		DevMode:                           devMode,
 		FeatureTestModeWhatsappSuppressed: featureTestModeWhatsappSuppressed,
 		TestModeWhatsappConfig:            testModeWhatsappConfig,
-		Config:                            whatsappConfig,
+		WhatsappConfig:                    whatsappConfig,
+		LocalizationConfig:                localizationConfig,
 		OnPremisesClient:                  onPremisesClient,
 		TokenStore:                        tokenStore,
 	}
@@ -55858,7 +55917,8 @@ func newWebAppErrorHandler(p *deps.RequestProvider) http.Handler {
 		DevMode:                           devMode,
 		FeatureTestModeWhatsappSuppressed: featureTestModeWhatsappSuppressed,
 		TestModeWhatsappConfig:            testModeWhatsappConfig,
-		Config:                            whatsappConfig,
+		WhatsappConfig:                    whatsappConfig,
+		LocalizationConfig:                localizationConfig,
 		OnPremisesClient:                  onPremisesClient,
 		TokenStore:                        tokenStore,
 	}
@@ -56709,7 +56769,8 @@ func newWebAppAuthflowV2ErrorHandler(p *deps.RequestProvider) http.Handler {
 		DevMode:                           devMode,
 		FeatureTestModeWhatsappSuppressed: featureTestModeWhatsappSuppressed,
 		TestModeWhatsappConfig:            testModeWhatsappConfig,
-		Config:                            whatsappConfig,
+		WhatsappConfig:                    whatsappConfig,
+		LocalizationConfig:                localizationConfig,
 		OnPremisesClient:                  onPremisesClient,
 		TokenStore:                        tokenStore,
 	}
@@ -57631,7 +57692,8 @@ func newWebAppNotFoundHandler(p *deps.RequestProvider) http.Handler {
 		DevMode:                           devMode,
 		FeatureTestModeWhatsappSuppressed: featureTestModeWhatsappSuppressed,
 		TestModeWhatsappConfig:            testModeWhatsappConfig,
-		Config:                            whatsappConfig,
+		WhatsappConfig:                    whatsappConfig,
+		LocalizationConfig:                localizationConfig,
 		OnPremisesClient:                  onPremisesClient,
 		TokenStore:                        tokenStore,
 	}
@@ -58498,7 +58560,8 @@ func newWebAppAuthflowV2NotFoundHandler(p *deps.RequestProvider) http.Handler {
 		DevMode:                           devMode,
 		FeatureTestModeWhatsappSuppressed: featureTestModeWhatsappSuppressed,
 		TestModeWhatsappConfig:            testModeWhatsappConfig,
-		Config:                            whatsappConfig,
+		WhatsappConfig:                    whatsappConfig,
+		LocalizationConfig:                localizationConfig,
 		OnPremisesClient:                  onPremisesClient,
 		TokenStore:                        tokenStore,
 	}
@@ -59383,7 +59446,8 @@ func newWebAppPasskeyCreationOptionsHandler(p *deps.RequestProvider) http.Handle
 		DevMode:                           devMode,
 		FeatureTestModeWhatsappSuppressed: featureTestModeWhatsappSuppressed,
 		TestModeWhatsappConfig:            testModeWhatsappConfig,
-		Config:                            whatsappConfig,
+		WhatsappConfig:                    whatsappConfig,
+		LocalizationConfig:                localizationConfig,
 		OnPremisesClient:                  onPremisesClient,
 		TokenStore:                        tokenStore,
 	}
@@ -60212,7 +60276,8 @@ func newWebAppPasskeyRequestOptionsHandler(p *deps.RequestProvider) http.Handler
 		DevMode:                           devMode,
 		FeatureTestModeWhatsappSuppressed: featureTestModeWhatsappSuppressed,
 		TestModeWhatsappConfig:            testModeWhatsappConfig,
-		Config:                            whatsappConfig,
+		WhatsappConfig:                    whatsappConfig,
+		LocalizationConfig:                localizationConfig,
 		OnPremisesClient:                  onPremisesClient,
 		TokenStore:                        tokenStore,
 	}
@@ -61040,7 +61105,8 @@ func newWebAppConnectWeb3AccountHandler(p *deps.RequestProvider) http.Handler {
 		DevMode:                           devMode,
 		FeatureTestModeWhatsappSuppressed: featureTestModeWhatsappSuppressed,
 		TestModeWhatsappConfig:            testModeWhatsappConfig,
-		Config:                            whatsappConfig,
+		WhatsappConfig:                    whatsappConfig,
+		LocalizationConfig:                localizationConfig,
 		OnPremisesClient:                  onPremisesClient,
 		TokenStore:                        tokenStore,
 	}
@@ -61917,7 +61983,8 @@ func newWebAppMissingWeb3WalletHandler(p *deps.RequestProvider) http.Handler {
 		DevMode:                           devMode,
 		FeatureTestModeWhatsappSuppressed: featureTestModeWhatsappSuppressed,
 		TestModeWhatsappConfig:            testModeWhatsappConfig,
-		Config:                            whatsappConfig,
+		WhatsappConfig:                    whatsappConfig,
+		LocalizationConfig:                localizationConfig,
 		OnPremisesClient:                  onPremisesClient,
 		TokenStore:                        tokenStore,
 	}
@@ -62785,7 +62852,8 @@ func newWebAppFeatureDisabledHandler(p *deps.RequestProvider) http.Handler {
 		DevMode:                           devMode,
 		FeatureTestModeWhatsappSuppressed: featureTestModeWhatsappSuppressed,
 		TestModeWhatsappConfig:            testModeWhatsappConfig,
-		Config:                            whatsappConfig,
+		WhatsappConfig:                    whatsappConfig,
+		LocalizationConfig:                localizationConfig,
 		OnPremisesClient:                  onPremisesClient,
 		TokenStore:                        tokenStore,
 	}
@@ -63652,7 +63720,8 @@ func newWebAppTesterHandler(p *deps.RequestProvider) http.Handler {
 		DevMode:                           devMode,
 		FeatureTestModeWhatsappSuppressed: featureTestModeWhatsappSuppressed,
 		TestModeWhatsappConfig:            testModeWhatsappConfig,
-		Config:                            whatsappConfig,
+		WhatsappConfig:                    whatsappConfig,
+		LocalizationConfig:                localizationConfig,
 		OnPremisesClient:                  onPremisesClient,
 		TokenStore:                        tokenStore,
 	}
@@ -64589,7 +64658,8 @@ func newAPIWorkflowNewHandler(p *deps.RequestProvider) http.Handler {
 		DevMode:                           devMode,
 		FeatureTestModeWhatsappSuppressed: featureTestModeWhatsappSuppressed,
 		TestModeWhatsappConfig:            testModeWhatsappConfig,
-		Config:                            whatsappConfig,
+		WhatsappConfig:                    whatsappConfig,
+		LocalizationConfig:                localizationConfig,
 		OnPremisesClient:                  onPremisesClient,
 		TokenStore:                        tokenStore,
 	}
@@ -65398,7 +65468,8 @@ func newAPIWorkflowGetHandler(p *deps.RequestProvider) http.Handler {
 		DevMode:                           devMode,
 		FeatureTestModeWhatsappSuppressed: featureTestModeWhatsappSuppressed,
 		TestModeWhatsappConfig:            testModeWhatsappConfig,
-		Config:                            whatsappConfig,
+		WhatsappConfig:                    whatsappConfig,
+		LocalizationConfig:                localizationConfig,
 		OnPremisesClient:                  onPremisesClient,
 		TokenStore:                        tokenStore,
 	}
@@ -66200,7 +66271,8 @@ func newAPIWorkflowInputHandler(p *deps.RequestProvider) http.Handler {
 		DevMode:                           devMode,
 		FeatureTestModeWhatsappSuppressed: featureTestModeWhatsappSuppressed,
 		TestModeWhatsappConfig:            testModeWhatsappConfig,
-		Config:                            whatsappConfig,
+		WhatsappConfig:                    whatsappConfig,
+		LocalizationConfig:                localizationConfig,
 		OnPremisesClient:                  onPremisesClient,
 		TokenStore:                        tokenStore,
 	}
@@ -67037,7 +67109,8 @@ func newAPIWorkflowV2Handler(p *deps.RequestProvider) http.Handler {
 		DevMode:                           devMode,
 		FeatureTestModeWhatsappSuppressed: featureTestModeWhatsappSuppressed,
 		TestModeWhatsappConfig:            testModeWhatsappConfig,
-		Config:                            whatsappConfig,
+		WhatsappConfig:                    whatsappConfig,
+		LocalizationConfig:                localizationConfig,
 		OnPremisesClient:                  onPremisesClient,
 		TokenStore:                        tokenStore,
 	}
@@ -67852,7 +67925,8 @@ func newAPIAuthenticationFlowV1CreateHandler(p *deps.RequestProvider) http.Handl
 		DevMode:                           devMode,
 		FeatureTestModeWhatsappSuppressed: featureTestModeWhatsappSuppressed,
 		TestModeWhatsappConfig:            testModeWhatsappConfig,
-		Config:                            whatsappConfig,
+		WhatsappConfig:                    whatsappConfig,
+		LocalizationConfig:                localizationConfig,
 		OnPremisesClient:                  onPremisesClient,
 		TokenStore:                        tokenStore,
 	}
@@ -68702,7 +68776,8 @@ func newAPIAuthenticationFlowV1InputHandler(p *deps.RequestProvider) http.Handle
 		DevMode:                           devMode,
 		FeatureTestModeWhatsappSuppressed: featureTestModeWhatsappSuppressed,
 		TestModeWhatsappConfig:            testModeWhatsappConfig,
-		Config:                            whatsappConfig,
+		WhatsappConfig:                    whatsappConfig,
+		LocalizationConfig:                localizationConfig,
 		OnPremisesClient:                  onPremisesClient,
 		TokenStore:                        tokenStore,
 	}
@@ -69545,7 +69620,8 @@ func newAPIAuthenticationFlowV1GetHandler(p *deps.RequestProvider) http.Handler 
 		DevMode:                           devMode,
 		FeatureTestModeWhatsappSuppressed: featureTestModeWhatsappSuppressed,
 		TestModeWhatsappConfig:            testModeWhatsappConfig,
-		Config:                            whatsappConfig,
+		WhatsappConfig:                    whatsappConfig,
+		LocalizationConfig:                localizationConfig,
 		OnPremisesClient:                  onPremisesClient,
 		TokenStore:                        tokenStore,
 	}
@@ -70430,7 +70506,8 @@ func newWebAppAuthflowLoginHandler(p *deps.RequestProvider) http.Handler {
 		DevMode:                           devMode,
 		FeatureTestModeWhatsappSuppressed: featureTestModeWhatsappSuppressed,
 		TestModeWhatsappConfig:            testModeWhatsappConfig,
-		Config:                            whatsappConfig,
+		WhatsappConfig:                    whatsappConfig,
+		LocalizationConfig:                localizationConfig,
 		OnPremisesClient:                  onPremisesClient,
 		TokenStore:                        tokenStore,
 	}
@@ -71360,7 +71437,8 @@ func newWebAppAuthflowV2LoginHandler(p *deps.RequestProvider) http.Handler {
 		DevMode:                           devMode,
 		FeatureTestModeWhatsappSuppressed: featureTestModeWhatsappSuppressed,
 		TestModeWhatsappConfig:            testModeWhatsappConfig,
-		Config:                            whatsappConfig,
+		WhatsappConfig:                    whatsappConfig,
+		LocalizationConfig:                localizationConfig,
 		OnPremisesClient:                  onPremisesClient,
 		TokenStore:                        tokenStore,
 	}
@@ -72302,7 +72380,8 @@ func newWebAppAuthflowSignupHandler(p *deps.RequestProvider) http.Handler {
 		DevMode:                           devMode,
 		FeatureTestModeWhatsappSuppressed: featureTestModeWhatsappSuppressed,
 		TestModeWhatsappConfig:            testModeWhatsappConfig,
-		Config:                            whatsappConfig,
+		WhatsappConfig:                    whatsappConfig,
+		LocalizationConfig:                localizationConfig,
 		OnPremisesClient:                  onPremisesClient,
 		TokenStore:                        tokenStore,
 	}
@@ -73231,7 +73310,8 @@ func newWebAppAuthflowV2SignupHandler(p *deps.RequestProvider) http.Handler {
 		DevMode:                           devMode,
 		FeatureTestModeWhatsappSuppressed: featureTestModeWhatsappSuppressed,
 		TestModeWhatsappConfig:            testModeWhatsappConfig,
-		Config:                            whatsappConfig,
+		WhatsappConfig:                    whatsappConfig,
+		LocalizationConfig:                localizationConfig,
 		OnPremisesClient:                  onPremisesClient,
 		TokenStore:                        tokenStore,
 	}
@@ -74164,7 +74244,8 @@ func newWebAppAuthflowPromoteHandler(p *deps.RequestProvider) http.Handler {
 		DevMode:                           devMode,
 		FeatureTestModeWhatsappSuppressed: featureTestModeWhatsappSuppressed,
 		TestModeWhatsappConfig:            testModeWhatsappConfig,
-		Config:                            whatsappConfig,
+		WhatsappConfig:                    whatsappConfig,
+		LocalizationConfig:                localizationConfig,
 		OnPremisesClient:                  onPremisesClient,
 		TokenStore:                        tokenStore,
 	}
@@ -75076,7 +75157,8 @@ func newWebAppAuthflowV2PromoteHandler(p *deps.RequestProvider) http.Handler {
 		DevMode:                           devMode,
 		FeatureTestModeWhatsappSuppressed: featureTestModeWhatsappSuppressed,
 		TestModeWhatsappConfig:            testModeWhatsappConfig,
-		Config:                            whatsappConfig,
+		WhatsappConfig:                    whatsappConfig,
+		LocalizationConfig:                localizationConfig,
 		OnPremisesClient:                  onPremisesClient,
 		TokenStore:                        tokenStore,
 	}
@@ -75988,7 +76070,8 @@ func newWebAppAuthflowEnterPasswordHandler(p *deps.RequestProvider) http.Handler
 		DevMode:                           devMode,
 		FeatureTestModeWhatsappSuppressed: featureTestModeWhatsappSuppressed,
 		TestModeWhatsappConfig:            testModeWhatsappConfig,
-		Config:                            whatsappConfig,
+		WhatsappConfig:                    whatsappConfig,
+		LocalizationConfig:                localizationConfig,
 		OnPremisesClient:                  onPremisesClient,
 		TokenStore:                        tokenStore,
 	}
@@ -76894,7 +76977,8 @@ func newWebAppAuthflowV2EnterPasswordHandler(p *deps.RequestProvider) http.Handl
 		DevMode:                           devMode,
 		FeatureTestModeWhatsappSuppressed: featureTestModeWhatsappSuppressed,
 		TestModeWhatsappConfig:            testModeWhatsappConfig,
-		Config:                            whatsappConfig,
+		WhatsappConfig:                    whatsappConfig,
+		LocalizationConfig:                localizationConfig,
 		OnPremisesClient:                  onPremisesClient,
 		TokenStore:                        tokenStore,
 	}
@@ -77800,7 +77884,8 @@ func newWebAppAuthflowEnterOOBOTPHandler(p *deps.RequestProvider) http.Handler {
 		DevMode:                           devMode,
 		FeatureTestModeWhatsappSuppressed: featureTestModeWhatsappSuppressed,
 		TestModeWhatsappConfig:            testModeWhatsappConfig,
-		Config:                            whatsappConfig,
+		WhatsappConfig:                    whatsappConfig,
+		LocalizationConfig:                localizationConfig,
 		OnPremisesClient:                  onPremisesClient,
 		TokenStore:                        tokenStore,
 	}
@@ -78708,7 +78793,8 @@ func newWebAppAuthflowV2EnterOOBOTPHandler(p *deps.RequestProvider) http.Handler
 		DevMode:                           devMode,
 		FeatureTestModeWhatsappSuppressed: featureTestModeWhatsappSuppressed,
 		TestModeWhatsappConfig:            testModeWhatsappConfig,
-		Config:                            whatsappConfig,
+		WhatsappConfig:                    whatsappConfig,
+		LocalizationConfig:                localizationConfig,
 		OnPremisesClient:                  onPremisesClient,
 		TokenStore:                        tokenStore,
 	}
@@ -79616,7 +79702,8 @@ func newWebAppAuthflowCreatePasswordHandler(p *deps.RequestProvider) http.Handle
 		DevMode:                           devMode,
 		FeatureTestModeWhatsappSuppressed: featureTestModeWhatsappSuppressed,
 		TestModeWhatsappConfig:            testModeWhatsappConfig,
-		Config:                            whatsappConfig,
+		WhatsappConfig:                    whatsappConfig,
+		LocalizationConfig:                localizationConfig,
 		OnPremisesClient:                  onPremisesClient,
 		TokenStore:                        tokenStore,
 	}
@@ -80522,7 +80609,8 @@ func newWebAppAuthflowV2CreatePasswordHandler(p *deps.RequestProvider) http.Hand
 		DevMode:                           devMode,
 		FeatureTestModeWhatsappSuppressed: featureTestModeWhatsappSuppressed,
 		TestModeWhatsappConfig:            testModeWhatsappConfig,
-		Config:                            whatsappConfig,
+		WhatsappConfig:                    whatsappConfig,
+		LocalizationConfig:                localizationConfig,
 		OnPremisesClient:                  onPremisesClient,
 		TokenStore:                        tokenStore,
 	}
@@ -81428,7 +81516,8 @@ func newWebAppAuthflowEnterTOTPHandler(p *deps.RequestProvider) http.Handler {
 		DevMode:                           devMode,
 		FeatureTestModeWhatsappSuppressed: featureTestModeWhatsappSuppressed,
 		TestModeWhatsappConfig:            testModeWhatsappConfig,
-		Config:                            whatsappConfig,
+		WhatsappConfig:                    whatsappConfig,
+		LocalizationConfig:                localizationConfig,
 		OnPremisesClient:                  onPremisesClient,
 		TokenStore:                        tokenStore,
 	}
@@ -82334,7 +82423,8 @@ func newWebAppAuthflowV2EnterTOTPHandler(p *deps.RequestProvider) http.Handler {
 		DevMode:                           devMode,
 		FeatureTestModeWhatsappSuppressed: featureTestModeWhatsappSuppressed,
 		TestModeWhatsappConfig:            testModeWhatsappConfig,
-		Config:                            whatsappConfig,
+		WhatsappConfig:                    whatsappConfig,
+		LocalizationConfig:                localizationConfig,
 		OnPremisesClient:                  onPremisesClient,
 		TokenStore:                        tokenStore,
 	}
@@ -83240,7 +83330,8 @@ func newWebAppAuthflowSetupTOTPHandler(p *deps.RequestProvider) http.Handler {
 		DevMode:                           devMode,
 		FeatureTestModeWhatsappSuppressed: featureTestModeWhatsappSuppressed,
 		TestModeWhatsappConfig:            testModeWhatsappConfig,
-		Config:                            whatsappConfig,
+		WhatsappConfig:                    whatsappConfig,
+		LocalizationConfig:                localizationConfig,
 		OnPremisesClient:                  onPremisesClient,
 		TokenStore:                        tokenStore,
 	}
@@ -84146,7 +84237,8 @@ func newWebAppAuthflowV2SetupTOTPHandler(p *deps.RequestProvider) http.Handler {
 		DevMode:                           devMode,
 		FeatureTestModeWhatsappSuppressed: featureTestModeWhatsappSuppressed,
 		TestModeWhatsappConfig:            testModeWhatsappConfig,
-		Config:                            whatsappConfig,
+		WhatsappConfig:                    whatsappConfig,
+		LocalizationConfig:                localizationConfig,
 		OnPremisesClient:                  onPremisesClient,
 		TokenStore:                        tokenStore,
 	}
@@ -85052,7 +85144,8 @@ func newWebAppAuthflowViewRecoveryCodeHandler(p *deps.RequestProvider) http.Hand
 		DevMode:                           devMode,
 		FeatureTestModeWhatsappSuppressed: featureTestModeWhatsappSuppressed,
 		TestModeWhatsappConfig:            testModeWhatsappConfig,
-		Config:                            whatsappConfig,
+		WhatsappConfig:                    whatsappConfig,
+		LocalizationConfig:                localizationConfig,
 		OnPremisesClient:                  onPremisesClient,
 		TokenStore:                        tokenStore,
 	}
@@ -85958,7 +86051,8 @@ func newWebAppAuthflowV2ViewRecoveryCodeHandler(p *deps.RequestProvider) http.Ha
 		DevMode:                           devMode,
 		FeatureTestModeWhatsappSuppressed: featureTestModeWhatsappSuppressed,
 		TestModeWhatsappConfig:            testModeWhatsappConfig,
-		Config:                            whatsappConfig,
+		WhatsappConfig:                    whatsappConfig,
+		LocalizationConfig:                localizationConfig,
 		OnPremisesClient:                  onPremisesClient,
 		TokenStore:                        tokenStore,
 	}
@@ -86864,7 +86958,8 @@ func newWebAppAuthflowWhatsappOTPHandler(p *deps.RequestProvider) http.Handler {
 		DevMode:                           devMode,
 		FeatureTestModeWhatsappSuppressed: featureTestModeWhatsappSuppressed,
 		TestModeWhatsappConfig:            testModeWhatsappConfig,
-		Config:                            whatsappConfig,
+		WhatsappConfig:                    whatsappConfig,
+		LocalizationConfig:                localizationConfig,
 		OnPremisesClient:                  onPremisesClient,
 		TokenStore:                        tokenStore,
 	}
@@ -87772,7 +87867,8 @@ func newWebAppAuthflowOOBOTPLinkHandler(p *deps.RequestProvider) http.Handler {
 		DevMode:                           devMode,
 		FeatureTestModeWhatsappSuppressed: featureTestModeWhatsappSuppressed,
 		TestModeWhatsappConfig:            testModeWhatsappConfig,
-		Config:                            whatsappConfig,
+		WhatsappConfig:                    whatsappConfig,
+		LocalizationConfig:                localizationConfig,
 		OnPremisesClient:                  onPremisesClient,
 		TokenStore:                        tokenStore,
 	}
@@ -88680,7 +88776,8 @@ func newWebAppAuthflowV2OOBOTPLinkHandler(p *deps.RequestProvider) http.Handler 
 		DevMode:                           devMode,
 		FeatureTestModeWhatsappSuppressed: featureTestModeWhatsappSuppressed,
 		TestModeWhatsappConfig:            testModeWhatsappConfig,
-		Config:                            whatsappConfig,
+		WhatsappConfig:                    whatsappConfig,
+		LocalizationConfig:                localizationConfig,
 		OnPremisesClient:                  onPremisesClient,
 		TokenStore:                        tokenStore,
 	}
@@ -89587,7 +89684,8 @@ func newWebAppAuthflowChangePasswordHandler(p *deps.RequestProvider) http.Handle
 		DevMode:                           devMode,
 		FeatureTestModeWhatsappSuppressed: featureTestModeWhatsappSuppressed,
 		TestModeWhatsappConfig:            testModeWhatsappConfig,
-		Config:                            whatsappConfig,
+		WhatsappConfig:                    whatsappConfig,
+		LocalizationConfig:                localizationConfig,
 		OnPremisesClient:                  onPremisesClient,
 		TokenStore:                        tokenStore,
 	}
@@ -90498,7 +90596,8 @@ func newWebAppAuthflowV2ChangePasswordHandler(p *deps.RequestProvider) http.Hand
 		DevMode:                           devMode,
 		FeatureTestModeWhatsappSuppressed: featureTestModeWhatsappSuppressed,
 		TestModeWhatsappConfig:            testModeWhatsappConfig,
-		Config:                            whatsappConfig,
+		WhatsappConfig:                    whatsappConfig,
+		LocalizationConfig:                localizationConfig,
 		OnPremisesClient:                  onPremisesClient,
 		TokenStore:                        tokenStore,
 	}
@@ -91410,7 +91509,8 @@ func newWebAppAuthflowV2ChangePasswordSuccessHandler(p *deps.RequestProvider) ht
 		DevMode:                           devMode,
 		FeatureTestModeWhatsappSuppressed: featureTestModeWhatsappSuppressed,
 		TestModeWhatsappConfig:            testModeWhatsappConfig,
-		Config:                            whatsappConfig,
+		WhatsappConfig:                    whatsappConfig,
+		LocalizationConfig:                localizationConfig,
 		OnPremisesClient:                  onPremisesClient,
 		TokenStore:                        tokenStore,
 	}
@@ -92316,7 +92416,8 @@ func newWebAppAuthflowUsePasskeyHandler(p *deps.RequestProvider) http.Handler {
 		DevMode:                           devMode,
 		FeatureTestModeWhatsappSuppressed: featureTestModeWhatsappSuppressed,
 		TestModeWhatsappConfig:            testModeWhatsappConfig,
-		Config:                            whatsappConfig,
+		WhatsappConfig:                    whatsappConfig,
+		LocalizationConfig:                localizationConfig,
 		OnPremisesClient:                  onPremisesClient,
 		TokenStore:                        tokenStore,
 	}
@@ -93222,7 +93323,8 @@ func newWebAppAuthflowV2UsePasskeyHandler(p *deps.RequestProvider) http.Handler 
 		DevMode:                           devMode,
 		FeatureTestModeWhatsappSuppressed: featureTestModeWhatsappSuppressed,
 		TestModeWhatsappConfig:            testModeWhatsappConfig,
-		Config:                            whatsappConfig,
+		WhatsappConfig:                    whatsappConfig,
+		LocalizationConfig:                localizationConfig,
 		OnPremisesClient:                  onPremisesClient,
 		TokenStore:                        tokenStore,
 	}
@@ -94128,7 +94230,8 @@ func newWebAppAuthflowPromptCreatePasskeyHandler(p *deps.RequestProvider) http.H
 		DevMode:                           devMode,
 		FeatureTestModeWhatsappSuppressed: featureTestModeWhatsappSuppressed,
 		TestModeWhatsappConfig:            testModeWhatsappConfig,
-		Config:                            whatsappConfig,
+		WhatsappConfig:                    whatsappConfig,
+		LocalizationConfig:                localizationConfig,
 		OnPremisesClient:                  onPremisesClient,
 		TokenStore:                        tokenStore,
 	}
@@ -95034,7 +95137,8 @@ func newWebAppAuthflowV2PromptCreatePasskeyHandler(p *deps.RequestProvider) http
 		DevMode:                           devMode,
 		FeatureTestModeWhatsappSuppressed: featureTestModeWhatsappSuppressed,
 		TestModeWhatsappConfig:            testModeWhatsappConfig,
-		Config:                            whatsappConfig,
+		WhatsappConfig:                    whatsappConfig,
+		LocalizationConfig:                localizationConfig,
 		OnPremisesClient:                  onPremisesClient,
 		TokenStore:                        tokenStore,
 	}
@@ -95940,7 +96044,8 @@ func newWebAppAuthflowEnterRecoveryCodeHandler(p *deps.RequestProvider) http.Han
 		DevMode:                           devMode,
 		FeatureTestModeWhatsappSuppressed: featureTestModeWhatsappSuppressed,
 		TestModeWhatsappConfig:            testModeWhatsappConfig,
-		Config:                            whatsappConfig,
+		WhatsappConfig:                    whatsappConfig,
+		LocalizationConfig:                localizationConfig,
 		OnPremisesClient:                  onPremisesClient,
 		TokenStore:                        tokenStore,
 	}
@@ -96846,7 +96951,8 @@ func newWebAppAuthflowV2EnterRecoveryCodeHandler(p *deps.RequestProvider) http.H
 		DevMode:                           devMode,
 		FeatureTestModeWhatsappSuppressed: featureTestModeWhatsappSuppressed,
 		TestModeWhatsappConfig:            testModeWhatsappConfig,
-		Config:                            whatsappConfig,
+		WhatsappConfig:                    whatsappConfig,
+		LocalizationConfig:                localizationConfig,
 		OnPremisesClient:                  onPremisesClient,
 		TokenStore:                        tokenStore,
 	}
@@ -97752,7 +97858,8 @@ func newWebAppAuthflowSetupOOBOTPHandler(p *deps.RequestProvider) http.Handler {
 		DevMode:                           devMode,
 		FeatureTestModeWhatsappSuppressed: featureTestModeWhatsappSuppressed,
 		TestModeWhatsappConfig:            testModeWhatsappConfig,
-		Config:                            whatsappConfig,
+		WhatsappConfig:                    whatsappConfig,
+		LocalizationConfig:                localizationConfig,
 		OnPremisesClient:                  onPremisesClient,
 		TokenStore:                        tokenStore,
 	}
@@ -98658,7 +98765,8 @@ func newWebAppAuthflowV2SetupOOBOTPHandler(p *deps.RequestProvider) http.Handler
 		DevMode:                           devMode,
 		FeatureTestModeWhatsappSuppressed: featureTestModeWhatsappSuppressed,
 		TestModeWhatsappConfig:            testModeWhatsappConfig,
-		Config:                            whatsappConfig,
+		WhatsappConfig:                    whatsappConfig,
+		LocalizationConfig:                localizationConfig,
 		OnPremisesClient:                  onPremisesClient,
 		TokenStore:                        tokenStore,
 	}
@@ -99564,7 +99672,8 @@ func newWebAppAuthflowTerminateOtherSessionsHandler(p *deps.RequestProvider) htt
 		DevMode:                           devMode,
 		FeatureTestModeWhatsappSuppressed: featureTestModeWhatsappSuppressed,
 		TestModeWhatsappConfig:            testModeWhatsappConfig,
-		Config:                            whatsappConfig,
+		WhatsappConfig:                    whatsappConfig,
+		LocalizationConfig:                localizationConfig,
 		OnPremisesClient:                  onPremisesClient,
 		TokenStore:                        tokenStore,
 	}
@@ -100470,7 +100579,8 @@ func newWebAppAuthflowV2TerminateOtherSessionsHandler(p *deps.RequestProvider) h
 		DevMode:                           devMode,
 		FeatureTestModeWhatsappSuppressed: featureTestModeWhatsappSuppressed,
 		TestModeWhatsappConfig:            testModeWhatsappConfig,
-		Config:                            whatsappConfig,
+		WhatsappConfig:                    whatsappConfig,
+		LocalizationConfig:                localizationConfig,
 		OnPremisesClient:                  onPremisesClient,
 		TokenStore:                        tokenStore,
 	}
@@ -101376,7 +101486,8 @@ func newWebAppAuthflowWechatHandler(p *deps.RequestProvider) http.Handler {
 		DevMode:                           devMode,
 		FeatureTestModeWhatsappSuppressed: featureTestModeWhatsappSuppressed,
 		TestModeWhatsappConfig:            testModeWhatsappConfig,
-		Config:                            whatsappConfig,
+		WhatsappConfig:                    whatsappConfig,
+		LocalizationConfig:                localizationConfig,
 		OnPremisesClient:                  onPremisesClient,
 		TokenStore:                        tokenStore,
 	}
@@ -102282,7 +102393,8 @@ func newWebAppAuthflowForgotPasswordHandler(p *deps.RequestProvider) http.Handle
 		DevMode:                           devMode,
 		FeatureTestModeWhatsappSuppressed: featureTestModeWhatsappSuppressed,
 		TestModeWhatsappConfig:            testModeWhatsappConfig,
-		Config:                            whatsappConfig,
+		WhatsappConfig:                    whatsappConfig,
+		LocalizationConfig:                localizationConfig,
 		OnPremisesClient:                  onPremisesClient,
 		TokenStore:                        tokenStore,
 	}
@@ -103188,7 +103300,8 @@ func newWebAppAuthflowV2ForgotPasswordHandler(p *deps.RequestProvider) http.Hand
 		DevMode:                           devMode,
 		FeatureTestModeWhatsappSuppressed: featureTestModeWhatsappSuppressed,
 		TestModeWhatsappConfig:            testModeWhatsappConfig,
-		Config:                            whatsappConfig,
+		WhatsappConfig:                    whatsappConfig,
+		LocalizationConfig:                localizationConfig,
 		OnPremisesClient:                  onPremisesClient,
 		TokenStore:                        tokenStore,
 	}
@@ -104094,7 +104207,8 @@ func newWebAppAuthflowForgotPasswordOTPHandler(p *deps.RequestProvider) http.Han
 		DevMode:                           devMode,
 		FeatureTestModeWhatsappSuppressed: featureTestModeWhatsappSuppressed,
 		TestModeWhatsappConfig:            testModeWhatsappConfig,
-		Config:                            whatsappConfig,
+		WhatsappConfig:                    whatsappConfig,
+		LocalizationConfig:                localizationConfig,
 		OnPremisesClient:                  onPremisesClient,
 		TokenStore:                        tokenStore,
 	}
@@ -105002,7 +105116,8 @@ func newWebAppAuthflowV2ForgotPasswordOTPHandler(p *deps.RequestProvider) http.H
 		DevMode:                           devMode,
 		FeatureTestModeWhatsappSuppressed: featureTestModeWhatsappSuppressed,
 		TestModeWhatsappConfig:            testModeWhatsappConfig,
-		Config:                            whatsappConfig,
+		WhatsappConfig:                    whatsappConfig,
+		LocalizationConfig:                localizationConfig,
 		OnPremisesClient:                  onPremisesClient,
 		TokenStore:                        tokenStore,
 	}
@@ -105910,7 +106025,8 @@ func newWebAppAuthflowForgotPasswordSuccessHandler(p *deps.RequestProvider) http
 		DevMode:                           devMode,
 		FeatureTestModeWhatsappSuppressed: featureTestModeWhatsappSuppressed,
 		TestModeWhatsappConfig:            testModeWhatsappConfig,
-		Config:                            whatsappConfig,
+		WhatsappConfig:                    whatsappConfig,
+		LocalizationConfig:                localizationConfig,
 		OnPremisesClient:                  onPremisesClient,
 		TokenStore:                        tokenStore,
 	}
@@ -106816,7 +106932,8 @@ func newWebAppAuthflowV2ForgotPasswordLinkSentHandler(p *deps.RequestProvider) h
 		DevMode:                           devMode,
 		FeatureTestModeWhatsappSuppressed: featureTestModeWhatsappSuppressed,
 		TestModeWhatsappConfig:            testModeWhatsappConfig,
-		Config:                            whatsappConfig,
+		WhatsappConfig:                    whatsappConfig,
+		LocalizationConfig:                localizationConfig,
 		OnPremisesClient:                  onPremisesClient,
 		TokenStore:                        tokenStore,
 	}
@@ -107739,7 +107856,8 @@ func newWebAppReauthHandler(p *deps.RequestProvider) http.Handler {
 		DevMode:                           devMode,
 		FeatureTestModeWhatsappSuppressed: featureTestModeWhatsappSuppressed,
 		TestModeWhatsappConfig:            testModeWhatsappConfig,
-		Config:                            whatsappConfig,
+		WhatsappConfig:                    whatsappConfig,
+		LocalizationConfig:                localizationConfig,
 		OnPremisesClient:                  onPremisesClient,
 		TokenStore:                        tokenStore,
 	}
@@ -108588,7 +108706,8 @@ func newWebAppAuthflowReauthHandler(p *deps.RequestProvider) http.Handler {
 		DevMode:                           devMode,
 		FeatureTestModeWhatsappSuppressed: featureTestModeWhatsappSuppressed,
 		TestModeWhatsappConfig:            testModeWhatsappConfig,
-		Config:                            whatsappConfig,
+		WhatsappConfig:                    whatsappConfig,
+		LocalizationConfig:                localizationConfig,
 		OnPremisesClient:                  onPremisesClient,
 		TokenStore:                        tokenStore,
 	}
@@ -109463,7 +109582,8 @@ func newWebAppAuthflowV2ReauthHandler(p *deps.RequestProvider) http.Handler {
 		DevMode:                           devMode,
 		FeatureTestModeWhatsappSuppressed: featureTestModeWhatsappSuppressed,
 		TestModeWhatsappConfig:            testModeWhatsappConfig,
-		Config:                            whatsappConfig,
+		WhatsappConfig:                    whatsappConfig,
+		LocalizationConfig:                localizationConfig,
 		OnPremisesClient:                  onPremisesClient,
 		TokenStore:                        tokenStore,
 	}
@@ -110338,7 +110458,8 @@ func newWebAppAuthflowResetPasswordHandler(p *deps.RequestProvider) http.Handler
 		DevMode:                           devMode,
 		FeatureTestModeWhatsappSuppressed: featureTestModeWhatsappSuppressed,
 		TestModeWhatsappConfig:            testModeWhatsappConfig,
-		Config:                            whatsappConfig,
+		WhatsappConfig:                    whatsappConfig,
+		LocalizationConfig:                localizationConfig,
 		OnPremisesClient:                  onPremisesClient,
 		TokenStore:                        tokenStore,
 	}
@@ -111244,7 +111365,8 @@ func newWebAppAuthflowV2ResetPasswordHandler(p *deps.RequestProvider) http.Handl
 		DevMode:                           devMode,
 		FeatureTestModeWhatsappSuppressed: featureTestModeWhatsappSuppressed,
 		TestModeWhatsappConfig:            testModeWhatsappConfig,
-		Config:                            whatsappConfig,
+		WhatsappConfig:                    whatsappConfig,
+		LocalizationConfig:                localizationConfig,
 		OnPremisesClient:                  onPremisesClient,
 		TokenStore:                        tokenStore,
 	}
@@ -112150,7 +112272,8 @@ func newWebAppAuthflowResetPasswordSuccessHandler(p *deps.RequestProvider) http.
 		DevMode:                           devMode,
 		FeatureTestModeWhatsappSuppressed: featureTestModeWhatsappSuppressed,
 		TestModeWhatsappConfig:            testModeWhatsappConfig,
-		Config:                            whatsappConfig,
+		WhatsappConfig:                    whatsappConfig,
+		LocalizationConfig:                localizationConfig,
 		OnPremisesClient:                  onPremisesClient,
 		TokenStore:                        tokenStore,
 	}
@@ -113056,7 +113179,8 @@ func newWebAppAuthflowV2ResetPasswordSuccessHandler(p *deps.RequestProvider) htt
 		DevMode:                           devMode,
 		FeatureTestModeWhatsappSuppressed: featureTestModeWhatsappSuppressed,
 		TestModeWhatsappConfig:            testModeWhatsappConfig,
-		Config:                            whatsappConfig,
+		WhatsappConfig:                    whatsappConfig,
+		LocalizationConfig:                localizationConfig,
 		OnPremisesClient:                  onPremisesClient,
 		TokenStore:                        tokenStore,
 	}
@@ -114259,7 +114383,8 @@ func newWebAppAuthflowFinishFlowHandler(p *deps.RequestProvider) http.Handler {
 		DevMode:                           devMode,
 		FeatureTestModeWhatsappSuppressed: featureTestModeWhatsappSuppressed,
 		TestModeWhatsappConfig:            testModeWhatsappConfig,
-		Config:                            whatsappConfig,
+		WhatsappConfig:                    whatsappConfig,
+		LocalizationConfig:                localizationConfig,
 		OnPremisesClient:                  onPremisesClient,
 		TokenStore:                        tokenStore,
 	}
@@ -115165,7 +115290,8 @@ func newWebAppAuthflowV2FinishFlowHandler(p *deps.RequestProvider) http.Handler 
 		DevMode:                           devMode,
 		FeatureTestModeWhatsappSuppressed: featureTestModeWhatsappSuppressed,
 		TestModeWhatsappConfig:            testModeWhatsappConfig,
-		Config:                            whatsappConfig,
+		WhatsappConfig:                    whatsappConfig,
+		LocalizationConfig:                localizationConfig,
 		OnPremisesClient:                  onPremisesClient,
 		TokenStore:                        tokenStore,
 	}
@@ -116170,7 +116296,8 @@ func newWebAppAuthflowV2WechatHandler(p *deps.RequestProvider) http.Handler {
 		DevMode:                           devMode,
 		FeatureTestModeWhatsappSuppressed: featureTestModeWhatsappSuppressed,
 		TestModeWhatsappConfig:            testModeWhatsappConfig,
-		Config:                            whatsappConfig,
+		WhatsappConfig:                    whatsappConfig,
+		LocalizationConfig:                localizationConfig,
 		OnPremisesClient:                  onPremisesClient,
 		TokenStore:                        tokenStore,
 	}
@@ -118100,7 +118227,8 @@ func newWebAppSessionMiddleware(p *deps.RequestProvider) httproute.Middleware {
 		DevMode:                           devMode,
 		FeatureTestModeWhatsappSuppressed: featureTestModeWhatsappSuppressed,
 		TestModeWhatsappConfig:            testModeWhatsappConfig,
-		Config:                            whatsappConfig,
+		WhatsappConfig:                    whatsappConfig,
+		LocalizationConfig:                localizationConfig,
 		OnPremisesClient:                  onPremisesClient,
 		TokenStore:                        tokenStore,
 	}

--- a/pkg/lib/infra/whatsapp/service.go
+++ b/pkg/lib/infra/whatsapp/service.go
@@ -47,7 +47,7 @@ func (s *Service) resolveTemplateLanguage(supportedLanguages []string) string {
 	}
 	preferredLanguageTags := intl.GetPreferredLanguageTags(s.Context)
 	supportedLanguageTags := intl.Supported(supportedLanguages, intl.Fallback(supportedLanguages[0]))
-	idx, _ := intl.Match(preferredLanguageTags, supportedLanguageTags)
+	idx, _ := intl.BestMatch(preferredLanguageTags, supportedLanguageTags)
 	return supportedLanguageTags[idx]
 }
 

--- a/pkg/lib/infra/whatsapp/service.go
+++ b/pkg/lib/infra/whatsapp/service.go
@@ -24,7 +24,8 @@ type Service struct {
 	DevMode                           config.DevMode
 	FeatureTestModeWhatsappSuppressed config.FeatureTestModeWhatsappSuppressed
 	TestModeWhatsappConfig            *config.TestModeWhatsappConfig
-	Config                            *config.WhatsappConfig
+	WhatsappConfig                    *config.WhatsappConfig
+	LocalizationConfig                *config.LocalizationConfig
 	OnPremisesClient                  *OnPremisesClient
 	TokenStore                        *TokenStore
 }
@@ -46,8 +47,17 @@ func (s *Service) resolveTemplateLanguage(supportedLanguages []string) string {
 		panic("whatsapp: template has no supported language")
 	}
 	preferredLanguageTags := intl.GetPreferredLanguageTags(s.Context)
+	configSupportedLanguageTags := intl.Supported(
+		s.LocalizationConfig.SupportedLanguages,
+		intl.Fallback(*s.LocalizationConfig.FallbackLanguage),
+	)
+	// First, resolve once based on supported language in config
+	// This is to avoid inconsistency of ui lanuage and whatsapp message language
+	_, resolvedTag := intl.BestMatch(preferredLanguageTags, configSupportedLanguageTags)
 	supportedLanguageTags := intl.Supported(supportedLanguages, intl.Fallback(supportedLanguages[0]))
-	idx, _ := intl.BestMatch(preferredLanguageTags, supportedLanguageTags)
+
+	// Then, resolve to a language supported by the whatsapp template
+	idx, _ := intl.BestMatch([]string{resolvedTag.String()}, supportedLanguageTags)
 	return supportedLanguageTags[idx]
 }
 
@@ -83,7 +93,7 @@ func (s *Service) getOTPTemplate() (*config.WhatsappTemplateConfig, error) {
 		}, nil
 	}
 
-	switch s.Config.APIType {
+	switch s.WhatsappConfig.APIType {
 	case config.WhatsappAPITypeOnPremises:
 		if s.OnPremisesClient == nil {
 			return nil, ErrNoAvailableClient
@@ -151,7 +161,7 @@ func (s *Service) SendTemplate(opts *SendTemplateOptions) error {
 		return nil
 	}
 
-	switch s.Config.APIType {
+	switch s.WhatsappConfig.APIType {
 	case config.WhatsappAPITypeOnPremises:
 		if s.OnPremisesClient == nil {
 			return ErrNoAvailableClient

--- a/pkg/lib/infra/whatsapp/service.go
+++ b/pkg/lib/infra/whatsapp/service.go
@@ -52,7 +52,7 @@ func (s *Service) resolveTemplateLanguage(supportedLanguages []string) string {
 		intl.Fallback(*s.LocalizationConfig.FallbackLanguage),
 	)
 	// First, resolve once based on supported language in config
-	// This is to avoid inconsistency of ui lanuage and whatsapp message language
+	// This is to avoid inconsistency of ui language and whatsapp message language
 	_, resolvedTag := intl.BestMatch(preferredLanguageTags, configSupportedLanguageTags)
 	supportedLanguageTags := intl.Supported(supportedLanguages, intl.Fallback(supportedLanguages[0]))
 

--- a/pkg/util/intl/match.go
+++ b/pkg/util/intl/match.go
@@ -42,6 +42,8 @@ func GetMatcher(supported []language.Tag) language.Matcher {
 
 // Match matches preferredLanguageTags to supportedLanguageTags
 // using fallbackLanguageTag as fallback.
+// NOTE(tung): Replaced by BestMatch. Use BestMatch instead.
+// This function were keep just for reference and testing
 func Match(preferredLanguageTags []string, supportedLanguageTags SupportedLanguages) (int, language.Tag) {
 	if len(supportedLanguageTags) <= 0 {
 		return -1, language.Und

--- a/pkg/util/intl/match.go
+++ b/pkg/util/intl/match.go
@@ -44,7 +44,7 @@ func GetMatcher(supported []language.Tag) language.Matcher {
 // using fallbackLanguageTag as fallback.
 // NOTE(tung): Replaced by BestMatch. Use BestMatch instead.
 // This function were keep just for reference and testing
-func Match(preferredLanguageTags []string, supportedLanguageTags SupportedLanguages) (int, language.Tag) {
+func Match_Deprecated(preferredLanguageTags []string, supportedLanguageTags SupportedLanguages) (int, language.Tag) {
 	if len(supportedLanguageTags) <= 0 {
 		return -1, language.Und
 	}

--- a/pkg/util/intl/match_test.go
+++ b/pkg/util/intl/match_test.go
@@ -9,7 +9,7 @@ import (
 func TestMatch(t *testing.T) {
 	Convey("Match", t, func() {
 		test := func(preferred []string, supported []string, expected int) {
-			actual, _ := Match(preferred, supported)
+			actual, _ := Match_Deprecated(preferred, supported)
 			So(actual, ShouldEqual, expected)
 		}
 
@@ -119,7 +119,7 @@ var benchmarkTestFixtures []*BenchmarkTestFixture = []*BenchmarkTestFixture{
 func BenchmarkMatch(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		for _, f := range benchmarkTestFixtures {
-			Match(f.Preferred, f.Supported)
+			Match_Deprecated(f.Preferred, f.Supported)
 		}
 	}
 }

--- a/pkg/util/intl/match_test.go
+++ b/pkg/util/intl/match_test.go
@@ -42,6 +42,13 @@ func TestMatch(t *testing.T) {
 			2,
 		)
 
+		// Simply select zh-HK
+		test(
+			[]string{"zh-hk"},
+			[]string{"zh-TW", "zh-HK", "en-US"},
+			1,
+		)
+
 		// Should select supported tag with higher confidence
 		test(
 			[]string{"zh-Hant"},
@@ -78,4 +85,48 @@ func TestMatch(t *testing.T) {
 			1,
 		)
 	})
+}
+
+type BenchmarkTestFixture struct {
+	Preferred []string
+	Supported []string
+}
+
+var benchmarkTestFixtures []*BenchmarkTestFixture = []*BenchmarkTestFixture{
+	{
+		Preferred: []string{},
+		Supported: []string{"en", "ja", "zh"},
+	},
+	{
+		Preferred: []string{"ja-JP", "en-US", "zh-Hant-HK"},
+		Supported: []string{"zh", "en", "ja"},
+	},
+	{
+		Preferred: []string{"zh-hk"},
+		Supported: []string{"zh-TW", "zh-HK", "en-US"},
+	},
+	{
+		Preferred: []string{"zh-Hant"},
+		Supported: []string{"zh-CN", "zh-HK", "zh-TW", "en-US"},
+	},
+	{
+		Preferred: []string{"zh-HK", "zh-Hant-HK", "zh-TW", "zh"},
+		Supported: []string{"zh-CN", "zh-HK", "zh-TW", "zh-SG", "zh-MC", "en-US", "en-GB", "ja-JP"},
+	},
+}
+
+func BenchmarkMatch(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		for _, f := range benchmarkTestFixtures {
+			Match(f.Preferred, f.Supported)
+		}
+	}
+}
+
+func BenchmarkBestMatch(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		for _, f := range benchmarkTestFixtures {
+			BestMatch(f.Preferred, f.Supported)
+		}
+	}
 }

--- a/pkg/util/intl/match_test.go
+++ b/pkg/util/intl/match_test.go
@@ -79,6 +79,7 @@ func TestMatch(t *testing.T) {
 			[]string{"zh-CN", "zh-HK", "zh-TW", "en-US"},
 			2,
 		)
+		// Should select zh-HK with exact confidence
 		test(
 			[]string{"zh-Hant-HK"},
 			[]string{"zh-CN", "zh-HK", "zh-TW", "en-US"},

--- a/pkg/util/intl/match_test.go
+++ b/pkg/util/intl/match_test.go
@@ -85,6 +85,13 @@ func TestMatch(t *testing.T) {
 			[]string{"zh-CN", "zh-HK", "zh-TW", "en-US"},
 			1,
 		)
+
+		// Should use preceding preferred language if possible
+		test(
+			[]string{"ja-JP", "en-GB", "zh-HK"},
+			[]string{"zh-HK", "zh-TW", "en-US"},
+			2,
+		)
 	})
 }
 

--- a/pkg/util/intl/match_test.go
+++ b/pkg/util/intl/match_test.go
@@ -24,4 +24,58 @@ func TestMatch(t *testing.T) {
 			2,
 		)
 	})
+
+	Convey("BestMatch", t, func() {
+		test := func(preferred []string, supported []string, expected int) {
+			actual, _ := BestMatch(preferred, supported)
+			So(actual, ShouldEqual, expected)
+		}
+
+		// Select default if there is no preferred languages
+		test(nil, []string{"en", "ja", "zh"}, 0)
+		test([]string{}, []string{"en", "ja", "zh"}, 0)
+
+		// Simply select japanese
+		test(
+			[]string{"ja-JP", "en-US", "zh-Hant-HK"},
+			[]string{"zh", "en", "ja"},
+			2,
+		)
+
+		// Should select supported tag with higher confidence
+		test(
+			[]string{"zh-Hant"},
+			[]string{"zh-CN", "zh-HK", "en-US"},
+			1,
+		)
+		test(
+			[]string{"en-UK"},
+			[]string{"zh-CN", "zh-HK", "zh-TW", "en-US"},
+			3,
+		)
+		test(
+			[]string{"zh-SG"},
+			[]string{"en-US", "zh-CN", "zh-HK", "zh-TW"},
+			1,
+		)
+
+		// Should select supported tag with lower index if confidence are same
+		test(
+			[]string{"en"},
+			[]string{"en-HK", "en-GB"},
+			0,
+		)
+
+		// Should select zh-TW with exact confidence
+		test(
+			[]string{"zh-Hant"},
+			[]string{"zh-CN", "zh-HK", "zh-TW", "en-US"},
+			2,
+		)
+		test(
+			[]string{"zh-Hant-HK"},
+			[]string{"zh-CN", "zh-HK", "zh-TW", "en-US"},
+			1,
+		)
+	})
 }

--- a/pkg/util/intl/oidc.go
+++ b/pkg/util/intl/oidc.go
@@ -29,7 +29,7 @@ func LocalizeJSONObject(preferredLanguageTags []string, fallbackLanguage Fallbac
 	}
 	supportedLanguageTags = Supported(supportedLanguageTags, fallbackLanguage)
 
-	idx, _ := Match(preferredLanguageTags, supportedLanguageTags)
+	idx, _ := BestMatch(preferredLanguageTags, supportedLanguageTags)
 	tag := supportedLanguageTags[idx]
 	value := m[tag]
 	return value
@@ -55,7 +55,7 @@ func LocalizeStringMap(preferredLanguageTags []string, fallbackLanguage Fallback
 	}
 	supportedLanguageTags = Supported(supportedLanguageTags, fallbackLanguage)
 
-	idx, _ := Match(preferredLanguageTags, supportedLanguageTags)
+	idx, _ := BestMatch(preferredLanguageTags, supportedLanguageTags)
 	tag := supportedLanguageTags[idx]
 	value := m[tag]
 	return value

--- a/pkg/util/intl/resolve.go
+++ b/pkg/util/intl/resolve.go
@@ -18,7 +18,7 @@ func Resolve(preferred []string, fallback string, supported []string) (int, lang
 		supportedLanguagesIdx[item] = i
 	}
 
-	idx, tag := Match(preferred, supportedLanguageTags)
+	idx, tag := BestMatch(preferred, supportedLanguageTags)
 	if idx == -1 {
 		return idx, tag
 	}

--- a/pkg/util/intlresource/match.go
+++ b/pkg/util/intlresource/match.go
@@ -21,7 +21,7 @@ func Match(preferred []string, fallback string, items []LanguageItem) (matched L
 
 	supportedLanguageTags := intl.Supported(rawSupported, intl.Fallback(fallback))
 
-	idx, _ := intl.Match(preferred, supportedLanguageTags)
+	idx, _ := intl.BestMatch(preferred, supportedLanguageTags)
 	tag := supportedLanguageTags[idx]
 
 	item, ok := languageTagToItem[tag]

--- a/pkg/util/template/translation_test.go
+++ b/pkg/util/template/translation_test.go
@@ -433,10 +433,10 @@ func TestTranslationResource(t *testing.T) {
 				data, err = read(er)
 				So(err, ShouldBeNil)
 				So(data, ShouldEqual, compact(`{
-					"app.name": { "LanguageTag": "en", "Value": "en app.name in fs A" },
+					"app.name": { "LanguageTag": "zh-HK", "Value": "zh-HK app.name in fs A" },
 					"email.default.sender": { "LanguageTag": "jp", "Value": "no-reply+jp@app.com" },
 					"some-key-1": { "LanguageTag": "jp", "Value": "jp some-key-1 in fs C" },
-					"some-key-2": { "LanguageTag": "en", "Value": "en some-key-2 in fs A" }
+					"some-key-2": { "LanguageTag": "zh-HK", "Value": "zh-HK some-key-2 in fs A" }
 				}`))
 
 				er.PreferredTags = []string{"ko"}

--- a/pkg/util/template/translation_test.go
+++ b/pkg/util/template/translation_test.go
@@ -263,7 +263,7 @@ func TestTranslationResource(t *testing.T) {
 			Convey("should resolve all keys when no keys are provided in higher fs level", func() {
 				er := resource.EffectiveResource{
 					DefaultTag:    "en",
-					SupportedTags: []string{"en", "zh-HK", "jp"},
+					SupportedTags: []string{"en", "zh-HK", "ja"},
 				}
 				data, err := read(er)
 				So(err, ShouldBeNil)
@@ -284,7 +284,7 @@ func TestTranslationResource(t *testing.T) {
 					"some-key-2": { "LanguageTag": "zh-HK", "Value": "zh-HK some-key-2 in fs A" }
 				}`))
 
-				er.PreferredTags = []string{"jp"}
+				er.PreferredTags = []string{"ja"}
 				data, err = read(er)
 				So(err, ShouldBeNil)
 				So(data, ShouldEqual, compact(`{
@@ -301,7 +301,7 @@ func TestTranslationResource(t *testing.T) {
 				}`)
 				er := resource.EffectiveResource{
 					DefaultTag:    "en",
-					SupportedTags: []string{"en", "zh-HK", "jp"},
+					SupportedTags: []string{"en", "zh-HK", "ja"},
 				}
 				er.PreferredTags = []string{"en"}
 				data, err := read(er)
@@ -323,7 +323,7 @@ func TestTranslationResource(t *testing.T) {
 					"some-key-2": { "LanguageTag": "zh-HK", "Value": "zh-HK some-key-2 in fs A" }
 				}`))
 
-				er.PreferredTags = []string{"jp"}
+				er.PreferredTags = []string{"ja"}
 				data, err = read(er)
 				So(err, ShouldBeNil)
 				So(data, ShouldEqual, compact(`{
@@ -348,20 +348,20 @@ func TestTranslationResource(t *testing.T) {
 				writeFile(fsB, "en", `{
 					"email.default.sender": "no-reply+en@custom.com"
 				}`)
-				writeFile(fsC, "jp", `{
-					"email.default.sender": "no-reply+jp@app.com",
-					"some-key-1": "jp some-key-1 in fs C"
+				writeFile(fsC, "ja", `{
+					"email.default.sender": "no-reply+ja@app.com",
+					"some-key-1": "ja some-key-1 in fs C"
 				}`)
 				er := resource.EffectiveResource{
-					DefaultTag:    "jp",
-					SupportedTags: []string{"en", "zh-HK", "jp"},
+					DefaultTag:    "ja",
+					SupportedTags: []string{"en", "zh-HK", "ja"},
 				}
 				er.PreferredTags = []string{"en"}
 				data, err := read(er)
 				So(err, ShouldBeNil)
 				So(data, ShouldEqual, compact(`{
 					"app.name": { "LanguageTag": "en", "Value": "en app.name in fs A" },
-					"email.default.sender": { "LanguageTag": "jp", "Value": "no-reply+jp@app.com" },
+					"email.default.sender": { "LanguageTag": "ja", "Value": "no-reply+ja@app.com" },
 					"some-key-1": { "LanguageTag": "en", "Value": "en some-key-1 in fs A" },
 					"some-key-2": { "LanguageTag": "en", "Value": "en some-key-2 in fs A" }
 				}`))
@@ -371,29 +371,29 @@ func TestTranslationResource(t *testing.T) {
 				So(err, ShouldBeNil)
 				So(data, ShouldEqual, compact(`{
 					"app.name": { "LanguageTag": "zh-HK", "Value": "zh-HK app.name in fs A" },
-					"email.default.sender": { "LanguageTag": "jp", "Value": "no-reply+jp@app.com" },
+					"email.default.sender": { "LanguageTag": "ja", "Value": "no-reply+ja@app.com" },
 					"some-key-1": { "LanguageTag": "zh-HK", "Value": "zh-HK some-key-1 in fs A" },
 					"some-key-2": { "LanguageTag": "zh-HK", "Value": "zh-HK some-key-2 in fs A" }
 				}`))
 
-				er.PreferredTags = []string{"jp"}
+				er.PreferredTags = []string{"ja"}
 				data, err = read(er)
 				So(err, ShouldBeNil)
 				So(data, ShouldEqual, compact(`{
-					"app.name": { "LanguageTag": "jp", "Value": "en app.name in fs A" },
-					"email.default.sender": { "LanguageTag": "jp", "Value": "no-reply+jp@app.com" },
-					"some-key-1": { "LanguageTag": "jp", "Value": "jp some-key-1 in fs C" },
-					"some-key-2": { "LanguageTag": "jp", "Value": "en some-key-2 in fs A" }
+					"app.name": { "LanguageTag": "ja", "Value": "en app.name in fs A" },
+					"email.default.sender": { "LanguageTag": "ja", "Value": "no-reply+ja@app.com" },
+					"some-key-1": { "LanguageTag": "ja", "Value": "ja some-key-1 in fs C" },
+					"some-key-2": { "LanguageTag": "ja", "Value": "en some-key-2 in fs A" }
 				}`))
 
 				er.PreferredTags = []string{"ko"}
 				data, err = read(er)
 				So(err, ShouldBeNil)
 				So(data, ShouldEqual, compact(`{
-					"app.name": { "LanguageTag": "jp", "Value": "en app.name in fs A" },
-					"email.default.sender": { "LanguageTag": "jp", "Value": "no-reply+jp@app.com" },
-					"some-key-1": { "LanguageTag": "jp", "Value": "jp some-key-1 in fs C" },
-					"some-key-2": { "LanguageTag": "jp", "Value": "en some-key-2 in fs A" }
+					"app.name": { "LanguageTag": "ja", "Value": "en app.name in fs A" },
+					"email.default.sender": { "LanguageTag": "ja", "Value": "no-reply+ja@app.com" },
+					"some-key-1": { "LanguageTag": "ja", "Value": "ja some-key-1 in fs C" },
+					"some-key-2": { "LanguageTag": "ja", "Value": "en some-key-2 in fs A" }
 				}`))
 			})
 
@@ -401,20 +401,20 @@ func TestTranslationResource(t *testing.T) {
 				writeFile(fsB, "en", `{
 					"email.default.sender": "no-reply+en@custom.com"
 				}`)
-				writeFile(fsC, "jp", `{
-					"email.default.sender": "no-reply+jp@app.com",
-					"some-key-1": "jp some-key-1 in fs C"
+				writeFile(fsC, "ja", `{
+					"email.default.sender": "no-reply+ja@app.com",
+					"some-key-1": "ja some-key-1 in fs C"
 				}`)
 				er := resource.EffectiveResource{
 					DefaultTag:    "zh-HK",
-					SupportedTags: []string{"en", "zh-HK", "jp"},
+					SupportedTags: []string{"en", "zh-HK", "ja"},
 				}
 				er.PreferredTags = []string{"en"}
 				data, err := read(er)
 				So(err, ShouldBeNil)
 				So(data, ShouldEqual, compact(`{
 					"app.name": { "LanguageTag": "en", "Value": "en app.name in fs A" },
-					"email.default.sender": { "LanguageTag": "jp", "Value": "no-reply+jp@app.com" },
+					"email.default.sender": { "LanguageTag": "ja", "Value": "no-reply+ja@app.com" },
 					"some-key-1": { "LanguageTag": "en", "Value": "en some-key-1 in fs A" },
 					"some-key-2": { "LanguageTag": "en", "Value": "en some-key-2 in fs A" }
 				}`))
@@ -424,18 +424,18 @@ func TestTranslationResource(t *testing.T) {
 				So(err, ShouldBeNil)
 				So(data, ShouldEqual, compact(`{
 					"app.name": { "LanguageTag": "zh-HK", "Value": "zh-HK app.name in fs A" },
-					"email.default.sender": { "LanguageTag": "jp", "Value": "no-reply+jp@app.com" },
+					"email.default.sender": { "LanguageTag": "ja", "Value": "no-reply+ja@app.com" },
 					"some-key-1": { "LanguageTag": "zh-HK", "Value": "zh-HK some-key-1 in fs A" },
 					"some-key-2": { "LanguageTag": "zh-HK", "Value": "zh-HK some-key-2 in fs A" }
 				}`))
 
-				er.PreferredTags = []string{"jp"}
+				er.PreferredTags = []string{"ja"}
 				data, err = read(er)
 				So(err, ShouldBeNil)
 				So(data, ShouldEqual, compact(`{
 					"app.name": { "LanguageTag": "zh-HK", "Value": "zh-HK app.name in fs A" },
-					"email.default.sender": { "LanguageTag": "jp", "Value": "no-reply+jp@app.com" },
-					"some-key-1": { "LanguageTag": "jp", "Value": "jp some-key-1 in fs C" },
+					"email.default.sender": { "LanguageTag": "ja", "Value": "no-reply+ja@app.com" },
+					"some-key-1": { "LanguageTag": "ja", "Value": "ja some-key-1 in fs C" },
 					"some-key-2": { "LanguageTag": "zh-HK", "Value": "zh-HK some-key-2 in fs A" }
 				}`))
 
@@ -444,7 +444,7 @@ func TestTranslationResource(t *testing.T) {
 				So(err, ShouldBeNil)
 				So(data, ShouldEqual, compact(`{
 					"app.name": { "LanguageTag": "zh-HK", "Value": "zh-HK app.name in fs A" },
-					"email.default.sender": { "LanguageTag": "jp", "Value": "no-reply+jp@app.com" },
+					"email.default.sender": { "LanguageTag": "ja", "Value": "no-reply+ja@app.com" },
 					"some-key-1": { "LanguageTag": "zh-HK", "Value": "zh-HK some-key-1 in fs A" },
 					"some-key-2": { "LanguageTag": "zh-HK", "Value": "zh-HK some-key-2 in fs A" }
 				}`))

--- a/pkg/worker/wire_gen.go
+++ b/pkg/worker/wire_gen.go
@@ -104,6 +104,7 @@ func newSendMessagesTask(p *deps.TaskProvider) task.Task {
 	featureTestModeWhatsappSuppressed := deps.ProvideTestModeWhatsappSuppressed(testModeFeatureConfig)
 	testModeWhatsappConfig := testModeConfig.Whatsapp
 	whatsappConfig := messagingConfig.Whatsapp
+	localizationConfig := appConfig.Localization
 	whatsappOnPremisesCredentials := deps.ProvideWhatsappOnPremisesCredentials(secretConfig)
 	handle := appProvider.Redis
 	appID := appConfig.ID
@@ -120,7 +121,8 @@ func newSendMessagesTask(p *deps.TaskProvider) task.Task {
 		DevMode:                           devMode,
 		FeatureTestModeWhatsappSuppressed: featureTestModeWhatsappSuppressed,
 		TestModeWhatsappConfig:            testModeWhatsappConfig,
-		Config:                            whatsappConfig,
+		WhatsappConfig:                    whatsappConfig,
+		LocalizationConfig:                localizationConfig,
 		OnPremisesClient:                  onPremisesClient,
 		TokenStore:                        tokenStore,
 	}


### PR DESCRIPTION
ref #3718 #3454 

Benchmark result

```
goos: darwin
goarch: amd64
pkg: github.com/authgear/authgear-server/pkg/util/intl
cpu: VirtualApple @ 2.50GHz
BenchmarkMatch-8       	   56115	     21034 ns/op
BenchmarkBestMatch-8   	   48363	     24730 ns/op
```