### PR TITLE
Fix incorrect deprecated captcha credential key

### DIFF
--- a/pkg/lib/config/secret.go
+++ b/pkg/lib/config/secret.go
@@ -310,7 +310,7 @@ var secretItemKeys = map[SecretKey]secretKeyDef{
 	WATICredentialsKey:                         {"WATICredentials", func() SecretItemData { return &WATICredentials{} }},
 	OAuthClientCredentialsKey:                  {"OAuthClientCredentials", func() SecretItemData { return &OAuthClientCredentials{} }},
 	CustomSMSProviderConfigKey:                 {"CustomSMSProviderConfig", func() SecretItemData { return &CustomSMSProviderConfig{} }},
-	Deprecated_CaptchaCloudflareCredentialsKey: {"LegeacyCaptchaCloudflareCredentials", func() SecretItemData { return &Deprecated_CaptchaCloudflareCredentials{} }},
+	Deprecated_CaptchaCloudflareCredentialsKey: {"Deprecated_CaptchaCloudflareCredentials", func() SecretItemData { return &Deprecated_CaptchaCloudflareCredentials{} }},
 	CaptchaProvidersCredentialsKey:             {"CaptchaProvidersCredentials", func() SecretItemData { return &CaptchaProvidersCredentials{} }},
 	WhatsappOnPremisesCredentialsKey:           {"WhatsappOnPremisesCredentials", func() SecretItemData { return &WhatsappOnPremisesCredentials{} }},
 }


### PR DESCRIPTION
In the current main, the server will crash if we have the legacy captcha credential specified.

@pkong-ds 