### PR TITLE
Fix access token issued can be resolved to a wrong user id

### DIFF
--- a/pkg/auth/handler/webapp/authflowv2/select_account.go
+++ b/pkg/auth/handler/webapp/authflowv2/select_account.go
@@ -146,7 +146,7 @@ func (h *AuthflowV2SelectAccountHandler) ServeHTTP(w http.ResponseWriter, r *htt
 
 		// Write authentication info cookie
 		if session != nil {
-			info := session.GetAuthenticationInfoByThisSession()
+			info := session.CreateNewAuthenticationInfoByThisSession()
 			entry := authenticationinfo.NewEntry(info, oauthSessionID)
 			err := h.AuthenticationInfoService.Save(entry)
 			if err != nil {

--- a/pkg/auth/handler/webapp/authflowv2/select_account.go
+++ b/pkg/auth/handler/webapp/authflowv2/select_account.go
@@ -146,7 +146,7 @@ func (h *AuthflowV2SelectAccountHandler) ServeHTTP(w http.ResponseWriter, r *htt
 
 		// Write authentication info cookie
 		if session != nil {
-			info := session.GetAuthenticationInfo()
+			info := session.GetAuthenticationInfoByThisSession()
 			entry := authenticationinfo.NewEntry(info, oauthSessionID)
 			err := h.AuthenticationInfoService.Save(entry)
 			if err != nil {

--- a/pkg/auth/handler/webapp/select_account.go
+++ b/pkg/auth/handler/webapp/select_account.go
@@ -140,7 +140,7 @@ func (h *SelectAccountHandler) ServeHTTP(w http.ResponseWriter, r *http.Request)
 
 		// Write authentication info cookie
 		if session != nil {
-			info := session.GetAuthenticationInfoByThisSession()
+			info := session.CreateNewAuthenticationInfoByThisSession()
 			entry := authenticationinfo.NewEntry(info, oauthSessionID)
 			err := h.AuthenticationInfoService.Save(entry)
 			if err != nil {

--- a/pkg/auth/handler/webapp/select_account.go
+++ b/pkg/auth/handler/webapp/select_account.go
@@ -140,7 +140,7 @@ func (h *SelectAccountHandler) ServeHTTP(w http.ResponseWriter, r *http.Request)
 
 		// Write authentication info cookie
 		if session != nil {
-			info := session.GetAuthenticationInfo()
+			info := session.GetAuthenticationInfoByThisSession()
 			entry := authenticationinfo.NewEntry(info, oauthSessionID)
 			err := h.AuthenticationInfoService.Save(entry)
 			if err != nil {

--- a/pkg/auth/handler/webapp/settings_delete_account.go
+++ b/pkg/auth/handler/webapp/settings_delete_account.go
@@ -123,7 +123,7 @@ func (h *SettingsDeleteAccountHandler) ServeHTTP(w http.ResponseWriter, r *http.
 			// delete account triggered by sdk via settings action
 			// handle settings action result here
 
-			authInfoEntry := authenticationinfo.NewEntry(currentSession.GetAuthenticationInfoByThisSession(), webSession.OAuthSessionID)
+			authInfoEntry := authenticationinfo.NewEntry(currentSession.CreateNewAuthenticationInfoByThisSession(), webSession.OAuthSessionID)
 			err := h.AuthenticationInfoService.Save(authInfoEntry)
 			if err != nil {
 				return err

--- a/pkg/auth/handler/webapp/settings_delete_account.go
+++ b/pkg/auth/handler/webapp/settings_delete_account.go
@@ -123,7 +123,7 @@ func (h *SettingsDeleteAccountHandler) ServeHTTP(w http.ResponseWriter, r *http.
 			// delete account triggered by sdk via settings action
 			// handle settings action result here
 
-			authInfoEntry := authenticationinfo.NewEntry(currentSession.GetAuthenticationInfo(), webSession.OAuthSessionID)
+			authInfoEntry := authenticationinfo.NewEntry(currentSession.GetAuthenticationInfoByThisSession(), webSession.OAuthSessionID)
 			err := h.AuthenticationInfoService.Save(authInfoEntry)
 			if err != nil {
 				return err

--- a/pkg/latte/intent_ensure_session.go
+++ b/pkg/latte/intent_ensure_session.go
@@ -58,7 +58,7 @@ func (i *IntentEnsureSession) ReactTo(ctx context.Context, deps *workflow.Depend
 		mode = EnsureSessionModeCreate
 	}
 
-	authnInfo := sessionToCreate.GetAuthenticationInfo()
+	authnInfo := sessionToCreate.GetAuthenticationInfoByThisSession()
 	authnInfo.ShouldFireAuthenticatedEventWhenIssueOfflineGrant = mode == EnsureSessionModeNoop && i.CreateReason == session.CreateReasonLogin
 	authnInfoEntry := authenticationinfo.NewEntry(
 		authnInfo,

--- a/pkg/latte/intent_ensure_session.go
+++ b/pkg/latte/intent_ensure_session.go
@@ -58,7 +58,7 @@ func (i *IntentEnsureSession) ReactTo(ctx context.Context, deps *workflow.Depend
 		mode = EnsureSessionModeCreate
 	}
 
-	authnInfo := sessionToCreate.GetAuthenticationInfoByThisSession()
+	authnInfo := sessionToCreate.CreateNewAuthenticationInfoByThisSession()
 	authnInfo.ShouldFireAuthenticatedEventWhenIssueOfflineGrant = mode == EnsureSessionModeNoop && i.CreateReason == session.CreateReasonLogin
 	authnInfoEntry := authenticationinfo.NewEntry(
 		authnInfo,

--- a/pkg/latte/intent_ensure_session.go
+++ b/pkg/latte/intent_ensure_session.go
@@ -50,7 +50,7 @@ func (*IntentEnsureSession) CanReactTo(ctx context.Context, deps *workflow.Depen
 func (i *IntentEnsureSession) ReactTo(ctx context.Context, deps *workflow.Dependencies, workflows workflow.Workflows, input workflow.Input) (*workflow.Node, error) {
 	attrs := session.NewAttrs(i.UserID)
 	attrs.SetAMR(i.AMR)
-	var sessionToCreate *idpsession.IDPSession = nil
+	var sessionToCreate *idpsession.IDPSession
 	newSession, token := deps.IDPSessions.MakeSession(attrs)
 	sessionToCreate = newSession
 	sessionCookie := deps.Cookies.ValueCookie(deps.SessionCookie.Def, token)

--- a/pkg/lib/authenticationflow/declarative/node_did_reauthenticate.go
+++ b/pkg/lib/authenticationflow/declarative/node_did_reauthenticate.go
@@ -26,9 +26,12 @@ func NewNodeDidReauthenticate(ctx context.Context, deps *authflow.Dependencies, 
 		return nil, err
 	}
 	attrs.SetAMR(amr)
-	s, _ := deps.IDPSessions.MakeSession(attrs)
+	authnInfo := authenticationinfo.T{
+		UserID:          n.UserID,
+		AuthenticatedAt: deps.Clock.NowUTC(),
+		AMR:             amr,
+	}
 
-	authnInfo := s.CreateNewAuthenticationInfoByThisSession()
 	authnInfoEntry := authenticationinfo.NewEntry(authnInfo, authflow.GetOAuthSessionID(ctx))
 
 	n.AuthenticationInfoEntry = authnInfoEntry

--- a/pkg/lib/authenticationflow/declarative/node_did_reauthenticate.go
+++ b/pkg/lib/authenticationflow/declarative/node_did_reauthenticate.go
@@ -28,7 +28,7 @@ func NewNodeDidReauthenticate(ctx context.Context, deps *authflow.Dependencies, 
 	attrs.SetAMR(amr)
 	s, _ := deps.IDPSessions.MakeSession(attrs)
 
-	authnInfo := s.GetAuthenticationInfo()
+	authnInfo := s.GetAuthenticationInfoByThisSession()
 	authnInfoEntry := authenticationinfo.NewEntry(authnInfo, authflow.GetOAuthSessionID(ctx))
 
 	n.AuthenticationInfoEntry = authnInfoEntry

--- a/pkg/lib/authenticationflow/declarative/node_did_reauthenticate.go
+++ b/pkg/lib/authenticationflow/declarative/node_did_reauthenticate.go
@@ -28,7 +28,7 @@ func NewNodeDidReauthenticate(ctx context.Context, deps *authflow.Dependencies, 
 	attrs.SetAMR(amr)
 	s, _ := deps.IDPSessions.MakeSession(attrs)
 
-	authnInfo := s.GetAuthenticationInfoByThisSession()
+	authnInfo := s.CreateNewAuthenticationInfoByThisSession()
 	authnInfoEntry := authenticationinfo.NewEntry(authnInfo, authflow.GetOAuthSessionID(ctx))
 
 	n.AuthenticationInfoEntry = authnInfoEntry

--- a/pkg/lib/authenticationflow/declarative/node_do_create_session.go
+++ b/pkg/lib/authenticationflow/declarative/node_do_create_session.go
@@ -35,7 +35,7 @@ func NewNodeDoCreateSession(ctx context.Context, deps *authflow.Dependencies, fl
 	s, token := deps.IDPSessions.MakeSession(attrs)
 	sessionCookie := deps.Cookies.ValueCookie(deps.SessionCookie.Def, token)
 
-	authnInfo := s.GetAuthenticationInfo()
+	authnInfo := s.GetAuthenticationInfoByThisSession()
 	authnInfo.ShouldFireAuthenticatedEventWhenIssueOfflineGrant = n.SkipCreate && n.CreateReason == session.CreateReasonLogin
 	authnInfoEntry := authenticationinfo.NewEntry(authnInfo, authflow.GetOAuthSessionID(ctx))
 

--- a/pkg/lib/authenticationflow/declarative/node_do_create_session.go
+++ b/pkg/lib/authenticationflow/declarative/node_do_create_session.go
@@ -32,24 +32,32 @@ func NewNodeDoCreateSession(ctx context.Context, deps *authflow.Dependencies, fl
 		return nil, err
 	}
 	attrs.SetAMR(amr)
-	s, token := deps.IDPSessions.MakeSession(attrs)
-	sessionCookie := deps.Cookies.ValueCookie(deps.SessionCookie.Def, token)
+	authnInfo := authenticationinfo.T{
+		UserID:          n.UserID,
+		AuthenticatedAt: deps.Clock.NowUTC(),
+		AMR:             amr,
+	}
+	var newSession *idpsession.IDPSession = nil
+	var sessionCookie *http.Cookie = nil
 
-	authnInfo := s.CreateNewAuthenticationInfoByThisSession()
 	authnInfo.ShouldFireAuthenticatedEventWhenIssueOfflineGrant = n.SkipCreate && n.CreateReason == session.CreateReasonLogin
-	authnInfoEntry := authenticationinfo.NewEntry(authnInfo, authflow.GetOAuthSessionID(ctx))
 
 	sameSiteStrictCookie := deps.Cookies.ValueCookie(
 		deps.SessionCookie.SameSiteStrictDef,
 		"true",
 	)
 
-	if n.SkipCreate {
-		s = nil
-		sessionCookie = nil
+	if !n.SkipCreate {
+		s, token := deps.IDPSessions.MakeSession(attrs)
+		newSession = s
+		sessionCookie = deps.Cookies.ValueCookie(deps.SessionCookie.Def, token)
+		authnInfo.AuthenticatedBySessionID = newSession.SessionID()
+		authnInfo.AuthenticatedBySessionType = string(newSession.SessionType())
 	}
 
-	n.Session = s
+	authnInfoEntry := authenticationinfo.NewEntry(authnInfo, authflow.GetOAuthSessionID(ctx))
+
+	n.Session = newSession
 	n.SessionCookie = sessionCookie
 	n.AuthenticationInfoEntry = authnInfoEntry
 	n.SameSiteStrictCookie = sameSiteStrictCookie

--- a/pkg/lib/authenticationflow/declarative/node_do_create_session.go
+++ b/pkg/lib/authenticationflow/declarative/node_do_create_session.go
@@ -35,7 +35,7 @@ func NewNodeDoCreateSession(ctx context.Context, deps *authflow.Dependencies, fl
 	s, token := deps.IDPSessions.MakeSession(attrs)
 	sessionCookie := deps.Cookies.ValueCookie(deps.SessionCookie.Def, token)
 
-	authnInfo := s.GetAuthenticationInfoByThisSession()
+	authnInfo := s.CreateNewAuthenticationInfoByThisSession()
 	authnInfo.ShouldFireAuthenticatedEventWhenIssueOfflineGrant = n.SkipCreate && n.CreateReason == session.CreateReasonLogin
 	authnInfoEntry := authenticationinfo.NewEntry(authnInfo, authflow.GetOAuthSessionID(ctx))
 

--- a/pkg/lib/authn/authenticationinfo/model.go
+++ b/pkg/lib/authn/authenticationinfo/model.go
@@ -20,6 +20,11 @@ type T struct {
 	// ShouldFireAuthenticatedEventWhenIssueOfflineGrant indicates we should fire authenticated event during code exchange
 	// This value will be filled in during interaction / workflow / authentication flow
 	ShouldFireAuthenticatedEventWhenIssueOfflineGrant bool `json:"should_fire_authenticated_event_when_issue_offline_grant,omitempty"`
+
+	// AuthenticatedBySessionType and AuthenticatedBySessionID
+	// means this authentication is done by an existing session.
+	AuthenticatedBySessionType string
+	AuthenticatedBySessionID   string
 }
 
 type Entry struct {

--- a/pkg/lib/interaction/nodes/do_ensure_session.go
+++ b/pkg/lib/interaction/nodes/do_ensure_session.go
@@ -44,7 +44,7 @@ func (e *EdgeDoEnsureSession) Instantiate(ctx *interaction.Context, graph *inter
 	sessionToCreate, token := ctx.Sessions.MakeSession(attrs)
 	sessionCookie := ctx.CookieManager.ValueCookie(ctx.SessionCookie.Def, token)
 
-	authenticationInfo := sessionToCreate.GetAuthenticationInfoByThisSession()
+	authenticationInfo := sessionToCreate.CreateNewAuthenticationInfoByThisSession()
 	authenticationInfo.ShouldFireAuthenticatedEventWhenIssueOfflineGrant = mode == EnsureSessionModeNoop && e.CreateReason == session.CreateReasonLogin
 	authenticationInfoEntry := authenticationinfo.NewEntry(authenticationInfo, ctx.OAuthSessionID)
 

--- a/pkg/lib/interaction/nodes/do_ensure_session.go
+++ b/pkg/lib/interaction/nodes/do_ensure_session.go
@@ -41,7 +41,7 @@ func (e *EdgeDoEnsureSession) Instantiate(ctx *interaction.Context, graph *inter
 
 	attrs := session.NewAttrs(userID)
 	attrs.SetAMR(amr)
-	var sessionToCreate *idpsession.IDPSession = nil
+	var sessionToCreate *idpsession.IDPSession
 	newSession, token := ctx.Sessions.MakeSession(attrs)
 	sessionToCreate = newSession
 	sessionCookie := ctx.CookieManager.ValueCookie(ctx.SessionCookie.Def, token)

--- a/pkg/lib/interaction/nodes/do_ensure_session.go
+++ b/pkg/lib/interaction/nodes/do_ensure_session.go
@@ -41,12 +41,10 @@ func (e *EdgeDoEnsureSession) Instantiate(ctx *interaction.Context, graph *inter
 
 	attrs := session.NewAttrs(userID)
 	attrs.SetAMR(amr)
-	sessionToCreate, token := ctx.Sessions.MakeSession(attrs)
+	var sessionToCreate *idpsession.IDPSession = nil
+	newSession, token := ctx.Sessions.MakeSession(attrs)
+	sessionToCreate = newSession
 	sessionCookie := ctx.CookieManager.ValueCookie(ctx.SessionCookie.Def, token)
-
-	authenticationInfo := sessionToCreate.CreateNewAuthenticationInfoByThisSession()
-	authenticationInfo.ShouldFireAuthenticatedEventWhenIssueOfflineGrant = mode == EnsureSessionModeNoop && e.CreateReason == session.CreateReasonLogin
-	authenticationInfoEntry := authenticationinfo.NewEntry(authenticationInfo, ctx.OAuthSessionID)
 
 	var updateSessionID string
 	var updateSessionAMR []string
@@ -73,6 +71,15 @@ func (e *EdgeDoEnsureSession) Instantiate(ctx *interaction.Context, graph *inter
 	)
 
 	now := ctx.Clock.NowUTC()
+
+	var authenticationInfo authenticationinfo.T
+	if sessionToCreate == nil {
+		authenticationInfo = newSession.GetAuthenticationInfo()
+	} else {
+		authenticationInfo = sessionToCreate.CreateNewAuthenticationInfoByThisSession()
+	}
+	authenticationInfo.ShouldFireAuthenticatedEventWhenIssueOfflineGrant = mode == EnsureSessionModeNoop && e.CreateReason == session.CreateReasonLogin
+	authenticationInfoEntry := authenticationinfo.NewEntry(authenticationInfo, ctx.OAuthSessionID)
 
 	return &NodeDoEnsureSession{
 		CreateReason:            e.CreateReason,

--- a/pkg/lib/interaction/nodes/do_ensure_session.go
+++ b/pkg/lib/interaction/nodes/do_ensure_session.go
@@ -44,7 +44,7 @@ func (e *EdgeDoEnsureSession) Instantiate(ctx *interaction.Context, graph *inter
 	sessionToCreate, token := ctx.Sessions.MakeSession(attrs)
 	sessionCookie := ctx.CookieManager.ValueCookie(ctx.SessionCookie.Def, token)
 
-	authenticationInfo := sessionToCreate.GetAuthenticationInfo()
+	authenticationInfo := sessionToCreate.GetAuthenticationInfoByThisSession()
 	authenticationInfo.ShouldFireAuthenticatedEventWhenIssueOfflineGrant = mode == EnsureSessionModeNoop && e.CreateReason == session.CreateReasonLogin
 	authenticationInfoEntry := authenticationinfo.NewEntry(authenticationInfo, ctx.OAuthSessionID)
 

--- a/pkg/lib/oauth/grant_code.go
+++ b/pkg/lib/oauth/grant_code.go
@@ -5,14 +5,11 @@ import (
 
 	"github.com/authgear/authgear-server/pkg/lib/authn/authenticationinfo"
 	"github.com/authgear/authgear-server/pkg/lib/oauth/protocol"
-	"github.com/authgear/authgear-server/pkg/lib/session"
 )
 
 type CodeGrant struct {
 	AppID              string               `json:"app_id"`
 	AuthorizationID    string               `json:"authz_id"`
-	SessionType        session.Type         `json:"session_type"`
-	SessionID          string               `json:"session_id"`
 	AuthenticationInfo authenticationinfo.T `json:"authentication_info"`
 	IDTokenHintSID     string               `json:"id_token_hint_sid"`
 

--- a/pkg/lib/oauth/grant_offline.go
+++ b/pkg/lib/oauth/grant_offline.go
@@ -82,7 +82,7 @@ func (o *OfflineGrantSession) GetAccessInfo() *access.Info {
 func (o *OfflineGrantSession) SSOGroupIDPSessionID() string {
 	return o.OfflineGrant.SSOGroupIDPSessionID()
 }
-func (o *OfflineGrantSession) GetAuthenticationInfoByThisSession() authenticationinfo.T {
+func (o *OfflineGrantSession) CreateNewAuthenticationInfoByThisSession() authenticationinfo.T {
 	amr, _ := o.OfflineGrant.GetOIDCAMR()
 	return authenticationinfo.T{
 		UserID:                     o.OfflineGrant.GetUserID(),

--- a/pkg/lib/oauth/grant_offline.go
+++ b/pkg/lib/oauth/grant_offline.go
@@ -82,6 +82,16 @@ func (o *OfflineGrantSession) GetAccessInfo() *access.Info {
 func (o *OfflineGrantSession) SSOGroupIDPSessionID() string {
 	return o.OfflineGrant.SSOGroupIDPSessionID()
 }
+func (o *OfflineGrantSession) GetAuthenticationInfoByThisSession() authenticationinfo.T {
+	amr, _ := o.OfflineGrant.GetOIDCAMR()
+	return authenticationinfo.T{
+		UserID:                     o.OfflineGrant.GetUserID(),
+		AuthenticatedAt:            o.OfflineGrant.GetAuthenticatedAt(),
+		AMR:                        amr,
+		AuthenticatedBySessionType: string(o.SessionType()),
+		AuthenticatedBySessionID:   o.SessionID(),
+	}
+}
 
 var _ session.ResolvedSession = &OfflineGrantSession{}
 

--- a/pkg/lib/oauth/handler/handler_authz.go
+++ b/pkg/lib/oauth/handler/handler_authz.go
@@ -655,9 +655,10 @@ func (h *AuthorizationHandler) doHandleConsentRequest(
 
 	sessionID := ""
 	var sessionType session.Type = ""
-	if s := session.GetSession(h.Context); s != nil && s.GetAuthenticationInfo().UserID == authenticationInfo.UserID {
-		sessionID = s.SessionID()
-		sessionType = s.SessionType()
+
+	if authenticationInfo.AuthenticatedBySessionID != "" {
+		sessionID = authenticationInfo.AuthenticatedBySessionID
+		sessionType = session.Type(authenticationInfo.AuthenticatedBySessionType)
 	}
 
 	return h.finish(redirectURI, r, sessionType, sessionID, authenticationInfo, idTokenHintSID, []*http.Cookie{}, grantAuthz)
@@ -791,10 +792,6 @@ func (h *AuthorizationHandler) generateSettingsActionResponse(
 	resp protocol.AuthorizationResponse,
 ) error {
 	code, _, err := h.SettingsActionGrantService.CreateSettingsActionGrant(&CreateSettingsActionGrantOptions{
-		Authorization:        authz,
-		IDPSessionID:         idpSessionID,
-		AuthenticationInfo:   authenticationInfo,
-		IDTokenHintSID:       idTokenHintSID,
 		RedirectURI:          redirectURI,
 		AuthorizationRequest: r,
 	})

--- a/pkg/lib/oauth/handler/handler_authz.go
+++ b/pkg/lib/oauth/handler/handler_authz.go
@@ -484,7 +484,7 @@ func (h *AuthorizationHandler) doHandle(
 		return nil, protocol.NewError("login_required", "authentication required")
 	}
 
-	authenticationInfo := resolvedSession.GetAuthenticationInfo()
+	authenticationInfo := resolvedSession.GetAuthenticationInfoByThisSession()
 	autoGrantAuthz := client.IsFirstParty()
 
 	sessionType := resolvedSession.SessionType()

--- a/pkg/lib/oauth/handler/handler_authz.go
+++ b/pkg/lib/oauth/handler/handler_authz.go
@@ -484,7 +484,7 @@ func (h *AuthorizationHandler) doHandle(
 		return nil, protocol.NewError("login_required", "authentication required")
 	}
 
-	authenticationInfo := resolvedSession.GetAuthenticationInfoByThisSession()
+	authenticationInfo := resolvedSession.CreateNewAuthenticationInfoByThisSession()
 	autoGrantAuthz := client.IsFirstParty()
 
 	sessionType := resolvedSession.SessionType()

--- a/pkg/lib/oauth/handler/handler_authz.go
+++ b/pkg/lib/oauth/handler/handler_authz.go
@@ -655,7 +655,7 @@ func (h *AuthorizationHandler) doHandleConsentRequest(
 
 	sessionID := ""
 	var sessionType session.Type = ""
-	if s := session.GetSession(h.Context); s != nil {
+	if s := session.GetSession(h.Context); s != nil && s.GetAuthenticationInfo().UserID == authenticationInfo.UserID {
 		sessionID = s.SessionID()
 		sessionType = s.SessionType()
 	}

--- a/pkg/lib/oauth/handler/handler_authz_test.go
+++ b/pkg/lib/oauth/handler/handler_authz_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/authgear/authgear-server/pkg/lib/oauth/handler"
 	"github.com/authgear/authgear-server/pkg/lib/oauth/oidc"
 	"github.com/authgear/authgear-server/pkg/lib/oauth/protocol"
+	"github.com/authgear/authgear-server/pkg/lib/session"
 	sessiontest "github.com/authgear/authgear-server/pkg/lib/session/test"
 	"github.com/authgear/authgear-server/pkg/util/clock"
 )
@@ -294,7 +295,9 @@ func TestAuthorizationHandler(t *testing.T) {
 						AppID:           "app-id",
 						AuthorizationID: authorization.ID,
 						AuthenticationInfo: authenticationinfo.T{
-							UserID: "user-id",
+							UserID:                     "user-id",
+							AuthenticatedBySessionID:   "session-id",
+							AuthenticatedBySessionType: string(session.TypeIdentityProvider),
 						},
 						CreatedAt:            time.Date(2020, 2, 1, 0, 0, 0, 0, time.UTC),
 						ExpireAt:             time.Date(2020, 2, 1, 0, 5, 0, 0, time.UTC),
@@ -345,7 +348,9 @@ func TestAuthorizationHandler(t *testing.T) {
 						AppID:           "app-id",
 						AuthorizationID: "authz-id",
 						AuthenticationInfo: authenticationinfo.T{
-							UserID: "user-id",
+							UserID:                     "user-id",
+							AuthenticatedBySessionID:   "session-id",
+							AuthenticatedBySessionType: string(session.TypeIdentityProvider),
 						},
 						CreatedAt:            time.Date(2020, 2, 1, 0, 0, 0, 0, time.UTC),
 						ExpireAt:             time.Date(2020, 2, 1, 0, 5, 0, 0, time.UTC),

--- a/pkg/lib/oauth/handler/handler_authz_test.go
+++ b/pkg/lib/oauth/handler/handler_authz_test.go
@@ -21,7 +21,6 @@ import (
 	"github.com/authgear/authgear-server/pkg/lib/oauth/handler"
 	"github.com/authgear/authgear-server/pkg/lib/oauth/oidc"
 	"github.com/authgear/authgear-server/pkg/lib/oauth/protocol"
-	"github.com/authgear/authgear-server/pkg/lib/session"
 	sessiontest "github.com/authgear/authgear-server/pkg/lib/session/test"
 	"github.com/authgear/authgear-server/pkg/util/clock"
 )
@@ -294,8 +293,6 @@ func TestAuthorizationHandler(t *testing.T) {
 					So(codeGrantStore.grants[0], ShouldResemble, oauth.CodeGrant{
 						AppID:           "app-id",
 						AuthorizationID: authorization.ID,
-						SessionType:     session.TypeIdentityProvider,
-						SessionID:       "session-id",
 						AuthenticationInfo: authenticationinfo.T{
 							UserID: "user-id",
 						},
@@ -347,8 +344,6 @@ func TestAuthorizationHandler(t *testing.T) {
 					So(codeGrantStore.grants[0], ShouldResemble, oauth.CodeGrant{
 						AppID:           "app-id",
 						AuthorizationID: "authz-id",
-						SessionType:     session.TypeIdentityProvider,
-						SessionID:       "session-id",
 						AuthenticationInfo: authenticationinfo.T{
 							UserID: "user-id",
 						},

--- a/pkg/lib/oauth/handler/service_code_grant.go
+++ b/pkg/lib/oauth/handler/service_code_grant.go
@@ -34,8 +34,6 @@ func (s *CodeGrantService) CreateCodeGrant(opts *CreateCodeGrantOptions) (code s
 	codeGrant := &oauth.CodeGrant{
 		AppID:              string(s.AppID),
 		AuthorizationID:    opts.Authorization.ID,
-		SessionType:        opts.SessionType,
-		SessionID:          opts.SessionID,
 		AuthenticationInfo: opts.AuthenticationInfo,
 		IDTokenHintSID:     opts.IDTokenHintSID,
 

--- a/pkg/lib/oauth/handler/service_settings_action_grant.go
+++ b/pkg/lib/oauth/handler/service_settings_action_grant.go
@@ -1,7 +1,6 @@
 package handler
 
 import (
-	"github.com/authgear/authgear-server/pkg/lib/authn/authenticationinfo"
 	"github.com/authgear/authgear-server/pkg/lib/config"
 	"github.com/authgear/authgear-server/pkg/lib/oauth"
 	"github.com/authgear/authgear-server/pkg/lib/oauth/protocol"
@@ -17,10 +16,6 @@ type SettingsActionGrantService struct {
 }
 
 type CreateSettingsActionGrantOptions struct {
-	Authorization        *oauth.Authorization
-	IDPSessionID         string
-	AuthenticationInfo   authenticationinfo.T
-	IDTokenHintSID       string
 	RedirectURI          string
 	AuthorizationRequest protocol.AuthorizationRequest
 }
@@ -30,11 +25,7 @@ func (s *SettingsActionGrantService) CreateSettingsActionGrant(opts *CreateSetti
 	codeHash := oauth.HashToken(code)
 
 	settingsActionGrant := &oauth.SettingsActionGrant{
-		AppID:              string(s.AppID),
-		AuthorizationID:    opts.Authorization.ID,
-		IDPSessionID:       opts.IDPSessionID,
-		AuthenticationInfo: opts.AuthenticationInfo,
-		IDTokenHintSID:     opts.IDTokenHintSID,
+		AppID: string(s.AppID),
 
 		CreatedAt: s.Clock.NowUTC(),
 		ExpireAt:  s.Clock.NowUTC().Add(SettingsActionGrantValidDuration),

--- a/pkg/lib/oauth/settings_action_code.go
+++ b/pkg/lib/oauth/settings_action_code.go
@@ -3,16 +3,11 @@ package oauth
 import (
 	"time"
 
-	"github.com/authgear/authgear-server/pkg/lib/authn/authenticationinfo"
 	"github.com/authgear/authgear-server/pkg/lib/oauth/protocol"
 )
 
 type SettingsActionGrant struct {
-	AppID              string               `json:"app_id"`
-	AuthorizationID    string               `json:"authz_id"`
-	IDPSessionID       string               `json:"session_id"`
-	AuthenticationInfo authenticationinfo.T `json:"authentication_info"`
-	IDTokenHintSID     string               `json:"id_token_hint_sid"`
+	AppID string `json:"app_id"`
 
 	CreatedAt time.Time `json:"created_at"`
 	ExpireAt  time.Time `json:"expire_at"`

--- a/pkg/lib/session/idpsession/session.go
+++ b/pkg/lib/session/idpsession/session.go
@@ -83,7 +83,7 @@ func (s *IDPSession) GetAuthenticationInfo() authenticationinfo.T {
 	}
 }
 
-func (s *IDPSession) GetAuthenticationInfoByThisSession() authenticationinfo.T {
+func (s *IDPSession) CreateNewAuthenticationInfoByThisSession() authenticationinfo.T {
 	amr, _ := s.GetOIDCAMR()
 	return authenticationinfo.T{
 		UserID:                     s.GetUserID(),

--- a/pkg/lib/session/idpsession/session.go
+++ b/pkg/lib/session/idpsession/session.go
@@ -83,6 +83,17 @@ func (s *IDPSession) GetAuthenticationInfo() authenticationinfo.T {
 	}
 }
 
+func (s *IDPSession) GetAuthenticationInfoByThisSession() authenticationinfo.T {
+	amr, _ := s.GetOIDCAMR()
+	return authenticationinfo.T{
+		UserID:                     s.GetUserID(),
+		AuthenticatedAt:            s.GetAuthenticatedAt(),
+		AMR:                        amr,
+		AuthenticatedBySessionType: string(s.SessionType()),
+		AuthenticatedBySessionID:   s.SessionID(),
+	}
+}
+
 func (s *IDPSession) SSOGroupIDPSessionID() string {
 	return s.SessionID()
 }

--- a/pkg/lib/session/session.go
+++ b/pkg/lib/session/session.go
@@ -29,6 +29,7 @@ type ResolvedSession interface {
 	Session()
 	GetCreatedAt() time.Time
 	GetAccessInfo() *access.Info
+	GetAuthenticationInfoByThisSession() authenticationinfo.T
 }
 
 type ListableSession interface {

--- a/pkg/lib/session/session.go
+++ b/pkg/lib/session/session.go
@@ -29,7 +29,7 @@ type ResolvedSession interface {
 	Session()
 	GetCreatedAt() time.Time
 	GetAccessInfo() *access.Info
-	GetAuthenticationInfoByThisSession() authenticationinfo.T
+	CreateNewAuthenticationInfoByThisSession() authenticationinfo.T
 }
 
 type ListableSession interface {

--- a/pkg/lib/session/test/context.go
+++ b/pkg/lib/session/test/context.go
@@ -58,6 +58,17 @@ func (m MockSession) GetAuthenticationInfo() authenticationinfo.T {
 	}
 }
 
+func (m *MockSession) GetAuthenticationInfoByThisSession() authenticationinfo.T {
+	amr, _ := m.GetOIDCAMR()
+	return authenticationinfo.T{
+		UserID:                     m.GetUserID(),
+		AMR:                        amr,
+		AuthenticatedAt:            m.GetAuthenticatedAt(),
+		AuthenticatedBySessionType: string(m.SessionType()),
+		AuthenticatedBySessionID:   m.SessionID(),
+	}
+}
+
 func (m *MockSession) SetUserID(id string) *MockSession {
 	m.Attrs.UserID = id
 	return m

--- a/pkg/lib/session/test/context.go
+++ b/pkg/lib/session/test/context.go
@@ -58,7 +58,7 @@ func (m MockSession) GetAuthenticationInfo() authenticationinfo.T {
 	}
 }
 
-func (m *MockSession) GetAuthenticationInfoByThisSession() authenticationinfo.T {
+func (m *MockSession) CreateNewAuthenticationInfoByThisSession() authenticationinfo.T {
 	amr, _ := m.GetOIDCAMR()
 	return authenticationinfo.T{
 		UserID:                     m.GetUserID(),


### PR DESCRIPTION
The bug occurs when:
1. You have an access token session of user A
2. You try to authenticate as user B
3. You got an access token of user B (sub=user-b-id), but internally the session id was the session in 1. As a result the server will think you are user A.

ref DEV-1589