### PR TITLE
Extend e2e test timeout

### DIFF
--- a/e2e/run.sh
+++ b/e2e/run.sh
@@ -63,7 +63,7 @@ function teardown {( set -e
 
 function tests {( set -e
     echo "[ ] Run tests..."
-    go test ./... -v -timeout 3m -parallel 5
+    go test ./... -v -timeout 10m -parallel 5
 )}
 
 function main {( set -e


### PR DESCRIPTION
Looks like per test timeout is not available yet
https://github.com/golang/go/issues/48157