### PR TITLE
Implement bot protection in auth flow handlers

### DIFF
--- a/pkg/lib/authenticationflow/context.go
+++ b/pkg/lib/authenticationflow/context.go
@@ -12,6 +12,14 @@ func GetOAuthSessionID(ctx context.Context) string {
 	return ctx.Value(contextKeyOAuthSessionID).(string)
 }
 
+type contextKeyTypeBotProtectionVerificationStatus struct{}
+
+var contextKeyBotProtectionVerificationStatus = contextKeyTypeBotProtectionVerificationStatus{}
+
+func GetBotProtectionVerificationStatus(ctx context.Context) BotProtectionVerificationStatus {
+	return ctx.Value(contextKeyBotProtectionVerificationStatus).(BotProtectionVerificationStatus)
+}
+
 type contextKeyTypeIDToken struct{}
 
 var contextKeyIDToken = contextKeyTypeIDToken{}

--- a/pkg/lib/authenticationflow/context.go
+++ b/pkg/lib/authenticationflow/context.go
@@ -12,12 +12,17 @@ func GetOAuthSessionID(ctx context.Context) string {
 	return ctx.Value(contextKeyOAuthSessionID).(string)
 }
 
-type contextKeyTypeBotProtectionVerificationStatus struct{}
+type contextKeyTypeBotProtectionVerificationResult struct{}
 
-var contextKeyBotProtectionVerificationStatus = contextKeyTypeBotProtectionVerificationStatus{}
+var contextKeyBotProtectionVerificationResult = contextKeyTypeBotProtectionVerificationResult{}
 
