### PR TITLE
Do not accidentally leak errors from phonenumbers

### DIFF
--- a/pkg/util/phone/legal_and_valid_parser.go
+++ b/pkg/util/phone/legal_and_valid_parser.go
@@ -18,6 +18,7 @@ func (p *legalAndValidParser) ParseInputPhoneNumber(phone string) (e164 string, 
 	}
 	num, err := phonenumbers.Parse(phone, "")
 	if err != nil {
+		err = ErrNotInE164Format
 		return
 	}
 	isPhoneValid := phonenumbers.IsValidNumber(num)

--- a/pkg/util/phone/legal_and_valid_parser_test.go
+++ b/pkg/util/phone/legal_and_valid_parser_test.go
@@ -25,11 +25,20 @@ func TestLegalAndValidParser(t *testing.T) {
 			tooShort := "+85222"
 			So(parser.CheckE164(tooShort), ShouldBeError, "invalid phone number")
 
-			// Hong Kong number starting with 7
-			So(parser.CheckE164("+85270123456"), ShouldBeNil)
+			plus := "+"
+			So(parser.CheckE164(plus), ShouldBeError, "not in E.164 format")
+
+			plusCountryCode := "+852"
+			So(parser.CheckE164(plusCountryCode), ShouldBeError, "not in E.164 format")
 
 			nonsense := "a"
-			So(parser.CheckE164(nonsense), ShouldNotBeNil)
+			So(parser.CheckE164(nonsense), ShouldBeError, "not in E.164 format")
+
+			empty := ""
+			So(parser.CheckE164(empty), ShouldBeError, "not in E.164 format")
+
+			// Hong Kong number starting with 7
+			So(parser.CheckE164("+85270123456"), ShouldBeNil)
 		})
 
 		Convey("ParseCountryCallingCodeAndNationalNumber", func() {

--- a/pkg/util/phone/legal_parser.go
+++ b/pkg/util/phone/legal_parser.go
@@ -18,6 +18,7 @@ func (p *legalParser) ParseInputPhoneNumber(phone string) (e164 string, err erro
 	}
 	num, err := phonenumbers.Parse(phone, "")
 	if err != nil {
+		err = ErrNotInE164Format
 		return
 	}
 	e164 = phonenumbers.Format(num, phonenumbers.E164)

--- a/pkg/util/phone/legal_parser_test.go
+++ b/pkg/util/phone/legal_parser_test.go
@@ -25,8 +25,17 @@ func TestLegalParser(t *testing.T) {
 			tooShort := "+85222"
 			So(parser.CheckE164(tooShort), ShouldBeNil)
 
+			plus := "+"
+			So(parser.CheckE164(plus), ShouldBeError, "not in E.164 format")
+
+			plusCountryCode := "+852"
+			So(parser.CheckE164(plusCountryCode), ShouldBeError, "not in E.164 format")
+
 			nonsense := "a"
-			So(parser.CheckE164(nonsense), ShouldNotBeNil)
+			So(parser.CheckE164(nonsense), ShouldBeError, "not in E.164 format")
+
+			empty := ""
+			So(parser.CheckE164(empty), ShouldBeError, "not in E.164 format")
 		})
 	})
 }


### PR DESCRIPTION
"the string supplied is too short to be a phone number" from here https://github.com/nyaruka/phonenumbers/blob/v1.3.6/phonenumbers.go#L2873

But I did not find an example of invalid phone number that can trigger this case.

ref DEV-1528