### PR TITLE
Fix intl tel input isn't selecting initial country correctly

### DIFF
--- a/authui/src/intlTelInput.ts
+++ b/authui/src/intlTelInput.ts
@@ -136,7 +136,7 @@ export class IntlTelInputController extends Controller {
       autoPlaceholder: "aggressive",
       onlyCountries,
       preferredCountries,
-      initialCountry,
+      initialCountry: initialCountry.toLowerCase(),
       customContainer,
       useFullscreenPopup: false,
     });


### PR DESCRIPTION
ref DEV-1386

It seems that it become case sensitive comparison.
The commit that changes the behavior:
https://github.com/jackocnr/intl-tel-input/commit/4bb581597c49e81626489c598dbe5a84916e0a51