### PR TITLE
Replace XHRSubmitFormController with TurboFormController for declarative form submission hijack

### DIFF
--- a/authui/src/authflowv2.ts
+++ b/authui/src/authflowv2.ts
@@ -8,7 +8,7 @@ import {
   RetainFormFormController,
   RetainFormInputController,
 } from "./form";
-import { XHRSubmitFormController } from "./authflowv2/form";
+import { TurboFormController } from "./authflowv2/turboForm";
 import { LoadingController } from "./authflowv2/loading";
 import { PreventDoubleTapController } from "./preventDoubleTap";
 import { LockoutController } from "./lockout";
@@ -57,7 +57,7 @@ start();
 
 const Stimulus = Application.start();
 
-Stimulus.register("xhr-submit-form", XHRSubmitFormController);
+Stimulus.register("turbo-form", TurboFormController);
 Stimulus.register("restore-form", RestoreFormController);
 Stimulus.register("retain-form-form", RetainFormFormController);
 Stimulus.register("retain-form-input", RetainFormInputController);

--- a/authui/src/authflowv2/turboForm.ts
+++ b/authui/src/authflowv2/turboForm.ts
@@ -23,18 +23,11 @@ import { handleAxiosError } from "./alert-message";
 // to stop Turbo from submitting forms.
 //
 // See https://github.com/authgear/authgear-server/issues/2333
