### PR TITLE
Adopt ubuntu base for docker images

### DIFF
--- a/cmd/authgear/Dockerfile
+++ b/cmd/authgear/Dockerfile
@@ -46,7 +46,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     ca-certificates \
     media-types \
     tzdata \
-    && rm -rf /var/lib/apt/lists/*
+    && apt-get upgrade -y && rm -rf /var/lib/apt/lists/*
 RUN update-ca-certificates
 COPY ./GeoLite2-Country.mmdb ./GeoLite2-Country.mmdb
 COPY ./migrations ./migrations

--- a/cmd/authgear/Dockerfile
+++ b/cmd/authgear/Dockerfile
@@ -1,5 +1,5 @@
 # Stage 1: Build the Go binary
-FROM golang:1.22.4-bookworm as stage1
+FROM quay.io/theauthgear/golang:1.22.4-noble as stage1
 
 # Install build time C dependencies
 RUN apt-get update && apt-get install -y --no-install-recommends \
@@ -32,10 +32,10 @@ COPY . .
 RUN make authui GIT_HASH=$GIT_HASH
 
 # Stage 3: Prepare the actual fs we use to run the program
-FROM debian:bookworm-slim
+FROM ubuntu:noble
 ARG GIT_HASH
 WORKDIR /app
-# /etc/mime.types (mime-support)
+# /etc/mime.types (media-types)
 # /usr/share/ca-certificates/*/* (ca-certificates)
 # /usr/share/zoneinfo/ (tzdata)
 RUN apt-get update && apt-get install -y --no-install-recommends \
@@ -44,7 +44,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     libmagic-dev \
     libmagic-mgc \
     ca-certificates \
-    mime-support \
+    media-types \
     tzdata \
     && rm -rf /var/lib/apt/lists/*
 RUN update-ca-certificates

--- a/cmd/portal/Dockerfile
+++ b/cmd/portal/Dockerfile
@@ -56,7 +56,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     ca-certificates \
     media-types \
     tzdata \
-    && rm -rf /var/lib/apt/lists/*
+    && apt-get upgrade -y && rm -rf /var/lib/apt/lists/*
 RUN update-ca-certificates
 COPY ./GeoLite2-Country.mmdb ./GeoLite2-Country.mmdb
 COPY ./migrations ./migrations

--- a/cmd/portal/Dockerfile
+++ b/cmd/portal/Dockerfile
@@ -1,5 +1,5 @@
 # Stage 1: Build the Go binary
-FROM golang:1.22.4-bookworm as stage1
+FROM quay.io/theauthgear/golang:1.22.4-noble as stage1
 
 # Install build time C dependencies
 RUN apt-get update && apt-get install -y --no-install-recommends \
@@ -42,10 +42,10 @@ COPY ./portal .
 RUN npm run build
 
 # Stage 4: Prepare the actual fs we use to run the program
-FROM debian:bookworm-slim
+FROM ubuntu:noble
 ARG GIT_HASH
 WORKDIR /app
-# /etc/mime.types (mime-support)
+# /etc/mime.types (media-types)
 # /usr/share/ca-certificates/*/* (ca-certificates)
 # /usr/share/zoneinfo/ (tzdata)
 RUN apt-get update && apt-get install -y --no-install-recommends \
@@ -54,7 +54,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     libmagic-dev \
     libmagic-mgc \
     ca-certificates \
-    mime-support \
+    media-types \
     tzdata \
     && rm -rf /var/lib/apt/lists/*
 RUN update-ca-certificates

--- a/custombuild/cmd/authgearx/Dockerfile
+++ b/custombuild/cmd/authgearx/Dockerfile
@@ -1,7 +1,7 @@
 # syntax=docker/dockerfile:1
 
 # Stage 1: Build the Go binary
-FROM golang:1.22.4-bookworm as stage1
+FROM quay.io/theauthgear/golang:1.22.4-noble as stage1
 
 # Install build time C dependencies
 RUN apt-get update && apt-get install -y --no-install-recommends \
@@ -50,10 +50,10 @@ COPY . .
 RUN make authui GIT_HASH=$GIT_HASH
 
 # Stage 3: Prepare the actual fs we use to run the program
-FROM debian:bookworm-slim
+FROM ubuntu:noble
 ARG GIT_HASH
 WORKDIR /app
-# /etc/mime.types (mime-support)
+# /etc/mime.types (media-types)
 # /usr/share/ca-certificates/*/* (ca-certificates)
 # /usr/share/zoneinfo/ (tzdata)
 RUN apt-get update && apt-get install -y --no-install-recommends \
