### PR TITLE
Make account linking config global to all flows

### DIFF
--- a/docs/specs/account-linking.md
+++ b/docs/specs/account-linking.md
@@ -15,6 +15,7 @@
 - [Login and Link Flow](#login-and-link-flow)
 - [Account Linking by Login IDs](#account-linking-by-login-ids)
   - [Defaults of Account Linking of Login IDs](#defaults-of-account-linking-of-Login-ids)
+- [Account Linking in Promote Flow](#account-linking-in-promote-flow)
 - [Q&A](#qa)
   - [Why we need to login the user before linking the account?](#why-we-need-to-login-the-user-before-linking-the-account)
   - [Why we need to continue the original signup flow instead of simply adding the oauth identity to the user?](#why-we-need-to-continue-the-original-signup-flow-instead-of-simply-adding-the-oauth-identity-to-the-user)
@@ -422,6 +423,12 @@ The default values of each login id types are different. Please see the below ta
 | `username`    | <pre><code>user_profile:<br/>&nbsp;&nbsp;pointer: "/preferred_username"<br/>action: error</code></pre> |
 
 Therefore when not specified, all attempts to link a new login id to existing users or idenitities will result in error.
+
+## Account Linking in Promote Flow
+
+Account linking can occur in promote flow, however, only `error` is allowed to be the action of account linking.
+
+Any action set in `authentication_flow.account_linking` will be treated as error. And `action` in `signup_flows.account_linking` only allows `error` as value.
 
 ## References
 

--- a/docs/specs/account-linking.md
+++ b/docs/specs/account-linking.md
@@ -19,6 +19,7 @@
 - [Q&A](#qa)
   - [Why we need to login the user before linking the account?](#why-we-need-to-login-the-user-before-linking-the-account)
   - [Why we need to continue the original signup flow instead of simply adding the oauth identity to the user?](#why-we-need-to-continue-the-original-signup-flow-instead-of-simply-adding-the-oauth-identity-to-the-user)
+- [Usecases](#usecases)
 - [References](#references)
 
 ## Introduction
@@ -441,6 +442,27 @@ Account linking can occur in promote flow, however, only `error` is allowed to b
 This is because currently prmote flow does not support logging in to existing user in promote flow. So actions such as `login_and_link` which actually logged in to an existing user is also not possible at the moment. However, this restriction could be relaxed after we supported logging in to an existing user in promote flow.
 
 Any action set in `authentication_flow.account_linking` will be treated as error. And `action` in `signup_flows.account_linking` only allows `error` as value.
+
+## Usecases
+
+1. User already owns an account in authgear, but logged in with an oauth account that is not known to authgear.
+  Expect one of the following results:
+  - Created a new account with no relationship with the existing account.
+  - Tell the user he has an existing account, and he should login to that account instead.
+  - Allow the user to continue login with the oauth account and finally he result in logged in the existing account, and the oauth account can also be used to login to this account in the future.
+
+2. User already owns an account in authgear, but tried to signup with a new email / phone number / username.
+  Expect one of the following results:
+  - Created a new account with no relationship with the existing account.
+  - Tell the user he has an existing account, and he should login to that account instead.
+  - Redirect the user to login to the existing account. And in future, that email / phone number / username can be used to login to same account.
+
+### Edge Cases
+
+1. Say a project has two clients, A and B. And he has two different signup flows and two login flows for the two clients. Each client should always use the flow belongs to that client. And the project want to enable account linking.
+  - Signup flow of A should use login flow of A during account linking. And signup flow of B should use login flow of B during account linking.
+  - Say if only signup flow of B allows signing up with email, while both flows support signing up with oauth. Then signup flow of B should not be able to trigger account linking by email while signing up with oauth.
+
 
 ## References
 

--- a/docs/specs/account-linking.md
+++ b/docs/specs/account-linking.md
@@ -438,6 +438,8 @@ Therefore when not specified, all attempts to link a new login id to existing us
 
 Account linking can occur in promote flow, however, only `error` is allowed to be the action of account linking.
 
+This is because currently prmote flow does not support logging in to existing user in promote flow. So actions such as `login_and_link` which actually logged in to an existing user is also not possible at the moment. However, this restriction could be relaxed after we supported logging in to an existing user in promote flow.
+
 Any action set in `authentication_flow.account_linking` will be treated as error. And `action` in `signup_flows.account_linking` only allows `error` as value.
 
 ## References


### PR DESCRIPTION
ref DEV-1246

The problem:

Starting at this example config:
```yaml
authentication_flow:
  signup_flows:
    - name: signup_flow_1
      account_linking:
        oauth:
        - alias: adfs
          oauth_claim:
            pointer: "/preferred_username"
          user_profile:
            pointer: "/preferred_username"
          action: login_and_link
          login_flow: default
      steps:
        - name: identify
          type: identify
          one_of:
            - identification: email
            - identification: oauth
  promote_flows:
    - name: promote_flow_1
      steps:
        - name: identify
          type: identify
          one_of:
            - identification: email
            - identification: oauth
```

The linking logics, (like `oauth_claim.pointer`, `user_profile.pointer`, which are originally the link_by part), is defined in the signup flow. And in the above example, promote flow didn't define any "link by what". But this seems doesn’t make sense because this kind of “link by what” logic should be shared across the flows. If they are not same in all flows, expected accounts could be created by the promote flow, which in signup flow it is a conflict.
So what this pr is trying to do is to change the “link by what” logics to a global config to all auth flows.

This pr is trying to fix this problem by:
1. Change `authentication_flow.default_account_linking` to `authentication_flow.account_linking`. Now it is not only a default, you must define this section to use account linking.
2. Limit the overridable fields inside a specific flow. Only `login_flow` and `action` is overridable.


And also, moved per flow config to per step, and added a new usecase to describe the reason.