-export class XHRSubmitFormController extends Controller {
+export class TurboFormController extends Controller {
   forms: HTMLFormElement[] = [];
 
-  onSubmitCapture = (e: Event) => {
-    e.preventDefault();
-  };
-
-  onSubmit = (e: Event) => {
-    void this.submitForm(e);
-  };
-
   async submitForm(e: Event) {
+    e.preventDefault();
     const form = e.currentTarget as HTMLFormElement;
 
     if (form.querySelector('[data-turbo="false"]')) {
@@ -71,7 +64,7 @@ export class XHRSubmitFormController extends Controller {
     }
     const loadingController: LoadingController | null =
       this.application.getControllerForElementAndIdentifier(
-        this.element,
+        document.body,
         "loading"
       ) as LoadingController | null;
     const { onError: onLoadingError, onFinally: onLoadingFinally } =
@@ -108,27 +101,6 @@ export class XHRSubmitFormController extends Controller {
       onLoadingError?.();
     } finally {
       onLoadingFinally?.();
-    }
-  }
-
-  connect() {
-    const elems = document.querySelectorAll("form");
-    for (let i = 0; i < elems.length; i++) {
-      if (elems[i].querySelector('[data-turbo="false"]')) {
-        continue;
-      }
-      this.forms.push(elems[i]);
-    }
-    for (const form of this.forms) {
-      form.addEventListener("submit", this.onSubmitCapture, true);
-      form.addEventListener("submit", this.onSubmit);
-    }
-  }
-
-  disconnect() {
-    for (const form of this.forms) {
-      form.removeEventListener("submit", this.onSubmitCapture, true);
-      form.removeEventListener("submit", this.onSubmit);
     }
   }
 }

--- a/resources/authgear/templates/en/web/authflowv2/__authflow_branch.html
+++ b/resources/authgear/templates/en/web/authflowv2/__authflow_branch.html
@@ -9,7 +9,13 @@
 {{- range $.Branches }}
   {{- if eq $.ActionType "authenticate" }}
     {{- if eq .Authentication "recovery_code" }}
-      <form class="text-left text-sm" method="post" novalidate>
+      <form 
+        class="text-left text-sm"
+        method="post"
+        novalidate
+        data-controller="turbo-form"
+        data-action="submit->turbo-form#submitForm"
+      >
         {{ $.CSRFField }}
         <input type="hidden" name="x_index" value="{{ .Index }}">
         <input type="hidden" name="x_channel" value="{{ .Channel }}">
@@ -26,7 +32,12 @@
 {{- range $.Branches }}
   {{- if eq .Authentication "recovery_code" -}}
   {{ else }}
-  <form method="post" novalidate>
+  <form 
+    method="post"
+    novalidate
+    data-controller="turbo-form"
+    data-action="submit->turbo-form#submitForm"
+  >
   {{ $.CSRFField }}
   <input type="hidden" name="x_index" value="{{ .Index }}">
   <input type="hidden" name="x_channel" value="{{ .Channel }}">

--- a/resources/authgear/templates/en/web/authflowv2/__forgot_password_alternatives.html
+++ b/resources/authgear/templates/en/web/authflowv2/__forgot_password_alternatives.html
@@ -7,7 +7,12 @@
 {{- if (len $.AlternativeChannels) }}
 <div class="flex flex-col gap-y-4">
 {{- range $.AlternativeChannels }}
-  <form method="post" novalidate>
+  <form
+    method="post"
+    novalidate
+    data-controller="turbo-form"
+    data-action="submit->turbo-form#submitForm"
+  >
     {{ $.CSRFField }}
     <input type="hidden" name="x_index" value="{{ .Index }}">
     <input type="hidden" name="x_action" value="select_channel">

--- a/resources/authgear/templates/en/web/authflowv2/__otp_input.html
+++ b/resources/authgear/templates/en/web/authflowv2/__otp_input.html
@@ -62,7 +62,12 @@
   </div>
 
   {{ if not $.ResendButtonHidden }}
-    <form method="post" novalidate>
+    <form
+      method="post"
+      novalidate
+      data-controller="turbo-form"
+      data-action="submit->turbo-form#submitForm"
+    >
       {{ $.CSRFField }}
       <button
         id="resend-button"

--- a/resources/authgear/templates/en/web/authflowv2/__page_frame.html
+++ b/resources/authgear/templates/en/web/authflowv2/__page_frame.html
@@ -19,7 +19,8 @@
 {{ end }}
 
 <body
-  data-controller="prevent-double-tap xhr-submit-form lockout restore-form loading authflow-passkey-error"
+  {{/* "loading" is assumed to be defined in document.body["data-controller"] in TurboFormController */}}
+  data-controller="prevent-double-tap lockout restore-form loading authflow-passkey-error"
   data-restore-form-json-value="{{ $.FormJSON }}"
   data-action="dblclick->prevent-double-tap#action"
   data-inline-preview-previewable-resource-outlet=".translated-message,.brand-logo"

--- a/resources/authgear/templates/en/web/authflowv2/account_linking.html
+++ b/resources/authgear/templates/en/web/authflowv2/account_linking.html
@@ -21,7 +21,13 @@
     <div
       class="flex flex-col gap-y-4">
       {{- range $.Options }}
-        <form class="contents" method="post" novalidate>
+        <form
+          class="contents"
+          method="post"
+          novalidate
+          data-controller="turbo-form"
+          data-action="submit->turbo-form#submitForm"
+        >
           {{ $.CSRFField }}
           {{- if eq .Identification "email" }}
             <button

--- a/resources/authgear/templates/en/web/authflowv2/change_password.html
+++ b/resources/authgear/templates/en/web/authflowv2/change_password.html
@@ -32,6 +32,8 @@
     method="post"
     novalidate
     class="flex flex-col gap-y-4 mt-8"
+    data-controller="turbo-form"
+    data-action="submit->turbo-form#submitForm"
   >
   {{ $.CSRFField }}
 

--- a/resources/authgear/templates/en/web/authflowv2/change_password_success.html
+++ b/resources/authgear/templates/en/web/authflowv2/change_password_success.html
@@ -1,6 +1,12 @@
 {{ template "authflowv2/__page_frame.html" . }}
 {{ define "page-content" }}
-<form method="post" novalidate class="flex-1-0-auto screen-icon-layout tablet:flex-none" >
+<form
+  method="post"
+  novalidate
+  class="flex-1-0-auto screen-icon-layout tablet:flex-none"
+  data-controller="turbo-form"
+  data-action="submit->turbo-form#submitForm"
+>
   {{ $.CSRFField }}
   <i class="material-icons screen-icon">check_circle</i>
   <header class="screen-title-description">

--- a/resources/authgear/templates/en/web/authflowv2/create_password.html
+++ b/resources/authgear/templates/en/web/authflowv2/create_password.html
@@ -21,6 +21,8 @@
     method="post"
     novalidate
     class="flex flex-col gap-y-4"
+    data-controller="turbo-form"
+    data-action="submit->turbo-form#submitForm"
   >
     {{ $.CSRFField }}
     {{ if $.PasswordManagerUsername }}

--- a/resources/authgear/templates/en/web/authflowv2/enter_oob_otp.html
+++ b/resources/authgear/templates/en/web/authflowv2/enter_oob_otp.html
@@ -51,7 +51,8 @@
       <form 
         id="main-form" 
         method="post"
-        novalidatedata-restore-form="false"
+        novalidate
+        data-restore-form="false"
         data-controller="turbo-form"
         data-action="submit->turbo-form#submitForm"
       >

--- a/resources/authgear/templates/en/web/authflowv2/enter_oob_otp.html
+++ b/resources/authgear/templates/en/web/authflowv2/enter_oob_otp.html
@@ -48,7 +48,13 @@
         {{ end }}
       {{ end }}
 
-      <form id="main-form" method="post" novalidate data-restore-form="false">
+      <form 
+        id="main-form" 
+        method="post"
+        novalidatedata-restore-form="false"
+        data-controller="turbo-form"
+        data-action="submit->turbo-form#submitForm"
+      >
         {{ $.CSRFField }}
       </form>
 

--- a/resources/authgear/templates/en/web/authflowv2/enter_password.html
+++ b/resources/authgear/templates/en/web/authflowv2/enter_password.html
@@ -38,7 +38,13 @@
       )
     }}
   </header>
