### PR TITLE
Navigate to separate verification page for oob_otp

### DIFF
--- a/authui/src/authflowv2.ts
+++ b/authui/src/authflowv2.ts
@@ -42,6 +42,7 @@ import { PreviewableResourceController } from "./previewable-resource";
 import { CloudflareTurnstileController } from "./authflowv2/botprotection/cloudflareTurnstile";
 import { RecaptchaV2Controller } from "./authflowv2/botprotection/recaptchav2";
 import { BotProtectionInputController } from "./authflowv2/botprotection/botProtectionInput";
+import { BotProtectionOnSuccessClickController } from "./authflowv2/botprotection/botProtectionOnSuccessClick";
 
 axios.defaults.withCredentials = true;
 
@@ -108,6 +109,10 @@ Stimulus.register("click-to-switch", ClickToSwitchController);
 Stimulus.register("inline-preview", InlinePreviewController);
 Stimulus.register("previewable-resource", PreviewableResourceController);
 Stimulus.register("bot-protection-input", BotProtectionInputController);
+Stimulus.register(
+  "bot-protection-on-success-click",
+  BotProtectionOnSuccessClickController
+);
 Stimulus.register("cloudflare-turnstile", CloudflareTurnstileController);
 Stimulus.register("recaptcha-v2", RecaptchaV2Controller);
 

--- a/authui/src/authflowv2/botprotection/botProtectionOnSuccessClick.ts
+++ b/authui/src/authflowv2/botprotection/botProtectionOnSuccessClick.ts
@@ -1,0 +1,41 @@
+import { Controller } from "@hotwired/stimulus";
+
+/**
+ * Controller for button that should be clicked on bot protection verification success
+ *  - listen to captcha widget provider events
+ *  - click target button
+ *
+ * Expected usage:
+ * - Add `data-controller="bot-protection-on-success-click"` to a `<button>` element
+ */
+export class BotProtectionOnSuccessClickController extends Controller {
+  getButtonElement = (): HTMLButtonElement => {
+    if (!(this.element instanceof HTMLButtonElement)) {
+      throw new Error(
+        "bot-protection-input must be used on `<button>` elements"
+      );
+    }
+    return this.element;
+  };
+
+  onVerifySuccess = (e: Event) => {
+    if (!(e instanceof CustomEvent)) {
+      throw new Error("Unexpected non-CustomEvent");
+    }
+    this.getButtonElement().click();
+  };
+
+  connect() {
+    document.addEventListener(
+      "bot-protection:verify-success",
+      this.onVerifySuccess
+    );
+  }
+
+  disconnect() {
+    document.removeEventListener(
+      "bot-protection:verify-success",
+      this.onVerifySuccess
+    );
+  }
+}

--- a/pkg/auth/handler/webapp/authflow_controller.go
+++ b/pkg/auth/handler/webapp/authflow_controller.go
@@ -92,6 +92,7 @@ type AuthflowNavigator interface {
 	NavigateNonRecoverableError(r *http.Request, u *url.URL, e error)
 	NavigateSelectAccount(result *webapp.Result)
 	NavigateResetPasswordSuccessPage() string
+	NavigateVerifyBotProtection(result *webapp.Result)
 }
 
 type AuthflowControllerLogger struct{ *log.Logger }

--- a/pkg/auth/handler/webapp/authflow_controller_mock_test.go
+++ b/pkg/auth/handler/webapp/authflow_controller_mock_test.go
@@ -419,3 +419,15 @@ func (mr *MockAuthflowNavigatorMockRecorder) NavigateSelectAccount(result interf
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NavigateSelectAccount", reflect.TypeOf((*MockAuthflowNavigator)(nil).NavigateSelectAccount), result)
 }
+
+// NavigateVerifyBotProtection mocks base method.
+func (m *MockAuthflowNavigator) NavigateVerifyBotProtection(result *webapp.Result) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "NavigateVerifyBotProtection", result)
+}
+
+// NavigateVerifyBotProtection indicates an expected call of NavigateVerifyBotProtection.
+func (mr *MockAuthflowNavigatorMockRecorder) NavigateVerifyBotProtection(result interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NavigateVerifyBotProtection", reflect.TypeOf((*MockAuthflowNavigator)(nil).NavigateVerifyBotProtection), result)
+}

--- a/pkg/auth/handler/webapp/authflow_controller_test.go
+++ b/pkg/auth/handler/webapp/authflow_controller_test.go
@@ -42,6 +42,9 @@ func (*NoopNavigator) NavigateChangePasswordSuccessPage(s *webapp.AuthflowScreen
 	return &webapp.Result{}
 }
 
+func (*NoopNavigator) NavigateVerifyBotProtection(result *webapp.Result) {
+}
+
 func NewNoopAuthflowNavigator() *NoopNavigator {
 	return &NoopNavigator{}
 }

