### PR TITLE
Fix wrong footer background color in verficiation success page

### DIFF
--- a/resources/authgear/templates/en/web/authflowv2/oob_otp_link.html
+++ b/resources/authgear/templates/en/web/authflowv2/oob_otp_link.html
@@ -88,11 +88,9 @@
       {{ template "v2-login-link-otp-resend-button-label" }}
     </button>
   </form>
-
   {{ template "authflowv2/__authflow_branch.html" . }}
-
-  {{- end }}
 </footer>
-
 </div>
+{{- end }}
+
 {{ end }}


### PR DESCRIPTION
ref DEV-1443
ref #4373

#### Before

<img width="1650" alt="Screenshot 2024-06-19 at 5 00 08 PM" src="https://github.com/authgear/authgear-server/assets/10144357/56c90c45-4801-4290-a36a-cf8f19519957">

#### After

<img width="1649" alt="Screenshot 2024-06-19 at 5 21 49 PM" src="https://github.com/authgear/authgear-server/assets/10144357/ad675344-4a0d-469d-91f8-c7bff34364e8">


@tung2744 