-  <form method="POST" novalidate class="flex flex-col gap-y-4 items-center">
+  <form 
+    method="POST"
+    novalidate
+    class="flex flex-col gap-y-4 items-center"
+    data-controller="turbo-form"
+    data-action="submit->turbo-form#submitForm"
+  >
     {{ $.CSRFField }}
     <!-- This field is for Chrome and Safari to correctly associate the username with the password -->
     <!-- both `class="hidden"` and `display:none` do not work for iOS autofill -->

--- a/resources/authgear/templates/en/web/authflowv2/enter_recovery_code.html
+++ b/resources/authgear/templates/en/web/authflowv2/enter_recovery_code.html
@@ -31,7 +31,13 @@
       }}
     </div>
 
-    <form id="main-form" method="post" novalidate>
+    <form
+      id="main-form"
+      method="post"
+      novalidate
+      data-controller="turbo-form"
+      data-action="submit->turbo-form#submitForm"
+    >
       {{ $.CSRFField }}
 
       {{ $input_error_message := "" }}

--- a/resources/authgear/templates/en/web/authflowv2/enter_totp.html
+++ b/resources/authgear/templates/en/web/authflowv2/enter_totp.html
@@ -40,7 +40,14 @@
         {{ end }}
       {{ end }}
 
-      <form id="main-form" method="post" novalidate data-restore-form="false">
+      <form
+        id="main-form"
+        method="post"
+        novalidate
+        data-restore-form="false"
+        data-controller="turbo-form"
+        data-action="submit->turbo-form#submitForm"
+      >
         {{ $.CSRFField }}
       </form>
 

--- a/resources/authgear/templates/en/web/authflowv2/forgot_password.html
+++ b/resources/authgear/templates/en/web/authflowv2/forgot_password.html
@@ -33,7 +33,13 @@
         }}
       </header>
       {{ if or $show_email_input $show_phone_input }}
-        <form class="flex flex-col gap-4" method="post" novalidate>
+        <form 
+          class="flex flex-col gap-4"
+          method="post"
+          novalidate
+          data-controller="turbo-form"
+          data-action="submit->turbo-form#submitForm"
+        >
           {{ $.CSRFField }}
           <div data-controller="text-field" class="flex flex-col gap-2">
             {{ if $show_email_input }}
@@ -109,7 +115,12 @@
         </p>
       </header>
       <footer class="flex flex-col gap-8" method="post" novalidate>
-        <form method="post" novalidate>
+        <form
+          method="post"
+          novalidate
+          data-controller="turbo-form"
+          data-action="submit->turbo-form#submitForm"
+        >
           {{ $.CSRFField }}
           <input type="hidden" name="x_login_id_type" value="{{ $.LoginIDInputType }}">
           <input type="hidden" name="x_login_id" value="{{ $.LoginID }}">

