### PR TITLE
Add bot protection handling in http handlers

### DIFF
--- a/pkg/auth/deps.go
+++ b/pkg/auth/deps.go
@@ -267,6 +267,10 @@ func ProvideGoogleTagManagerConfig() *config.GoogleTagManagerConfig {
 	return &config.GoogleTagManagerConfig{}
 }
 
+func ProvideBotProtectionConfig() *config.BotProtectionConfig {
+	return &config.BotProtectionConfig{}
+}
+
 func ProvideLocalizationConfig(defaultLang template.DefaultLanguageTag, supported template.SupportedLanguageTags) *config.LocalizationConfig {
 	defaultLangStr := string(defaultLang)
 	return &config.LocalizationConfig{
@@ -297,6 +301,7 @@ var RequestMiddlewareDependencySet = wire.NewSet(
 	ProvideAuthenticationConfig,
 	ProvideGoogleTagManagerConfig,
 	ProvideLocalizationConfig,
+	ProvideBotProtectionConfig,
 
 	ProvideCookieManager,
 

--- a/pkg/auth/handler/webapp/authflowv2/forgot_password.go
+++ b/pkg/auth/handler/webapp/authflowv2/forgot_password.go
@@ -182,9 +182,10 @@ func NewAuthFlowV2ForgotPasswordViewModel(
 }
 
 type AuthflowV2ForgotPasswordHandler struct {
-	Controller    *handlerwebapp.AuthflowController
-	BaseViewModel *viewmodels.BaseViewModeler
-	Renderer      handlerwebapp.Renderer
+	Controller        *handlerwebapp.AuthflowController
+	BaseViewModel     *viewmodels.BaseViewModeler
+	AuthflowViewModel *viewmodels.AuthflowViewModeler
+	Renderer          handlerwebapp.Renderer
 }
 
 func (h *AuthflowV2ForgotPasswordHandler) GetData(
@@ -194,6 +195,10 @@ func (h *AuthflowV2ForgotPasswordHandler) GetData(
 	initialScreen *webapp.AuthflowScreenWithFlowResponse,
 	selectDestinationScreen *webapp.AuthflowScreenWithFlowResponse) (map[string]interface{}, error) {
 	data := make(map[string]interface{})
+
+	// Put authflowViewModel first to avoid other fields of authflowViewModel override below
+	authflowViewModel := h.AuthflowViewModel.NewWithAccountRecoveryAuthflow(initialScreen.StateTokenFlowResponse, r)
+	viewmodels.Embed(data, authflowViewModel)
 
 	baseViewModel := h.BaseViewModel.ViewModelForAuthFlow(r, w)
 	viewmodels.Embed(data, baseViewModel)

--- a/pkg/auth/handler/webapp/authflowv2/forgot_password.go
+++ b/pkg/auth/handler/webapp/authflowv2/forgot_password.go
@@ -139,7 +139,8 @@ func NewAuthFlowV2ForgotPasswordViewModel(
 		loginIDInputType = qLoginIDInputType
 	}
 
-	loginID := r.Form.Get("q_login_id")
+	qLoginID := r.Form.Get("q_login_id")
+	loginID := qLoginID
 
 	phoneLoginIDEnabled := false
 	emailLoginIDEnabled := false
@@ -159,6 +160,9 @@ func NewAuthFlowV2ForgotPasswordViewModel(
 		requiresLoginIDInput = false
 	}
 
+	if qLoginID != "" && qLoginIDInputType.IsValid() {
+		requiresLoginIDInput = false
+	}
 	alternatives := deriveForgotPasswordAlternatives(
 		r,
 		loginIDInputType,

--- a/pkg/auth/handler/webapp/authflowv2/forgot_password.go
+++ b/pkg/auth/handler/webapp/authflowv2/forgot_password.go
@@ -250,6 +250,13 @@ func (h *AuthflowV2ForgotPasswordHandler) ServeHTTP(w http.ResponseWriter, r *ht
 
 		inputs := h.makeInputs(screen, identification, loginID, 0)
 
+		for _, input := range inputs {
+			err = handlerwebapp.HandleAccountRecoveryIdentificationBotProtection(config.AuthenticationFlowAccountRecoveryIdentification(identification), screen.StateTokenFlowResponse, r.Form, input)
+			if err != nil {
+				return err
+			}
+		}
+
 		result, err := h.Controller.AdvanceWithInputs(r, s, screen, inputs, nil)
 		if errors.Is(err, otp.ErrInvalidWhatsappUser) {
 			// The code failed to send because it is not a valid whatsapp user

--- a/pkg/auth/handler/webapp/authflowv2/forgot_password.go
+++ b/pkg/auth/handler/webapp/authflowv2/forgot_password.go
@@ -260,19 +260,7 @@ func (h *AuthflowV2ForgotPasswordHandler) ServeHTTP(w http.ResponseWriter, r *ht
 		return nil
 	})
 
-	identification := r.URL.Query().Get("q_login_id_input_type")
-	loginID := r.URL.Query().Get("q_login_id")
-
-	var input interface{} = nil
-
-	if identification != "" && loginID != "" {
-		input = map[string]interface{}{
-			"identification": identification,
-			"login_id":       loginID,
-		}
-	}
-
-	h.Controller.HandleStartOfFlow(w, r, webapp.SessionOptions{}, authflow.FlowTypeAccountRecovery, &handlers, input)
+	h.Controller.HandleStartOfFlow(w, r, webapp.SessionOptions{}, authflow.FlowTypeAccountRecovery, &handlers, nil)
 }
 
 func (h *AuthflowV2ForgotPasswordHandler) fallbackToSMS(

--- a/pkg/auth/handler/webapp/authflowv2/internal_signup_login.go
+++ b/pkg/auth/handler/webapp/authflowv2/internal_signup_login.go
@@ -12,6 +12,7 @@ import (
 	"github.com/authgear/authgear-server/pkg/auth/handler/webapp/viewmodels"
 	"github.com/authgear/authgear-server/pkg/auth/webapp"
 	authflow "github.com/authgear/authgear-server/pkg/lib/authenticationflow"
+	"github.com/authgear/authgear-server/pkg/lib/config"
 	"github.com/authgear/authgear-server/pkg/lib/meter"
 	"github.com/authgear/authgear-server/pkg/util/httputil"
 	"github.com/authgear/authgear-server/pkg/util/template"
@@ -134,6 +135,11 @@ func (h *InternalAuthflowV2SignupLoginHandler) ServeHTTP(w http.ResponseWriter, 
 			"response_mode":  oauthrelyingparty.ResponseModeFormPost,
 		}
 
+		err := handlerwebapp.HandleIdentificationBotProtection(config.AuthenticationFlowIdentificationOAuth, screen.StateTokenFlowResponse, r.Form, input)
+		if err != nil {
+			return err
+		}
+
 		result, err := h.Controller.ReplaceScreen(r, s, authflow.FlowTypeSignupLogin, input)
 		if err != nil {
 			return err
@@ -154,6 +160,11 @@ func (h *InternalAuthflowV2SignupLoginHandler) ServeHTTP(w http.ResponseWriter, 
 		input := map[string]interface{}{
 			"identification": identification,
 			"login_id":       loginID,
+		}
+
+		err = handlerwebapp.HandleIdentificationBotProtection(config.AuthenticationFlowIdentification(identification), screen.StateTokenFlowResponse, r.Form, input)
+		if err != nil {
+			return err
 		}
 
 		result, err := h.Controller.AdvanceWithInput(r, s, screen, input, nil)
@@ -177,6 +188,11 @@ func (h *InternalAuthflowV2SignupLoginHandler) ServeHTTP(w http.ResponseWriter, 
 		input := map[string]interface{}{
 			"identification":     "passkey",
 			"assertion_response": assertionResponseJSON,
+		}
+
+		err = handlerwebapp.HandleIdentificationBotProtection(config.AuthenticationFlowIdentificationPasskey, screen.StateTokenFlowResponse, r.Form, input)
+		if err != nil {
+			return err
 		}
 
 		result, err := h.Controller.AdvanceWithInput(r, s, screen, input, nil)

--- a/pkg/auth/handler/webapp/authflowv2/login.go
+++ b/pkg/auth/handler/webapp/authflowv2/login.go
@@ -104,13 +104,18 @@ func (h *AuthflowV2LoginHandler) ServeHTTP(w http.ResponseWriter, r *http.Reques
 		RedirectURI: h.Controller.RedirectURI(r),
 	}
 
-	oauthPostAction := func(s *webapp.Session, providerAlias string) error {
+	oauthPostAction := func(s *webapp.Session, screen *webapp.AuthflowScreenWithFlowResponse, providerAlias string) error {
 		callbackURL := h.Endpoints.SSOCallbackURL(providerAlias).String()
 		input := map[string]interface{}{
 			"identification": "oauth",
 			"alias":          providerAlias,
 			"redirect_uri":   callbackURL,
 			"response_mode":  oauthrelyingparty.ResponseModeFormPost,
+		}
+
+		err := handlerwebapp.HandleIdentificationBotProtection(config.AuthenticationFlowIdentificationOAuth, screen.StateTokenFlowResponse, r.Form, input)
+		if err != nil {
+			return err
 		}
 
 		result, err := h.Controller.ReplaceScreen(r, s, authflow.FlowTypeSignupLogin, input)
@@ -144,7 +149,7 @@ func (h *AuthflowV2LoginHandler) ServeHTTP(w http.ResponseWriter, r *http.Reques
 		// If there is error in the ErrorCookie, the user will stay in the login
 		// page to see the error message and the redirection won't be performed
 		if !hasErr && oauthProviderAlias != "" {
-			return oauthPostAction(s, oauthProviderAlias)
+			return oauthPostAction(s, screen, oauthProviderAlias)
 		}
 
 		data, err := h.GetData(w, r, screen, allowLoginOnly)
@@ -156,9 +161,9 @@ func (h *AuthflowV2LoginHandler) ServeHTTP(w http.ResponseWriter, r *http.Reques
 		return nil
 	})
 
-	handlers.PostAction("oauth", func(s *webapp.Session, _ *webapp.AuthflowScreenWithFlowResponse) error {
+	handlers.PostAction("oauth", func(s *webapp.Session, screen *webapp.AuthflowScreenWithFlowResponse) error {
 		providerAlias := r.Form.Get("x_provider_alias")
-		return oauthPostAction(s, providerAlias)
+		return oauthPostAction(s, screen, providerAlias)
 	})
 
 	handlers.PostAction("login_id", func(s *webapp.Session, screen *webapp.AuthflowScreenWithFlowResponse) error {
@@ -173,6 +178,11 @@ func (h *AuthflowV2LoginHandler) ServeHTTP(w http.ResponseWriter, r *http.Reques
 		input := map[string]interface{}{
 			"identification": identification,
 			"login_id":       loginID,
+		}
+
+		err = handlerwebapp.HandleIdentificationBotProtection(identification, screen.StateTokenFlowResponse, r.Form, input)
+		if err != nil {
+			return err
 		}
 
 		result, err := h.Controller.AdvanceWithInput(r, s, screen, input, nil)
@@ -196,6 +206,11 @@ func (h *AuthflowV2LoginHandler) ServeHTTP(w http.ResponseWriter, r *http.Reques
 		input := map[string]interface{}{
 			"identification":     "passkey",
 			"assertion_response": assertionResponseJSON,
+		}
+
+		err = handlerwebapp.HandleIdentificationBotProtection(config.AuthenticationFlowIdentificationPasskey, screen.StateTokenFlowResponse, r.Form, input)
+		if err != nil {
+			return err
 		}
 
 		result, err := h.Controller.AdvanceWithInput(r, s, screen, input, nil)

--- a/pkg/auth/handler/webapp/authflowv2/promote.go
+++ b/pkg/auth/handler/webapp/authflowv2/promote.go
@@ -10,6 +10,7 @@ import (
 	"github.com/authgear/authgear-server/pkg/auth/handler/webapp/viewmodels"
 	"github.com/authgear/authgear-server/pkg/auth/webapp"
 	authflow "github.com/authgear/authgear-server/pkg/lib/authenticationflow"
+	"github.com/authgear/authgear-server/pkg/lib/config"
 	"github.com/authgear/authgear-server/pkg/util/httproute"
 	"github.com/authgear/authgear-server/pkg/util/validation"
 )
@@ -87,6 +88,11 @@ func (h *AuthflowV2PromoteHandler) ServeHTTP(w http.ResponseWriter, r *http.Requ
 			"response_mode":  oauthrelyingparty.ResponseModeFormPost,
 		}
 
+		err := handlerwebapp.HandleIdentificationBotProtection(config.AuthenticationFlowIdentificationOAuth, screen.StateTokenFlowResponse, r.Form, input)
+		if err != nil {
+			return err
+		}
+
 		result, err := h.Controller.AdvanceWithInput(r, s, screen, input, nil)
 		if err != nil {
 			return err
@@ -108,6 +114,11 @@ func (h *AuthflowV2PromoteHandler) ServeHTTP(w http.ResponseWriter, r *http.Requ
 		input := map[string]interface{}{
 			"identification": identification,
 			"login_id":       loginID,
+		}
+
+		err = handlerwebapp.HandleIdentificationBotProtection(config.AuthenticationFlowIdentification(identification), screen.StateTokenFlowResponse, r.Form, input)
+		if err != nil {
+			return err
 		}
 
 		result, err := h.Controller.AdvanceWithInput(r, s, screen, input, nil)

--- a/pkg/auth/handler/webapp/bot_protection.go
+++ b/pkg/auth/handler/webapp/bot_protection.go
@@ -1,0 +1,50 @@
+package webapp
+
+import (
+	"net/url"
+
+	"github.com/authgear/authgear-server/pkg/auth/webapp"
+	authflow "github.com/authgear/authgear-server/pkg/lib/authenticationflow"
+	"github.com/authgear/authgear-server/pkg/lib/config"
+	"github.com/authgear/authgear-server/pkg/util/validation"
+)
+
+var AuthflowBotProtectionSchema = validation.NewSimpleSchema(`
+	{
+		"type": "object",
+		"properties": {
+			"x_bot_protection_provider_type": { "type": "string" },
+			"x_bot_protection_provider_response": { "type": "string" }
+		},
+		"required": ["x_bot_protection_provider_type", "x_bot_protection_provider_response"]
+	}
+`)
+
+func ValidateBotProtectionInput(formData url.Values) error {
+	return AuthflowBotProtectionSchema.Validator().ValidateValue(FormToJSON(formData))
+}
+
+func InsertBotProtection(formData url.Values, input map[string]interface{}) {
+	bpType := formData.Get("x_bot_protection_provider_type")
+	bpResp := formData.Get("x_bot_protection_provider_response")
+	bot_protection := map[string]interface{}{
+		"type":     bpType,
+		"response": bpResp,
+	}
+	input["bot_protection"] = bot_protection
+}
+
+func HandleIdentificationBotProtection(identification config.AuthenticationFlowIdentification, flowResp *authflow.FlowResponse, formData url.Values, input map[string]interface{}) (err error) {
+	bpRequired, err := webapp.IsIdentifyStepBotProtectionRequired(identification, flowResp)
+	if err != nil {
+		panic(err)
+	}
+	if bpRequired {
+		err = ValidateBotProtectionInput(formData)
+		if err != nil {
+			return err
+		}
+		InsertBotProtection(formData, input)
+	}
+	return
+}

--- a/pkg/auth/handler/webapp/bot_protection.go
+++ b/pkg/auth/handler/webapp/bot_protection.go
@@ -65,3 +65,18 @@ func HandleAccountRecoveryIdentificationBotProtection(identification config.Auth
 	}
 	return
 }
+
+func HandleAuthenticationBotProtection(authentication config.AuthenticationFlowAuthentication, flowResp *authflow.FlowResponse, formData url.Values, input map[string]interface{}) (err error) {
+	bpRequired, err := webapp.IsAuthenticateStepBotProtectionRequired(authentication, flowResp)
+	if err != nil {
+		panic(err)
+	}
+	if bpRequired {
+		err = ValidateBotProtectionInput(formData)
+		if err != nil {
+			return err
+		}
+		InsertBotProtection(formData, input)
+	}
+	return
+}

--- a/pkg/auth/handler/webapp/bot_protection.go
+++ b/pkg/auth/handler/webapp/bot_protection.go
@@ -48,3 +48,20 @@ func HandleIdentificationBotProtection(identification config.AuthenticationFlowI
 	}
 	return
 }
+
+// As IntentAccountRecoveryFlowStepIdentify has it's own IdentificationData type to narrow down Identification as {"email", "phone"},
+// we imitate the same logic in HandleIdentificationBotProtection here for account recovery
+func HandleAccountRecoveryIdentificationBotProtection(identification config.AuthenticationFlowAccountRecoveryIdentification, flowResp *authflow.FlowResponse, formData url.Values, input map[string]interface{}) (err error) {
+	bpRequired, err := webapp.IsAccountRecoveryIdentifyStepBotProtectionRequired(identification, flowResp)
+	if err != nil {
+		panic(err)
+	}
+	if bpRequired {
+		err = ValidateBotProtectionInput(formData)
+		if err != nil {
+			return err
+		}
+		InsertBotProtection(formData, input)
+	}
+	return
+}

--- a/pkg/auth/handler/webapp/viewmodels/authflow.go
+++ b/pkg/auth/handler/webapp/viewmodels/authflow.go
@@ -48,7 +48,7 @@ type AuthflowViewModel struct {
 	EmailLoginIDBotProtectionRequired    bool
 	UsernameLoginIDBotProtectionRequired bool
 	PasskeyBotProtectionRequired         bool
-	OauthBotProtectionRequired           bool
+	OAuthBotProtectionRequired           bool
 }
 
 type AuthflowViewModeler struct {
@@ -73,7 +73,7 @@ func (m *AuthflowViewModeler) NewWithAuthflow(f *authflow.FlowResponse, r *http.
 	bpRequiredPhone := false
 	bpRequiredUsername := false
 	bpRequiredPasskey := false
-	bpRequiredOauth := false
+	bpRequiredOAuth := false
 
 	for _, o := range options {
 		switch o.Identification {
@@ -119,7 +119,7 @@ func (m *AuthflowViewModeler) NewWithAuthflow(f *authflow.FlowResponse, r *http.
 			}
 		case config.AuthenticationFlowIdentificationOAuth:
 			if o.BotProtection.IsRequired() {
-				bpRequiredOauth = true
+				bpRequiredOAuth = true
 			}
 		}
 	}
@@ -261,7 +261,7 @@ func (m *AuthflowViewModeler) NewWithAuthflow(f *authflow.FlowResponse, r *http.
 		EmailLoginIDBotProtectionRequired:    bpRequiredEmail,
 		UsernameLoginIDBotProtectionRequired: bpRequiredUsername,
 		PasskeyBotProtectionRequired:         bpRequiredPasskey,
-		OauthBotProtectionRequired:           bpRequiredOauth,
+		OAuthBotProtectionRequired:           bpRequiredOAuth,
 	}
 }
 

--- a/pkg/auth/handler/webapp/viewmodels/authflow.go
+++ b/pkg/auth/handler/webapp/viewmodels/authflow.go
@@ -231,6 +231,26 @@ func (m *AuthflowViewModeler) NewWithAuthflow(f *authflow.FlowResponse, r *http.
 	}
 }
 
+func (m *AuthflowViewModeler) NewWithAccountRecoveryAuthflow(f *authflow.FlowResponse, r *http.Request) AuthflowViewModel {
+	options := webapp.GetAccountRecoveryIdentificationOptions(f)
+	bpRequiredEmail := false
+	bpRequiredPhone := false
+
+	for _, opt := range options {
+		switch opt.Identification {
+		case config.AuthenticationFlowAccountRecoveryIdentificationEmail:
+			bpRequiredEmail = opt.BotProtection.IsRequired()
+		case config.AuthenticationFlowAccountRecoveryIdentificationPhone:
+			bpRequiredPhone = opt.BotProtection.IsRequired()
+		}
+	}
+
+	return AuthflowViewModel{
+		EmailLoginIDBotProtectionRequired: bpRequiredEmail,
+		PhoneLoginIDBotProtectionRequired: bpRequiredPhone,
+	}
+}
+
 // nolint: gocognit
 func (m *AuthflowViewModeler) NewWithConfig() AuthflowViewModel {
 	var firstLoginIDIdentification config.AuthenticationFlowIdentification

--- a/pkg/auth/handler/webapp/viewmodels/authflow.go
+++ b/pkg/auth/handler/webapp/viewmodels/authflow.go
@@ -43,6 +43,12 @@ type AuthflowViewModel struct {
 	LoginIDContextualType string
 
 	PasskeyRequestOptionsJSON string
+
+	PhoneLoginIDBotProtectionRequired    bool
+	EmailLoginIDBotProtectionRequired    bool
+	UsernameLoginIDBotProtectionRequired bool
+	PasskeyBotProtectionRequired         bool
+	OauthBotProtectionRequired           bool
 }
 
 type AuthflowViewModeler struct {
@@ -63,6 +69,12 @@ func (m *AuthflowViewModeler) NewWithAuthflow(f *authflow.FlowResponse, r *http.
 	passkeyEnabled := false
 	passkeyRequestOptionsJSON := ""
 
+	bpRequiredEmail := false
+	bpRequiredPhone := false
+	bpRequiredUsername := false
+	bpRequiredPasskey := false
+	bpRequiredOauth := false
+
 	for _, o := range options {
 		switch o.Identification {
 		case config.AuthenticationFlowIdentificationEmail:
@@ -73,11 +85,17 @@ func (m *AuthflowViewModeler) NewWithAuthflow(f *authflow.FlowResponse, r *http.
 				firstNonPhoneLoginIDIdentification = config.AuthenticationFlowIdentificationEmail
 			}
 			hasEmail = true
+			if o.BotProtection.IsRequired() {
+				bpRequiredEmail = true
+			}
 		case config.AuthenticationFlowIdentificationPhone:
 			if firstLoginIDIdentification == "" {
 				firstLoginIDIdentification = config.AuthenticationFlowIdentificationPhone
 			}
 			hasPhone = true
+			if o.BotProtection.IsRequired() {
+				bpRequiredPhone = true
+			}
 		case config.AuthenticationFlowIdentificationUsername:
 			if firstLoginIDIdentification == "" {
 				firstLoginIDIdentification = config.AuthenticationFlowIdentificationUsername
@@ -86,6 +104,9 @@ func (m *AuthflowViewModeler) NewWithAuthflow(f *authflow.FlowResponse, r *http.
 				firstNonPhoneLoginIDIdentification = config.AuthenticationFlowIdentificationUsername
 			}
 			hasUsername = true
+			if o.BotProtection.IsRequired() {
+				bpRequiredUsername = true
+			}
 		case config.AuthenticationFlowIdentificationPasskey:
 			passkeyEnabled = true
 			bytes, err := json.Marshal(o.RequestOptions)
@@ -93,6 +114,13 @@ func (m *AuthflowViewModeler) NewWithAuthflow(f *authflow.FlowResponse, r *http.
 				panic(err)
 			}
 			passkeyRequestOptionsJSON = string(bytes)
+			if o.BotProtection.IsRequired() {
+				bpRequiredPasskey = true
+			}
+		case config.AuthenticationFlowIdentificationOAuth:
+			if o.BotProtection.IsRequired() {
+				bpRequiredOauth = true
+			}
 		}
 	}
 
@@ -228,6 +256,12 @@ func (m *AuthflowViewModeler) NewWithAuthflow(f *authflow.FlowResponse, r *http.
 		NonPhoneLoginIDInputType: nonPhoneLoginIDInputType,
 		NonPhoneLoginIDType:      nonPhoneLoginIDType,
 		LoginIDContextualType:    loginIDContextualType,
+
+		PhoneLoginIDBotProtectionRequired:    bpRequiredPhone,
+		EmailLoginIDBotProtectionRequired:    bpRequiredEmail,
+		UsernameLoginIDBotProtectionRequired: bpRequiredUsername,
+		PasskeyBotProtectionRequired:         bpRequiredPasskey,
+		OauthBotProtectionRequired:           bpRequiredOauth,
 	}
 }
 

--- a/pkg/auth/handler/webapp/viewmodels/base.go
+++ b/pkg/auth/handler/webapp/viewmodels/base.go
@@ -88,6 +88,10 @@ type BaseViewModel struct {
 
 	ShouldFocusInput bool
 	LogUnknownError  func(err map[string]interface{}) string
+
+	BotProtectionEnabled         bool
+	BotProtectionProviderType    string
+	BotProtectionProviderSiteKey string
 }
 
 func (m *BaseViewModel) SetError(err error) {
@@ -154,6 +158,7 @@ type BaseViewModeler struct {
 	ForgotPassword                    *config.ForgotPasswordConfig
 	Authentication                    *config.AuthenticationConfig
 	GoogleTagManager                  *config.GoogleTagManagerConfig
+	BotProtection                     *config.BotProtectionConfig
 	ErrorCookie                       ErrorCookie
 	Translations                      TranslationService
 	Clock                             clock.Clock
@@ -273,16 +278,19 @@ func (m *BaseViewModeler) ViewModel(r *http.Request, rw http.ResponseWriter) Bas
 			}
 			return webapp.MakeURL(u, path, outQuery).String()
 		},
-		ForgotPasswordEnabled:       *m.ForgotPassword.Enabled,
-		PublicSignupDisabled:        m.Authentication.PublicSignupDisabled,
-		PageLoadedAt:                int(now),
-		FlashMessageType:            m.FlashMessage.Pop(r, rw),
-		ResolvedLanguageTag:         resolvedLanguageTag,
-		ResolvedCLDRLocale:          locale,
-		HTMLDir:                     htmlDir,
-		GoogleTagManagerContainerID: m.GoogleTagManager.ContainerID,
-		HasThirdPartyClient:         hasThirdPartyApp,
-		AuthUISentryDSN:             string(m.AuthUISentryDSN),
+		ForgotPasswordEnabled:        *m.ForgotPassword.Enabled,
+		PublicSignupDisabled:         m.Authentication.PublicSignupDisabled,
+		PageLoadedAt:                 int(now),
+		FlashMessageType:             m.FlashMessage.Pop(r, rw),
+		ResolvedLanguageTag:          resolvedLanguageTag,
+		ResolvedCLDRLocale:           locale,
+		HTMLDir:                      htmlDir,
+		GoogleTagManagerContainerID:  m.GoogleTagManager.ContainerID,
+		BotProtectionEnabled:         m.BotProtection.IsEnabled(),
+		BotProtectionProviderType:    string(m.BotProtection.GetProviderType()),
+		BotProtectionProviderSiteKey: m.BotProtection.GetSiteKey(),
+		HasThirdPartyClient:          hasThirdPartyApp,
+		AuthUISentryDSN:              string(m.AuthUISentryDSN),
 		AuthUIWindowMessageAllowedOrigins: func() string {
 			requestProto := httputil.GetProto(r, bool(m.TrustProxy))
 			processedAllowedOrgins := slice.Map(m.AuthUIWindowMessageAllowedOrigins, func(origin string) string {

--- a/pkg/auth/webapp/authflow.go
+++ b/pkg/auth/webapp/authflow.go
@@ -114,3 +114,14 @@ func GetMostAppropriateIdentification(f *authflow.FlowResponse, loginID string, 
 
 	return iden
 }
+
+func GetAuthenticationOptions(f *authflow.FlowResponse) []declarative.AuthenticateOptionForOutput {
+	var options []declarative.AuthenticateOptionForOutput
+	switch data := f.Action.Data.(type) {
+	case declarative.StepAuthenticateData:
+		options = data.Options
+	default:
+		panic(fmt.Errorf("unexpected type of data: %T", f.Action.Data))
+	}
+	return options
+}

--- a/pkg/auth/webapp/authflow.go
+++ b/pkg/auth/webapp/authflow.go
@@ -25,6 +25,19 @@ func GetIdentificationOptions(f *authflow.FlowResponse) []declarative.Identifica
 	return options
 }
 
+// As IntentAccountRecoveryFlowStepIdentify has it's own IdentificationData type to narrow down Identification as {"email", "phone"},
+// we imitate the same logic in GetIdentificationOptions here
+func GetAccountRecoveryIdentificationOptions(f *authflow.FlowResponse) []declarative.AccountRecoveryIdentificationOption {
+	var options []declarative.AccountRecoveryIdentificationOption
+	switch data := f.Action.Data.(type) {
+	case declarative.IntentAccountRecoveryFlowStepIdentifyData:
+		options = data.Options
+	default:
+		panic(fmt.Errorf("unexpected type of data: %T", f.Action.Data))
+	}
+	return options
+}
+
 func GetMostAppropriateIdentification(f *authflow.FlowResponse, loginID string, loginIDInputType string) config.AuthenticationFlowIdentification {
 	// If loginIDInputType already tell us the login id type, return the corresponding type
 	switch loginIDInputType {

--- a/pkg/auth/webapp/bot_protection.go
+++ b/pkg/auth/webapp/bot_protection.go
@@ -18,3 +18,14 @@ func IsIdentifyStepBotProtectionRequired(identificationType config.Authenticatio
 
 	return false, fmt.Errorf("identification type: \"%v\" not found in flow response options: [%v]", identificationType, options)
 }
+
+func IsAccountRecoveryIdentifyStepBotProtectionRequired(identificationType config.AuthenticationFlowAccountRecoveryIdentification, f *authflow.FlowResponse) (bool, error) {
+	options := GetAccountRecoveryIdentificationOptions(f)
+	for _, option := range options {
+		if option.Identification == identificationType {
+			return option.BotProtection.IsRequired(), nil
+		}
+	}
+
+	return false, fmt.Errorf("identification type: \"%v\" not found in flow response options: [%v]", identificationType, options)
+}

--- a/pkg/auth/webapp/bot_protection.go
+++ b/pkg/auth/webapp/bot_protection.go
@@ -33,7 +33,6 @@ func IsAccountRecoveryIdentifyStepBotProtectionRequired(identificationType confi
 func IsAuthenticateStepBotProtectionRequired(authenticationType config.AuthenticationFlowAuthentication, f *authflow.FlowResponse) (bool, error) {
 	options := GetAuthenticationOptions(f)
 	for _, option := range options {
-		fmt.Printf("option: %+v\n", option)
 		if option.Authentication == authenticationType {
 			return option.BotProtection.IsRequired(), nil
 		}

--- a/pkg/auth/webapp/bot_protection.go
+++ b/pkg/auth/webapp/bot_protection.go
@@ -29,3 +29,14 @@ func IsAccountRecoveryIdentifyStepBotProtectionRequired(identificationType confi
 
 	return false, fmt.Errorf("identification type: \"%v\" not found in flow response options: [%v]", identificationType, options)
 }
+
+func IsAuthenticateStepBotProtectionRequired(authenticationType config.AuthenticationFlowAuthentication, f *authflow.FlowResponse) (bool, error) {
+	options := GetAuthenticationOptions(f)
+	for _, option := range options {
+		fmt.Printf("option: %+v\n", option)
+		if option.Authentication == authenticationType {
+			return option.BotProtection.IsRequired(), nil
+		}
+	}
+	return false, fmt.Errorf("authentication type: \"%v\" not found in flow response options: [%v]", authenticationType, options)
+}

--- a/pkg/auth/webapp/bot_protection.go
+++ b/pkg/auth/webapp/bot_protection.go
@@ -1,0 +1,20 @@
+package webapp
+
+import (
+	"fmt"
+
+	authflow "github.com/authgear/authgear-server/pkg/lib/authenticationflow"
+	"github.com/authgear/authgear-server/pkg/lib/config"
+)
+
+func IsIdentifyStepBotProtectionRequired(identificationType config.AuthenticationFlowIdentification, f *authflow.FlowResponse) (bool, error) {
+	options := GetIdentificationOptions(f)
+
+	for _, option := range options {
+		if option.Identification == identificationType {
+			return option.BotProtection.IsRequired(), nil
+		}
+	}
+
+	return false, fmt.Errorf("identification type: \"%v\" not found in flow response options: [%v]", identificationType, options)
+}

--- a/pkg/lib/authenticationflow/declarative/data_bot_protection.go
+++ b/pkg/lib/authenticationflow/declarative/data_bot_protection.go
@@ -9,6 +9,10 @@ type BotProtectionData struct {
 	Provider *BotProtectionDataProvider `json:"provider,omitempty"`
 }
 
+func (d *BotProtectionData) IsRequired() bool {
+	return d != nil && d.Enabled != nil && *d.Enabled && d.Provider != nil && d.Provider.Type != ""
+}
+
 type BotProtectionDataProvider struct {
 	Type config.BotProtectionProviderType `json:"type,omitempty"`
 }

--- a/pkg/lib/config/bot_protection.go
+++ b/pkg/lib/config/bot_protection.go
@@ -43,6 +43,22 @@ type BotProtectionConfig struct {
 	Provider *BotProtectionProvider `json:"provider,omitempty" nullable:"true"`
 }
 
+func (c *BotProtectionConfig) IsEnabled() bool {
+	return c != nil && c.Enabled && c.Provider != nil && c.Provider.Type != "" && c.Provider.SiteKey != ""
+}
+func (c *BotProtectionConfig) GetProviderType() BotProtectionProviderType {
+	if !c.IsEnabled() {
+		return ""
+	}
+	return c.Provider.Type
+}
+func (c *BotProtectionConfig) GetSiteKey() string {
+	if !c.IsEnabled() {
+		return ""
+	}
+	return c.Provider.SiteKey
+}
+
 type BotProtectionProvider struct {
 	Type    BotProtectionProviderType `json:"type,omitempty"`
 	SiteKey string                    `json:"site_key,omitempty"` // only for some cloudflare, recaptchav2


### PR DESCRIPTION
## What's in this PR?
- guard captcha if required in below http handlers in AuthUI
  - signup identify, all branches
  - signup-login identify, all branches
  - promote identify, all branches
  - login identify, all branches
  - login primary authentication, password, passkey (non-oob-otp branches)
  - login secondary authentication, additional password, totp, recovery code (non-oob-otp branches)
  - reauth primary authentication, password, passkey (non-oob-otp branches)
  - reauth secondary authentication, additional password, totp, recovery code (non-oob-otp branches)

### Note
This PR only implements server-side guarding (server as in SSR, not api serever)

## Upcoming
- special handling on `oob-otp-email` and `oob-otp-sms` which requires an extra screen
