### PR TITLE
Fix resources/portal/static/img/* were excluded from docker build

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -9,8 +9,11 @@
 **/__pycache__
 **/venv
 **/var
-**/resources/**/generated
-**/resources/portal/static/*
+
+resources/**/generated
+resources/portal/static/*
+!resources/portal/static/img/*
+
 **/__generated_asset.html
 pkg/lib/webparcel/parcel_gen.go
 .env


### PR DESCRIPTION
The bug

<img width="383" alt="SCR-20240613-ocvb" src="https://github.com/authgear/authgear-server/assets/15082564/d5f44754-1927-4017-b7b1-463b565b1a9d">