--- a/resources/authgear/templates/en/web/authflowv2/forgot_password_link_sent.html
+++ b/resources/authgear/templates/en/web/authflowv2/forgot_password_link_sent.html
@@ -1,6 +1,12 @@
 {{ template "authflowv2/__page_frame.html" . }}
 {{ define "page-content" }}
-  <form class="screen-icon-layout flex-1-0-auto" method="post" novalidate>
+  <form
+    class="screen-icon-layout flex-1-0-auto"
+    method="post"
+    novalidate
+    data-controller="turbo-form"
+    data-action="submit->turbo-form#submitForm"
+  >
     <i class="screen-icon material-icons">forward_to_inbox</i>
 
     <header class="screen-title-description">

--- a/resources/authgear/templates/en/web/authflowv2/forgot_password_otp.html
+++ b/resources/authgear/templates/en/web/authflowv2/forgot_password_otp.html
@@ -37,7 +37,14 @@
         {{ end }}
       {{ end }}
 
-      <form id="main-form" method="post" novalidate data-restore-form="false">
+      <form
+        id="main-form"
+        method="post"
+        novalidate
+        data-restore-form="false"
+        data-controller="turbo-form"
+        data-action="submit->turbo-form#submitForm"
+      >
         {{ $.CSRFField }}
       </form>
 

--- a/resources/authgear/templates/en/web/authflowv2/login.html
+++ b/resources/authgear/templates/en/web/authflowv2/login.html
@@ -88,12 +88,14 @@
     {{ if $.InlinePreview }}
       {{ $formController = "" }}
     {{ end }}
+    {{/* Form with disabled turbo drive, submit button has data-turbo="false" */}}
     <form
       class="flex flex-col gap-4 mt-8"
       method="post"
       novalidate
       data-controller="{{ $formController }}"
-      data-retain-form-form-id-value="auth-form">
+      data-retain-form-form-id-value="auth-form"
+    >
       {{ $.CSRFField }}
       <input type="hidden" name="x_login_id_input_type" value="{{ $.LoginIDInputType }}"/>
 
@@ -214,6 +216,7 @@
             {{ end }}
 
             {{- if not $skip -}}
+              {{/* Form with disabled turbo drive, submit button has data-turbo="false" */}}
               <form class="block" method="post" data-turbo="false" novalidate>
                 {{ $.CSRFField }}
                 <input type="hidden" name="x_provider_alias" value="{{ .provider_alias }}">
@@ -259,7 +262,13 @@
               </div>
               </span>
             </button>
-            <form class="hidden" method="post" novalidate>
+            <form
+              class="hidden"
+              method="post"
+              novalidate
+              data-controller="turbo-form"
+              data-action="submit->turbo-form#submitForm"
+            >
               {{ $.CSRFField }}
               <input type="hidden" name="x_assertion_response" data-authflow-passkey-request-target="input">
               <button type="submit" class="hidden" name="x_action" value="passkey" data-authflow-passkey-request-target="submit"></button>

--- a/resources/authgear/templates/en/web/authflowv2/login.html
+++ b/resources/authgear/templates/en/web/authflowv2/login.html
@@ -88,13 +88,14 @@
     {{ if $.InlinePreview }}
       {{ $formController = "" }}
     {{ end }}
-    {{/* Form with disabled turbo drive, submit button has data-turbo="false" */}}
+    {{/* Form with disabled turbo drive */}}
     <form
       class="flex flex-col gap-4 mt-8"
       method="post"
       novalidate
       data-controller="{{ $formController }}"
       data-retain-form-form-id-value="auth-form"
+      data-turbo="false"
     >
       {{ $.CSRFField }}
       <input type="hidden" name="x_login_id_input_type" value="{{ $.LoginIDInputType }}"/>
@@ -161,7 +162,6 @@
           {{/* rejected with a NotAllowedError immediately after invocation. */}}
           {{/* Therefore, in this page, we opt-out for Turbo form submission. */}}
           {{/* Then the next page can use modal mediation normally. */}}
-          data-turbo="false"
           data-authgear-event="authgear.button.sign_in"
         >{{ template "v2-button-label-login" }}</button>
       {{ end }}
@@ -216,7 +216,7 @@
             {{ end }}
 
             {{- if not $skip -}}