--- a/pkg/auth/handler/webapp/authflowv2/deps.go
+++ b/pkg/auth/handler/webapp/authflowv2/deps.go
@@ -19,6 +19,7 @@ var DependencySet = wire.NewSet(
 	wire.Struct(new(AuthflowV2AccountStatusHandler), "*"),
 	wire.Struct(new(AuthflowV2NotFoundHandler), "*"),
 	wire.Struct(new(AuthflowV2SelectAccountHandler), "*"),
+	wire.Struct(new(AuthflowV2VerifyBotProtectionHandler), "*"),
 	wire.Struct(new(AuthflowV2EnterRecoveryCodeHandler), "*"),
 	wire.Struct(new(AuthflowV2ChangePasswordHandler), "*"),
 	wire.Struct(new(AuthflowV2ChangePasswordSuccessHandler), "*"),

--- a/pkg/auth/handler/webapp/authflowv2/routes.go
+++ b/pkg/auth/handler/webapp/authflowv2/routes.go
@@ -21,11 +21,12 @@ import (
 )
 
 const (
-	AuthflowV2RouteLogin         = "/login"
-	AuthflowV2RouteSignup        = "/signup"
-	AuthflowV2RoutePromote       = "/flows/promote_user"
-	AuthflowV2RouteReauth        = "/reauth"
-	AuthflowV2RouteSelectAccount = "/authflow/v2/select_account"
+	AuthflowV2RouteLogin               = "/login"
+	AuthflowV2RouteSignup              = "/signup"
+	AuthflowV2RoutePromote             = "/flows/promote_user"
+	AuthflowV2RouteReauth              = "/reauth"
+	AuthflowV2RouteSelectAccount       = "/authflow/v2/select_account"
+	AuthflowV2RouteVerifyBotProtection = "/authflow/v2/verify_bot_protection"
 	// AuthflowV2RouteSignupLogin is login because login page has passkey.
 	AuthflowV2RouteSignupLogin = AuthflowV2RouteLogin
 
@@ -73,6 +74,7 @@ const (
 type AuthflowV2NavigatorEndpointsProvider interface {
 	ErrorEndpointURL(uiImpl config.UIImplementation) *url.URL
 	SelectAccountEndpointURL(uiImpl config.UIImplementation) *url.URL
+	VerifyBotProtectionEndpointURL(uiImpl config.UIImplementation) *url.URL
 }
 
 type AuthflowV2NavigatorOAuthStateStore interface {
@@ -487,5 +489,10 @@ func (n *AuthflowV2Navigator) navigateAccountRecovery(s *webapp.AuthflowScreenWi
 
 func (n *AuthflowV2Navigator) NavigateSelectAccount(result *webapp.Result) {
 	url := n.Endpoints.SelectAccountEndpointURL(n.UIConfig.Implementation)
+	result.RedirectURI = url.String()
+}
+
+func (n *AuthflowV2Navigator) NavigateVerifyBotProtection(result *webapp.Result) {
+	url := n.Endpoints.VerifyBotProtectionEndpointURL(n.UIConfig.Implementation)
 	result.RedirectURI = url.String()
 }

--- a/pkg/auth/handler/webapp/authflowv2/routes.go
+++ b/pkg/auth/handler/webapp/authflowv2/routes.go
@@ -384,6 +384,10 @@ func (n *AuthflowV2Navigator) navigateLoginStepAuthenticate(s *webapp.AuthflowSc
 	}
 }
 func (n *AuthflowV2Navigator) navigateLogin(s *webapp.AuthflowScreenWithFlowResponse, r *http.Request, webSessionID string, result *webapp.Result) {
+	if s.Screen.IsBotProtectionRequired {
+		s.Advance(AuthflowV2RouteVerifyBotProtection, result)
+		return
+	}
 	switch config.AuthenticationFlowStepType(s.StateTokenFlowResponse.Action.Type) {
 	case config.AuthenticationFlowStepTypeIdentify:
 		n.navigateStepIdentify(s, r, webSessionID, result, AuthflowV2RouteLogin)

--- a/pkg/auth/handler/webapp/authflowv2/routes.go
+++ b/pkg/auth/handler/webapp/authflowv2/routes.go
@@ -407,6 +407,10 @@ func (n *AuthflowV2Navigator) navigateLogin(s *webapp.AuthflowScreenWithFlowResp
 }
 
 func (n *AuthflowV2Navigator) navigateReauth(s *webapp.AuthflowScreenWithFlowResponse, r *http.Request, webSessionID string, result *webapp.Result) {
+	if s.Screen.IsBotProtectionRequired {
+		s.Advance(AuthflowV2RouteVerifyBotProtection, result)
+		return
+	}
 	switch config.AuthenticationFlowStepType(s.StateTokenFlowResponse.Action.Type) {
 	case config.AuthenticationFlowStepTypeIdentify:
 		n.navigateStepIdentify(s, r, webSessionID, result, AuthflowV2RouteReauth)

--- a/pkg/auth/handler/webapp/authflowv2/routes.go
+++ b/pkg/auth/handler/webapp/authflowv2/routes.go
@@ -321,12 +321,7 @@ func (n *AuthflowV2Navigator) navigateStepIdentify(s *webapp.AuthflowScreenWithF
 		panic(fmt.Errorf("unexpected identification: %v", identification))
 	}
 }
-
-func (n *AuthflowV2Navigator) navigateLogin(s *webapp.AuthflowScreenWithFlowResponse, r *http.Request, webSessionID string, result *webapp.Result) {
-	switch config.AuthenticationFlowStepType(s.StateTokenFlowResponse.Action.Type) {
-	case config.AuthenticationFlowStepTypeIdentify:
-		n.navigateStepIdentify(s, r, webSessionID, result, AuthflowV2RouteLogin)
-	case config.AuthenticationFlowStepTypeAuthenticate:
+func (n *AuthflowV2Navigator) navigateLoginStepAuthenticate(s *webapp.AuthflowScreenWithFlowResponse, r *http.Request, webSessionID string, result *webapp.Result) {
 	switch data := s.BranchStateTokenFlowResponse.Action.Data.(type) {
 	case declarative.StepAuthenticateData:
 		options := data.Options
@@ -386,6 +381,14 @@ func (n *AuthflowV2Navigator) navigateLogin(s *webapp.AuthflowScreenWithFlowResp
 		}
 	default:
 		panic(fmt.Errorf("unexpected data type: %T", s.StateTokenFlowResponse.Action.Data))
+	}
+}
+func (n *AuthflowV2Navigator) navigateLogin(s *webapp.AuthflowScreenWithFlowResponse, r *http.Request, webSessionID string, result *webapp.Result) {
+	switch config.AuthenticationFlowStepType(s.StateTokenFlowResponse.Action.Type) {
+	case config.AuthenticationFlowStepTypeIdentify:
+		n.navigateStepIdentify(s, r, webSessionID, result, AuthflowV2RouteLogin)
+	case config.AuthenticationFlowStepTypeAuthenticate:
+		n.navigateLoginStepAuthenticate(s, r, webSessionID, result)
 	case config.AuthenticationFlowStepTypeCheckAccountStatus:
 		s.Advance(AuthflowV2RouteAccountStatus, result)
 	case config.AuthenticationFlowStepTypeTerminateOtherSessions:

--- a/pkg/auth/handler/webapp/authflowv2/verify_bot_protection.go
+++ b/pkg/auth/handler/webapp/authflowv2/verify_bot_protection.go
@@ -70,7 +70,10 @@ func (h *AuthflowV2VerifyBotProtectionHandler) ServeHTTP(w http.ResponseWriter, 
 
 		handlerwebapp.InsertBotProtection(r.Form, input)
 
-		result, err := h.Controller.AdvanceWithInput(r, s, screen, input, nil)
+		// advance with previous screen inherit
+		result, err := h.Controller.AdvanceWithInput(r, s, screen, input, &handlerwebapp.AdvanceOptions{
+			InheritTakenBranchState: true,
+		})
 		if err != nil {
 			return err
 		}

--- a/pkg/auth/handler/webapp/authflowv2/verify_bot_protection.go
+++ b/pkg/auth/handler/webapp/authflowv2/verify_bot_protection.go
@@ -1,0 +1,82 @@
+package authflowv2
+
+import (
+	"net/http"
+
+	handlerwebapp "github.com/authgear/authgear-server/pkg/auth/handler/webapp"
+	"github.com/authgear/authgear-server/pkg/auth/handler/webapp/viewmodels"
+	"github.com/authgear/authgear-server/pkg/auth/webapp"
+	"github.com/authgear/authgear-server/pkg/lib/authenticationflow/declarative"
+	"github.com/authgear/authgear-server/pkg/util/httproute"
+	"github.com/authgear/authgear-server/pkg/util/template"
+)
+
+var TemplateWebAuthflowVerifyBotProtectionHTML = template.RegisterHTML(
+	"web/authflowv2/verify_bot_protection.html",
+	handlerwebapp.Components...,
+)
+
+func ConfigureAuthflowV2VerifyBotProtectionRoute(route httproute.Route) httproute.Route {
+	return route.
+		WithMethods("OPTIONS", "POST", "GET").
+		WithPathPattern(AuthflowV2RouteVerifyBotProtection)
+}
+
+type AuthflowV2VerifyBotProtectionHandler struct {
+	Controller    *handlerwebapp.AuthflowController
+	BaseViewModel *viewmodels.BaseViewModeler
+	Renderer      handlerwebapp.Renderer
+}
+
+func (h *AuthflowV2VerifyBotProtectionHandler) GetData(w http.ResponseWriter, r *http.Request, screen *webapp.AuthflowScreenWithFlowResponse) (map[string]interface{}, error) {
+	data := make(map[string]interface{})
+	baseViewModel := h.BaseViewModel.ViewModelForAuthFlow(r, w)
+	viewmodels.Embed(data, baseViewModel)
+	return data, nil
+}
+
+func (h *AuthflowV2VerifyBotProtectionHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	var handlers handlerwebapp.AuthflowControllerHandlers
+	handlers.Get(func(s *webapp.Session, screen *webapp.AuthflowScreenWithFlowResponse) error {
+		data, err := h.GetData(w, r, screen)
+		if err != nil {
+			return err
+		}
+
+		h.Renderer.RenderHTML(w, r, TemplateWebAuthflowVerifyBotProtectionHTML, data)
+		return nil
+	})
+
+	handlers.PostAction("", func(s *webapp.Session, screen *webapp.AuthflowScreenWithFlowResponse) error {
+		err := handlerwebapp.ValidateBotProtectionInput(r.Form)
+		if err != nil {
+			return err
+		}
+
+		index := *screen.Screen.TakenBranchIndex
+		channel := screen.Screen.TakenChannel
+		data := screen.StateTokenFlowResponse.Action.Data.(declarative.StepAuthenticateData)
+		option := data.Options[index]
+
+		input := map[string]interface{}{
+			"authentication": option.Authentication,
+			"index":          index,
+		}
+
+		// Only set channel if not empty because this screen might be used by flows other than
+		if channel != "" {
+			input["channel"] = channel
+		}
+
+		handlerwebapp.InsertBotProtection(r.Form, input)
+
+		result, err := h.Controller.AdvanceWithInput(r, s, screen, input, nil)
+		if err != nil {
+			return err
+		}
+		result.WriteResponse(w, r)
+		return nil
+	})
+
+	h.Controller.HandleStep(w, r, &handlers)
+}

--- a/pkg/auth/routes.go
+++ b/pkg/auth/routes.go
@@ -212,6 +212,9 @@ func NewRouter(p *deps.RootProvider, configSource *configsource.ConfigSource) *h
 		newWebappPageChain(),
 		p.Middleware(newAuthEntryPointMiddleware),
 	)
+	webappVerifyBotProtectionChain := httproute.Chain(
+		webappPageChain,
+	)
 	// consent page only accepts idp session
 	webappConsentPageChain := httproute.Chain(
 		newWebappChain(),
@@ -272,6 +275,7 @@ func NewRouter(p *deps.RootProvider, configSource *configsource.ConfigSource) *h
 	webappAuthEntrypointRoute := httproute.Route{Middleware: webappAuthEntrypointChain}
 	webappRequireAuthEnabledAuthEntrypointRoute := httproute.Route{Middleware: webappRequireAuthEnabledAuthEntrypointChain}
 	webappSelectAccountRoute := httproute.Route{Middleware: webappSelectAccountChain}
+	webappVerifyBotProtectionRoute := httproute.Route{Middleware: webappVerifyBotProtectionChain}
 	webappConsentPageRoute := httproute.Route{Middleware: webappConsentPageChain}
 	webappAuthenticatedRoute := httproute.Route{Middleware: webappAuthenticatedChain}
 	webappSuccessPageRoute := httproute.Route{Middleware: webappSuccessPageChain}
@@ -314,6 +318,7 @@ func NewRouter(p *deps.RootProvider, configSource *configsource.ConfigSource) *h
 
 	router.Add(webapphandler.ConfigureSelectAccountRoute(webappSelectAccountRoute), p.Handler(newWebAppSelectAccountHandler))
 	router.Add(webapphandlerauthflowv2.ConfigureAuthflowV2SelectAccountRoute(webappSelectAccountRoute), p.Handler(newWebAppAuthflowV2SelectAccountHandler))
+	router.Add(webapphandlerauthflowv2.ConfigureAuthflowV2VerifyBotProtectionRoute(webappVerifyBotProtectionRoute), p.Handler(newWebAppAuthflowV2VerifyBotProtectionHandler))
 
 	router.Add(webapphandlerauthflowv2.ConfigureAuthflowV2EnterPasswordRoute(webappPageRoute), p.Handler(newWebAppAuthflowV2EnterPasswordHandler))
 	router.Add(webapphandlerauthflowv2.ConfigureAuthflowV2EnterOOBOTPRoute(webappPageRoute), p.Handler(newWebAppAuthflowV2EnterOOBOTPHandler))

--- a/pkg/auth/webapp/authflow_routes.go
+++ b/pkg/auth/webapp/authflow_routes.go
@@ -67,6 +67,7 @@ const (
 type AuthflowNavigatorEndpointsProvider interface {
 	ErrorEndpointURL(uiImpl config.UIImplementation) *url.URL
 	SelectAccountEndpointURL(uiImpl config.UIImplementation) *url.URL
+	VerifyBotProtectionEndpointURL(uiImpl config.UIImplementation) *url.URL
 }
 
 type AuthflowNavigatorOAuthStateStore interface {
@@ -459,5 +460,10 @@ func (n *AuthflowNavigator) navigateAccountRecovery(s *AuthflowScreenWithFlowRes
 
 func (n *AuthflowNavigator) NavigateSelectAccount(result *Result) {
 	url := n.Endpoints.SelectAccountEndpointURL(n.UIConfig.Implementation)
+	result.RedirectURI = url.String()
+}
+
+func (n *AuthflowNavigator) NavigateVerifyBotProtection(result *Result) {
+	url := n.Endpoints.VerifyBotProtectionEndpointURL(n.UIConfig.Implementation)
 	result.RedirectURI = url.String()
 }

--- a/pkg/auth/webapp/session_authflow.go
+++ b/pkg/auth/webapp/session_authflow.go
@@ -644,6 +644,10 @@ func (s *AuthflowScreenWithFlowResponse) takeBranchReauth(index int, channel mod
 				channel = option.Channels[0]
 			}
 
+			if option.BotProtection.IsRequired() {
+				return s.takeBranchResultSimple(index, channel, true)
+			}
+
 			inputFactory := func(c model.AuthenticatorOOBChannel) map[string]interface{} {
 				return map[string]interface{}{
 					"authentication": option.Authentication,

--- a/pkg/auth/webapp/session_authflow.go
+++ b/pkg/auth/webapp/session_authflow.go
@@ -102,6 +102,8 @@ type AuthflowScreen struct {
 	TakenChannel model.AuthenticatorOOBChannel `json:"taken_channel,omitempty"`
 	// WechatCallbackData is only relevant for wechat login.
 	WechatCallbackData *AuthflowWechatCallbackData `json:"wechat_callback_data,omitempty"`
+	// IsBotProtectionRequired will be used to determine whether to navigate to bot protection verification screen.
+	IsBotProtectionRequired bool `json:"is_bot_protection_required,omitempty"`
 }
 
 func newAuthflowScreen(flowResponse *authflow.FlowResponse, previousXStep string, previousInput map[string]interface{}) *AuthflowScreen {
@@ -412,7 +414,7 @@ func (s *AuthflowScreenWithFlowResponse) takeBranchSignupPromote(index int, chan
 	case config.AuthenticationFlowStepTypeIdentify:
 		// In identify, the user input actually takes the branch.
 		// The branch taken here is unimportant.
-		return s.takeBranchResultSimple(index, channel)
+		return s.takeBranchResultSimple(index, channel, false)
 	case config.AuthenticationFlowStepTypeCreateAuthenticator:
 		data := s.StateTokenFlowResponse.Action.Data.(declarative.IntentSignupFlowStepCreateAuthenticatorData)
 		option := data.Options[index]
@@ -421,7 +423,7 @@ func (s *AuthflowScreenWithFlowResponse) takeBranchSignupPromote(index int, chan
 			fallthrough
 		case config.AuthenticationFlowAuthenticationSecondaryPassword:
 			// Password branches can be taken by setting index.
-			return s.takeBranchResultSimple(index, channel)
+			return s.takeBranchResultSimple(index, channel, false)
 		case config.AuthenticationFlowAuthenticationSecondaryTOTP:
 			// This branch requires input to take.
 			input := map[string]interface{}{
@@ -481,7 +483,7 @@ func (s *AuthflowScreenWithFlowResponse) takeBranchSignupPromote(index int, chan
 			if channel == "" {
 				channel = option.Channels[0]
 			}
-			return s.takeBranchResultSimple(index, channel)
+			return s.takeBranchResultSimple(index, channel, false)
 		default:
 			panic(fmt.Errorf("unexpected authentication: %v", option.Authentication))
 		}
@@ -543,7 +545,7 @@ func (s *AuthflowScreenWithFlowResponse) takeBranchLogin(index int, channel mode
 			fallthrough
 		case config.AuthenticationFlowAuthenticationPrimaryPasskey:
 			// All these can take the branch simply by setting index.
-			return s.takeBranchResultSimple(index, channel)
+			return s.takeBranchResultSimple(index, channel, false)
 		case config.AuthenticationFlowAuthenticationPrimaryOOBOTPEmail:
 			fallthrough
 		case config.AuthenticationFlowAuthenticationPrimaryOOBOTPSMS:
@@ -554,6 +556,9 @@ func (s *AuthflowScreenWithFlowResponse) takeBranchLogin(index int, channel mode
 			// This branch requires input to take.
 			if channel == "" {
 				channel = option.Channels[0]
+			}
+			if option.BotProtection.IsRequired() {
+				return s.takeBranchResultSimple(index, channel, true)
 			}
 
 			inputFactory := func(c model.AuthenticatorOOBChannel) map[string]interface{} {
@@ -602,7 +607,7 @@ func (s *AuthflowScreenWithFlowResponse) takeBranchReauth(index int, channel mod
 	case config.AuthenticationFlowStepTypeIdentify:
 		// In identify, id_token is used.
 		// The branch taken here is unimportant.
-		return s.takeBranchResultSimple(index, channel)
+		return s.takeBranchResultSimple(index, channel, false)
 	case config.AuthenticationFlowStepTypeAuthenticate:
 		data := s.StateTokenFlowResponse.Action.Data.(declarative.StepAuthenticateData)
 		option := data.Options[index]
@@ -615,7 +620,7 @@ func (s *AuthflowScreenWithFlowResponse) takeBranchReauth(index int, channel mod
 			fallthrough
 		case config.AuthenticationFlowAuthenticationPrimaryPasskey:
 			// All these can take the branch simply by setting index.
-			return s.takeBranchResultSimple(index, channel)
+			return s.takeBranchResultSimple(index, channel, false)
 		case config.AuthenticationFlowAuthenticationPrimaryOOBOTPEmail:
 			fallthrough
 		case config.AuthenticationFlowAuthenticationPrimaryOOBOTPSMS:
@@ -674,7 +679,7 @@ func (s *AuthflowScreenWithFlowResponse) takeBranchSignupLogin(index int, option
 	case config.AuthenticationFlowStepTypeIdentify:
 		// In identify, the user input actually takes the branch.
 		// The branch taken here is unimportant.
-		return s.takeBranchResultSimple(index, "")
+		return s.takeBranchResultSimple(index, "", false)
 	default:
 		panic(fmt.Errorf("unexpected action type: %v", s.StateTokenFlowResponse.Action.Type))
 	}
@@ -685,19 +690,20 @@ func (s *AuthflowScreenWithFlowResponse) takeBranchAccountRecovery(index int, op
 	case config.AuthenticationFlowStepTypeIdentify:
 		// In identify, the user input actually takes the branch.
 		// The branch taken here is unimportant.
-		return s.takeBranchResultSimple(index, "")
+		return s.takeBranchResultSimple(index, "", false)
 	default:
 		panic(fmt.Errorf("unexpected action type: %v", s.StateTokenFlowResponse.Action.Type))
 	}
 }
 
-func (s *AuthflowScreenWithFlowResponse) takeBranchResultSimple(index int, channel model.AuthenticatorOOBChannel) TakeBranchResultSimple {
+func (s *AuthflowScreenWithFlowResponse) takeBranchResultSimple(index int, channel model.AuthenticatorOOBChannel, botProtectionRequired bool) TakeBranchResultSimple {
 	xStep := s.Screen.StateToken.XStep
 	screen := NewAuthflowScreenWithFlowResponse(s.StateTokenFlowResponse, xStep, nil)
 	screen.Screen.BranchStateToken = s.Screen.StateToken
 	screen.BranchStateTokenFlowResponse = s.BranchStateTokenFlowResponse
 	screen.Screen.TakenBranchIndex = &index
 	screen.Screen.TakenChannel = channel
+	screen.Screen.IsBotProtectionRequired = botProtectionRequired
 	return TakeBranchResultSimple{
 		Screen: screen,
 	}

--- a/pkg/auth/wire_handler.go
+++ b/pkg/auth/wire_handler.go
@@ -183,6 +183,14 @@ func newWebAppSelectAccountHandler(p *deps.RequestProvider) http.Handler {
 	))
 }
 
+func newWebAppAuthflowV2VerifyBotProtectionHandler(p *deps.RequestProvider) http.Handler {
+	panic(wire.Build(
+		DependencySet,
+		AuthflowV2UIHandlerDependencySet,
+		wire.Bind(new(http.Handler), new(*handlerwebappauthflowv2.AuthflowV2VerifyBotProtectionHandler)),
+	))
+}
+
 func newWebAppAuthflowV2SelectAccountHandler(p *deps.RequestProvider) http.Handler {
 	panic(wire.Build(
 		DependencySet,

--- a/pkg/lib/endpoints/endpoints.go
+++ b/pkg/lib/endpoints/endpoints.go
@@ -93,6 +93,15 @@ func (e *Endpoints) SelectAccountEndpointURL(uiImpl config.UIImplementation) *ur
 		panic(fmt.Errorf("unexpected ui implementation %s", uiImpl))
 	}
 }
+func (e *Endpoints) VerifyBotProtectionEndpointURL(uiImpl config.UIImplementation) *url.URL {
+	uiImpl = uiImpl.WithDefault()
+	switch uiImpl {
+	case config.UIImplementationAuthflowV2:
+		return e.urlOf("/authflow/v2/verify_bot_protection")
+	default:
+		panic(fmt.Errorf("unexpected ui implementation %s", uiImpl))
+	}
+}
 func (e *Endpoints) SSOCallbackEndpointURL() *url.URL { return e.urlOf("sso/oauth2/callback") }
 
 func (e *Endpoints) WeChatAuthorizeEndpointURL() *url.URL { return e.urlOf("sso/wechat/auth") }

--- a/resources/authgear/templates/de/translation.json
+++ b/resources/authgear/templates/de/translation.json
@@ -871,6 +871,8 @@
   "v2-placeholder-password": "Aktuelles Passwort",
   "v2-placeholder-new-password": "Neues Passwort",
   "v2-placeholder-confirm-password": "Passwort erneut eingeben",
+  "v2-verify-bot-protection-header": "Überprüfung deines Systems...",
+  "v2-verify-bot-protection-label": "Du wirst kurz nach Abschluss der Herausforderung weitergeleitet",
   "v2-button-label-continue": "Weiter",
   "v2-button-label-login": "Anmelden",
   "v2-button-label-send": "Senden",

--- a/resources/authgear/templates/el/translation.json
+++ b/resources/authgear/templates/el/translation.json
@@ -871,6 +871,8 @@
   "v2-placeholder-password": "Τρέχων Κωδικός Πρόσβασης",
   "v2-placeholder-new-password": "Νέος Κωδικός Πρόσβασης",
   "v2-placeholder-confirm-password": "Επαναλάβετε Κωδικό Πρόσβασης",
+  "v2-verify-bot-protection-header": "Έλεγχος του συστήματός σας...",
+  "v2-verify-bot-protection-label": "Θα ανακατευθυνθείτε σύντομα αφού ολοκληρώσετε την πρόκληση",
   "v2-button-label-continue": "Συνέχεια",
   "v2-button-label-login": "Σύνδεση",
   "v2-button-label-send": "Αποστολή",

--- a/resources/authgear/templates/en/translation.json
+++ b/resources/authgear/templates/en/translation.json
@@ -871,6 +871,8 @@
   "v2-placeholder-password": "Current Password",
   "v2-placeholder-new-password": "New Password",
   "v2-placeholder-confirm-password": "Re-enter Password",
+  "v2-verify-bot-protection-header": "Checking your system...",
+  "v2-verify-bot-protection-label": "You will be redirected shortly after you completed the challenge",
   "v2-button-label-continue": "Continue",
   "v2-button-label-login": "Login",
   "v2-button-label-send": "Send",

--- a/resources/authgear/templates/en/web/authflowv2/__bot_protection_form_input.html
+++ b/resources/authgear/templates/en/web/authflowv2/__bot_protection_form_input.html
@@ -1,6 +1,2 @@
 <input type="hidden" name="x_bot_protection_provider_type" value="{{$.BotProtectionProviderType}}">
-{{ if (eq $.BotProtectionProviderType "cloudflare" ) }}
-    <input type="hidden" name="x_bot_protection_provider_response" data-cloudflare-turnstile-target="tokenInput" />
-{{ else if (eq $.BotProtectionProviderType "recaptchav2" ) }}
-    <input type="hidden" name="x_bot_protection_provider_response" data-recaptcha-v2-target="tokenInput" />
-{{ end }}
+<input type="hidden" name="x_bot_protection_provider_response" data-controller="bot-protection-input" />

--- a/resources/authgear/templates/en/web/authflowv2/verify_bot_protection.html
+++ b/resources/authgear/templates/en/web/authflowv2/verify_bot_protection.html
@@ -32,10 +32,11 @@
     {{ template "web/authflowv2/__bot_protection_widget.html" . }}
     <!-- TODO: Handle button loading state in https://github.com/authgear/authgear-server/issues/3676 -->
     <button
-      class="primary-btn w-full"
+      class="primary-btn w-full hidden"
       type="submit"
       name="x_action"
       value=""
+      data-controller="bot-protection-on-success-click"
       data-authgear-event="authgear.button.verify_bot_protection"
       data-action-button
     >

--- a/resources/authgear/templates/en/web/authflowv2/verify_bot_protection.html
+++ b/resources/authgear/templates/en/web/authflowv2/verify_bot_protection.html
@@ -1,0 +1,47 @@
+{{ template "authflowv2/__page_frame.html" . }}
+{{ define "page-content" }}
+
+{{ $error_message := "" }}
+{{ if .Error }}
+  {{ $error_message = (include "authflowv2/__error.html" .) }}
+{{ end }}
+
+<div 
+  class="flex flex-col gap-y-4 flex-1-0-auto"
+  data-controller="{{ template "web/authflowv2/__bot_protection_controller.html" . }}"
+  {{ template "web/authflowv2/__bot_protection_controller_attr.html" . }}
+>
+  <header class="screen-title-description">
+    <h1 class="screen-title">
+      {{ template "v2-verify-bot-protection-header" }}
+    </h1>
+    {{ template "authflowv2/__alert_message.html"
+      (dict
+        "Type" "error"
+        "Message" $error_message
+      )
+    }}
+    <p class="screen-description">
+      {{ template "v2-verify-bot-protection-label" }}
+    </p>
+  </header>
+  <form method="POST" novalidate class="flex flex-col gap-y-4 items-center">
+    {{ $.CSRFField }} 
+    
+    {{ template "web/authflowv2/__bot_protection_form_input.html" . }}
+    {{ template "web/authflowv2/__bot_protection_widget.html" . }}
+    <!-- TODO: Handle button loading state in https://github.com/authgear/authgear-server/issues/3676 -->
+    <button
+      class="primary-btn w-full"
+      type="submit"
+      name="x_action"
+      value=""
+      data-authgear-event="authgear.button.verify_bot_protection"
+      data-action-button
+    >
+      {{ template "v2-button-label-continue" }}
+    </button>
+  </form>
+</div>
+
+{{ end }}

--- a/resources/authgear/templates/es-419/translation.json
+++ b/resources/authgear/templates/es-419/translation.json
@@ -871,6 +871,8 @@
   "v2-placeholder-password": "Contraseña actual",
   "v2-placeholder-new-password": "Nueva contraseña",
   "v2-placeholder-confirm-password": "Vuelve a ingresar la contraseña",
+  "v2-verify-bot-protection-header": "Verificando tu sistema...",
+  "v2-verify-bot-protection-label": "Serás redirigido poco después de que completes el desafío",
   "v2-button-label-continue": "Continuar",
   "v2-button-label-login": "Iniciar sesión",
   "v2-button-label-send": "Enviar",

--- a/resources/authgear/templates/es-ES/translation.json
+++ b/resources/authgear/templates/es-ES/translation.json
@@ -871,6 +871,8 @@
   "v2-placeholder-password": "Contraseña actual",
   "v2-placeholder-new-password": "Nueva contraseña",
   "v2-placeholder-confirm-password": "Vuelve a introducir la contraseña",
+  "v2-verify-bot-protection-header": "Comprobando tu sistema...",
+  "v2-verify-bot-protection-label": "Serás redirigido poco después de que hayas completado el desafío",
   "v2-button-label-continue": "Continuar",
   "v2-button-label-login": "Iniciar sesión",
   "v2-button-label-send": "Enviar",

--- a/resources/authgear/templates/es/translation.json
+++ b/resources/authgear/templates/es/translation.json
@@ -871,6 +871,8 @@
   "v2-placeholder-password": "Contraseña actual",
   "v2-placeholder-new-password": "Nueva Contraseña",
   "v2-placeholder-confirm-password": "Vuelva a ingresar la Contraseña",
+  "v2-verify-bot-protection-header": "Comprobando tu sistema...",
+  "v2-verify-bot-protection-label": "Serás redirigido poco después de que hayas completado el desafío",
   "v2-button-label-continue": "Continuar",
   "v2-button-label-login": "Iniciar Sesión",
   "v2-button-label-send": "Enviar",

--- a/resources/authgear/templates/fil/translation.json
+++ b/resources/authgear/templates/fil/translation.json
@@ -871,6 +871,8 @@
   "v2-placeholder-password": "Kasalukuyang Password",
   "v2-placeholder-new-password": "Bagong Password",
   "v2-placeholder-confirm-password": "I-reenter ang Password",
+  "v2-verify-bot-protection-header": "Sinusuri ang iyong sistema...",
+  "v2-verify-bot-protection-label": "Mailalipat ka sa ibang pahina pagkatapos mong makumpleto ang hamon na ito",
   "v2-button-label-continue": "Magpatuloy",
   "v2-button-label-login": "Mag-log in",
   "v2-button-label-send": "Ipadala",

--- a/resources/authgear/templates/fr/translation.json
+++ b/resources/authgear/templates/fr/translation.json
@@ -871,6 +871,8 @@
   "v2-placeholder-password": "Mot de passe actuel",
   "v2-placeholder-new-password": "Nouveau mot de passe",
   "v2-placeholder-confirm-password": "Ressaisir le mot de passe",
+  "v2-verify-bot-protection-header": "Vérification de votre système...",
+  "v2-verify-bot-protection-label": "Vous serez redirigé peu après avoir terminé le défi",
   "v2-button-label-continue": "Continuer",
   "v2-button-label-login": "Se connecter",
   "v2-button-label-send": "Envoyer",

--- a/resources/authgear/templates/id/translation.json
+++ b/resources/authgear/templates/id/translation.json
@@ -871,6 +871,8 @@
   "v2-placeholder-password": "Kata Sandi Saat Ini",
   "v2-placeholder-new-password": "Kata Sandi Baru",
   "v2-placeholder-confirm-password": "Masukkan Ulang Kata Sandi",
+  "v2-verify-bot-protection-header": "Memeriksa sistem Anda...",
+  "v2-verify-bot-protection-label": "Anda akan dialihkan setelah Anda menyelesaikan tantangan ini",
   "v2-button-label-continue": "Lanjutkan",
   "v2-button-label-login": "Masuk",
   "v2-button-label-send": "Kirim",

--- a/resources/authgear/templates/it/translation.json
+++ b/resources/authgear/templates/it/translation.json
@@ -871,6 +871,8 @@
   "v2-placeholder-password": "Password attuale",
   "v2-placeholder-new-password": "Nuova password",
   "v2-placeholder-confirm-password": "Reinserisci la password",
+  "v2-verify-bot-protection-header": "Verifica del tuo sistema...",
+  "v2-verify-bot-protection-label": "Verrai reindirizzato a breve dopo aver completato la sfida",
   "v2-button-label-continue": "Continua",
   "v2-button-label-login": "Accedi",
   "v2-button-label-send": "Invia",

--- a/resources/authgear/templates/ja/translation.json
+++ b/resources/authgear/templates/ja/translation.json
@@ -871,6 +871,8 @@
   "v2-placeholder-password": "現在のパスワード",
   "v2-placeholder-new-password": "新しいパスワード",
   "v2-placeholder-confirm-password": "パスワードを再入力",
+  "v2-verify-bot-protection-header": "システムを確認しています...",
+  "v2-verify-bot-protection-label": "チャレンジを完了した後、すぐにリダイレクトされます。",
   "v2-button-label-continue": "続ける",
   "v2-button-label-login": "ログイン",
   "v2-button-label-send": "送信",

--- a/resources/authgear/templates/ko/translation.json
+++ b/resources/authgear/templates/ko/translation.json
@@ -871,6 +871,8 @@
   "v2-placeholder-password": "현재 비밀번호",
   "v2-placeholder-new-password": "새 비밀번호",
   "v2-placeholder-confirm-password": "비밀번호 다시 입력",
+  "v2-verify-bot-protection-header": "시스템 확인 중...",
+  "v2-verify-bot-protection-label": "챌린지를 완료한 후 곧 리디렉션됩니다.",
   "v2-button-label-continue": "계속",
   "v2-button-label-login": "로그인",
   "v2-button-label-send": "보내기",

--- a/resources/authgear/templates/ms/translation.json
+++ b/resources/authgear/templates/ms/translation.json
@@ -871,6 +871,8 @@
   "v2-placeholder-password": "Kata Laluan Semasa",
   "v2-placeholder-new-password": "Kata Laluan Baru",
   "v2-placeholder-confirm-password": "Masukkan Semula Kata Laluan",
+  "v2-verify-bot-protection-header": "Menyemak sistem anda...",
+  "v2-verify-bot-protection-label": "Anda akan dialihkan tidak lama selepas anda melengkapkan cabaran",
   "v2-button-label-continue": "Teruskan",
   "v2-button-label-login": "Log masuk",
   "v2-button-label-send": "Hantar",

--- a/resources/authgear/templates/nl/translation.json
+++ b/resources/authgear/templates/nl/translation.json
@@ -871,6 +871,8 @@
   "v2-placeholder-password": "Huidig wachtwoord",
   "v2-placeholder-new-password": "Nieuw wachtwoord",
   "v2-placeholder-confirm-password": "Voer wachtwoord opnieuw in",
+  "v2-verify-bot-protection-header": "Uw systeem controleren...",
+  "v2-verify-bot-protection-label": "U wordt binnenkort doorgestuurd nadat u de uitdaging heeft voltooid",
   "v2-button-label-continue": "Doorgaan",
   "v2-button-label-login": "Inloggen",
   "v2-button-label-send": "Verzenden",

--- a/resources/authgear/templates/pl/translation.json
+++ b/resources/authgear/templates/pl/translation.json
@@ -871,6 +871,8 @@
   "v2-placeholder-password": "Obecne hasło",
   "v2-placeholder-new-password": "Nowe hasło",
   "v2-placeholder-confirm-password": "Powtórz hasło",
+  "v2-verify-bot-protection-header": "Sprawdzanie Twojego systemu...",
+  "v2-verify-bot-protection-label": "Zostaniesz przekierowany wkrótce po ukończeniu wyzwania",
   "v2-button-label-continue": "Kontynuuj",
   "v2-button-label-login": "Zaloguj się",
   "v2-button-label-send": "Wyślij",

--- a/resources/authgear/templates/pt-BR/translation.json
+++ b/resources/authgear/templates/pt-BR/translation.json
@@ -871,6 +871,8 @@
   "v2-placeholder-password": "Senha atual",
   "v2-placeholder-new-password": "Nova Senha",
   "v2-placeholder-confirm-password": "Redigite a Senha",
+  "v2-verify-bot-protection-header": "Verificando seu sistema...",
+  "v2-verify-bot-protection-label": "Você será redirecionado em breve após concluir o desafio",
   "v2-button-label-continue": "Continuar",
   "v2-button-label-login": "Entrar",
   "v2-button-label-send": "Enviar",

--- a/resources/authgear/templates/pt-PT/translation.json
+++ b/resources/authgear/templates/pt-PT/translation.json
@@ -871,6 +871,8 @@
   "v2-placeholder-password": "Palavra-passe atual",
   "v2-placeholder-new-password": "Nova Palavra-passe",
   "v2-placeholder-confirm-password": "Reintroduza a Palavra-passe",
+  "v2-verify-bot-protection-header": "A verificar o seu sistema...",
+  "v2-verify-bot-protection-label": "Será redirecionado brevemente após concluir o desafio",
   "v2-button-label-continue": "Continuar",
   "v2-button-label-login": "Iniciar sessão",
   "v2-button-label-send": "Enviar",

--- a/resources/authgear/templates/pt/translation.json
+++ b/resources/authgear/templates/pt/translation.json
@@ -871,6 +871,8 @@
   "v2-placeholder-password": "Senha atual",
   "v2-placeholder-new-password": "Nova Senha",
   "v2-placeholder-confirm-password": "Confirmar Senha",
+  "v2-verify-bot-protection-header": "Verificando o seu sistema...",
+  "v2-verify-bot-protection-label": "Você será redirecionado em breve após concluir o desafio 'Passkey'",
   "v2-button-label-continue": "Continuar",
   "v2-button-label-login": "Entrar",
   "v2-button-label-send": "Enviar",

--- a/resources/authgear/templates/th/translation.json
+++ b/resources/authgear/templates/th/translation.json
@@ -871,6 +871,8 @@
   "v2-placeholder-password": "รหัสผ่านปัจจุบัน",
   "v2-placeholder-new-password": "รหัสผ่านใหม่",
   "v2-placeholder-confirm-password": "ป้อนรหัสผ่านอีกครั้ง",
+  "v2-verify-bot-protection-header": "กำลังตรวจสอบระบบของคุณ...",
+  "v2-verify-bot-protection-label": "คุณจะถูกเปลี่ยนเส้นทางหลังจากที่คุณผ่านการทดสอบแล้ว",
   "v2-button-label-continue": "ดำเนินการต่อ",
   "v2-button-label-login": "เข้าสู่ระบบ",
   "v2-button-label-send": "ส่ง",

--- a/resources/authgear/templates/vi/translation.json
+++ b/resources/authgear/templates/vi/translation.json
@@ -871,6 +871,8 @@
   "v2-placeholder-password": "Mật khẩu hiện tại",
   "v2-placeholder-new-password": "Mật khẩu mới",
   "v2-placeholder-confirm-password": "Nhập lại mật khẩu",
+  "v2-verify-bot-protection-header": "Đang kiểm tra hệ thống của bạn...",
+  "v2-verify-bot-protection-label": "Bạn sẽ được chuyển hướng ngay sau khi hoàn thành thử thách",
   "v2-button-label-continue": "Tiếp tục",
   "v2-button-label-login": "Đăng nhập",
   "v2-button-label-send": "Gửi",

--- a/resources/authgear/templates/zh-CN/translation.json
+++ b/resources/authgear/templates/zh-CN/translation.json
@@ -871,6 +871,8 @@
   "v2-placeholder-password": "当前密码",
   "v2-placeholder-new-password": "新密码",
   "v2-placeholder-confirm-password": "重新输入密码",
+  "v2-verify-bot-protection-header": "正在检查您的系统...",
+  "v2-verify-bot-protection-label": "您完成挑战后将很快被重定向",
   "v2-button-label-continue": "继续",
   "v2-button-label-login": "登录",
   "v2-button-label-send": "发送",

--- a/resources/authgear/templates/zh-HK/translation.json
+++ b/resources/authgear/templates/zh-HK/translation.json
@@ -871,6 +871,8 @@
   "v2-placeholder-password": "目前密碼",
   "v2-placeholder-new-password": "新密碼",
   "v2-placeholder-confirm-password": "再次輸入新密碼",
+  "v2-verify-bot-protection-header": "正在驗證你的系統...",
+  "v2-verify-bot-protection-label": "在您完成驗證後，您將很快被重新導向",
   "v2-button-label-continue": "繼續",
   "v2-button-label-login": "登入",
   "v2-button-label-send": "傳送",

--- a/resources/authgear/templates/zh-TW/translation.json
+++ b/resources/authgear/templates/zh-TW/translation.json
@@ -871,6 +871,8 @@
   "v2-placeholder-password": "目前密碼",
   "v2-placeholder-new-password": "新密碼",
   "v2-placeholder-confirm-password": "再次輸入新密碼",
+  "v2-verify-bot-protection-header": "正在驗證你的系統...",
+  "v2-verify-bot-protection-label": "在您完成驗證後，您將很快被重新導向",
   "v2-button-label-continue": "繼續",
   "v2-button-label-login": "登入",
   "v2-button-label-send": "傳送",


### PR DESCRIPTION
## Blocked by
- #4474 
- #4475 

## What's this PR?
Authgear currently auto-picks `index=0` (first) option branch. If the first branch is `oob-otp`, email/otp are directly send on previous step finished. 

This PR allows user input between
- previous step finish
- next step auto-pick

For more context on UX, see [slack thread](https://oursky.slack.com/archives/C03AH1ACM/p1721291221300689)

## Preview 1 - `primary_oob_otp_email`

https://github.com/user-attachments/assets/96d72b27-ef64-4b3a-8d87-1e672aa574ce

## Preview 2 - `primary_oob_otp_sms`

https://github.com/user-attachments/assets/9d1bd898-b4ca-41e0-8aa8-6464638f8d1b

## Preview 3 - `secondary_oob_otp_email`

https://github.com/user-attachments/assets/20b4ac35-76d7-4a60-ab5d-8ead578f9b07

## Preview 4 - `secondary_oob_otp_sms`

https://github.com/user-attachments/assets/bb02f2f2-f393-48a7-b34f-4bb9d19190d9


