### PR TITLE
Implement captcha modal in AuthUI v2

### DIFF
--- a/authui/src/authflowv2.ts
+++ b/authui/src/authflowv2.ts
@@ -41,7 +41,7 @@ import { InlinePreviewController } from "./inline-preview";
 import { PreviewableResourceController } from "./previewable-resource";
 import { CloudflareTurnstileController } from "./authflowv2/botprotection/cloudflareTurnstile";
 import { RecaptchaV2Controller } from "./authflowv2/botprotection/recaptchav2";
-import { BotProtectionInputController } from "./authflowv2/botprotection/botProtectionInput";
+import { BotProtectionTokenInputController } from "./authflowv2/botprotection/botProtectionTokenInput";
 import { BotProtectionOnSuccessClickController } from "./authflowv2/botprotection/botProtectionOnSuccessClick";
 
 axios.defaults.withCredentials = true;
@@ -108,7 +108,10 @@ Stimulus.register("body-scroll-lock", BodyScrollLockController);
 Stimulus.register("click-to-switch", ClickToSwitchController);
 Stimulus.register("inline-preview", InlinePreviewController);
 Stimulus.register("previewable-resource", PreviewableResourceController);
-Stimulus.register("bot-protection-input", BotProtectionInputController);
+Stimulus.register(
+  "bot-protection-token-input",
+  BotProtectionTokenInputController
+);
 Stimulus.register(
   "bot-protection-on-success-click",
   BotProtectionOnSuccessClickController

--- a/authui/src/authflowv2.ts
+++ b/authui/src/authflowv2.ts
@@ -42,7 +42,7 @@ import { PreviewableResourceController } from "./previewable-resource";
 import { CloudflareTurnstileController } from "./authflowv2/botprotection/cloudflareTurnstile";
 import { RecaptchaV2Controller } from "./authflowv2/botprotection/recaptchav2";
 import { BotProtectionTokenInputController } from "./authflowv2/botprotection/botProtectionTokenInput";
-import { BotProtectionOnSuccessClickController } from "./authflowv2/botprotection/botProtectionOnSuccessClick";
+import { BotProtectionStandalonePageController } from "./authflowv2/botprotection/botProtectionStandalonePage";
 
 axios.defaults.withCredentials = true;
 
@@ -113,8 +113,8 @@ Stimulus.register(
   BotProtectionTokenInputController
 );
 Stimulus.register(
-  "bot-protection-on-success-click",
-  BotProtectionOnSuccessClickController
+  "bot-protection-standalone-button",
+  BotProtectionStandalonePageController
 );
 Stimulus.register("cloudflare-turnstile", CloudflareTurnstileController);
 Stimulus.register("recaptcha-v2", RecaptchaV2Controller);

--- a/authui/src/authflowv2.ts
+++ b/authui/src/authflowv2.ts
@@ -43,6 +43,7 @@ import { CloudflareTurnstileController } from "./authflowv2/botprotection/cloudf
 import { RecaptchaV2Controller } from "./authflowv2/botprotection/recaptchav2";
 import { BotProtectionTokenInputController } from "./authflowv2/botprotection/botProtectionTokenInput";
 import { BotProtectionStandalonePageController } from "./authflowv2/botprotection/botProtectionStandalonePage";
+import { BotProtectionController } from "./authflowv2/botprotection/botProtection";
 import { BotProtectionDialogController } from "./authflowv2/botprotection/botProtectionDialog";
 
 axios.defaults.withCredentials = true;
@@ -119,6 +120,7 @@ Stimulus.register(
 );
 Stimulus.register("cloudflare-turnstile", CloudflareTurnstileController);
 Stimulus.register("recaptcha-v2", RecaptchaV2Controller);
+Stimulus.register("bot-protection", BotProtectionController);
 Stimulus.register("bot-protection-dialog", BotProtectionDialogController);
 
 injectCSSAttrs(document.documentElement);

--- a/authui/src/authflowv2.ts
+++ b/authui/src/authflowv2.ts
@@ -43,6 +43,7 @@ import { CloudflareTurnstileController } from "./authflowv2/botprotection/cloudf
 import { RecaptchaV2Controller } from "./authflowv2/botprotection/recaptchav2";
 import { BotProtectionTokenInputController } from "./authflowv2/botprotection/botProtectionTokenInput";
 import { BotProtectionStandalonePageController } from "./authflowv2/botprotection/botProtectionStandalonePage";
+import { BotProtectionDialogController } from "./authflowv2/botprotection/botProtectionDialog";
 
 axios.defaults.withCredentials = true;
 
@@ -118,5 +119,6 @@ Stimulus.register(
 );
 Stimulus.register("cloudflare-turnstile", CloudflareTurnstileController);
 Stimulus.register("recaptcha-v2", RecaptchaV2Controller);
+Stimulus.register("bot-protection-dialog", BotProtectionDialogController);
 
 injectCSSAttrs(document.documentElement);

--- a/authui/src/authflowv2/botprotection/botProtection.ts
+++ b/authui/src/authflowv2/botprotection/botProtection.ts
@@ -75,7 +75,7 @@ export class BotProtectionController extends Controller {
 
   onVerifySuccess = () => {
     this.isVerified = true;
-    this.formSubmitTarget?.click();
+    setTimeout(() => this.formSubmitTarget?.click(), 0);
   };
 
   onVerifyFailed = () => {

--- a/authui/src/authflowv2/botprotection/botProtection.ts
+++ b/authui/src/authflowv2/botprotection/botProtection.ts
@@ -75,6 +75,8 @@ export class BotProtectionController extends Controller {
 
   onVerifySuccess = () => {
     this.isVerified = true;
+    // Wait for bot-protection-token-input to process "bot-protection:verify-success" event
+    // so that the form submission will have bot protection token injected.
     setTimeout(() => this.formSubmitTarget?.click(), 0);
   };
 

--- a/authui/src/authflowv2/botprotection/botProtectionDialog.ts
+++ b/authui/src/authflowv2/botprotection/botProtectionDialog.ts
@@ -1,0 +1,46 @@
+import { Controller } from "@hotwired/stimulus";
+import { dispatchBotProtectionWidgetEventRender } from "./botProtectionWidget";
+
+/**
+ * Dispatch a custom event to set captcha dialog open
+ */
+export function dispatchBotProtectionDialogOpen() {
+  document.dispatchEvent(new CustomEvent("bot-protection-dialog:open"));
+}
+
+/**
+ * Dispatch a custom event to set captcha dialog close
+ */
+export function dispatchBotProtectionDialogClose() {
+  document.dispatchEvent(new CustomEvent("bot-protection-dialog:close"));
+}
+
+/**
+ * Controller for bot protection dialog display
+ *
+ * Expected usage:
+ * - Add `data-controller="bot-protection-dialog"` to a dialog
+ */
+export class BotProtectionDialogController extends Controller {
+  open = (e: Event) => {
+    if (!(e instanceof CustomEvent)) {
+      throw new Error("Unexpected non-CustomEvent");
+    }
+    dispatchBotProtectionWidgetEventRender();
+    this.element.classList.add("open");
+  };
+
+  close = () => {
+    this.element.classList.remove("open");
+  };
+
+  connect() {
+    document.addEventListener("bot-protection-dialog:open", this.open);
+    document.addEventListener("bot-protection-dialog:close", this.close);
+  }
+
+  disconnect() {
+    document.removeEventListener("bot-protection-dialog:open", this.open);
+    document.removeEventListener("bot-protection-dialog:close", this.close);
+  }
+}

--- a/authui/src/authflowv2/botprotection/botProtectionStandalonePage.ts
+++ b/authui/src/authflowv2/botprotection/botProtectionStandalonePage.ts
@@ -6,13 +6,13 @@ import { Controller } from "@hotwired/stimulus";
  *  - click target button
  *
  * Expected usage:
- * - Add `data-controller="bot-protection-on-success-click"` to a `<button>` element
+ * - Add `data-controller="bot-protection-standalone-page"` to a `<button>` element
  */
-export class BotProtectionOnSuccessClickController extends Controller {
+export class BotProtectionStandalonePageController extends Controller {
   getButtonElement = (): HTMLButtonElement => {
     if (!(this.element instanceof HTMLButtonElement)) {
       throw new Error(
-        "bot-protection-input must be used on `<button>` elements"
+        "bot-protection-standalone-page must be used on `<button>` elements"
       );
     }
     return this.element;

--- a/authui/src/authflowv2/botprotection/botProtectionTokenInput.ts
+++ b/authui/src/authflowv2/botprotection/botProtectionTokenInput.ts
@@ -6,13 +6,13 @@ import { Controller } from "@hotwired/stimulus";
  *  - update form inputs for submission
  *
  * Expected usage:
- * - Add `data-controller="bot-protection-input"` to an `<input>` element inside `<form>` that requires bot protection verification
+ * - Add `data-controller="bot-protection-token-input"` to an `<input>` element inside `<form>` that requires bot protection verification
  */
-export class BotProtectionInputController extends Controller {
+export class BotProtectionTokenInputController extends Controller {
   getInputElement = (): HTMLInputElement => {
     if (!(this.element instanceof HTMLInputElement)) {
       throw new Error(
-        "bot-protection-input must be used on `<input>` elements"
+        "bot-protection-token-input must be used on `<input>` elements"
       );
     }
     return this.element;

--- a/authui/src/authflowv2/botprotection/botProtectionWidget.ts
+++ b/authui/src/authflowv2/botprotection/botProtectionWidget.ts
@@ -1,0 +1,13 @@
+/**
+ * Dispatch a custom event to render bot protection widget
+ */
+export function dispatchBotProtectionWidgetEventRender() {
+  document.dispatchEvent(new CustomEvent("bot-protection-widget:render"));
+}
+
+/**
+ * Dispatch a custom event to set captcha failed
+ */
+export function dispatchBotProtectionWidgetEventUndoRender() {
+  document.dispatchEvent(new CustomEvent("bot-protection-widget:undo-render"));
+}

--- a/authui/src/authflowv2/botprotection/cloudflareTurnstile.ts
+++ b/authui/src/authflowv2/botprotection/cloudflareTurnstile.ts
@@ -36,6 +36,7 @@ export class CloudflareTurnstileController extends Controller {
   declare widgetTarget: HTMLDivElement;
   declare widgetContainer: HTMLDivElement | undefined;
   declare widgetID: string | undefined;
+  declare isReadyForRendering: boolean;
 
   hasExistingWidget = () => {
     return this.widgetContainer != null && this.widgetID != null;
@@ -47,77 +48,78 @@ export class CloudflareTurnstileController extends Controller {
     window.turnstile.reset(this.widgetID);
   };
 
-  connect() {
-    window.turnstile.ready(() => {
-      if (this.hasExistingWidget()) {
-        return;
-      }
-      const colorScheme = getColorScheme();
+  renderWidget() {
+    if (!this.isReadyForRendering) {
+      throw new Error("turnstile target is not ready for rendering");
+    }
+    if (this.hasExistingWidget()) {
+      return;
+    }
+    const colorScheme = getColorScheme();
 
-      // Note how we wrap an extra layer of div here, because on cleanup we can just remove this extra layer of div.
-      // container-container
-      //   container <-- can just remove this on cleanup
-      //     widget
-      const widgetContainer = document.createElement("div");
-      this.widgetContainer = widgetContainer;
-      this.widgetTarget.appendChild(widgetContainer);
-      const widgetID = window.turnstile.render(widgetContainer, {
-        sitekey: this.siteKeyValue,
-        theme: parseTheme(colorScheme),
-        language: this.langValue,
-        callback: (token: string) => {
-          dispatchBotProtectionEventVerified(token);
-        },
-        "error-callback": (errCode: string) => {
-          const {
-            error: parsedError,
-            shouldRetry,
-            shouldDisplayErrMsg,
-          } = parseCloudflareTurnstileErrorCode(errCode);
-          console.error(
-            `Cloudflare Turnstile failed with error code "${errCode}". Authgear parsed it as "${parsedError}".`
-          );
-          dispatchBotProtectionEventFailed(errCode);
+    // Note how we wrap an extra layer of div here, because on cleanup we can just remove this extra layer of div.
+    // container-container
+    //   container <-- can just remove this on cleanup
+    //     widget
+    const widgetContainer = document.createElement("div");
+    this.widgetContainer = widgetContainer;
+    this.widgetTarget.appendChild(widgetContainer);
+    const widgetID = window.turnstile.render(widgetContainer, {
+      sitekey: this.siteKeyValue,
+      theme: parseTheme(colorScheme),
+      language: this.langValue,
+      callback: (token: string) => {
+        dispatchBotProtectionEventVerified(token);
+      },
+      "error-callback": (errCode: string) => {
+        const {
+          error: parsedError,
+          shouldRetry,
+          shouldDisplayErrMsg,
+        } = parseCloudflareTurnstileErrorCode(errCode);
+        console.error(
+          `Cloudflare Turnstile failed with error code "${errCode}". Authgear parsed it as "${parsedError}".`
+        );
+        dispatchBotProtectionEventFailed(errCode);
 
-          if (shouldRetry) {
-            this.resetWidget();
-          }
-          if (shouldDisplayErrMsg) {
-            setErrorMessage(CLOUDFLARE_TURNSTILE_ERROR_MSG_ID);
-          }
-          return true; // return non-falsy value to tell cloudflare we handled error already
-        },
-        "expired-callback": (token: string) => {
-          dispatchBotProtectionEventExpired(token);
-        },
-        "timeout-callback": () => {
-          // reset the widget to allow a visitor to solve the challenge again
+        if (shouldRetry) {
           this.resetWidget();
-        },
-        "response-field": false,
+        }
+        if (shouldDisplayErrMsg) {
+          setErrorMessage(CLOUDFLARE_TURNSTILE_ERROR_MSG_ID);
+        }
+        return true; // return non-falsy value to tell cloudflare we handled error already
+      },
+      "expired-callback": (token: string) => {
+        dispatchBotProtectionEventExpired(token);
+      },
+      "timeout-callback": () => {
+        // reset the widget to allow a visitor to solve the challenge again
+        this.resetWidget();
+      },
+      "response-field": false,
 
-        // below are default values, added for clarity
-        size: "normal",
-        appearance: "always",
-        action: undefined, // no need differentiate widgets under same site key
-        cData: undefined, // no need customer data, already available server-side
-        "before-interactive-callback": undefined, // we do not track interactive callback
-        "after-interactive-callback": undefined, // we do not track interactive callback
-        "unsupported-callback": undefined, // we handled unsupported browser in error-callback by code 110500
-        tabindex: 0, // a11y
-        retry: "auto", // automatically retry to obtain a token on unsuccessful attempts
-        "retry-interval": 8000, // default
-        "refresh-expired": "auto", // automatically refresh expired token
-        "refresh-timeout": "auto", // automatically refreshes upon encountering an interactive timeout
+      // below are default values, added for clarity
+      size: "normal",
+      appearance: "always",
+      action: undefined, // no need differentiate widgets under same site key
+      cData: undefined, // no need customer data, already available server-side
+      "before-interactive-callback": undefined, // we do not track interactive callback
+      "after-interactive-callback": undefined, // we do not track interactive callback
+      "unsupported-callback": undefined, // we handled unsupported browser in error-callback by code 110500
+      tabindex: 0, // a11y
+      retry: "auto", // automatically retry to obtain a token on unsuccessful attempts
+      "retry-interval": 8000, // default
+      "refresh-expired": "auto", // automatically refresh expired token
+      "refresh-timeout": "auto", // automatically refreshes upon encountering an interactive timeout
 
-        // below fields are not available in @types/cloudflare-turnstile package yet, submitting a PR for it ref https://github.com/DefinitelyTyped/DefinitelyTyped/pull/70139
-        // execution: "render", // render is default, challenge runs automatically after calling the render() function.
-      });
-      this.widgetID = widgetID ?? undefined;
+      // below fields are not available in @types/cloudflare-turnstile package yet, submitting a PR for it ref https://github.com/DefinitelyTyped/DefinitelyTyped/pull/70139
+      // execution: "render", // render is default, challenge runs automatically after calling the render() function.
     });
+    this.widgetID = widgetID ?? undefined;
   }
 
-  disconnect() {
+  undoRenderWidget() {
     if (this.widgetID != null) {
       window.turnstile.remove(this.widgetID);
     }
@@ -127,5 +129,15 @@ export class CloudflareTurnstileController extends Controller {
       this.widgetTarget.removeChild(this.widgetContainer);
     }
     this.widgetContainer = undefined;
+  }
+
+  connect() {
+    window.turnstile.ready(() => {
+      this.isReadyForRendering = true;
+    });
+  }
+
+  disconnect() {
+    this.undoRenderWidget();
   }
 }

--- a/authui/src/authflowv2/botprotection/cloudflareTurnstile.ts
+++ b/authui/src/authflowv2/botprotection/cloudflareTurnstile.ts
@@ -48,7 +48,7 @@ export class CloudflareTurnstileController extends Controller {
     window.turnstile.reset(this.widgetID);
   };
 
-  renderWidget() {
+  renderWidget = () => {
     if (!this.isReadyForRendering) {
       throw new Error("turnstile target is not ready for rendering");
     }
@@ -117,7 +117,7 @@ export class CloudflareTurnstileController extends Controller {
       // execution: "render", // render is default, challenge runs automatically after calling the render() function.
     });
     this.widgetID = widgetID ?? undefined;
-  }
+  };
 
   undoRenderWidget() {
     if (this.widgetID != null) {
@@ -135,9 +135,17 @@ export class CloudflareTurnstileController extends Controller {
     window.turnstile.ready(() => {
       this.isReadyForRendering = true;
     });
+    document.addEventListener(
+      "bot-protection-widget:render",
+      this.renderWidget
+    );
   }
 
   disconnect() {
+    document.removeEventListener(
+      "bot-protection-widget:render",
+      this.renderWidget
+    );
     this.undoRenderWidget();
   }
 }

--- a/authui/src/authflowv2/botprotection/recaptchav2.ts
+++ b/authui/src/authflowv2/botprotection/recaptchav2.ts
@@ -44,7 +44,7 @@ export class RecaptchaV2Controller extends Controller {
     window.grecaptcha.reset(this.widgetID); // default to first widget created
   };
 
-  renderWidget() {
+  renderWidget = () => {
     if (!this.isReadyForRendering) {
       throw new Error("recaptchav2 target is not ready for rendering");
     }
@@ -88,7 +88,7 @@ export class RecaptchaV2Controller extends Controller {
       badge: "bottomright",
     });
     this.widgetID = widgetID;
-  }
+  };
 
   undoRenderWidget() {
     this.widgetID = undefined;
@@ -102,9 +102,17 @@ export class RecaptchaV2Controller extends Controller {
     window.grecaptcha.ready(() => {
       this.isReadyForRendering = true;
     });
+    document.addEventListener(
+      "bot-protection-widget:render",
+      this.renderWidget
+    );
   }
 
   disconnect() {
+    document.removeEventListener(
+      "bot-protection-widget:render",
+      this.renderWidget
+    );
     this.undoRenderWidget();
   }
 }

--- a/pkg/lib/web/html.go
+++ b/pkg/lib/web/html.go
@@ -38,6 +38,7 @@ var TemplateWebAuthflowV2BotProtectionWidgetHTML = template.RegisterHTML("web/au
 var TemplateWebAuthflowV2BotProtectionFormInputHTML = template.RegisterHTML("web/authflowv2/__bot_protection_form_input.html")
 var TemplateWebAuthflowV2BotProtectionControllerHTML = template.RegisterHTML("web/authflowv2/__bot_protection_controller.html")
 var TemplateWebAuthflowV2BotProtectionControllerAttrHTML = template.RegisterHTML("web/authflowv2/__bot_protection_controller_attr.html")
+var TemplateWebAuthflowV2BotProtectionDialogHTML = template.RegisterHTML("web/authflowv2/__bot_protection_dialog.html")
 var TemplateWebAuthflowV2HeaderHTML = template.RegisterHTML("web/authflowv2/__header.html")
 var TemplateWebAuthflowV2DividerHTML = template.RegisterHTML("web/authflowv2/__divider.html")
 var TemplateWebAuthflowV2AlertMessageHTML = template.RegisterHTML("web/authflowv2/__alert_message.html")
@@ -90,6 +91,7 @@ var ComponentsHTML = []*template.HTML{
 	TemplateWebAuthflowV2BotProtectionFormInputHTML,
 	TemplateWebAuthflowV2BotProtectionControllerHTML,
 	TemplateWebAuthflowV2BotProtectionControllerAttrHTML,
+	TemplateWebAuthflowV2BotProtectionDialogHTML,
 	TemplateWebAuthflowV2HeaderHTML,
 	TemplateWebAuthflowV2DividerHTML,
 	TemplateWebAuthflowV2AlertMessageHTML,

--- a/resources/authgear/templates/en/web/authflowv2/__bot_protection_dialog.html
+++ b/resources/authgear/templates/en/web/authflowv2/__bot_protection_dialog.html
@@ -1,0 +1,22 @@
+{{/* TODO: Implement actual captcha dialog when design is ready */}}
+<div
+  class="dialog"
+  role="dialog"
+  aria-labelledby="bot-protection-title"
+  data-controller="bot-protection-dialog {{ template "web/authflowv2/__bot_protection_controller.html" . }}"
+  {{ template "web/authflowv2/__bot_protection_controller_attr.html" . }}
+  aria-modal="true"
+  tabindex="-1"
+>
+  <div class="flex flex-col gap-y-4 flex-1-0-auto">
+    <header class="screen-title-description">
+      <h1 class="screen-title" id="bot-protection-title">
+        {{ template "v2-verify-bot-protection-header" }}
+      </h1>
+      <h2 class="screen-description">
+        {{ template "v2-verify-bot-protection-label" }}
+      </h2>
+    </header>
+    {{ template "web/authflowv2/__bot_protection_widget.html" . }}
+  </div>
+</div>

--- a/resources/authgear/templates/en/web/authflowv2/__bot_protection_form_input.html
+++ b/resources/authgear/templates/en/web/authflowv2/__bot_protection_form_input.html
@@ -1,2 +1,10 @@
-<input type="hidden" name="x_bot_protection_provider_type" value="{{$.BotProtectionProviderType}}">
-<input type="hidden" name="x_bot_protection_provider_response" data-controller="bot-protection-input" />
+<input
+  type="hidden"
+  name="x_bot_protection_provider_type"
+  value="{{$.BotProtectionProviderType}}"
+/>
+<input
+  type="hidden"
+  name="x_bot_protection_provider_response"
+  data-controller="bot-protection-token-input"
+/>

--- a/resources/authgear/templates/en/web/authflowv2/__page_frame.html
+++ b/resources/authgear/templates/en/web/authflowv2/__page_frame.html
@@ -24,7 +24,7 @@
 
 <body
   {{/* "loading" is assumed to be defined in document.body["data-controller"] in TurboFormController */}}
-  data-controller="prevent-double-tap lockout restore-form loading authflow-passkey-error"
+  data-controller="prevent-double-tap lockout restore-form loading authflow-passkey-error bot-protection"
   data-restore-form-json-value="{{ $.FormJSON }}"
   data-action="dblclick->prevent-double-tap#action"
   data-inline-preview-previewable-resource-outlet=".translated-message,.brand-logo"

--- a/resources/authgear/templates/en/web/authflowv2/__page_frame.html
+++ b/resources/authgear/templates/en/web/authflowv2/__page_frame.html
@@ -51,6 +51,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
       {{ template "page-content" . }}
       {{ template "authflowv2/__lockout.html" . }}
       {{ template "authflowv2/__watermark.html" . }}
+      {{ template "web/authflowv2/__bot_protection_dialog.html" . }}
     </div>
   </div>
 {{ end }}

--- a/resources/authgear/templates/en/web/authflowv2/enter_password.html
+++ b/resources/authgear/templates/en/web/authflowv2/enter_password.html
@@ -5,6 +5,11 @@
 {{ if $.HasUnknownError }}
   {{ $unknown_error_message = (include "authflowv2/__error.html" .) }}
 {{ end }}
+{{ $show_captcha := false }}
+{{ if $.IsBotProtectionRequired }}
+  {{ $show_captcha = true }}
+{{ end }}
+
 <div class="flex flex-col gap-y-8 flex-1-0-auto">
   <header class="screen-title-description">
     <h1 class="screen-title">
@@ -43,9 +48,12 @@
     novalidate
     class="flex flex-col gap-y-4 items-center"
     data-controller="turbo-form"
-    data-action="submit->turbo-form#submitForm"
+    data-action="{{ if $show_captcha }}submit->bot-protection#verifyFormSubmit {{ end }}submit->turbo-form#submitForm"
   >
     {{ $.CSRFField }}
+    {{ if $show_captcha }}
+      {{ template "web/authflowv2/__bot_protection_form_input.html" . }}
+    {{ end }}
     <!-- This field is for Chrome and Safari to correctly associate the username with the password -->
     <!-- both `class="hidden"` and `display:none` do not work for iOS autofill -->
     {{ if $.PasswordManagerUsername }}

--- a/resources/authgear/templates/en/web/authflowv2/forgot_password.html
+++ b/resources/authgear/templates/en/web/authflowv2/forgot_password.html
@@ -50,7 +50,7 @@
           method="post"
           novalidate
           data-controller="turbo-form"
-          data-action="{{ if (or $show_captcha_email $show_captcha_phone) }}submit->bot-protection#verifyFormSubmit {{ end }}submit->turbo-form#submitForm"
+          data-action="{{ if $has_captcha }}submit->bot-protection#verifyFormSubmit {{ end }}submit->turbo-form#submitForm"
         >
           {{ $.CSRFField }}
           {{ if $has_captcha }}
@@ -134,7 +134,7 @@
           method="post"
           novalidate
           data-controller="turbo-form"
-          data-action="{{ if (or $show_captcha_phone $show_captcha_email) }}submit->bot-protection#verifyFormSubmit {{ end }}submit->turbo-form#submitForm"
+          data-action="{{ if $has_captcha }}submit->bot-protection#verifyFormSubmit {{ end }}submit->turbo-form#submitForm"
         >
           {{ $.CSRFField }}
           {{ if $has_captcha }}

--- a/resources/authgear/templates/en/web/authflowv2/forgot_password.html
+++ b/resources/authgear/templates/en/web/authflowv2/forgot_password.html
@@ -3,12 +3,24 @@
   {{ $show_email_input := false }}
   {{ $show_phone_input := false }}
   {{ $display_error := false }}
+  {{ $show_captcha_phone := false }}
+  {{ $show_captcha_email := false }}
 
   {{ if and (eq $.LoginIDInputType "phone") ($.PhoneLoginIDEnabled) }}
     {{ $show_phone_input = true }}
   {{ else if and (not (eq $.LoginIDInputType "phone")) ($.EmailLoginIDEnabled) }}
     {{ $show_email_input = true }}
   {{ end }}
+
+  {{ if $show_phone_input }}{{ if $.PhoneLoginIDBotProtectionRequired }}
+    {{ $show_captcha_phone = true  }}
+  {{ end }}{{ end }}
+
+  {{ if $show_email_input }}{{ if $.EmailLoginIDBotProtectionRequired }}
+    {{ $show_captcha_email = true  }}
+  {{ end }}{{ end }}
+
+  {{ $has_captcha := (or $show_captcha_phone $show_captcha_email) }}
 
   {{ if $.Error }}
     {{ $display_error = true }}
@@ -38,9 +50,12 @@
           method="post"
           novalidate
           data-controller="turbo-form"
-          data-action="submit->turbo-form#submitForm"
+          data-action="{{ if (or $show_captcha_email $show_captcha_phone) }}submit->bot-protection#verifyFormSubmit {{ end }}submit->turbo-form#submitForm"
         >
           {{ $.CSRFField }}
+          {{ if $has_captcha }}
+            {{ template "web/authflowv2/__bot_protection_form_input.html" . }}
+          {{ end}}
           <div data-controller="text-field" class="flex flex-col gap-2">
             {{ if $show_email_input }}
               <input type="hidden" name="x_login_id_type" value="email">
@@ -119,11 +134,21 @@
           method="post"
           novalidate
           data-controller="turbo-form"
-          data-action="submit->turbo-form#submitForm"
+          data-action="{{ if (or $show_captcha_phone $show_captcha_email) }}submit->bot-protection#verifyFormSubmit {{ end }}submit->turbo-form#submitForm"
         >
           {{ $.CSRFField }}
+          {{ if $has_captcha }}
+            {{ template "web/authflowv2/__bot_protection_form_input.html" . }}
+          {{ end }}
           <input type="hidden" name="x_login_id_type" value="{{ $.LoginIDInputType }}">
           <input type="hidden" name="x_login_id" value="{{ $.LoginID }}">
+          {{ if $display_error }}
+            <div class="mb-6">
+              <p class="input__error-message" data-text-field-target="errorMessage">
+                {{ template "authflowv2/__error.html" $ }}
+              </p>
+            </div>
+          {{ end }}
           <button
             class="primary-btn w-full"
             type="submit"

--- a/resources/authgear/templates/en/web/authflowv2/login.html
+++ b/resources/authgear/templates/en/web/authflowv2/login.html
@@ -15,6 +15,9 @@
   {{ $has_alternatives := false }}
   {{ $show_use_text_login_id_option := false }}
   {{ $show_use_phone_login_id_option := false }}
+  {{ $show_captcha_phone := false }}
+  {{ $show_captcha_email := false }}
+  {{ $show_captcha_username := false }}
   {{ range $.IdentityCandidates }}
     {{ if eq .type "oauth" }}
       {{ $has_alternatives = true }}
@@ -48,6 +51,14 @@
     {{ $show_text_input = true }}
   {{ end }}{{ end }}{{ end }}
 
+  {{ if $show_phone_input }}{{ if $.PhoneLoginIDBotProtectionRequired }}
+    {{ $show_captcha_phone = true  }}
+  {{ end }}{{ end }}
+
+  {{ if $show_text_input }}{{ if (or $.UsernameLoginIDBotProtectionRequired $.EmailLoginIDBotProtectionRequired )}}
+    {{ $show_captcha_email = true  }}
+    {{ $show_captcha_username = true  }}
+  {{ end }}{{ end }}
   {{ $appName := (translate "app.name" nil) }}
   {{ $clientName := or $.ClientName "null" }}
 
@@ -91,6 +102,9 @@
       class="flex flex-col gap-4 mt-8"
       method="post"
       novalidate
+      {{ if (or (and $show_phone_input $show_captcha_phone) (and $show_text_input (or $show_captcha_email $show_captcha_username)))}}
+        data-action="submit->bot-protection#verifyFormSubmit"
+      {{ end }}
       data-controller="{{ $formController }}"
       data-retain-form-form-id-value="auth-form"
       data-turbo="false"
@@ -101,6 +115,9 @@
       {{ if (or $show_phone_input $show_text_input)}}
         <div data-controller="text-field" class="flex flex-col gap-2">
           {{ if $show_phone_input }}
+            {{ if $show_captcha_phone }}
+              {{ template "web/authflowv2/__bot_protection_form_input.html" . }}
+            {{ end }}
             {{ template "authflowv2/__phone_input.html"
               (dict
                 "Placeholder" (include "v2-placeholder-phone" nil)
@@ -122,6 +139,9 @@
           {{ end }}
 
           {{ if $show_text_input }}
+            {{ if (or $show_captcha_email $show_captcha_username) }}
+              {{ template "web/authflowv2/__bot_protection_form_input.html" . }}
+            {{ end }}
             <input
               data-text-field-target="input"
               class="block input w-full {{ if $display_input_error }}input--error{{end}}"

--- a/resources/authgear/templates/en/web/authflowv2/login.html
+++ b/resources/authgear/templates/en/web/authflowv2/login.html
@@ -102,7 +102,7 @@
       class="flex flex-col gap-4 mt-8"
       method="post"
       novalidate
-      {{ if (or (and $show_phone_input $show_captcha_phone) (and $show_text_input (or $show_captcha_email $show_captcha_username)))}}
+      {{ if (or $show_captcha_phone $show_captcha_email $show_captcha_username)}}
         data-action="submit->bot-protection#verifyFormSubmit"
       {{ end }}
       data-controller="{{ $formController }}"

--- a/resources/authgear/templates/en/web/authflowv2/signup.html
+++ b/resources/authgear/templates/en/web/authflowv2/signup.html
@@ -13,6 +13,8 @@
 
   {{ $has_login_id := false }}
   {{ $has_alternatives := false }}
+  {{ $show_captcha_phone := false }}
+  {{ $show_captcha_text := false }} {{/* both email & username */}}
   {{ range $.IdentityCandidates }}
     {{ if eq .type "oauth" }}
       {{ $has_alternatives = true }}
@@ -21,6 +23,17 @@
       {{ $has_login_id = true }}
       {{ if not (eq .login_id_key $.LoginIDKey) }}
         {{ $has_alternatives = true }}
+      {{ end }}
+      {{ if eq .login_id_key $.LoginIDKey }}
+        {{if eq .login_id_type "phone" }}{{ if $.PhoneLoginIDBotProtectionRequired }}
+          {{ $show_captcha_phone = true  }}
+        {{ end }}{{ end }}
+        {{if eq .login_id_type "username" }}{{ if $.UsernameLoginIDBotProtectionRequired }}
+          {{ $show_captcha_text = true  }}
+        {{ end }}{{ end }}
+        {{if eq .login_id_type "email" }}{{ if $.EmailLoginIDBotProtectionRequired }}
+          {{ $show_captcha_text = true  }}
+        {{ end }}{{ end }}
       {{ end }}
     {{ end }}
   {{ end }}
@@ -83,7 +96,7 @@
     data-controller="{{ $formController }}"
     data-retain-form-form-id-value="auth-form"
     data-controller="turbo-form"
-    data-action="submit->turbo-form#submitForm"
+    data-action="{{ if (or $show_captcha_phone $show_captcha_text) }}submit->bot-protection#verifyFormSubmit {{ end }}submit->turbo-form#submitForm"
   >
     {{ $.CSRFField }}
     <input type="hidden" name="q_login_id_key" value="{{ $.LoginIDKey }}">
@@ -110,6 +123,9 @@
               `
             )
           }}
+          {{ if $show_captcha_phone }}
+            {{ template "web/authflowv2/__bot_protection_form_input.html" $ }}
+          {{ end }}
         {{ else }}
           <input
             data-text-field-target="input"
@@ -125,6 +141,9 @@
             data-retain-form-form-target="input"
             data-retain-form-form-name-param="text"
           >
+          {{ if $show_captcha_text }}
+            {{ template "web/authflowv2/__bot_protection_form_input.html" $ }}
+          {{ end }}
         {{ end }}
         {{ if $display_input_error }}
           <p class="input__error-message" data-text-field-target="errorMessage">

--- a/resources/authgear/templates/en/web/authflowv2/verify_bot_protection.html
+++ b/resources/authgear/templates/en/web/authflowv2/verify_bot_protection.html
@@ -36,7 +36,7 @@
       type="submit"
       name="x_action"
       value=""
-      data-controller="bot-protection-on-success-click"
+      data-controller="bot-protection-standalone-page"
       data-authgear-event="authgear.button.verify_bot_protection"
       data-action-button
     >


### PR DESCRIPTION
## What's in this PR?
Implement captcha guard in
- [x] signup flow
  - [x] identify
    - [x] username
    - [x] email
    - [x] phone
- [x] promote flow
  - [x] identify
    - [x] username
    - [x] email
    - [x] phone
- [x] login flow
  - [x] identify
    - [x] loginid
  - [x] authenticate
    - [x] password
    - [ ] oobotp (in separate page)
- [x] signup_login flow
  - [x] switch flow success
  - [x] identify
    - [x] loginid
- [x] account_recovery_flow
  - [x] identify
  
## Preview 

https://github.com/user-attachments/assets/b4568a15-abf4-47b5-9dd2-6348f641c0a6

## Notes on 502 error

If you noticed a 502 gate error in preview, it's because of header too large (>4kb) again.

1. grecaptcha has an embedded `<textarea />` input, which store the very long grecaptcha token
2. I also have an input field `x_bot_protection_provider_token`, store the very long grecaptcha token _again_
3. Empty phone input will return an error, **with entire form input returned**
4. Each token cost ~ 500b - 1kb, so the response headers with `web_err` in set cookie exceeded 4kb easily.

<details>
<summary> Sample repsonse Header (4372 bytes) </summary>

```
Cache-Control: no-store
Content-Security-Policy: default-src 'self'; script-src 'strict-dynamic' 'nonce-SASWCQCQ9NNC3NZRB68QDMXM7CTZHKDQ' www.googletagmanager.com eu-assets.i.posthog.com challenges.cloudflare.com www.google.com https://browser.sentry-cdn.com 'self'; frame-src www.googletagmanager.com challenges.cloudflare.com www.google.com 'self'; font-src cdnjs.cloudflare.com static2.sharepointonline.com fonts.googleapis.com fonts.gstatic.com 'self'; style-src 'unsafe-inline' cdnjs.cloudflare.com www.googletagmanager.com fonts.googleapis.com 'self'; img-src http: https: data: 'self'; object-src 'none'; base-uri 'none'; connect-src 'self' https://www.google-analytics.com ws://accounts.portal.localhost:3000 wss://accounts.portal.localhost:3000; block-all-mixed-content; frame-ancestors 'none'
Location: /login?q_login_id_input_type=phone
Permissions-Policy: accelerometer=(), ambient-light-sensor=(), autoplay=*, battery=(), bluetooth=(), browsing-topics=(), camera=(), display-capture=(), document-domain=(), encrypted-media=(), execution-while-not-rendered=*, execution-while-out-of-viewport=*, fullscreen=*, gamepad=(), geolocation=(), gyroscope=(), hid=(), identity-credentials-get=(), idle-detection=(), local-fonts=(), magnetometer=(), microphone=(), midi=(), otp-credentials=(), payment=(), picture-in-picture=(), publickey-credentials-create=(self), publickey-credentials-get=(self), screen-wake-lock=(), serial=(), speaker-selection=(), storage-access=(), usb=(), web-share=(), window-management=(), xr-spatial-tracking=()
Pragma: no-cache
Set-Cookie: debug_csrf_same_site_omit=exists; Path=/; Domain=portal.localhost; Max-Age=1200; HttpOnly
Set-Cookie: debug_csrf_same_site_none=exists; Path=/; Domain=portal.localhost; Max-Age=1200; HttpOnly
Set-Cookie: debug_csrf_same_site_lax=exists; Path=/; Domain=portal.localhost; Max-Age=1200; HttpOnly; SameSite=Lax
Set-Cookie: debug_csrf_same_site_strict=exists; Path=/; Domain=portal.localhost; Max-Age=1200; HttpOnly; SameSite=Strict
Set-Cookie: web_err=eyJGb3JtIjp7ImctcmVjYXB0Y2hhLXJlc3BvbnNlIjpbIjAzQUZjV2VBN05sc2s5WXNqb0tLYXUwLUEzNE5Pa2tUUXdQRDJKc29oRmRacG92TDAxRS1EYUtwNk5wNTlOUDNfTjRZVXhyaF9PSkwyc3hHekgwakNVQks3LXV4eWh0TDhIZXRFdUpKWGtKbHAwcWN4UG0zVzFoY2s4Qnh2QTJYY2pOVVZpaS1TYndKVEdMRkVaTjBvejJNTEZZRDczem1PT2pfWFBTTVdtMkNVZE5PajgxSlpEQnVxOFlaVGNRTFZsSFlMdnRFbGR3OEo0b2dNazUxWUIxTkRhdTVvQWllWnBNaWJtXzNwOXFZQ2JfbENSblJEZ0NXTXAzUzhfZ0RQM3Y5SlBNUHZ2Yll0WWtSQ001SGFlV1V2aUR0dFVWWE9HdUh6OTBTNndwUWNhUEdmVnZ3OFNvZ19RdVNXX193ODRya1BmSkp4NGluS05DTV9MRjZ2bHN2a2NoanRJVmxaNXJxSXhRZV9kek5tSFpjczhaMHh2SDBpcHZnc3FNOW55V0V1MUdXMi1zcUhUUXV1Si1ta0xiV0RaU3JSUGREa05TbjhEUGFDZ3lrVllBNUgzY3VEZEJ4S2NtemFmUkt4bmZTdW5Ebjc4S1dyTml0TEU3N0haejIwSTZVUkxvOWVzdld0bmpZUUpHNVBVZlphQ3ZVWmVBc3pXb0dWM250T3FyVk1PM1dtTVR5eXFwQTY3MmxWUWh5bVBIamNiVXZLY2Z3Il0sImdvcmlsbGEuY3NyZi5Ub2tlbiI6WyIwS0QzSDlQdEZaMC9VTVpaazQweko0RE1wYmluV0Zrd3RhNTNzWHlQeDZuTTFCck54RWthMjVTam4ra01ZVGFxZWY3UVhvdkxSU0YvQ3hXUTFPU1pTUT09Il0sInFfbG9naW5faWRfaW5wdXRfdHlwZSI6WyJwaG9uZSJdLCJ4X2FjdGlvbiI6WyJsb2dpbl9pZCJdLCJ4X2JvdF9wcm90ZWN0aW9uX3Byb3ZpZGVyX3Jlc3BvbnNlIjpbIjAzQUZjV2VBN05sc2s5WXNqb0tLYXUwLUEzNE5Pa2tUUXdQRDJKc29oRmRacG92TDAxRS1EYUtwNk5wNTlOUDNfTjRZVXhyaF9PSkwyc3hHekgwakNVQks3LXV4eWh0TDhIZXRFdUpKWGtKbHAwcWN4UG0zVzFoY2s4Qnh2QTJYY2pOVVZpaS1TYndKVEdMRkVaTjBvejJNTEZZRDczem1PT2pfWFBTTVdtMkNVZE5PajgxSlpEQnVxOFlaVGNRTFZsSFlMdnRFbGR3OEo0b2dNazUxWUIxTkRhdTVvQWllWnBNaWJtXzNwOXFZQ2JfbENSblJEZ0NXTXAzUzhfZ0RQM3Y5SlBNUHZ2Yll0WWtSQ001SGFlV1V2aUR0dFVWWE9HdUh6OTBTNndwUWNhUEdmVnZ3OFNvZ19RdVNXX193ODRya1BmSkp4NGluS05DTV9MRjZ2bHN2a2NoanRJVmxaNXJxSXhRZV9kek5tSFpjczhaMHh2SDBpcHZnc3FNOW55V0V1MUdXMi1zcUhUUXV1Si1ta0xiV0RaU3JSUGREa05TbjhEUGFDZ3lrVllBNUgzY3VEZEJ4S2NtemFmUkt4bmZTdW5Ebjc4S1dyTml0TEU3N0haejIwSTZVUkxvOWVzdld0bmpZUUpHNVBVZlphQ3ZVWmVBc3pXb0dWM250T3FyVk1PM1dtTVR5eXFwQTY3MmxWUWh5bVBIamNiVXZLY2Z3Il0sInhfYm90X3Byb3RlY3Rpb25fcHJvdmlkZXJfdHlwZSI6WyJyZWNhcHRjaGF2MiJdLCJ4X2xvZ2luX2lkIjpbIis4NTIiXSwieF9sb2dpbl9pZF9pbnB1dF90eXBlIjpbInBob25lIl19LCJFcnJvciI6eyJuYW1lIjoiTm90Rm91bmQiLCJyZWFzb24iOiJVc2VyTm90Rm91bmQiLCJtZXNzYWdlIjoidXNlciBub3QgZm91bmQiLCJjb2RlIjo0MDQsImluZm8iOnsiRmxvd1R5cGUiOiJsb2dpbiIsIklkZW50aXR5VHlwZUluY29taW5nIjoibG9naW5faWQiLCJMb2dpbklEVHlwZUluY29taW5nIjoiIn19fQ; Path=/; Domain=portal.localhost; HttpOnly; SameSite=Lax
Vary: Cookie
X-Content-Type-Options: nosniff
X-Frame-Options: DENY
Date: Thu, 18 Jul 2024 18:14:11 GMT
Content-Length: 0
```

</details>

<details>

<summary>  `base64 -d web_err`   </summary>

```json5
{
  "Form": {
    "g-recaptcha-response": [
      "03AFcWeA7Nlsk9YsjoKKau0-A34NOkkTQwPD2JsohFdZpovL01E-DaKp6Np59NP3_N4YUxrh_OJL2sxGzH0jCUBK7-uxyhtL8HetEuJJXkJlp0qcxPm3W1hck8BxvA2XcjNUVii-SbwJTGLFEZN0oz2MLFYD73zmOOj_XPSMWm2CUdNOj81JZDBuq8YZTcQLVlHYLvtEldw8J4ogMk51YB1NDau5oAieZpMibm_3p9qYCb_lCRnRDgCWMp3S8_gDP3v9JPMPvvbYtYkRCM5HaeWUviDttUVXOGuHz90S6wpQcaPGfVvw8Sog_QuSW__w84rkPfJJx4inKNCM_LF6vlsvkchjtIVlZ5rqIxQe_dzNmHZcs8Z0xvH0ipvgsqM9nyWEu1GW2-sqHTQuuJ-mkLbWDZSrRPdDkNSn8DPaCgykVYA5H3cuDdBxKcmzafRKxnfSunDn78KWrNitLE77HZz20I6URLo9esvWtnjYQJG5PUfZaCvUZeAszWoGV3ntOqrVMO3WmMTyyqpA672lVQhymPHjcbUvKcfw"
    ],
    "gorilla.csrf.Token": [
      "0KD3H9PtFZ0/UMZZk40zJ4DMpbinWFkwta53sXyPx6nM1BrNxEka25Sjn+kMYTaqef7QXovLRSF/CxWQ1OSZSQ=="
    ],
    "q_login_id_input_type": ["phone"],
    "x_action": ["login_id"],
    "x_bot_protection_provider_response": [
      "03AFcWeA7Nlsk9YsjoKKau0-A34NOkkTQwPD2JsohFdZpovL01E-DaKp6Np59NP3_N4YUxrh_OJL2sxGzH0jCUBK7-uxyhtL8HetEuJJXkJlp0qcxPm3W1hck8BxvA2XcjNUVii-SbwJTGLFEZN0oz2MLFYD73zmOOj_XPSMWm2CUdNOj81JZDBuq8YZTcQLVlHYLvtEldw8J4ogMk51YB1NDau5oAieZpMibm_3p9qYCb_lCRnRDgCWMp3S8_gDP3v9JPMPvvbYtYkRCM5HaeWUviDttUVXOGuHz90S6wpQcaPGfVvw8Sog_QuSW__w84rkPfJJx4inKNCM_LF6vlsvkchjtIVlZ5rqIxQe_dzNmHZcs8Z0xvH0ipvgsqM9nyWEu1GW2-sqHTQuuJ-mkLbWDZSrRPdDkNSn8DPaCgykVYA5H3cuDdBxKcmzafRKxnfSunDn78KWrNitLE77HZz20I6URLo9esvWtnjYQJG5PUfZaCvUZeAszWoGV3ntOqrVMO3WmMTyyqpA672lVQhymPHjcbUvKcfw"
    ],
    "x_bot_protection_provider_type": ["recaptchav2"],
    "x_login_id": ["+852"],
    "x_login_id_input_type": ["phone"]
  },
  "Error": {
    "name": "NotFound",
    "reason": "UserNotFound",
    "message": "user not found",
    "code": 404,
    "info": {
      "FlowType": "login",
      "IdentityTypeIncoming": "login_id",
      "LoginIDTypeIncoming": ""
    }
  }
}

```

</details>

Related [Linear Issue](https://linear.app/authgear/issue/DEV-1537/review-response-headers-content-security-policy)

Will look into more tmr how to workaround this

Note - [cloudflare supports enabling/disabling this](https://developers.cloudflare.com/turnstile/get-started/client-side-rendering/#configurations), but not recaptcha :sadfrog: 

> `response_field` - A boolean that controls if an input element with the response token is created, defaults to true.