-              {{/* Form with disabled turbo drive, submit button has data-turbo="false" */}}
+              {{/* Form with disabled turbo drive */}}
               <form class="block" method="post" data-turbo="false" novalidate>
                 {{ $.CSRFField }}
                 <input type="hidden" name="x_provider_alias" value="{{ .provider_alias }}">
@@ -225,7 +225,6 @@
                   type="submit"
                   name="x_action"
                   value="oauth"
-                  data-turbo="false"
                   data-authgear-event="authgear.button.oauth"
                 >
                   {{- $icon_class := printf "%s-icon" .provider_type -}}

--- a/resources/authgear/templates/en/web/authflowv2/oob_otp_link.html
+++ b/resources/authgear/templates/en/web/authflowv2/oob_otp_link.html
@@ -1,7 +1,14 @@
 {{ template "authflowv2/__page_frame.html" . }}
 {{ define "page-content" }}
 {{- if eq $.StateQuery "matched" }}
-  <form id="next-form" class="screen-icon-layout flex-1-0-auto" method="post" novalidate>
+  <form
+    id="next-form"
+    class="screen-icon-layout flex-1-0-auto"
+    method="post"
+    novalidate
+    data-controller="turbo-form"
+    data-action="submit->turbo-form#submitForm"
+  >
     <i class="screen-icon material-icons">check_circle</i>
     <header class="screen-title-description">
       <h1 class="screen-title">
@@ -73,14 +80,20 @@
   {{- if $.WebsocketURL }}
   <div class="hidden" data-controller="authflow-websocket authflow-polling" data-authflow-websocket-url-value="{{ $.WebsocketURL }}" data-authflow-polling-statetoken-value="{{ $.StateToken }}"></div>
   {{- end }}
-  <form method="post" novalidate>
+  <form
+    method="post"
+    novalidate
+    data-controller="turbo-form"
+    data-action="submit->turbo-form#submitForm"
+  >
     {{ $.CSRFField }}
     <button
       class="primary-btn w-full"
       type="submit"
       name="x_action"
       value="resend"
-      data-controller="countdown"
+      data-controller="countdown turbo-form"
+      data-action="submit->turbo-form#submitForm"
       data-countdown-target="button"
       data-countdown-cooldown-value="{{ $.ResendCooldown }}"
       data-countdown-label-value='{{ template "v2-login-link-otp-resend-button-label" }}'

--- a/resources/authgear/templates/en/web/authflowv2/oob_otp_link.html
+++ b/resources/authgear/templates/en/web/authflowv2/oob_otp_link.html
@@ -92,8 +92,7 @@
       type="submit"
       name="x_action"
       value="resend"
-      data-controller="countdown turbo-form"
-      data-action="submit->turbo-form#submitForm"
+      data-controller="countdown"
       data-countdown-target="button"
       data-countdown-cooldown-value="{{ $.ResendCooldown }}"
       data-countdown-label-value='{{ template "v2-login-link-otp-resend-button-label" }}'

--- a/resources/authgear/templates/en/web/authflowv2/prompt_create_passkey.html
+++ b/resources/authgear/templates/en/web/authflowv2/prompt_create_passkey.html
@@ -32,7 +32,12 @@
         >
         {{ template "v2-button-label-continue" }}
       </button>
-      <form method="post" novalidate>
+      <form
+        method="post"
+        novalidate
+        data-controller="turbo-form"
+        data-action="submit->turbo-form#submitForm"
+      >
         {{ $.CSRFField }}
         <button
           class="label-btn w-full"
@@ -44,7 +49,13 @@
         </button>
       </form>
     </footer>
-    <form class="hidden" method="post" novalidate>
+    <form
+      class="hidden"
+      method="post"
+      novalidate
+      data-controller="turbo-form"
+      data-action="submit->turbo-form#submitForm"
+    >
       {{ $.CSRFField }}
       <input
         type="hidden"

--- a/resources/authgear/templates/en/web/authflowv2/reset_password.html
+++ b/resources/authgear/templates/en/web/authflowv2/reset_password.html
@@ -40,6 +40,8 @@
     method="post"
     novalidate
     class="flex flex-col gap-y-4 mt-8"
