### PR TITLE
Fix missing nil err return in bot protection verification logic

### DIFF
--- a/pkg/lib/botprotection/provider.go
+++ b/pkg/lib/botprotection/provider.go
@@ -43,6 +43,8 @@ func (p *Provider) Verify(token string) (err error) {
 		err = p.verifyTokenByCloudflare(token)
 	case config.BotProtectionProviderTypeRecaptchaV2:
 		err = p.verifyTokenByRecaptchaV2(token)
+	default:
+		panic(fmt.Errorf("unknown bot_protection provider"))
 	}
 
 	if errors.Is(err, ErrVerificationFailed) {
@@ -53,11 +55,7 @@ func (p *Provider) Verify(token string) (err error) {
 		err = errors.Join(err, dispatchErr)
 	}
 
-	if err != nil {
-		return err
-	}
-
-	return fmt.Errorf("unknown bot_protection provider")
+	return
 }
 
 func (p *Provider) verifyTokenByCloudflare(token string) error {


### PR DESCRIPTION
## What's in this PR?

Fix e2e tests failing on `authgear/main` after #4493 is merged

The problem - `err == nil` case not handled. 

e2e tests pass locally now

```
ok  	github.com/authgear/authgear-server/e2e/pkg/testrunner	16.735s
```

Sorry for all inconvenience caused 🙏  