-func GetBotProtectionVerificationStatus(ctx context.Context) BotProtectionVerificationStatus {
-	return ctx.Value(contextKeyBotProtectionVerificationStatus).(BotProtectionVerificationStatus)
+func GetBotProtectionVerificationResult(ctx context.Context) *BotProtectionVerificationResult {
+	result, ok := ctx.Value(contextKeyBotProtectionVerificationResult).(BotProtectionVerificationResult)
+
+	if !ok {
+		return nil
+	}
+	return &result
 }
 
 type contextKeyTypeIDToken struct{}

--- a/pkg/lib/authenticationflow/declarative/bot_protection.go
+++ b/pkg/lib/authenticationflow/declarative/bot_protection.go
@@ -1,0 +1,37 @@
+package declarative
+
+import "github.com/authgear/authgear-server/pkg/lib/config"
+
+// For identification option, authentication option & create_authenticator option
+
+type BotProtectionData struct {
+	Enabled  *bool                      `json:"enabled,omitempty"`
+	Provider *BotProtectionDataProvider `json:"provider,omitempty"`
+}
+
+type BotProtectionDataProvider struct {
+	Type config.BotProtectionProviderType `json:"type,omitempty"`
+}
+
+func NewBotProtectionData(t config.BotProtectionProviderType) *BotProtectionData {
+	var varTrue = true
+	return &BotProtectionData{
+		Enabled: &varTrue,
+		Provider: &BotProtectionDataProvider{
+			Type: t,
+		},
+	}
+}
+
+func GetBotProtectionData(authflowCfg *config.AuthenticationFlowBotProtection, appCfg *config.BotProtectionConfig) *BotProtectionData {
+	if authflowCfg == nil || appCfg == nil || !appCfg.Enabled || appCfg.Provider == nil {
+		return nil
+	}
+	switch authflowCfg.Mode {
+	case config.AuthenticationFlowBotProtectionModeNever:
+		break
+	case config.AuthenticationFlowBotProtectionModeAlways:
+		return NewBotProtectionData(appCfg.Provider.Type)
+	}
+	return nil
+}

--- a/pkg/lib/authenticationflow/declarative/data_authenticate_option.go
+++ b/pkg/lib/authenticationflow/declarative/data_authenticate_option.go
@@ -15,6 +15,7 @@ import (
 type AuthenticateOptionForOutput struct {
 	Authentication config.AuthenticationFlowAuthentication `json:"authentication"`
 
+	BotProtection *BotProtectionData `json:"bot_protection,omitempty"`
 	// OTPForm is specific to OOBOTP.
 	OTPForm otp.Form `json:"otp_form,omitempty"`
 	// MaskedDisplayName is specific to OOBOTP.
@@ -29,6 +30,7 @@ type AuthenticateOptionForOutput struct {
 type AuthenticateOption struct {
 	Authentication config.AuthenticationFlowAuthentication `json:"authentication"`
 
+	BotProtection *BotProtectionData `json:"bot_protection,omitempty"`
 	// OTPForm is specific to OOBOTP.
 	OTPForm otp.Form `json:"otp_form,omitempty"`
 	// MaskedDisplayName is specific to OOBOTP.
@@ -48,38 +50,43 @@ func (o *AuthenticateOption) ToOutput() AuthenticateOptionForOutput {
 	return AuthenticateOptionForOutput{
 		Authentication:    o.Authentication,
 		OTPForm:           o.OTPForm,
+		BotProtection:     o.BotProtection,
 		MaskedDisplayName: o.MaskedDisplayName,
 		Channels:          o.Channels,
 		RequestOptions:    o.RequestOptions,
 	}
 }
 
-func NewAuthenticateOptionRecoveryCode() AuthenticateOption {
+func NewAuthenticateOptionRecoveryCode(authflowBotProtectionCfg *config.AuthenticationFlowBotProtection, appBotProtectionConfig *config.BotProtectionConfig) AuthenticateOption {
 	return AuthenticateOption{
 		Authentication: config.AuthenticationFlowAuthenticationRecoveryCode,
+		BotProtection:  GetBotProtectionData(authflowBotProtectionCfg, appBotProtectionConfig),
 	}
 }
 
-func NewAuthenticateOptionPassword(am config.AuthenticationFlowAuthentication) AuthenticateOption {
+func NewAuthenticateOptionPassword(am config.AuthenticationFlowAuthentication, authflowBotProtectionCfg *config.AuthenticationFlowBotProtection, appBotProtectionConfig *config.BotProtectionConfig) AuthenticateOption {
 	return AuthenticateOption{
 		Authentication: am,
+		BotProtection:  GetBotProtectionData(authflowBotProtectionCfg, appBotProtectionConfig),
 	}
 }
 
-func NewAuthenticateOptionPasskey(requestOptions *model.WebAuthnRequestOptions) AuthenticateOption {
+func NewAuthenticateOptionPasskey(requestOptions *model.WebAuthnRequestOptions, authflowBotProtectionCfg *config.AuthenticationFlowBotProtection, appBotProtectionConfig *config.BotProtectionConfig) AuthenticateOption {
 	return AuthenticateOption{
 		Authentication: config.AuthenticationFlowAuthenticationPrimaryPasskey,
 		RequestOptions: requestOptions,
+		BotProtection:  GetBotProtectionData(authflowBotProtectionCfg, appBotProtectionConfig),
 	}
 }
 
-func NewAuthenticateOptionTOTP() AuthenticateOption {
+func NewAuthenticateOptionTOTP(authflowBotProtectionCfg *config.AuthenticationFlowBotProtection, appBotProtectionConfig *config.BotProtectionConfig) AuthenticateOption {
 	return AuthenticateOption{
 		Authentication: config.AuthenticationFlowAuthenticationSecondaryTOTP,
+		BotProtection:  GetBotProtectionData(authflowBotProtectionCfg, appBotProtectionConfig),
 	}
 }
 
-func NewAuthenticateOptionOOBOTPFromAuthenticator(oobConfig *config.AuthenticatorOOBConfig, i *authenticator.Info) (*AuthenticateOption, bool) {
+func NewAuthenticateOptionOOBOTPFromAuthenticator(oobConfig *config.AuthenticatorOOBConfig, i *authenticator.Info, authflowBotProtectionCfg *config.AuthenticationFlowBotProtection, appBotProtectionConfig *config.BotProtectionConfig) (*AuthenticateOption, bool) {
 	am := AuthenticationFromAuthenticator(i)
 	switch am {
 	case config.AuthenticationFlowAuthenticationPrimaryOOBOTPEmail:
@@ -94,6 +101,7 @@ func NewAuthenticateOptionOOBOTPFromAuthenticator(oobConfig *config.Authenticato
 			Channels:          channels,
 			MaskedDisplayName: mail.MaskAddress(i.OOBOTP.Email),
 			AuthenticatorID:   i.ID,
+			BotProtection:     GetBotProtectionData(authflowBotProtectionCfg, appBotProtectionConfig),
 		}, true
 	case config.AuthenticationFlowAuthenticationPrimaryOOBOTPSMS:
 		fallthrough
@@ -107,13 +115,14 @@ func NewAuthenticateOptionOOBOTPFromAuthenticator(oobConfig *config.Authenticato
 			Channels:          channels,
 			MaskedDisplayName: phone.Mask(i.OOBOTP.Phone),
 			AuthenticatorID:   i.ID,
+			BotProtection:     GetBotProtectionData(authflowBotProtectionCfg, appBotProtectionConfig),
 		}, true
 	default:
 		return nil, false
 	}
 }
 
-func NewAuthenticateOptionOOBOTPFromIdentity(oobConfig *config.AuthenticatorOOBConfig, i *identity.Info) (*AuthenticateOption, bool) {
+func NewAuthenticateOptionOOBOTPFromIdentity(oobConfig *config.AuthenticatorOOBConfig, i *identity.Info, authflowBotProtectionCfg *config.AuthenticationFlowBotProtection, appBotProtectionConfig *config.BotProtectionConfig) (*AuthenticateOption, bool) {
 	switch i.Type {
 	case model.IdentityTypeLoginID:
 		switch i.LoginID.LoginIDType {
@@ -127,6 +136,7 @@ func NewAuthenticateOptionOOBOTPFromIdentity(oobConfig *config.AuthenticatorOOBC
 				Channels:          channels,
 				MaskedDisplayName: mail.MaskAddress(i.LoginID.LoginID),
 				IdentityID:        i.ID,
+				BotProtection:     GetBotProtectionData(authflowBotProtectionCfg, appBotProtectionConfig),
 			}, true
 		case model.LoginIDKeyTypePhone:
 			purpose := otp.PurposeOOBOTP
@@ -138,6 +148,7 @@ func NewAuthenticateOptionOOBOTPFromIdentity(oobConfig *config.AuthenticatorOOBC
 				Channels:          channels,
 				MaskedDisplayName: phone.Mask(i.LoginID.LoginID),
 				IdentityID:        i.ID,
+				BotProtection:     GetBotProtectionData(authflowBotProtectionCfg, appBotProtectionConfig),
 			}, true
 		default:
 			return nil, false

--- a/pkg/lib/authenticationflow/declarative/data_create_authenticator_option.go
+++ b/pkg/lib/authenticationflow/declarative/data_create_authenticator_option.go
@@ -14,6 +14,7 @@ import (
 type CreateAuthenticatorOption struct {
 	Authentication config.AuthenticationFlowAuthentication `json:"authentication"`
 
+	BotProtection *BotProtectionData `json:"bot_protection,omitempty"`
 	// OTPForm is specific to OOBOTP.
 	OTPForm otp.Form `json:"otp_form,omitempty"`
 	// Channels is specific to OOBOTP.
@@ -92,6 +93,7 @@ func NewCreateAuthenticationOptions(
 				CreateAuthenticatorOption: CreateAuthenticatorOption{
 					Authentication: b.Authentication,
 					PasswordPolicy: passwordPolicy,
+					BotProtection:  GetBotProtectionData(b.BotProtection, deps.Config.BotProtection),
 				},
 			})
 		case config.AuthenticationFlowAuthenticationPrimaryPasskey:
@@ -118,6 +120,7 @@ func NewCreateAuthenticationOptions(
 					OTPForm:        otpForm,
 					Channels:       channels,
 					Target:         target,
+					BotProtection:  GetBotProtectionData(b.BotProtection, deps.Config.BotProtection),
 				},
 			})
 		case config.AuthenticationFlowAuthenticationPrimaryOOBOTPSMS:
@@ -140,6 +143,7 @@ func NewCreateAuthenticationOptions(
 					OTPForm:        otpForm,
 					Channels:       channels,
 					Target:         target,
+					BotProtection:  GetBotProtectionData(b.BotProtection, deps.Config.BotProtection),
 				},
 				UnmaskedTarget: unmaskedTarget,
 			})
@@ -147,6 +151,7 @@ func NewCreateAuthenticationOptions(
 			options = append(options, CreateAuthenticatorOptionInternal{
 				CreateAuthenticatorOption: CreateAuthenticatorOption{
 					Authentication: b.Authentication,
+					BotProtection:  GetBotProtectionData(b.BotProtection, deps.Config.BotProtection),
 				},
 			})
 		case config.AuthenticationFlowAuthenticationRecoveryCode:

--- a/pkg/lib/authenticationflow/declarative/data_identification.go
+++ b/pkg/lib/authenticationflow/declarative/data_identification.go
@@ -25,6 +25,7 @@ func (IdentificationData) Data() {}
 type IdentificationOption struct {
 	Identification config.AuthenticationFlowIdentification `json:"identification"`
 
+	BotProtection *BotProtectionData `json:"bot_protection,omitempty" nullable:"true"`
 	// ProviderType is specific to OAuth.
 	ProviderType string `json:"provider_type,omitempty"`
 	// Alias is specific to OAuth.
@@ -36,24 +37,27 @@ type IdentificationOption struct {
 	RequestOptions *model.WebAuthnRequestOptions `json:"request_options,omitempty"`
 }
 
-func NewIdentificationOptionIDToken(i config.AuthenticationFlowIdentification) IdentificationOption {
+func NewIdentificationOptionIDToken(i config.AuthenticationFlowIdentification, authflowCfg *config.AuthenticationFlowBotProtection, appCfg *config.BotProtectionConfig) IdentificationOption {
 	return IdentificationOption{
 		Identification: i,
+		BotProtection:  GetBotProtectionData(authflowCfg, appCfg),
 	}
 }
 
-func NewIdentificationOptionLoginID(i config.AuthenticationFlowIdentification) IdentificationOption {
+func NewIdentificationOptionLoginID(i config.AuthenticationFlowIdentification, authflowCfg *config.AuthenticationFlowBotProtection, appCfg *config.BotProtectionConfig) IdentificationOption {
 	return IdentificationOption{
 		Identification: i,
+		BotProtection:  GetBotProtectionData(authflowCfg, appCfg),
 	}
 }
 
-func NewIdentificationOptionsOAuth(oauthConfig *config.OAuthSSOConfig, oauthFeatureConfig *config.OAuthSSOProvidersFeatureConfig) []IdentificationOption {
+func NewIdentificationOptionsOAuth(oauthConfig *config.OAuthSSOConfig, oauthFeatureConfig *config.OAuthSSOProvidersFeatureConfig, authflowCfg *config.AuthenticationFlowBotProtection, appCfg *config.BotProtectionConfig) []IdentificationOption {
 	output := []IdentificationOption{}
 	for _, p := range oauthConfig.Providers {
 		if !identity.IsOAuthSSOProviderTypeDisabled(p.AsProviderConfig(), oauthFeatureConfig) {
 			output = append(output, IdentificationOption{
 				Identification: config.AuthenticationFlowIdentificationOAuth,
+				BotProtection:  GetBotProtectionData(authflowCfg, appCfg),
 				ProviderType:   p.AsProviderConfig().Type(),
 				Alias:          p.Alias(),
 				WechatAppType:  wechat.ProviderConfig(p).AppType(),
@@ -63,9 +67,10 @@ func NewIdentificationOptionsOAuth(oauthConfig *config.OAuthSSOConfig, oauthFeat
 	return output
 }
 
-func NewIdentificationOptionPasskey(requestOptions *model.WebAuthnRequestOptions) IdentificationOption {
+func NewIdentificationOptionPasskey(requestOptions *model.WebAuthnRequestOptions, authflowCfg *config.AuthenticationFlowBotProtection, appCfg *config.BotProtectionConfig) IdentificationOption {
 	return IdentificationOption{
 		Identification: config.AuthenticationFlowIdentificationPasskey,
+		BotProtection:  GetBotProtectionData(authflowCfg, appCfg),
 		RequestOptions: requestOptions,
 	}
 }

--- a/pkg/lib/authenticationflow/declarative/data_identification.go
+++ b/pkg/lib/authenticationflow/declarative/data_identification.go
@@ -25,7 +25,7 @@ func (IdentificationData) Data() {}
 type IdentificationOption struct {
 	Identification config.AuthenticationFlowIdentification `json:"identification"`
 
-	BotProtection *BotProtectionData `json:"bot_protection,omitempty" nullable:"true"`
+	BotProtection *BotProtectionData `json:"bot_protection,omitempty"`
 	// ProviderType is specific to OAuth.
 	ProviderType string `json:"provider_type,omitempty"`
 	// Alias is specific to OAuth.

--- a/pkg/lib/authenticationflow/declarative/intent_login_flow_step_identify.go
+++ b/pkg/lib/authenticationflow/declarative/intent_login_flow_step_identify.go
@@ -78,12 +78,12 @@ func NewIntentLoginFlowStepIdentify(ctx context.Context, deps *authflow.Dependen
 		case config.AuthenticationFlowIdentificationPhone:
 			fallthrough
 		case config.AuthenticationFlowIdentificationUsername:
-			c := NewIdentificationOptionLoginID(b.Identification)
+			c := NewIdentificationOptionLoginID(b.Identification, b.BotProtection, deps.Config.BotProtection)
 			options = append(options, c)
 		case config.AuthenticationFlowIdentificationOAuth:
 			oauthOptions := NewIdentificationOptionsOAuth(
 				deps.Config.Identity.OAuth,
-				deps.FeatureConfig.Identity.OAuth.Providers,
+				deps.FeatureConfig.Identity.OAuth.Providers, b.BotProtection, deps.Config.BotProtection,
 			)
 			options = append(options, oauthOptions...)
 		case config.AuthenticationFlowIdentificationPasskey:
@@ -91,7 +91,7 @@ func NewIntentLoginFlowStepIdentify(ctx context.Context, deps *authflow.Dependen
 			if err != nil {
 				return nil, err
 			}
-			c := NewIdentificationOptionPasskey(requestOptions)
+			c := NewIdentificationOptionPasskey(requestOptions, b.BotProtection, deps.Config.BotProtection)
 			options = append(options, c)
 		}
 	}

--- a/pkg/lib/authenticationflow/declarative/intent_lookup_identity_oauth.go
+++ b/pkg/lib/authenticationflow/declarative/intent_lookup_identity_oauth.go
@@ -34,11 +34,20 @@ func (i *IntentLookupIdentityOAuth) MilestoneIdentificationMethod() config.Authe
 
 func (i *IntentLookupIdentityOAuth) CanReactTo(ctx context.Context, deps *authflow.Dependencies, flows authflow.Flows) (authflow.InputSchema, error) {
 	if len(flows.Nearest.Nodes) == 0 {
-		oauthOptions := NewIdentificationOptionsOAuth(deps.Config.Identity.OAuth, deps.FeatureConfig.Identity.OAuth.Providers)
 		flowRootObject, err := findFlowRootObjectInFlow(deps, flows)
 		if err != nil {
 			return nil, err
 		}
+		current, err := authflow.FlowObject(flowRootObject, i.JSONPointer)
+		if err != nil {
+			return nil, err
+		}
+		var authflowCfg *config.AuthenticationFlowBotProtection = nil
+		if currentBranch, ok := current.(config.AuthenticationFlowObjectBotProtectionConfigProvider); ok {
+			authflowCfg = currentBranch.GetBotProtectionConfig()
+		}
+
+		oauthOptions := NewIdentificationOptionsOAuth(deps.Config.Identity.OAuth, deps.FeatureConfig.Identity.OAuth.Providers, authflowCfg, deps.Config.BotProtection)
 		return &InputSchemaTakeOAuthAuthorizationRequest{
 			FlowRootObject: flowRootObject,
 			JSONPointer:    i.JSONPointer,

--- a/pkg/lib/authenticationflow/declarative/intent_promote_flow_step_identify.go
+++ b/pkg/lib/authenticationflow/declarative/intent_promote_flow_step_identify.go
@@ -97,12 +97,14 @@ func NewIntentPromoteFlowStepIdentify(ctx context.Context, deps *authflow.Depend
 		case config.AuthenticationFlowIdentificationPhone:
 			fallthrough
 		case config.AuthenticationFlowIdentificationUsername:
-			c := NewIdentificationOptionLoginID(b.Identification)
+			c := NewIdentificationOptionLoginID(b.Identification, b.BotProtection, deps.Config.BotProtection)
 			options = append(options, c)
 		case config.AuthenticationFlowIdentificationOAuth:
 			oauthOptions := NewIdentificationOptionsOAuth(
 				deps.Config.Identity.OAuth,
 				deps.FeatureConfig.Identity.OAuth.Providers,
+				b.BotProtection,
+				deps.Config.BotProtection,
 			)
 			options = append(options, oauthOptions...)
 		case config.AuthenticationFlowIdentificationPasskey:

--- a/pkg/lib/authenticationflow/declarative/intent_promote_identity_oauth.go
+++ b/pkg/lib/authenticationflow/declarative/intent_promote_identity_oauth.go
@@ -39,11 +39,20 @@ func (*IntentPromoteIdentityOAuth) MilestoneFlowCreateIdentity(flows authflow.Fl
 
 func (i *IntentPromoteIdentityOAuth) CanReactTo(ctx context.Context, deps *authflow.Dependencies, flows authflow.Flows) (authflow.InputSchema, error) {
 	if len(flows.Nearest.Nodes) == 0 {
-		oauthOptions := NewIdentificationOptionsOAuth(deps.Config.Identity.OAuth, deps.FeatureConfig.Identity.OAuth.Providers)
 		flowRootObject, err := findFlowRootObjectInFlow(deps, flows)
 		if err != nil {
 			return nil, err
 		}
+		current, err := authflow.FlowObject(flowRootObject, i.JSONPointer)
+		if err != nil {
+			return nil, err
+		}
+		var authflowCfg *config.AuthenticationFlowBotProtection = nil
+		if currentBranch, ok := current.(config.AuthenticationFlowObjectBotProtectionConfigProvider); ok {
+			authflowCfg = currentBranch.GetBotProtectionConfig()
+		}
+		oauthOptions := NewIdentificationOptionsOAuth(deps.Config.Identity.OAuth, deps.FeatureConfig.Identity.OAuth.Providers, authflowCfg, deps.Config.BotProtection)
+
 		return &InputSchemaTakeOAuthAuthorizationRequest{
 			FlowRootObject: flowRootObject,
 			JSONPointer:    i.JSONPointer,

--- a/pkg/lib/authenticationflow/declarative/intent_reauth_flow_step_identify.go
+++ b/pkg/lib/authenticationflow/declarative/intent_reauth_flow_step_identify.go
@@ -35,7 +35,9 @@ func NewIntentReauthFlowStepIdentify(ctx context.Context, deps *authflow.Depende
 	for _, b := range step.OneOf {
 		switch b.Identification {
 		case config.AuthenticationFlowIdentificationIDToken:
-			c := NewIdentificationOptionIDToken(b.Identification)
+			// Reauth flow identify step has no user interaction. It's called by our own backend to identify user. Thus, no bot protection is needed.
+			var botProtection *config.AuthenticationFlowBotProtection = nil
+			c := NewIdentificationOptionIDToken(b.Identification, botProtection, deps.Config.BotProtection)
 			options = append(options, c)
 		}
 	}

--- a/pkg/lib/authenticationflow/declarative/intent_signup_flow_step_identify.go
+++ b/pkg/lib/authenticationflow/declarative/intent_signup_flow_step_identify.go
@@ -147,12 +147,14 @@ func NewIntentSignupFlowStepIdentify(ctx context.Context, deps *authflow.Depende
 		case config.AuthenticationFlowIdentificationPhone:
 			fallthrough
 		case config.AuthenticationFlowIdentificationUsername:
-			c := NewIdentificationOptionLoginID(b.Identification)
+			c := NewIdentificationOptionLoginID(b.Identification, b.BotProtection, deps.Config.BotProtection)
 			options = append(options, c)
 		case config.AuthenticationFlowIdentificationOAuth:
 			oauthOptions := NewIdentificationOptionsOAuth(
 				deps.Config.Identity.OAuth,
 				deps.FeatureConfig.Identity.OAuth.Providers,
+				b.BotProtection,
+				deps.Config.BotProtection,
 			)
 			options = append(options, oauthOptions...)
 		case config.AuthenticationFlowIdentificationPasskey:

--- a/pkg/lib/authenticationflow/declarative/intent_signup_login_flow_step_identify.go
+++ b/pkg/lib/authenticationflow/declarative/intent_signup_login_flow_step_identify.go
@@ -39,12 +39,14 @@ func NewIntentSignupLoginFlowStepIdentify(ctx context.Context, deps *authflow.De
 		case config.AuthenticationFlowIdentificationPhone:
 			fallthrough
 		case config.AuthenticationFlowIdentificationUsername:
-			c := NewIdentificationOptionLoginID(b.Identification)
+			c := NewIdentificationOptionLoginID(b.Identification, b.BotProtection, deps.Config.BotProtection)
 			options = append(options, c)
 		case config.AuthenticationFlowIdentificationOAuth:
 			oauthOptions := NewIdentificationOptionsOAuth(
 				deps.Config.Identity.OAuth,
 				deps.FeatureConfig.Identity.OAuth.Providers,
+				b.BotProtection,
+				deps.Config.BotProtection,
 			)
 			options = append(options, oauthOptions...)
 		case config.AuthenticationFlowIdentificationPasskey:
@@ -53,7 +55,7 @@ func NewIntentSignupLoginFlowStepIdentify(ctx context.Context, deps *authflow.De
 			if err != nil {
 				return nil, err
 			}
-			c := NewIdentificationOptionPasskey(requestOptions)
+			c := NewIdentificationOptionPasskey(requestOptions, b.BotProtection, deps.Config.BotProtection)
 			options = append(options, c)
 		}
 	}

--- a/pkg/lib/authenticationflow/session.go
+++ b/pkg/lib/authenticationflow/session.go
@@ -21,10 +21,11 @@ type Session struct {
 	XState      string   `json:"x_state,omitempty"`
 	UILocales   string   `json:"ui_locales,omitempty"`
 
-	IDToken                  string `json:"id_token,omitempty"`
-	SuppressIDPSessionCookie bool   `json:"suppress_idp_session_cookie,omitempty"`
-	UserIDHint               string `json:"user_id_hint,omitempty"`
-	LoginHint                string `json:"login_hint,omitempty"`
+	BotProtectionVerificationStatus BotProtectionVerificationStatus `json:"bot_protection_verification_status,omitempty"`
+	IDToken                         string                          `json:"id_token,omitempty"`
+	SuppressIDPSessionCookie        bool                            `json:"suppress_idp_session_cookie,omitempty"`
+	UserIDHint                      string                          `json:"user_id_hint,omitempty"`
+	LoginHint                       string                          `json:"login_hint,omitempty"`
 }
 
 type SessionOutput struct {
@@ -43,10 +44,11 @@ type SessionOptions struct {
 	XState      string
 	UILocales   string
 
-	IDToken                  string
-	SuppressIDPSessionCookie bool
-	UserIDHint               string
-	LoginHint                string
+	BotProtectionVerificationStatus BotProtectionVerificationStatus
+	IDToken                         string
+	SuppressIDPSessionCookie        bool
+	UserIDHint                      string
+	LoginHint                       string
 }
 
 func (s *SessionOptions) PartiallyMergeFrom(o *SessionOptions) *SessionOptions {
@@ -61,6 +63,7 @@ func (s *SessionOptions) PartiallyMergeFrom(o *SessionOptions) *SessionOptions {
 		out.XState = s.XState
 		out.UILocales = s.UILocales
 
+		out.BotProtectionVerificationStatus = s.BotProtectionVerificationStatus
 		out.IDToken = s.IDToken
 		out.SuppressIDPSessionCookie = s.SuppressIDPSessionCookie
 		out.UserIDHint = s.UserIDHint
@@ -96,10 +99,11 @@ func NewSession(opts *SessionOptions) *Session {
 		XState:      opts.XState,
 		UILocales:   opts.UILocales,
 
-		IDToken:                  opts.IDToken,
-		SuppressIDPSessionCookie: opts.SuppressIDPSessionCookie,
-		UserIDHint:               opts.UserIDHint,
-		LoginHint:                opts.LoginHint,
+		BotProtectionVerificationStatus: opts.BotProtectionVerificationStatus,
+		IDToken:                         opts.IDToken,
+		SuppressIDPSessionCookie:        opts.SuppressIDPSessionCookie,
+		UserIDHint:                      opts.UserIDHint,
+		LoginHint:                       opts.LoginHint,
 	}
 }
 
@@ -131,6 +135,7 @@ func (s *Session) MakeContext(ctx context.Context, deps *Dependencies) (context.
 		ctx = intl.WithPreferredLanguageTags(ctx, tags)
 	}
 
+	ctx = context.WithValue(ctx, contextKeyBotProtectionVerificationStatus, s.BotProtectionVerificationStatus)
 	ctx = context.WithValue(ctx, contextKeyIDToken, s.IDToken)
 	ctx = context.WithValue(ctx, contextKeySuppressIDPSessionCookie, s.SuppressIDPSessionCookie)
 	ctx = context.WithValue(ctx, contextKeyUserIDHint, s.UserIDHint)

--- a/pkg/lib/authenticationflow/session.go
+++ b/pkg/lib/authenticationflow/session.go
@@ -21,11 +21,11 @@ type Session struct {
 	XState      string   `json:"x_state,omitempty"`
 	UILocales   string   `json:"ui_locales,omitempty"`
 
-	BotProtectionVerificationStatus BotProtectionVerificationStatus `json:"bot_protection_verification_status,omitempty"`
-	IDToken                         string                          `json:"id_token,omitempty"`
-	SuppressIDPSessionCookie        bool                            `json:"suppress_idp_session_cookie,omitempty"`
-	UserIDHint                      string                          `json:"user_id_hint,omitempty"`
-	LoginHint                       string                          `json:"login_hint,omitempty"`
+	BotProtectionVerificationResult *BotProtectionVerificationResult `json:"bot_protection_verification_result,omitempty"`
+	IDToken                         string                           `json:"id_token,omitempty"`
+	SuppressIDPSessionCookie        bool                             `json:"suppress_idp_session_cookie,omitempty"`
+	UserIDHint                      string                           `json:"user_id_hint,omitempty"`
+	LoginHint                       string                           `json:"login_hint,omitempty"`
 }
 
 type SessionOutput struct {
@@ -44,7 +44,7 @@ type SessionOptions struct {
 	XState      string
 	UILocales   string
 
-	BotProtectionVerificationStatus BotProtectionVerificationStatus
+	BotProtectionVerificationResult *BotProtectionVerificationResult
 	IDToken                         string
 	SuppressIDPSessionCookie        bool
 	UserIDHint                      string
@@ -63,7 +63,7 @@ func (s *SessionOptions) PartiallyMergeFrom(o *SessionOptions) *SessionOptions {
 		out.XState = s.XState
 		out.UILocales = s.UILocales
 
-		out.BotProtectionVerificationStatus = s.BotProtectionVerificationStatus
+		out.BotProtectionVerificationResult = s.BotProtectionVerificationResult
 		out.IDToken = s.IDToken
 		out.SuppressIDPSessionCookie = s.SuppressIDPSessionCookie
 		out.UserIDHint = s.UserIDHint
@@ -99,7 +99,7 @@ func NewSession(opts *SessionOptions) *Session {
 		XState:      opts.XState,
 		UILocales:   opts.UILocales,
 
-		BotProtectionVerificationStatus: opts.BotProtectionVerificationStatus,
+		BotProtectionVerificationResult: opts.BotProtectionVerificationResult,
 		IDToken:                         opts.IDToken,
 		SuppressIDPSessionCookie:        opts.SuppressIDPSessionCookie,
 		UserIDHint:                      opts.UserIDHint,
@@ -135,7 +135,7 @@ func (s *Session) MakeContext(ctx context.Context, deps *Dependencies) (context.
 		ctx = intl.WithPreferredLanguageTags(ctx, tags)
 	}
 
-	ctx = context.WithValue(ctx, contextKeyBotProtectionVerificationStatus, s.BotProtectionVerificationStatus)
+	ctx = context.WithValue(ctx, contextKeyBotProtectionVerificationResult, s.BotProtectionVerificationResult)
 	ctx = context.WithValue(ctx, contextKeyIDToken, s.IDToken)
 	ctx = context.WithValue(ctx, contextKeySuppressIDPSessionCookie, s.SuppressIDPSessionCookie)
 	ctx = context.WithValue(ctx, contextKeyUserIDHint, s.UserIDHint)

--- a/pkg/lib/authenticationflow/session_bot_protection.go
+++ b/pkg/lib/authenticationflow/session_bot_protection.go
@@ -1,0 +1,13 @@
+package authenticationflow
+
+type BotProtectionVerificationStatus string
+
+const (
+	// initial status
+	BotProtectionVerificationStatusDefault BotProtectionVerificationStatus = ""
+
+	// terminal status
+	BotProtectionVerificationStatusFailed             BotProtectionVerificationStatus = "failed"
+	BotProtectionVerificationStatusSuccess            BotProtectionVerificationStatus = "success"
+	BotProtectionVerificationStatusServiceUnavailable BotProtectionVerificationStatus = "service_unavailable"
+)

--- a/pkg/lib/authenticationflow/session_bot_protection.go
+++ b/pkg/lib/authenticationflow/session_bot_protection.go
@@ -1,13 +1,14 @@
 package authenticationflow
 
-type BotProtectionVerificationStatus string
+type BotProtectionVerificationResult struct {
+	Outcome  BotProtectionVerificationOutcome `json:"outcome,omitempty"`
+	Response interface{}                      `json:"response,omitempty"`
+}
+
+type BotProtectionVerificationOutcome string
 
 const (
-	// initial status
-	BotProtectionVerificationStatusDefault BotProtectionVerificationStatus = ""
-
-	// terminal status
-	BotProtectionVerificationStatusFailed             BotProtectionVerificationStatus = "failed"
-	BotProtectionVerificationStatusSuccess            BotProtectionVerificationStatus = "success"
-	BotProtectionVerificationStatusServiceUnavailable BotProtectionVerificationStatus = "service_unavailable"
+	BotProtectionVerificationOutcomeFailed             = "failed"
+	BotProtectionVerificationOutcomeVerified           = "verified"
+	BotProtectionVerificationOutcomeServiceUnavailable = "service_unavailable"
 )

--- a/pkg/lib/config/authentication_flow.go
+++ b/pkg/lib/config/authentication_flow.go
@@ -935,6 +935,7 @@ type AuthenticationFlowSignupFlowOneOf struct {
 
 var _ AuthenticationFlowObjectFlowBranch = &AuthenticationFlowSignupFlowOneOf{}
 var _ AuthenticationFlowObjectAccountLinkingConfigProvider = &AuthenticationFlowSignupFlowOneOf{}
+var _ AuthenticationFlowObjectBotProtectionConfigProvider = &AuthenticationFlowSignupFlowOneOf{}
 
 func (f *AuthenticationFlowSignupFlowOneOf) IsFlowObject() {}
 
@@ -961,6 +962,10 @@ func (f *AuthenticationFlowSignupFlowOneOf) IsVerificationRequired() bool {
 
 func (f *AuthenticationFlowSignupFlowOneOf) GetAccountLinkingConfig() *AuthenticationFlowAccountLinking {
 	return f.AccountLinking
+}
+
+func (f *AuthenticationFlowSignupFlowOneOf) GetBotProtectionConfig() *AuthenticationFlowBotProtection {
+	return f.BotProtection
 }
 
 type AuthenticationFlowSignupFlowUserProfile struct {
@@ -1063,6 +1068,7 @@ type AuthenticationFlowLoginFlowOneOf struct {
 }
 
 var _ AuthenticationFlowObjectFlowBranch = &AuthenticationFlowLoginFlowOneOf{}
+var _ AuthenticationFlowObjectBotProtectionConfigProvider = &AuthenticationFlowLoginFlowOneOf{}
 
 func (f *AuthenticationFlowLoginFlowOneOf) IsFlowObject() {}
 
@@ -1080,6 +1086,10 @@ func (f *AuthenticationFlowLoginFlowOneOf) GetBranchInfo() AuthenticationFlowObj
 		Identification: f.Identification,
 		Authentication: f.Authentication,
 	}
+}
+
+func (f *AuthenticationFlowLoginFlowOneOf) GetBotProtectionConfig() *AuthenticationFlowBotProtection {
+	return f.BotProtection
 }
 
 type AuthenticationFlowSignupLoginFlow struct {
@@ -1143,6 +1153,7 @@ type AuthenticationFlowSignupLoginFlowOneOf struct {
 }
 
 var _ AuthenticationFlowObjectFlowBranch = &AuthenticationFlowSignupLoginFlowOneOf{}
+var _ AuthenticationFlowObjectBotProtectionConfigProvider = &AuthenticationFlowSignupLoginFlowOneOf{}
 
 func (s *AuthenticationFlowSignupLoginFlowOneOf) IsFlowObject() {}
 
@@ -1154,6 +1165,10 @@ func (s *AuthenticationFlowSignupLoginFlowOneOf) GetBranchInfo() AuthenticationF
 	return AuthenticationFlowObjectFlowBranchInfo{
 		Identification: s.Identification,
 	}
+}
+
+func (s *AuthenticationFlowSignupLoginFlowOneOf) GetBotProtectionConfig() *AuthenticationFlowBotProtection {
+	return s.BotProtection
 }
 
 type AuthenticationFlowReauthFlow struct {
@@ -1229,6 +1244,7 @@ type AuthenticationFlowReauthFlowOneOf struct {
 }
 
 var _ AuthenticationFlowObjectFlowBranch = &AuthenticationFlowReauthFlowOneOf{}
+var _ AuthenticationFlowObjectBotProtectionConfigProvider = &AuthenticationFlowReauthFlowOneOf{}
 
 func (f *AuthenticationFlowReauthFlowOneOf) IsFlowObject() {}
 
@@ -1246,6 +1262,10 @@ func (f *AuthenticationFlowReauthFlowOneOf) GetBranchInfo() AuthenticationFlowOb
 		Identification: f.Identification,
 		Authentication: f.Authentication,
 	}
+}
+
+func (f *AuthenticationFlowReauthFlowOneOf) GetBotProtectionConfig() *AuthenticationFlowBotProtection {
+	return f.BotProtection
 }
 
 type AuthenticationFlowAccountRecoveryFlow struct {
@@ -1364,6 +1384,7 @@ type AuthenticationFlowAccountRecoveryFlowOneOf struct {
 }
 
 var _ AuthenticationFlowObjectFlowBranch = &AuthenticationFlowAccountRecoveryFlowOneOf{}
+var _ AuthenticationFlowObjectBotProtectionConfigProvider = &AuthenticationFlowAccountRecoveryFlowOneOf{}
 
 func (f *AuthenticationFlowAccountRecoveryFlowOneOf) IsFlowObject() {}
 func (f *AuthenticationFlowAccountRecoveryFlowOneOf) GetSteps() []AuthenticationFlowObject {
@@ -1378,6 +1399,9 @@ func (f *AuthenticationFlowAccountRecoveryFlowOneOf) GetBranchInfo() Authenticat
 	return AuthenticationFlowObjectFlowBranchInfo{
 		Identification: AuthenticationFlowIdentification(f.Identification),
 	}
+}
+func (f *AuthenticationFlowAccountRecoveryFlowOneOf) GetBotProtectionConfig() *AuthenticationFlowBotProtection {
+	return f.BotProtection
 }
 
 type AuthenticationFlowAccountRecoveryIdentification AuthenticationFlowIdentification
@@ -1417,6 +1441,10 @@ type AuthenticationFlowAccountLinkingLoginIDItem struct {
 
 type AuthenticationFlowObjectAccountLinkingConfigProvider interface {
 	GetAccountLinkingConfig() *AuthenticationFlowAccountLinking
+}
+
+type AuthenticationFlowObjectBotProtectionConfigProvider interface {
+	GetBotProtectionConfig() *AuthenticationFlowBotProtection
 }
 
 func init() {


### PR DESCRIPTION
## Blocked by
- #4382 

## Notes
This PR only address 3 out of 4 items of DEV-1413
- [x] ~Output captcha information when captcha is enabled in the flow response.~ Outdated, ref https://github.com/authgear/authgear-server/pull/4282#discussion_r1646846518
- [x] Output captcha requirement in branches.
- [x] Store captcha verification status in authenticationflow.Session
- [ ] Enforce captcha in branches. That is, when accepting input in a branch that requires captcha, it should check is the authflow session has captcha verification passed. If not, return the error as specified in the spec.` 

Why? - to prevent conflict of 4th point with another PR #4372 