+    data-controller="turbo-form"
+    data-action="submit->turbo-form#submitForm"
   >
   {{ $.CSRFField }}
 

--- a/resources/authgear/templates/en/web/authflowv2/select_account.html
+++ b/resources/authgear/templates/en/web/authflowv2/select_account.html
@@ -1,8 +1,8 @@
 {{ template "authflowv2/__page_frame.html" . }}
 {{ define "page-content" }}
 
-{{/* Form with disabled turbo drive, submit button has data-turbo="false" */}}
-<form class="screen-icon-layout flex-1-0-auto" method="post" novalidate>
+{{/* Form with disabled turbo drive */}}
+<form class="screen-icon-layout flex-1-0-auto" method="post" novalidate data-turbo="false">
   {{ $.CSRFField }}
   <i class="screen-icon material-icons">account_circle</i>
   <header class="screen-title-description">
@@ -32,7 +32,6 @@
       type="submit"
       name="x_action"
       value="continue"
-      data-turbo="false"
       data-authgear-event="authgear.button.continue_with_current_account"
       >
       {{ template "v2-button-label-continue" }}
@@ -42,7 +41,6 @@
       type="submit"
       name="x_action"
       value="login"
-      data-turbo="false"
       data-authgear-event="authgear.button.use_another_account"
       >
       {{ template "v2-select-account-use-another-account" }}

--- a/resources/authgear/templates/en/web/authflowv2/select_account.html
+++ b/resources/authgear/templates/en/web/authflowv2/select_account.html
@@ -1,6 +1,7 @@
 {{ template "authflowv2/__page_frame.html" . }}
 {{ define "page-content" }}
 
+{{/* Form with disabled turbo drive, submit button has data-turbo="false" */}}
 <form class="screen-icon-layout flex-1-0-auto" method="post" novalidate>
   {{ $.CSRFField }}
   <i class="screen-icon material-icons">account_circle</i>

--- a/resources/authgear/templates/en/web/authflowv2/setup_oob_otp.html
+++ b/resources/authgear/templates/en/web/authflowv2/setup_oob_otp.html
@@ -35,7 +35,12 @@
       }}
     </div>
 
-    <form method="post" novalidate>
+    <form
+      method="post"
+      novalidate
+      data-controller="turbo-form"
+      data-action="submit->turbo-form#submitForm"
+    >
       {{ $.CSRFField }}
 
       {{ $otp_error_message := "" }}

--- a/resources/authgear/templates/en/web/authflowv2/setup_totp_verify.html
+++ b/resources/authgear/templates/en/web/authflowv2/setup_totp_verify.html
@@ -33,7 +33,14 @@
         {{ end }}
       {{ end }}
 
-      <form id="main-form" method="post" novalidate data-restore-form="false">
+      <form
+        id="main-form"
+        method="post"
+        novalidate
+        data-restore-form="false"
+        data-controller="turbo-form"
+        data-action="submit->turbo-form#submitForm" 
+      >
         {{ $.CSRFField }}
       </form>
 

--- a/resources/authgear/templates/en/web/authflowv2/signup.html
+++ b/resources/authgear/templates/en/web/authflowv2/signup.html
@@ -202,7 +202,7 @@
           {{ end }}
 
           {{- if not $skip -}}
-            {{/* Form with disabled turbo drive, submit button has data-turbo="false" */}}
+            {{/* Form with disabled turbo drive */}}
             <form class="block" method="post" data-turbo="false" novalidate>
               {{ $.CSRFField }}
               <input type="hidden" name="x_provider_alias" value="{{ .provider_alias }}">
@@ -211,7 +211,6 @@
                 type="submit"
                 name="x_action"
                 value="oauth"
-                data-turbo="false"
                 data-authgear-event="authgear.button.oauth"
               >
                 {{- $icon_class := printf "%s-icon" .provider_type -}}

--- a/resources/authgear/templates/en/web/authflowv2/signup.html
+++ b/resources/authgear/templates/en/web/authflowv2/signup.html
@@ -83,7 +83,10 @@
     method="post"
     novalidate
     data-controller="{{ $formController }}"