@@ -62,7 +62,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     libmagic-dev \
     libmagic-mgc \
     ca-certificates \
-    mime-support \
+    media-types \
     tzdata \
     && rm -rf /var/lib/apt/lists/*
 RUN update-ca-certificates

--- a/custombuild/cmd/authgearx/Dockerfile
+++ b/custombuild/cmd/authgearx/Dockerfile
@@ -64,7 +64,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     ca-certificates \
     media-types \
     tzdata \
-    && rm -rf /var/lib/apt/lists/*
+    && apt-get upgrade -y && rm -rf /var/lib/apt/lists/*
 RUN update-ca-certificates
 COPY ./GeoLite2-Country.mmdb ./GeoLite2-Country.mmdb
 COPY ./migrations ./migrations

--- a/custombuild/cmd/portalx/Dockerfile
+++ b/custombuild/cmd/portalx/Dockerfile
@@ -1,15 +1,15 @@
 # syntax=docker/dockerfile:1
 
 # Stage 1: Build the Go binary
-FROM golang:1.22.4-bookworm as stage1
+FROM quay.io/theauthgear/golang:1.22.4-noble as stage1
 
 # Install build time C dependencies
 RUN apt-get update && apt-get install -y --no-install-recommends \
-    pkg-config \
-    libicu-dev \
-    libvips-dev \
-    libmagic-dev \
-    && rm -rf /var/lib/apt/lists/*
+  pkg-config \
+  libicu-dev \
+  libvips-dev \
+  libmagic-dev \
+  && rm -rf /var/lib/apt/lists/*
 
 # In order to build a Go program that uses private modules in Docker,
 # we need the following
@@ -60,21 +60,21 @@ COPY ./portal .
 RUN npm run build
 
 # Stage 4: Prepare the actual fs we use to run the program
-FROM debian:bookworm-slim
+FROM ubuntu:noble
 ARG GIT_HASH
 WORKDIR /app
-# /etc/mime.types (mime-support)
+# /etc/mime.types (media-types)
 # /usr/share/ca-certificates/*/* (ca-certificates)
 # /usr/share/zoneinfo/ (tzdata)
 RUN apt-get update && apt-get install -y --no-install-recommends \
-    libicu-dev \
-    libvips-dev \
-    libmagic-dev \
-    libmagic-mgc \
-    ca-certificates \
-    mime-support \
-    tzdata \
-    && rm -rf /var/lib/apt/lists/*
+  libicu-dev \
+  libvips-dev \
+  libmagic-dev \
+  libmagic-mgc \
+  ca-certificates \
+  media-types \
+  tzdata \
+  && rm -rf /var/lib/apt/lists/*
 RUN update-ca-certificates
 COPY ./GeoLite2-Country.mmdb ./GeoLite2-Country.mmdb
 COPY ./migrations ./migrations

--- a/custombuild/cmd/portalx/Dockerfile
+++ b/custombuild/cmd/portalx/Dockerfile
@@ -74,7 +74,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
   ca-certificates \
   media-types \
   tzdata \
-  && rm -rf /var/lib/apt/lists/*
+  && apt-get upgrade -y && rm -rf /var/lib/apt/lists/*
 RUN update-ca-certificates
 COPY ./GeoLite2-Country.mmdb ./GeoLite2-Country.mmdb
 COPY ./migrations ./migrations


### PR DESCRIPTION
Ref DEV-1379

- [x] Fork official golang dockerfile to use ubuntu as base: see https://github.com/elise-ng/golang-docker
- [x] Move fork to under authgear org
- [x] Move golang image to under authgear container repo
- [x] Migrate dockerfiles to build with ubuntu base
- [x] Check if audit report improves

--- 

quay.io report:

Base image (golang on noble): 31 mid, 37 low; https://quay.io/repository/elise-oursky/golang/manifest/sha256:2e97d55dc96a0bdd6031ca1e1f147cff9d33f69ff31706f3163bc8019ec9d841?tab=vulnerabilities

Authgear Server: 582 medium, 94 low; https://quay.io/repository/elise-oursky/authgear-server/manifest/sha256:c61f6437b88b1e251b6aab8347e05605ed3d493f3a5721126e26a611699052c6?tab=vulnerabilities

Authgear portal: same as above; https://quay.io/repository/elise-oursky/authgear-portal/manifest/sha256:ef218e503b7486096bbb855511b2318937c859e2ee433914f1e573d6380eab22?tab=vulnerabilities
