### PR TITLE
Make generated auth flows aware of captcha

### DIFF
--- a/pkg/lib/authenticationflow/declarative/generate_config_account_recovery_flow.go
+++ b/pkg/lib/authenticationflow/declarative/generate_config_account_recovery_flow.go
@@ -46,8 +46,16 @@ func GenerateAccountRecoveryFlowConfig(cfg *config.AppConfig) *config.Authentica
 		})
 	}
 
+	if hasCaptcha(cfg) {
+		for _, oneOf := range oneOfs {
+			oneOf.Captcha = &config.AuthenticationFlowCaptcha{
+				Required: getBoolPtr(true),
+			}
+		}
+	}
 	return &config.AuthenticationFlowAccountRecoveryFlow{
-		Name: nameGeneratedFlow,
+		Name:    nameGeneratedFlow,
+		Captcha: generateFlowCaptcha(cfg),
 		Steps: []*config.AuthenticationFlowAccountRecoveryFlowStep{
 			{
 				Type:  config.AuthenticationFlowAccountRecoveryFlowTypeIdentify,

--- a/pkg/lib/authenticationflow/declarative/generate_config_captcha.go
+++ b/pkg/lib/authenticationflow/declarative/generate_config_captcha.go
@@ -1,0 +1,23 @@
+package declarative
+
+import "github.com/authgear/authgear-server/pkg/lib/config"
+
+func hasCaptcha(cfg *config.AppConfig) bool {
+	return cfg.Captcha != nil && cfg.Captcha.Enabled && len(cfg.Captcha.Providers) > 0
+}
+
+func getBoolPtr(b bool) *bool {
+	return &b
+}
+
+func generateFlowCaptcha(cfg *config.AppConfig) *config.AuthenticationFlowObjectCaptchaConfig {
+	if cfg.Captcha == nil {
+		return nil
+	}
+	if cfg.Captcha.Enabled && len(cfg.Captcha.Providers) > 0 {
+		return &config.AuthenticationFlowObjectCaptchaConfig{
+			Enabled: getBoolPtr(true),
+		}
+	}
+	return nil
+}

--- a/pkg/lib/authenticationflow/declarative/generate_config_login_flow.go
+++ b/pkg/lib/authenticationflow/declarative/generate_config_login_flow.go
@@ -9,7 +9,8 @@ import (
 
 func GenerateLoginFlowConfig(cfg *config.AppConfig) *config.AuthenticationFlowLoginFlow {
 	flow := &config.AuthenticationFlowLoginFlow{
-		Name: nameGeneratedFlow,
+		Name:    nameGeneratedFlow,
+		Captcha: generateFlowCaptcha(cfg),
 		Steps: []*config.AuthenticationFlowLoginFlowStep{
 			generateLoginFlowStepIdentify(cfg),
 		},
@@ -47,6 +48,15 @@ func generateLoginFlowStepIdentify(cfg *config.AppConfig) *config.Authentication
 		case model.IdentityTypePasskey:
 			oneOf := generateLoginFlowStepIdentifyPasskey(cfg)
 			step.OneOf = append(step.OneOf, oneOf...)
+		}
+	}
+
+	// Add captcha if enabled
+	if hasCaptcha(cfg) {
+		for _, oneOf := range step.OneOf {
+			oneOf.Captcha = &config.AuthenticationFlowCaptcha{
+				Required: getBoolPtr(true),
+			}
 		}
 	}
 

--- a/pkg/lib/authenticationflow/declarative/generate_config_reauth_flow.go
+++ b/pkg/lib/authenticationflow/declarative/generate_config_reauth_flow.go
@@ -7,7 +7,8 @@ import (
 
 func GenerateReauthFlowConfig(cfg *config.AppConfig) *config.AuthenticationFlowReauthFlow {
 	flow := &config.AuthenticationFlowReauthFlow{
-		Name: nameGeneratedFlow,
+		Name:    nameGeneratedFlow,
+		Captcha: generateFlowCaptcha(cfg),
 		Steps: []*config.AuthenticationFlowReauthFlowStep{
 			generateReauthFlowStepIdentify(cfg),
 			generateReauthFlowStepAuthenticate(cfg),
@@ -37,9 +38,15 @@ func generateReauthFlowStepAuthenticate(cfg *config.AppConfig) *config.Authentic
 	}
 
 	addOneOf := func(authentication config.AuthenticationFlowAuthentication) {
-		step.OneOf = append(step.OneOf, &config.AuthenticationFlowReauthFlowOneOf{
+		oneOf := &config.AuthenticationFlowReauthFlowOneOf{
 			Authentication: authentication,
-		})
+		}
+		if hasCaptcha(cfg) {
+			oneOf.Captcha = &config.AuthenticationFlowCaptcha{
+				Required: getBoolPtr(true),
+			}
+		}
+		step.OneOf = append(step.OneOf, oneOf)
 	}
 
 	for _, authenticatorType := range *cfg.Authentication.PrimaryAuthenticators {

--- a/pkg/lib/authenticationflow/declarative/generate_config_reauth_flow_test.go
+++ b/pkg/lib/authenticationflow/declarative/generate_config_reauth_flow_test.go
@@ -283,5 +283,82 @@ steps:
   - authentication: primary_passkey
   - authentication: secondary_totp
 `)
+		// captcha, 1 branch
+		test(`
+authentication:
+  identities:
+  - login_id
+  primary_authenticators:
+  - password
+  secondary_authenticators: []
+identity:
+  login_id:
+    keys:
+    - type: email
+captcha:
+  enabled: true
+  providers:
+  - type: recaptchav2
+    alias: recaptchav2-a
+    site_key: some-site-key
+`, `
+name: default
+captcha:
+  enabled: true
+steps:
+- name: identify
+  type: identify
+  one_of:
+  - identification: id_token
+- name: reauthenticate
+  type: authenticate
+  one_of:
+  - authentication: primary_password
+    captcha:
+      required: true
+`)
+		// captcha, 3 branches
+		test(`
+authentication:
+  identities:
+  - login_id
+  primary_authenticators:
+  - password
+  - oob_otp_email
+  - oob_otp_sms
+  secondary_authenticators: []
+identity:
+  login_id:
+    keys:
+    - type: email
+    - type: phone
+captcha:
+  enabled: true
+  providers:
+  - type: recaptchav2
+    alias: recaptchav2-a
+    site_key: some-site-key
+`, `
+name: default
+captcha:
+  enabled: true
+steps:
+- name: identify
+  type: identify
+  one_of:
+  - identification: id_token
+- name: reauthenticate
+  type: authenticate
+  one_of:
+  - authentication: primary_password
+    captcha:
+      required: true
+  - authentication: primary_oob_otp_email
+    captcha:
+      required: true
+  - authentication: primary_oob_otp_sms
+    captcha:
+      required: true
+`)
 	})
 }

--- a/pkg/lib/authenticationflow/declarative/generate_config_signup_flow.go
+++ b/pkg/lib/authenticationflow/declarative/generate_config_signup_flow.go
@@ -9,7 +9,8 @@ import (
 
 func GenerateSignupFlowConfig(cfg *config.AppConfig) *config.AuthenticationFlowSignupFlow {
 	flow := &config.AuthenticationFlowSignupFlow{
-		Name: nameGeneratedFlow,
+		Name:    nameGeneratedFlow,
+		Captcha: generateFlowCaptcha(cfg),
 		Steps: []*config.AuthenticationFlowSignupFlowStep{
 			generateSignupFlowStepIdentify(cfg),
 		},
@@ -39,6 +40,15 @@ func generateSignupFlowStepIdentify(cfg *config.AppConfig) *config.Authenticatio
 		case model.IdentityTypePasskey:
 			// Cannot create paskey in this step.
 			break
+		}
+	}
+
+	// Add captcha if enabled
+	if hasCaptcha(cfg) {
+		for _, oneOf := range step.OneOf {
+			oneOf.Captcha = &config.AuthenticationFlowCaptcha{
+				Required: getBoolPtr(true),
+			}
 		}
 	}
 

--- a/pkg/lib/authenticationflow/declarative/generate_config_signup_flow_test.go
+++ b/pkg/lib/authenticationflow/declarative/generate_config_signup_flow_test.go
@@ -319,6 +319,97 @@ steps:
       - authentication: secondary_totp
   - identification: oauth
 `)
-
+		// captcha, 1 branch
+		test(`
+authentication:
+  identities:
+  - login_id
+  primary_authenticators:
+  - password
+identity:
+  login_id:
+    keys:
+    - type: email
+captcha:
+  enabled: true
+  providers:
+  - type: recaptchav2
+    alias: recaptchav2-1
+    site_key: recaptchav2-site-key
+`, `
+name: default
+captcha:
+  enabled: true
+steps:
+- name: identify
+  type: identify
+  one_of:
+  - identification: email
+    captcha:
+      required: true
+    steps:
+    - target_step: identify
+      type: verify
+    - name: authenticate_primary_email
+      type: create_authenticator
+      one_of:
+      - authentication: primary_password  
+`)
+		// captcha, 3 branches
+		test(`
+authentication:
+  identities:
+  - login_id
+  primary_authenticators:
+  - password
+identity:
+  login_id:
+    keys:
+    - type: email
+    - type: phone
+    - type: username
+captcha:
+  enabled: true
+  providers:
+  - type: recaptchav2
+    alias: recaptchav2-1
+    site_key: recaptchav2-site-key
+`, `
+name: default
+captcha:
+  enabled: true
+steps:
+- name: identify
+  type: identify
+  one_of:
+  - identification: email
+    captcha:
+      required: true
+    steps:
+    - target_step: identify
+      type: verify
+    - name: authenticate_primary_email
+      type: create_authenticator
+      one_of:
+      - authentication: primary_password
+  - identification: phone
+    captcha:
+      required: true
+    steps:
+    - target_step: identify
+      type: verify
+    - name: authenticate_primary_phone
+      type: create_authenticator
+      one_of:
+      - authentication: primary_password
+  - identification: username
+    captcha:
+      required: true
+    steps:
+    - name: authenticate_primary_username
+      type: create_authenticator
+      one_of:
+      - authentication: primary_password
+`)
 	})
 }

--- a/pkg/lib/authenticationflow/declarative/generate_config_signup_login_flow.go
+++ b/pkg/lib/authenticationflow/declarative/generate_config_signup_login_flow.go
@@ -7,7 +7,8 @@ import (
 
 func GenerateSignupLoginFlowConfig(cfg *config.AppConfig) *config.AuthenticationFlowSignupLoginFlow {
 	flow := &config.AuthenticationFlowSignupLoginFlow{
-		Name: nameGeneratedFlow,
+		Name:    nameGeneratedFlow,
+		Captcha: generateFlowCaptcha(cfg),
 		Steps: []*config.AuthenticationFlowSignupLoginFlowStep{
 			generateSignupLoginFlowStepIdentify(cfg),
 		},
@@ -33,6 +34,15 @@ func generateSignupLoginFlowStepIdentify(cfg *config.AppConfig) *config.Authenti
 		case model.IdentityTypePasskey:
 			oneOf := generateSignupLoginFlowStepIdentifyPasskey(cfg)
 			step.OneOf = append(step.OneOf, oneOf...)
+		}
+	}
+
+	// Add captcha if enabled
+	if hasCaptcha(cfg) {
+		for _, oneOf := range step.OneOf {
+			oneOf.Captcha = &config.AuthenticationFlowCaptcha{
+				Required: getBoolPtr(true),
+			}
 		}
 	}
 

--- a/pkg/lib/authenticationflow/declarative/generate_config_signup_login_flow_test.go
+++ b/pkg/lib/authenticationflow/declarative/generate_config_signup_login_flow_test.go
@@ -224,5 +224,102 @@ steps:
   - identification: passkey
     login_flow: default
 `)
+		// captcha, 1 branch
+		test(`
+authentication:
+  identities:
+  - login_id
+  primary_authenticators:
+  - password
+identity:
+  login_id:
+    keys:
+    - type: email
+captcha:
+  enabled: true
+  providers:
+  - type: recaptchav2
+    alias: recaptchav2
+    site_key: some-site-key
+`, `
+name: default
+captcha:
+  enabled: true
+steps:
+- name: identify
+  type: identify
+  one_of:
+  - identification: email
+    captcha:
+      required: true
+    signup_flow: default
+    login_flow: default
+`)
+		// captcha, all branches
+		test(`
+authentication:
+  identities:
+  - login_id
+  - oauth
+  - passkey
+  primary_authenticators:
+  - password
+  - passkey
+  secondary_authenticators:
+  - totp
+  secondary_authentication_mode: required
+  device_token:
+    disabled: true
+  recovery_code:
+    disabled: true
+identity:
+  login_id:
+    keys:
+    - type: email
+    - type: phone
+    - type: username
+  oauth:
+    providers:
+    - alias: google
+      type: google
+captcha:
+  enabled: true
+  providers:
+  - type: recaptchav2
+    alias: recaptchav2
+    site_key: some-site-key
+`, `
+name: default
+captcha:
+  enabled: true
+steps:
+- name: identify
+  type: identify
+  one_of:
+  - identification: email
+    captcha:
+      required: true
+    signup_flow: default
+    login_flow: default
+  - identification: phone
+    captcha:
+      required: true
+    signup_flow: default
+    login_flow: default
+  - identification: username
+    captcha:
+      required: true
+    signup_flow: default
+    login_flow: default
+  - identification: oauth
+    captcha:
+      required: true
+    signup_flow: default
+    login_flow: default
+  - identification: passkey
+    captcha:
+      required: true
+    login_flow: default
+`)
 	})
 }

--- a/pkg/lib/config/authentication_flow.go
+++ b/pkg/lib/config/authentication_flow.go
@@ -176,6 +176,7 @@ var _ = Schema.Add("AuthenticationFlowSignupFlowIdentify", `
 	"required": ["identification"],
 	"properties": {
 		"identification": { "$ref": "#/$defs/AuthenticationFlowIdentification" },
+		"captcha": { "$ref": "#/$defs/AuthenticationFlowCaptcha" },
 		"steps": {
 			"type": "array",
 			"items": { "$ref": "#/$defs/AuthenticationFlowSignupFlowStep" }
@@ -202,6 +203,7 @@ var _ = Schema.Add("AuthenticationFlowSignupFlowAuthenticate", `
 				"secondary_oob_otp_sms"
 			]
 		},
+		"captcha": { "$ref": "#/$defs/AuthenticationFlowCaptcha" },
 		"target_step": { "$ref": "#/$defs/AuthenticationFlowObjectName" },
 		"steps": {
 			"type": "array",
@@ -319,6 +321,7 @@ var _ = Schema.Add("AuthenticationFlowLoginFlowIdentify", `
 	"required": ["identification"],
 	"properties": {
 		"identification": { "$ref": "#/$defs/AuthenticationFlowIdentification" },
+		"captcha": { "$ref": "#/$defs/AuthenticationFlowCaptcha" },
 		"steps": {
 			"type": "array",
 			"items": { "$ref": "#/$defs/AuthenticationFlowLoginFlowStep" }
@@ -347,6 +350,7 @@ var _ = Schema.Add("AuthenticationFlowLoginFlowAuthenticate", `
 				"device_token"
 			]
 		},
+		"captcha": { "$ref": "#/$defs/AuthenticationFlowCaptcha" },
 		"target_step": { "$ref": "#/$defs/AuthenticationFlowObjectName" },
 		"steps": {
 			"type": "array",
@@ -411,6 +415,7 @@ var _ = Schema.Add("AuthenticationFlowSignupLoginFlowIdentify", `
 	"required": ["identification", "signup_flow", "login_flow"],
 	"properties": {
 		"identification": { "$ref": "#/$defs/AuthenticationFlowIdentification" },
+		"captcha": { "$ref": "#/$defs/AuthenticationFlowCaptcha" },
 		"signup_flow": { "$ref": "#/$defs/AuthenticationFlowObjectName" },
 		"login_flow": { "$ref": "#/$defs/AuthenticationFlowObjectName" }
 	}
@@ -523,6 +528,7 @@ var _ = Schema.Add("AuthenticationFlowReauthFlowAuthenticate", `
 				"secondary_oob_otp_sms"
 			]
 		},
+		"captcha": { "$ref": "#/$defs/AuthenticationFlowCaptcha" },
 		"steps": {
 			"type": "array",
 			"items": { "$ref": "#/$defs/AuthenticationFlowReauthFlowStep" }
@@ -610,6 +616,7 @@ var _ = Schema.Add("AuthenticationFlowAccountRecoveryFlowOneOf", `
 	"required": ["identification"],
 	"properties": {
 		"identification": { "$ref": "#/$defs/AuthenticationFlowAccountRecoveryIdentification" },
+		"captcha": { "$ref": "#/$defs/AuthenticationFlowCaptcha" },
 		"on_failure": { "type": "string", "enum": [ "error", "ignore"] },
 		"steps": {
 			"type": "array",
@@ -909,6 +916,9 @@ type AuthenticationFlowSignupFlowOneOf struct {
 	// VerificationRequired is specific to OOB.
 	VerificationRequired *bool `json:"verification_required,omitempty"`
 
+	// Captcha is specific to identify & create_authenticator
+	Captcha *AuthenticationFlowCaptcha `json:"captcha,omitempty"`
+
 	// Steps are common.
 	Steps []*AuthenticationFlowSignupFlowStep `json:"steps,omitempty"`
 }
@@ -1036,6 +1046,9 @@ type AuthenticationFlowLoginFlowOneOf struct {
 	// TargetStep is specific to authenticate.
 	TargetStep string `json:"target_step,omitempty"`
 
+	// Captcha is common
+	Captcha *AuthenticationFlowCaptcha `json:"captcha,omitempty"`
+
 	// Steps are common.
 	Steps []*AuthenticationFlowLoginFlowStep `json:"steps,omitempty"`
 }
@@ -1116,6 +1129,7 @@ const (
 
 type AuthenticationFlowSignupLoginFlowOneOf struct {
 	Identification AuthenticationFlowIdentification `json:"identification,omitempty"`
+	Captcha        *AuthenticationFlowCaptcha       `json:"captcha,omitempty"`
 	SignupFlow     string                           `json:"signup_flow,omitempty"`
 	LoginFlow      string                           `json:"login_flow,omitempty"`
 }
@@ -1196,6 +1210,9 @@ func (s *AuthenticationFlowReauthFlowStep) GetOneOf() []AuthenticationFlowObject
 type AuthenticationFlowReauthFlowOneOf struct {
 	// Identification is specific to identify.
 	Identification AuthenticationFlowIdentification `json:"identification,omitempty"`
+
+	// Captcha is specific to authenticate.
+	Captcha *AuthenticationFlowCaptcha `json:"captcha,omitempty"`
 
 	// Authentication is specific to authenticate.
 	Authentication AuthenticationFlowAuthentication `json:"authentication,omitempty"`
@@ -1335,6 +1352,7 @@ const (
 
 type AuthenticationFlowAccountRecoveryFlowOneOf struct {
 	Identification AuthenticationFlowAccountRecoveryIdentification          `json:"identification,omitempty"`
+	Captcha        *AuthenticationFlowCaptcha                               `json:"captcha,omitempty"`
 	OnFailure      AuthenticationFlowAccountRecoveryIdentificationOnFailure `json:"on_failure,omitempty"`
 	Steps          []*AuthenticationFlowAccountRecoveryFlowStep             `json:"steps,omitempty"`
 }

--- a/pkg/lib/config/authentication_flow.go
+++ b/pkg/lib/config/authentication_flow.go
@@ -72,6 +72,7 @@ var _ = Schema.Add("AuthenticationFlowSignupFlow", `
 	"required": ["name", "steps"],
 	"properties": {
 		"name": { "$ref": "#/$defs/AuthenticationFlowObjectName" },
+		"captcha": { "$ref": "#/$defs/AuthenticationFlowObjectCaptchaConfig" },
 		"steps": {
 			"type": "array",
 			"minItems": 1,
@@ -230,6 +231,7 @@ var _ = Schema.Add("AuthenticationFlowLoginFlow", `
 	"required": ["name", "steps"],
 	"properties": {
 		"name": { "$ref": "#/$defs/AuthenticationFlowObjectName" },
+		"captcha": { "$ref": "#/$defs/AuthenticationFlowObjectCaptchaConfig" },
 		"steps": {
 			"type": "array",
 			"minItems": 1,
@@ -360,6 +362,7 @@ var _ = Schema.Add("AuthenticationFlowSignupLoginFlow", `
 	"required": ["name", "steps"],
 	"properties": {
 		"name": { "$ref": "#/$defs/AuthenticationFlowObjectName" },
+		"captcha": { "$ref": "#/$defs/AuthenticationFlowObjectCaptchaConfig" },
 		"steps": {
 			"type": "array",
 			"minItems": 1,
@@ -420,6 +423,7 @@ var _ = Schema.Add("AuthenticationFlowReauthFlow", `
 	"required": ["name", "steps"],
 	"properties": {
 		"name": { "$ref": "#/$defs/AuthenticationFlowObjectName" },
+		"captcha": { "$ref": "#/$defs/AuthenticationFlowObjectCaptchaConfig" },
 		"steps": {
 			"type": "array",
 			"minItems": 1,
@@ -533,6 +537,7 @@ var _ = Schema.Add("AuthenticationFlowAccountRecoveryFlow", `
 	"required": ["name", "steps"],
 	"properties": {
 		"name": { "$ref": "#/$defs/AuthenticationFlowObjectName" },
+		"captcha": { "$ref": "#/$defs/AuthenticationFlowObjectCaptchaConfig" },
 		"steps": {
 			"type": "array",
 			"minItems": 1,
@@ -827,8 +832,9 @@ type AuthenticationFlowConfig struct {
 }
 
 type AuthenticationFlowSignupFlow struct {
-	Name  string                              `json:"name,omitempty"`
-	Steps []*AuthenticationFlowSignupFlowStep `json:"steps,omitempty"`
+	Name    string                                 `json:"name,omitempty"`
+	Captcha *AuthenticationFlowObjectCaptchaConfig `json:"captcha,omitempty"`
+	Steps   []*AuthenticationFlowSignupFlowStep    `json:"steps,omitempty"`
 }
 
 var _ AuthenticationFlowObjectFlowRoot = &AuthenticationFlowSignupFlow{}
@@ -943,8 +949,9 @@ type AuthenticationFlowSignupFlowUserProfile struct {
 }
 
 type AuthenticationFlowLoginFlow struct {
-	Name  string                             `json:"name,omitempty"`
-	Steps []*AuthenticationFlowLoginFlowStep `json:"steps,omitempty"`
+	Name    string                                 `json:"name,omitempty"`
+	Captcha *AuthenticationFlowObjectCaptchaConfig `json:"captcha,omitempty"`
+	Steps   []*AuthenticationFlowLoginFlowStep     `json:"steps,omitempty"`
 }
 
 var _ AuthenticationFlowObjectFlowRoot = &AuthenticationFlowLoginFlow{}
@@ -1054,8 +1061,9 @@ func (f *AuthenticationFlowLoginFlowOneOf) GetBranchInfo() AuthenticationFlowObj
 }
 
 type AuthenticationFlowSignupLoginFlow struct {
-	Name  string                                   `json:"name,omitempty"`
-	Steps []*AuthenticationFlowSignupLoginFlowStep `json:"steps,omitempty"`
+	Name    string                                   `json:"name,omitempty"`
+	Captcha *AuthenticationFlowObjectCaptchaConfig   `json:"captcha,omitempty"`
+	Steps   []*AuthenticationFlowSignupLoginFlowStep `json:"steps,omitempty"`
 }
 
 var _ AuthenticationFlowObjectFlowRoot = &AuthenticationFlowSignupLoginFlow{}
@@ -1127,8 +1135,9 @@ func (s *AuthenticationFlowSignupLoginFlowOneOf) GetBranchInfo() AuthenticationF
 }
 
 type AuthenticationFlowReauthFlow struct {
-	Name  string                              `json:"name,omitempty"`
-	Steps []*AuthenticationFlowReauthFlowStep `json:"steps,omitempty"`
+	Name    string                                 `json:"name,omitempty"`
+	Captcha *AuthenticationFlowObjectCaptchaConfig `json:"captcha,omitempty"`
+	Steps   []*AuthenticationFlowReauthFlowStep    `json:"steps,omitempty"`
 }
 
 var _ AuthenticationFlowObjectFlowRoot = &AuthenticationFlowReauthFlow{}
@@ -1216,8 +1225,9 @@ func (f *AuthenticationFlowReauthFlowOneOf) GetBranchInfo() AuthenticationFlowOb
 }
 
 type AuthenticationFlowAccountRecoveryFlow struct {
-	Name  string                                       `json:"name,omitempty"`
-	Steps []*AuthenticationFlowAccountRecoveryFlowStep `json:"steps,omitempty"`
+	Name    string                                       `json:"name,omitempty"`
+	Captcha *AuthenticationFlowObjectCaptchaConfig       `json:"captcha,omitempty"`
+	Steps   []*AuthenticationFlowAccountRecoveryFlowStep `json:"steps,omitempty"`
 }
 
 var _ AuthenticationFlowObjectFlowRoot = &AuthenticationFlowAccountRecoveryFlow{}

--- a/pkg/lib/config/authentication_flow_object_captcha.go
+++ b/pkg/lib/config/authentication_flow_object_captcha.go
@@ -4,7 +4,6 @@ var _ = Schema.Add("AuthenticationFlowObjectCaptchaConfig", `
 {
 	"type": "object",
 	"additionalProperties": false,
-	"required": ["enabled"],
 	"properties": {
 		"enabled": { "type": "boolean" }
 	}
@@ -19,7 +18,6 @@ var _ = Schema.Add("AuthenticationFlowCaptcha", `
 {
 	"type": "object",
 	"additionalProperties": false,
-	"required": ["required"],
 	"properties": {
 		"required": { "type": "boolean" }
 	}

--- a/pkg/lib/config/authentication_flow_object_captcha.go
+++ b/pkg/lib/config/authentication_flow_object_captcha.go
@@ -1,0 +1,16 @@
+package config
+
+var _ = Schema.Add("AuthenticationFlowObjectCaptchaConfig", `
+{
+	"type": "object",
+	"additionalProperties": false,
+	"required": ["enabled"],
+	"properties": {
+		"enabled": { "type": "boolean" }
+	}
+}
+`)
+
+type AuthenticationFlowObjectCaptchaConfig struct {
+	Enabled *bool `json:"enabled,omitempty"`
+}

--- a/pkg/lib/config/authentication_flow_object_captcha.go
+++ b/pkg/lib/config/authentication_flow_object_captcha.go
@@ -14,3 +14,18 @@ var _ = Schema.Add("AuthenticationFlowObjectCaptchaConfig", `
 type AuthenticationFlowObjectCaptchaConfig struct {
 	Enabled *bool `json:"enabled,omitempty"`
 }
+
+var _ = Schema.Add("AuthenticationFlowCaptcha", `
+{
+	"type": "object",
+	"additionalProperties": false,
+	"required": ["required"],
+	"properties": {
+		"required": { "type": "boolean" }
+	}
+}
+`)
+
+type AuthenticationFlowCaptcha struct {
+	Required *bool `json:"required,omitempty"`
+}

--- a/pkg/lib/config/testdata/login_flow_tests.yaml
+++ b/pkg/lib/config/testdata/login_flow_tests.yaml
@@ -6,8 +6,12 @@ value:
   steps:
   - type: identify
     name: my_step
+    captcha: 
+      enabled: true
     one_of:
     - identification: email
+      captcha:
+        required: true
       steps:
       - type: authenticate
         one_of:
@@ -40,6 +44,12 @@ part: AuthenticationFlowLoginFlow
 name: invalid
 error: |-
   invalid value:
+  /captcha: required
+    map[actual:[foobar] expected:[enabled] missing:[enabled]]
+  /captcha/foobar: 
+  /steps/0/one_of/0/captcha: required
+    map[actual:[foobar] expected:[required] missing:[required]]
+  /steps/0/one_of/0/captcha/foobar: 
   /steps/0/one_of/0/steps/0/one_of/0/authentication: enum
     map[actual:foobar expected:[primary_password primary_passkey primary_oob_otp_email primary_oob_otp_sms secondary_password secondary_totp secondary_oob_otp_email secondary_oob_otp_sms recovery_code device_token]]
   /steps/0/one_of/0/steps/0/one_of/0/target_step: type
@@ -52,11 +62,15 @@ error: |-
     map[actual:foobar expected:[identify authenticate check_account_status terminate_other_sessions change_password prompt_create_passkey]]
 value:
   name: id
+  captcha:
+    foobar: true
   steps:
   - type: identify
     name: my_step
     one_of:
     - identification: email
+      captcha:
+        foobar: true
       steps:
       - type: authenticate
         one_of:

--- a/pkg/lib/config/testdata/login_flow_tests.yaml
+++ b/pkg/lib/config/testdata/login_flow_tests.yaml
@@ -3,11 +3,11 @@ name: valid
 error: null
 value:
   name: id
+  captcha: 
+    enabled: true
   steps:
   - type: identify
     name: my_step
-    captcha: 
-      enabled: true
     one_of:
     - identification: email
       captcha:
@@ -44,11 +44,7 @@ part: AuthenticationFlowLoginFlow
 name: invalid
 error: |-
   invalid value:
-  /captcha: required
-    map[actual:[foobar] expected:[enabled] missing:[enabled]]
   /captcha/foobar: 
-  /steps/0/one_of/0/captcha: required
-    map[actual:[foobar] expected:[required] missing:[required]]
   /steps/0/one_of/0/captcha/foobar: 
   /steps/0/one_of/0/steps/0/one_of/0/authentication: enum
     map[actual:foobar expected:[primary_password primary_passkey primary_oob_otp_email primary_oob_otp_sms secondary_password secondary_totp secondary_oob_otp_email secondary_oob_otp_sms recovery_code device_token]]

--- a/pkg/lib/config/testdata/reauth_flow_tests.yaml
+++ b/pkg/lib/config/testdata/reauth_flow_tests.yaml
@@ -21,8 +21,6 @@ part: AuthenticationFlowReauthFlow
 name: invalid
 error: |-
   invalid value:
-  /captcha: required
-    map[actual:[foobar] expected:[enabled] missing:[enabled]]
   /captcha/foobar: 
   /steps/0/type: enum
     map[actual:foobar expected:[identify authenticate]]
@@ -30,8 +28,6 @@ error: |-
     map[actual:foobar expected:[id_token]]
   /steps/2/one_of/0/authentication: enum
     map[actual:foobar expected:[primary_password primary_passkey primary_oob_otp_email primary_oob_otp_sms secondary_password secondary_totp secondary_oob_otp_email secondary_oob_otp_sms]]
-  /steps/2/one_of/0/captcha: required
-    map[actual:[foobar] expected:[required] missing:[required]]
   /steps/2/one_of/0/captcha/foobar: 
 value:
   name: id

--- a/pkg/lib/config/testdata/reauth_flow_tests.yaml
+++ b/pkg/lib/config/testdata/reauth_flow_tests.yaml
@@ -3,10 +3,14 @@ name: valid
 error: null
 value:
   name: id
+  captcha:
+    enabled: true
   steps:
   - type: authenticate
     one_of:
     - authentication: primary_password
+      captcha:
+        required: true
       steps:
       - type: authenticate
         one_of:
@@ -17,14 +21,22 @@ part: AuthenticationFlowReauthFlow
 name: invalid
 error: |-
   invalid value:
+  /captcha: required
+    map[actual:[foobar] expected:[enabled] missing:[enabled]]
+  /captcha/foobar: 
   /steps/0/type: enum
     map[actual:foobar expected:[identify authenticate]]
   /steps/1/one_of/0/identification: enum
     map[actual:foobar expected:[id_token]]
   /steps/2/one_of/0/authentication: enum
     map[actual:foobar expected:[primary_password primary_passkey primary_oob_otp_email primary_oob_otp_sms secondary_password secondary_totp secondary_oob_otp_email secondary_oob_otp_sms]]
+  /steps/2/one_of/0/captcha: required
+    map[actual:[foobar] expected:[required] missing:[required]]
+  /steps/2/one_of/0/captcha/foobar: 
 value:
   name: id
+  captcha:
+    foobar: true
   steps:
   - type: foobar
   - type: identify
@@ -33,3 +45,5 @@ value:
   - type: authenticate
     one_of:
     - authentication: foobar
+      captcha:
+        foobar: true

--- a/pkg/lib/config/testdata/signup_flow_tests.yaml
+++ b/pkg/lib/config/testdata/signup_flow_tests.yaml
@@ -3,11 +3,15 @@ name: valid
 error: null
 value:
   name: id
+  captcha:
+    enabled: true
   steps:
   - type: identify
     name: my_step
     one_of:
     - identification: email
+      captcha:
+        required: true
       steps:
       - type: create_authenticator
         one_of:
@@ -25,6 +29,12 @@ part: AuthenticationFlowSignupFlow
 name: invalid
 error: |-
   invalid value:
+  /captcha: required
+    map[actual:[foobar] expected:[enabled] missing:[enabled]]
+  /captcha/foobar: 
+  /steps/0/one_of/0/captcha: required
+    map[actual:[foobar] expected:[required] missing:[required]]
+  /steps/0/one_of/0/captcha/foobar: 
   /steps/0/one_of/0/identification: enum
     map[actual:foobar expected:[email phone username oauth passkey]]
   /steps/0/one_of/0/steps/0/one_of/0/authentication: enum
@@ -39,11 +49,15 @@ error: |-
     map[actual:foobar expected:[identify create_authenticator verify fill_in_user_profile view_recovery_code prompt_create_passkey]]
 value:
   name: id
+  captcha:
+    foobar: true # should be enabled
   steps:
   - type: identify
     name: my_step
     one_of:
     - identification: foobar
+      captcha:
+        foobar: true # should be required
       steps:
       - type: create_authenticator
         one_of:

--- a/pkg/lib/config/testdata/signup_flow_tests.yaml
+++ b/pkg/lib/config/testdata/signup_flow_tests.yaml
@@ -29,11 +29,7 @@ part: AuthenticationFlowSignupFlow
 name: invalid
 error: |-
   invalid value:
-  /captcha: required
-    map[actual:[foobar] expected:[enabled] missing:[enabled]]
   /captcha/foobar: 
-  /steps/0/one_of/0/captcha: required
-    map[actual:[foobar] expected:[required] missing:[required]]
   /steps/0/one_of/0/captcha/foobar: 
   /steps/0/one_of/0/identification: enum
     map[actual:foobar expected:[email phone username oauth passkey]]

--- a/pkg/lib/config/testdata/signup_login_flow_tests.yaml
+++ b/pkg/lib/config/testdata/signup_login_flow_tests.yaml
@@ -19,15 +19,11 @@ part: AuthenticationFlowSignupLoginFlow
 name: invalid
 error: |-
   invalid value:
-  /captcha: required
-    map[actual:[foobar] expected:[enabled] missing:[enabled]]
   /captcha/foobar: 
   /steps/0/type: enum
     map[actual:foobar expected:[identify]]
   /steps/1/one_of/0: required
     map[actual:[captcha identification] expected:[identification login_flow signup_flow] missing:[login_flow signup_flow]]
-  /steps/1/one_of/0/captcha: required
-    map[actual:[foobar] expected:[required] missing:[required]]
   /steps/1/one_of/0/captcha/foobar: 
   /steps/1/one_of/0/identification: enum
     map[actual:foobar expected:[email phone username oauth passkey]]

--- a/pkg/lib/config/testdata/signup_login_flow_tests.yaml
+++ b/pkg/lib/config/testdata/signup_login_flow_tests.yaml
@@ -3,10 +3,14 @@ name: valid
 error: null
 value:
   name: id
+  captcha:
+    enabled: true
   steps:
   - type: identify
     one_of:
     - identification: email
+      captcha:
+        required: true
       signup_flow: a
       login_flow: b
 
@@ -15,14 +19,22 @@ part: AuthenticationFlowSignupLoginFlow
 name: invalid
 error: |-
   invalid value:
+  /captcha: required
+    map[actual:[foobar] expected:[enabled] missing:[enabled]]
+  /captcha/foobar: 
   /steps/0/type: enum
     map[actual:foobar expected:[identify]]
   /steps/1/one_of/0: required
-    map[actual:[identification] expected:[identification login_flow signup_flow] missing:[login_flow signup_flow]]
+    map[actual:[captcha identification] expected:[identification login_flow signup_flow] missing:[login_flow signup_flow]]
+  /steps/1/one_of/0/captcha: required
+    map[actual:[foobar] expected:[required] missing:[required]]
+  /steps/1/one_of/0/captcha/foobar: 
   /steps/1/one_of/0/identification: enum
     map[actual:foobar expected:[email phone username oauth passkey]]
 value:
   name: id
+  captcha:
+    foobar: true
   steps:
   - type: foobar
     one_of:
@@ -30,3 +42,5 @@ value:
   - type: identify
     one_of:
     - identification: foobar
+      captcha:
+        foobar: true


### PR DESCRIPTION
## Discussions
1. [Resolved - `No`] Should allow captcha for reauth's identify step too? (ongoing discussion [here](https://github.com/authgear/authgear-server/pull/4282#discussion_r1641979288)) 
2. [Resolved - `Yes, but specify when consuming`]Should specify cascading relationship of root captcha (enabled) & branch captcha (required)? (ongoing discussion [here](https://github.com/authgear/authgear-server/pull/4282#discussion_r1641965018))
   - More test cases if necessary
3. Account recovery flow test case is missing - is it
    1. intentional; OR
    2. because JSON schema is dynamically generated? ref pkg/lib/config/authentication_flow.go:1438
4. Currently supports recursive definition of captcha; Assume only top layer is read