-    data-retain-form-form-id-value="auth-form">
+    data-retain-form-form-id-value="auth-form"
+    data-controller="turbo-form"
+    data-action="submit->turbo-form#submitForm"
+  >
     {{ $.CSRFField }}
     <input type="hidden" name="q_login_id_key" value="{{ $.LoginIDKey }}">
     {{ range $.IdentityCandidates }}
@@ -199,6 +202,7 @@
           {{ end }}
 
           {{- if not $skip -}}
+            {{/* Form with disabled turbo drive, submit button has data-turbo="false" */}}
             <form class="block" method="post" data-turbo="false" novalidate>
               {{ $.CSRFField }}
               <input type="hidden" name="x_provider_alias" value="{{ .provider_alias }}">
@@ -245,7 +249,13 @@
             </div>
             </span>
           </button>
-          <form class="hidden" method="post" novalidate>
+          <form
+            class="hidden"
+            method="post"
+            novalidate
+            data-controller="turbo-form"
+            data-action="submit->turbo-form#submitForm"
+          >
             {{ $.CSRFField }}
             <input type="hidden" name="x_assertion_response" data-authflow-passkey-request-target="input">
             <button type="submit" class="hidden" name="x_action" value="passkey" data-authflow-passkey-request-target="submit"></button>

--- a/resources/authgear/templates/en/web/authflowv2/terminate_other_sessions.html
+++ b/resources/authgear/templates/en/web/authflowv2/terminate_other_sessions.html
@@ -1,6 +1,7 @@
 {{ template "authflowv2/__page_frame.html" . }}
 
 {{ define "page-content" }}
+  {{/* Form with disabled turbo drive, submit button has data-turbo="false" */}}
   <form class="screen-icon-layout flex-1-0-auto" method="post" novalidate>
     {{ $.CSRFField }}
     <i class="material-icons screen-icon">phone_iphone</i>

--- a/resources/authgear/templates/en/web/authflowv2/terminate_other_sessions.html
+++ b/resources/authgear/templates/en/web/authflowv2/terminate_other_sessions.html
@@ -1,8 +1,13 @@
 {{ template "authflowv2/__page_frame.html" . }}
 
 {{ define "page-content" }}
-  {{/* Form with disabled turbo drive, submit button has data-turbo="false" */}}
-  <form class="screen-icon-layout flex-1-0-auto" method="post" novalidate>
+  {{/* Form with disabled turbo drive */}}
+  <form
+    class="screen-icon-layout flex-1-0-auto"
+    method="post"
+    novalidate
+    data-turbo="false"
+  >
     {{ $.CSRFField }}
     <i class="material-icons screen-icon">phone_iphone</i>
     <header class="screen-title-description">
@@ -24,7 +29,6 @@
         type="submit"
         name="x_action"
         value="confirm"
-        data-turbo="false"
         data-authgear-event="authgear.button.confirm_terminate_other_sessions"
       >
         {{ template "v2-button-label-continue" }}
@@ -34,7 +38,6 @@
         type="submit"
         name="x_action"
         value="cancel"
-        data-turbo="false"
         data-authgear-event="authgear.button.cancel_terminate_other_sessions"
       >
         {{ template "v2-confirm-terminate-other-sessions-cancel-button-label" }}

--- a/resources/authgear/templates/en/web/authflowv2/use_passkey.html
+++ b/resources/authgear/templates/en/web/authflowv2/use_passkey.html
@@ -40,7 +40,13 @@
       >
         {{ template "v2-use-passkey-action" }}
       </button>
-      <form class="hidden" method="post" novalidate>
+      <form
+        class="hidden"
+        method="post"
+        novalidate
+        data-controller="turbo-form"
+        data-action="submit->turbo-form#submitForm"
+      >
         {{ $.CSRFField }}
         <input type="hidden" name="x_assertion_response" data-authflow-passkey-request-target="input">
         <button type="submit" class="hidden" name="x_action" value="" data-authflow-passkey-request-target="submit"></button>

--- a/resources/authgear/templates/en/web/authflowv2/verify_login_link.html
+++ b/resources/authgear/templates/en/web/authflowv2/verify_login_link.html
@@ -32,7 +32,10 @@
       class="flex-1-0-auto flex flex-col pt-32 gap-4"
       method="post"
       action="{{ $.FormActionPath }}"
-      novalidate>
+      novalidate
+      data-controller="turbo-form"
+      data-action="submit->turbo-form#submitForm"
+    >
       {{ $.CSRFField }}
       <input type="hidden" name="x_oob_otp_code" value="{{ .Code }}">
       <h1 class="screen-title">{{ template "v2-verify-login-link-title" }}</h1>

--- a/resources/authgear/templates/en/web/authflowv2/view_recovery_code.html
+++ b/resources/authgear/templates/en/web/authflowv2/view_recovery_code.html
@@ -25,7 +25,13 @@
     <code id="copy-button-source" class="hidden">{{ template "__recovery_code.html" . }}</code>
     <div class="mt-5 w-full grid gap-4 {{ if not .IsNativePlatform }}grid-cols-2{{ else }}grid-cols-1{{ end }}">
       {{ if not .IsNativePlatform }}
-      <form id="download-form" method="post" novalidate target="_blank">
+      {{/* Form with disabled turbo drive, submit button has data-turbo="false" */}}
+      <form
+        id="download-form"
+        method="post"
+        novalidate
+        target="_blank"
+      >
         {{ $.CSRFField }}
         <button
           form="download-form"
@@ -51,7 +57,12 @@
     </div>
   </div>
 
-  <form method="post" novalidate>
+  <form
+    method="post"
+    novalidate
+    data-controller="turbo-form"
+    data-action="submit->turbo-form#submitForm"
+  >
     {{ $.CSRFField }}
     <button class="btn primary-btn w-full" type="submit" name="x_action" value="proceed">
     {{ template "v2-button-label-continue" }}

--- a/resources/authgear/templates/en/web/authflowv2/view_recovery_code.html
+++ b/resources/authgear/templates/en/web/authflowv2/view_recovery_code.html
@@ -25,12 +25,13 @@
     <code id="copy-button-source" class="hidden">{{ template "__recovery_code.html" . }}</code>
     <div class="mt-5 w-full grid gap-4 {{ if not .IsNativePlatform }}grid-cols-2{{ else }}grid-cols-1{{ end }}">
       {{ if not .IsNativePlatform }}
-      {{/* Form with disabled turbo drive, submit button has data-turbo="false" */}}
+      {{/* Form with disabled turbo drive */}}
       <form
         id="download-form"
         method="post"
         novalidate
         target="_blank"
+        data-turbo="false"
       >
         {{ $.CSRFField }}
         <button
@@ -39,7 +40,6 @@
           type="submit"
           name="x_action"
           value="download"
-          data-turbo="false"
         >
           {{ template "download-button-label" }}
         </button>

--- a/resources/authgear/templates/en/web/authflowv2/wechat.html
+++ b/resources/authgear/templates/en/web/authflowv2/wechat.html
@@ -31,6 +31,8 @@
     data-controller="click-to-switch"
     method="post"
     novalidate
+    data-controller="turbo-form"
+    data-action="submit->turbo-form#submitForm"
   >
   {{ $.CSRFField }}
 


### PR DESCRIPTION
<details>
<summary>Outdated</summary>

## Motivation
As per offline discussion, it was found that `<form>` `submit` events using stimulius syntax like below did not stop other methods the form from submitting


```html
<!-- html -->
<form
...
data-action="submit->someController#someMethod"
>
...
```

```ts
// someController.ts

class SomeController extends Controller {
  someMethod(e: Event) {
    e.preventDefault()
    e.stopImmediatePropagation() // This did not stop other actions
  }
}

```

This PR exists to make `e.stopImmediatePropagation` in `someMethod` works as expected



</details>

## Regression Test

Tested turbo-enabled forms submission, still behaves like SPA

## How are you sure all forms are updated?

Total 36 forms

```bash
rg '<form' ./resources/authgear/templates/en/web/authflowv2 | rg '<form' -c
```

30 forms have `data-controller="turbo-form"` added

```bash
rg '<form' ./resources/authgear/templates/en/web/authflowv2 -C 10 | rg 'data-controller="turbo-form"' -c
```

6 forms were originally turbo-disabled form, added comment to specify

```bash
rg '<form' ./resources/authgear/templates/en/web/authflowv2 -C 5 | rg 'Form with disabled' -c
```