### PR TITLE
Allow captcha configuration in signup create_authenticator oob_otp

### DIFF
--- a/e2e/tests/bot_protection/signup/create_authenticator/primary_oob_otp_email/error_missing_required_field.test.yaml
+++ b/e2e/tests/bot_protection/signup/create_authenticator/primary_oob_otp_email/error_missing_required_field.test.yaml
@@ -1,0 +1,112 @@
+name: Signup with Bot Protection - Create Authenticator - Primary OOB OTP Email - Missing Bot Protection Required Field
+authgear.yaml:
+  override: |
+    bot_protection:
+      enabled: true
+      provider:
+        type: cloudflare
+        site_key: dummy
+    authentication_flow:
+      signup_flows:
+      - name: f1
+        steps:
+        - name: signup_identify
+          type: identify
+          one_of:
+          - identification: email
+            steps:
+            - name: authenticate_primary_email
+              type: create_authenticator
+              one_of:
+              - authentication: primary_oob_otp_email
+                bot_protection:
+                  mode: always
+                  provider: 
+                    type: cloudflare
+steps:
+  - action: "create"
+    input: |
+      {
+        "type": "signup",
+        "name": "f1"
+      }
+    output:
+      result: |
+        {
+          "action": {
+            "type": "identify",
+            "data": {
+              "options": [
+                "[[arrayof]]",
+                {
+                  "identification": "email"
+                }
+              ]
+            }
+          }
+        }
+  - action: input
+    input: |
+      {
+        "identification": "email",
+        "login_id": "signup_bp_email@example.com"
+      }
+    output: 
+      result: |
+        {
+          "action": {
+            "type": "create_authenticator",
+            "data": {
+              "options": [
+                "[[arrayof]]",
+                {
+                  "authentication": "primary_oob_otp_email",
+                  "bot_protection": {
+                    "enabled": true,
+                    "provider": {
+                      "type": "cloudflare"
+                    }
+                  },
+                  "channels": [
+                    "[[arrayof]]",
+                    "email"
+                  ],
+                  "otp_form": "link"
+                }
+              ]
+            }
+          }
+        }
+  - action: input
+    input: |
+      {
+        "authentication": "primary_oob_otp_email",
+        "target": "signup_bp_email@example.com",
+        "bot_protection": {
+          "invalid_field": "invalid_value"
+        }
+      }
+    output: 
+      error: |
+        {
+          "name": "Invalid",
+          "reason": "ValidationFailed",
+          "message": "invalid value",
+          "code": 400,
+          "info": {
+            "causes": [
+              "[[arrayof]]",
+              {
+                "details": {
+                  "actual": [
+                    "[[arrayof]]",
+                    "invalid_field"
+                  ],
+                  "missing": "[[array]]"
+                },
+                "kind": "required",
+                "location": "/bot_protection"
+              }
+            ]
+          }
+        }

--- a/e2e/tests/bot_protection/signup/create_authenticator/primary_oob_otp_email/fail.test.yaml
+++ b/e2e/tests/bot_protection/signup/create_authenticator/primary_oob_otp_email/fail.test.yaml
@@ -1,0 +1,97 @@
+name: Signup with Bot Protection - Create Authenticator - Primary OOB OTP Email - Bot Protection Verification Fail
+authgear.yaml:
+  override: |
+    bot_protection:
+      enabled: true
+      provider:
+        type: cloudflare
+        site_key: dummy
+    authentication_flow:
+      signup_flows:
+      - name: f1
+        steps:
+        - name: signup_identify
+          type: identify
+          one_of:
+          - identification: email
+            steps:
+            - name: authenticate_primary_email
+              type: create_authenticator
+              one_of:
+              - authentication: primary_oob_otp_email
+                bot_protection:
+                  mode: always
+                  provider: 
+                    type: cloudflare
+steps:
+  - action: "create"
+    input: |
+      {
+        "type": "signup",
+        "name": "f1"
+      }
+    output:
+      result: |
+        {
+          "action": {
+            "type": "identify",
+            "data": {
+              "options": [
+                "[[arrayof]]",
+                {
+                  "identification": "email"
+                }
+              ]
+            }
+          }
+        }
+  - action: input
+    input: |
+      {
+        "identification": "email",
+        "login_id": "signup_bp_email@example.com"
+      }
+    output: 
+      result: |
+        {
+          "action": {
+            "type": "create_authenticator",
+            "data": {
+              "options": [
+                "[[arrayof]]",
+                {
+                  "authentication": "primary_oob_otp_email",
+                  "bot_protection": {
+                    "enabled": true,
+                    "provider": {
+                      "type": "cloudflare"
+                    }
+                  },
+                  "channels": [
+                    "[[arrayof]]",
+                    "email"
+                  ],
+                  "otp_form": "link"
+                }
+              ]
+            }
+          }
+        }
+  - action: input
+    input: |
+      {
+        "authentication": "primary_oob_otp_email",
+        "target": "signup_bp_email@example.com",
+        "bot_protection": {
+          "type": "cloudflare",
+          "response": "fail"
+        }
+      }
+    output: 
+      error: |
+        {
+          "name": "Forbidden",
+          "reason": "BotProtectionVerificationFailed",
+          "message": "bot protection verification failed",
+          "code": 403
+        }

--- a/e2e/tests/bot_protection/signup/create_authenticator/primary_oob_otp_email/sucess.test.yaml
+++ b/e2e/tests/bot_protection/signup/create_authenticator/primary_oob_otp_email/sucess.test.yaml
@@ -101,3 +101,5 @@ steps:
             }
           }
         }
+# TODO: Finish this flow when verify_login_link action is supported
+    

--- a/e2e/tests/bot_protection/signup/create_authenticator/primary_oob_otp_email/sucess.test.yaml
+++ b/e2e/tests/bot_protection/signup/create_authenticator/primary_oob_otp_email/sucess.test.yaml
@@ -1,0 +1,103 @@
+name: Signup with Bot Protection - Create Authenticator - Primary OOB OTP Email - Bot Protection Verification Success
+authgear.yaml:
+  override: |
+    bot_protection:
+      enabled: true
+      provider:
+        type: cloudflare
+        site_key: dummy
+    authentication_flow:
+      signup_flows:
+      - name: f1
+        steps:
+        - name: signup_identify
+          type: identify
+          one_of:
+          - identification: email
+            steps:
+            - name: authenticate_primary_email
+              type: create_authenticator
+              one_of:
+              - authentication: primary_oob_otp_email
+                bot_protection:
+                  mode: always
+                  provider: 
+                    type: cloudflare
+steps:
+  - action: "create"
+    input: |
+      {
+        "type": "signup",
+        "name": "f1"
+      }
+    output:
+      result: |
+        {
+          "action": {
+            "type": "identify",
+            "data": {
+              "options": [
+                "[[arrayof]]",
+                {
+                  "identification": "email"
+                }
+              ]
+            }
+          }
+        }
+  - action: input
+    input: |
+      {
+        "identification": "email",
+        "login_id": "signup_bp_email@example.com"
+      }
+    output: 
+      result: |
+        {
+          "action": {
+            "type": "create_authenticator",
+            "data": {
+              "options": [
+                "[[arrayof]]",
+                {
+                  "authentication": "primary_oob_otp_email",
+                  "bot_protection": {
+                    "enabled": true,
+                    "provider": {
+                      "type": "cloudflare"
+                    }
+                  },
+                  "channels": [
+                    "[[arrayof]]",
+                    "email"
+                  ],
+                  "otp_form": "link"
+                }
+              ]
+            }
+          }
+        }
+  - action: input
+    input: |
+      {
+        "authentication": "primary_oob_otp_email",
+        "target": "signup_bp_email@example.com",
+        "bot_protection": {
+          "type": "cloudflare",
+          "response": "pass"
+        }
+      }
+    output: 
+      result: |
+        {
+          "action": {
+            "authentication": "primary_oob_otp_email",
+            "data": {
+              "channel": "email",
+              "code_length": 32,
+              "masked_claim_value": "signup_********@example.com",
+              "otp_form": "link",
+              "type": "verify_oob_otp_data"
+            }
+          }
+        }

--- a/e2e/tests/bot_protection/signup/create_authenticator/primary_oob_otp_sms/error_missing_required_field.test.yaml
+++ b/e2e/tests/bot_protection/signup/create_authenticator/primary_oob_otp_sms/error_missing_required_field.test.yaml
@@ -1,0 +1,112 @@
+name: Signup with Bot Protection - Create Authenticator - Primary OOB OTP SMS - Missing Bot Protection Required Field
+authgear.yaml:
+  override: |
+    bot_protection:
+      enabled: true
+      provider:
+        type: cloudflare
+        site_key: dummy
+    authentication_flow:
+      signup_flows:
+      - name: f1
+        steps:
+        - name: signup_identify
+          type: identify
+          one_of:
+          - identification: phone
+            steps:
+            - name: authenticate_primary_sms
+              type: create_authenticator
+              one_of:
+              - authentication: primary_oob_otp_sms
+                bot_protection:
+                  mode: always
+                  provider: 
+                    type: cloudflare
+steps:
+  - action: "create"
+    input: |
+      {
+        "type": "signup",
+        "name": "f1"
+      }
+    output:
+      result: |
+        {
+          "action": {
+            "type": "identify",
+            "data": {
+              "options": [
+                "[[arrayof]]",
+                {
+                  "identification": "phone"
+                }
+              ]
+            }
+          }
+        }
+  - action: input
+    input: |
+      {
+        "identification": "phone",
+        "login_id": "+85298765432"
+      }
+    output: 
+      result: |
+        {
+          "action": {
+            "type": "create_authenticator",
+            "data": {
+              "options": [
+                "[[arrayof]]",
+                {
+                  "authentication": "primary_oob_otp_sms",
+                  "bot_protection": {
+                    "enabled": true,
+                    "provider": {
+                      "type": "cloudflare"
+                    }
+                  },
+                  "channels": [
+                    "[[arrayof]]",
+                    "[[string]]"
+                  ],
+                  "otp_form": "code"
+                }
+              ]
+            }
+          }
+        }
+  - action: input
+    input: |
+      {
+        "authentication": "primary_oob_otp_sms",
+        "target": "+85298765432",
+        "bot_protection": {
+          "invalid_field": "invalid_value"
+        }
+      }
+    output: 
+      error: |
+        {
+          "name": "Invalid",
+          "reason": "ValidationFailed",
+          "message": "invalid value",
+          "code": 400,
+          "info": {
+            "causes": [
+              "[[arrayof]]",
+              {
+                "details": {
+                  "actual": [
+                    "[[arrayof]]",
+                    "invalid_field"
+                  ],
+                  "missing": "[[array]]"
+                },
+                "kind": "required",
+                "location": "/bot_protection"
+              }
+            ]
+          }
+        }

--- a/e2e/tests/bot_protection/signup/create_authenticator/primary_oob_otp_sms/fail.test.yaml
+++ b/e2e/tests/bot_protection/signup/create_authenticator/primary_oob_otp_sms/fail.test.yaml
@@ -1,0 +1,97 @@
+name: Signup with Bot Protection - Create Authenticator - Primary OOB OTP SMS - Bot Protection Verification Fail
+authgear.yaml:
+  override: |
+    bot_protection:
+      enabled: true
+      provider:
+        type: cloudflare
+        site_key: dummy
+    authentication_flow:
+      signup_flows:
+      - name: f1
+        steps:
+        - name: signup_identify
+          type: identify
+          one_of:
+          - identification: phone
+            steps:
+            - name: authenticate_primary_sms
+              type: create_authenticator
+              one_of:
+              - authentication: primary_oob_otp_sms
+                bot_protection:
+                  mode: always
+                  provider: 
+                    type: cloudflare
+steps:
+  - action: "create"
+    input: |
+      {
+        "type": "signup",
+        "name": "f1"
+      }
+    output:
+      result: |
+        {
+          "action": {
+            "type": "identify",
+            "data": {
+              "options": [
+                "[[arrayof]]",
+                {
+                  "identification": "phone"
+                }
+              ]
+            }
+          }
+        }
+  - action: input
+    input: |
+      {
+        "identification": "phone",
+        "login_id": "+85298765432"
+      }
+    output: 
+      result: |
+        {
+          "action": {
+            "type": "create_authenticator",
+            "data": {
+              "options": [
+                "[[arrayof]]",
+                {
+                  "authentication": "primary_oob_otp_sms",
+                  "bot_protection": {
+                    "enabled": true,
+                    "provider": {
+                      "type": "cloudflare"
+                    }
+                  },
+                  "channels": [
+                    "[[arrayof]]",
+                    "[[string]]"
+                  ],
+                  "otp_form": "code"
+                }
+              ]
+            }
+          }
+        }
+  - action: input
+    input: |
+      {
+        "authentication": "primary_oob_otp_sms",
+        "target": "+85298765432",
+        "bot_protection": {
+          "type": "cloudflare",
+          "response": "fail"
+        }
+      }
+    output: 
+      error: |
+        {
+          "name": "Forbidden",
+          "reason": "BotProtectionVerificationFailed",
+          "message": "bot protection verification failed",
+          "code": 403
+        }

--- a/e2e/tests/bot_protection/signup/create_authenticator/primary_oob_otp_sms/sucess.test.yaml
+++ b/e2e/tests/bot_protection/signup/create_authenticator/primary_oob_otp_sms/sucess.test.yaml
@@ -103,3 +103,36 @@ steps:
             }
           }
         }
+  - action: input
+    input: |
+      {
+        "channel": "sms"
+      }
+    output: 
+      result: |
+        {
+          "action": {
+            "type": "create_authenticator",
+            "authentication": "primary_oob_otp_sms",
+            "data": {
+              "channel": "sms",
+              "code_length": 6,
+              "failed_attempt_rate_limit_exceeded": false,
+              "masked_claim_value": "+8529876****",
+              "otp_form": "code",
+              "type": "verify_oob_otp_data"
+            }
+          }
+        }
+  - action: input
+    input: |
+      {
+        "code": "111111"
+      }
+    output: 
+      result: |
+        {
+          "action": {
+            "type": "finished"
+          }
+        }

--- a/e2e/tests/bot_protection/signup/create_authenticator/primary_oob_otp_sms/sucess.test.yaml
+++ b/e2e/tests/bot_protection/signup/create_authenticator/primary_oob_otp_sms/sucess.test.yaml
@@ -1,0 +1,105 @@
+name: Signup with Bot Protection - Create Authenticator - Primary OOB OTP SMS - Bot Protection Verification Success
+authgear.yaml:
+  override: |
+    bot_protection:
+      enabled: true
+      provider:
+        type: cloudflare
+        site_key: dummy
+    authentication_flow:
+      signup_flows:
+      - name: f1
+        steps:
+        - name: signup_identify
+          type: identify
+          one_of:
+          - identification: phone
+            steps:
+            - name: authenticate_primary_sms
+              type: create_authenticator
+              one_of:
+              - authentication: primary_oob_otp_sms
+                bot_protection:
+                  mode: always
+                  provider: 
+                    type: cloudflare
+steps:
+  - action: "create"
+    input: |
+      {
+        "type": "signup",
+        "name": "f1"
+      }
+    output:
+      result: |
+        {
+          "action": {
+            "type": "identify",
+            "data": {
+              "options": [
+                "[[arrayof]]",
+                {
+                  "identification": "phone"
+                }
+              ]
+            }
+          }
+        }
+  - action: input
+    input: |
+      {
+        "identification": "phone",
+        "login_id": "+85298765432"
+      }
+    output: 
+      result: |
+        {
+          "action": {
+            "type": "create_authenticator",
+            "data": {
+              "options": [
+                "[[arrayof]]",
+                {
+                  "authentication": "primary_oob_otp_sms",
+                  "bot_protection": {
+                    "enabled": true,
+                    "provider": {
+                      "type": "cloudflare"
+                    }
+                  },
+                  "channels": [
+                    "[[arrayof]]",
+                    "[[string]]"
+                  ],
+                  "otp_form": "code"
+                }
+              ]
+            }
+          }
+        }
+  - action: input
+    input: |
+      {
+        "authentication": "primary_oob_otp_sms",
+        "target": "+85298765432",
+        "bot_protection": {
+          "type": "cloudflare",
+          "response": "pass"
+        }
+      }
+    output: 
+      result: |
+        {
+          "action": {
+            "type": "create_authenticator",
+            "authentication": "primary_oob_otp_sms",
+            "data": {
+              "channels": [
+                "[[arrayof]]",
+                "[[string]]"
+              ],
+              "masked_claim_value": "+8529876****",
+              "type": "select_oob_otp_channels_data"
+            }
+          }
+        }

--- a/e2e/tests/bot_protection/signup/create_authenticator/secondary_oob_otp_email/error_missing_required_field.test.yaml
+++ b/e2e/tests/bot_protection/signup/create_authenticator/secondary_oob_otp_email/error_missing_required_field.test.yaml
@@ -1,0 +1,134 @@
+name: Signup with Bot Protection - Create Authenticator - Secondary OOB OTP Email - Missing Bot Protection Required Field
+authgear.yaml:
+  override: |
+    bot_protection:
+      enabled: true
+      provider:
+        type: cloudflare
+        site_key: dummy
+    authentication_flow:
+      signup_flows:
+      - name: f1
+        steps:
+        - name: signup_identify
+          type: identify
+          one_of:
+          - identification: username
+            steps:
+            - name: authenticate_primary_username
+              type: create_authenticator
+              one_of:
+              - authentication: primary_password
+            - name: authenticate_secondary_email
+              type: create_authenticator
+              one_of:
+              - authentication: secondary_oob_otp_email
+                bot_protection:
+                  mode: always
+                  provider: 
+                    type: cloudflare
+steps:
+  - action: "create"
+    input: |
+      {
+        "type": "signup",
+        "name": "f1"
+      }
+    output:
+      result: |
+        {
+          "action": {
+            "type": "identify",
+            "data": {
+              "options": [
+                "[[arrayof]]",
+                {
+                  "identification": "username"
+                }
+              ]
+            }
+          }
+        }
+  - action: input
+    input: |
+      {
+        "identification": "username",
+        "login_id": "signup_bp_username"
+      }
+    output: 
+      result: |
+        {
+          "action": {
+            "type": "create_authenticator",
+            "data": {
+              "options": [
+                "[[arrayof]]",
+                {
+                  "authentication": "primary_password"
+                }
+              ]
+            }
+          }
+        }
+  - action: input
+    input: |
+      {
+        "authentication": "primary_password",
+        "new_password": "signup_bp_primary_pwd"
+      }
+    output: 
+      result: |
+        {
+          "action": {
+            "type": "create_authenticator",
+            "data": {
+              "options": [
+                "[[arrayof]]",
+                {
+                  "authentication": "secondary_oob_otp_email",
+                  "bot_protection": {
+                    "enabled": true,
+                    "provider": {
+                      "type": "cloudflare"
+                    }
+                  },
+                  "otp_form": "link"
+                }
+              ],
+              "type": "create_authenticator_data"
+            }
+          }
+        }
+  - action: input
+    input: |
+      {
+        "authentication": "secondary_oob_otp_email",
+        "target": "signup_bp@example.com",
+        "bot_protection": {
+          "invalid_field": "invalid_value"
+        }
+      }
+    output: 
+      error: |
+        {
+          "name": "Invalid",
+          "reason": "ValidationFailed",
+          "message": "invalid value",
+          "code": 400,
+          "info": {
+            "causes": [
+              "[[arrayof]]",
+              {
+                "details": {
+                  "actual": [
+                    "[[arrayof]]",
+                    "invalid_field"
+                  ],
+                  "missing": "[[array]]"
+                },
+                "kind": "required",
+                "location": "/bot_protection"
+              }
+            ]
+          }
+        }

--- a/e2e/tests/bot_protection/signup/create_authenticator/secondary_oob_otp_email/fail.test.yaml
+++ b/e2e/tests/bot_protection/signup/create_authenticator/secondary_oob_otp_email/fail.test.yaml
@@ -1,0 +1,119 @@
+name: Signup with Bot Protection - Create Authenticator - Secondary OOB OTP Email - Bot Protection Verification Fail
+authgear.yaml:
+  override: |
+    bot_protection:
+      enabled: true
+      provider:
+        type: cloudflare
+        site_key: dummy
+    authentication_flow:
+      signup_flows:
+      - name: f1
+        steps:
+        - name: signup_identify
+          type: identify
+          one_of:
+          - identification: username
+            steps:
+            - name: authenticate_primary_username
+              type: create_authenticator
+              one_of:
+              - authentication: primary_password
+            - name: authenticate_secondary_email
+              type: create_authenticator
+              one_of:
+              - authentication: secondary_oob_otp_email
+                bot_protection:
+                  mode: always
+                  provider: 
+                    type: cloudflare
+steps:
+  - action: "create"
+    input: |
+      {
+        "type": "signup",
+        "name": "f1"
+      }
+    output:
+      result: |
+        {
+          "action": {
+            "type": "identify",
+            "data": {
+              "options": [
+                "[[arrayof]]",
+                {
+                  "identification": "username"
+                }
+              ]
+            }
+          }
+        }
+  - action: input
+    input: |
+      {
+        "identification": "username",
+        "login_id": "signup_bp_username"
+      }
+    output: 
+      result: |
+        {
+          "action": {
+            "type": "create_authenticator",
+            "data": {
+              "options": [
+                "[[arrayof]]",
+                {
+                  "authentication": "primary_password"
+                }
+              ]
+            }
+          }
+        }
+  - action: input
+    input: |
+      {
+        "authentication": "primary_password",
+        "new_password": "signup_bp_primary_pwd"
+      }
+    output: 
+      result: |
+        {
+          "action": {
+            "type": "create_authenticator",
+            "data": {
+              "options": [
+                "[[arrayof]]",
+                {
+                  "authentication": "secondary_oob_otp_email",
+                  "bot_protection": {
+                    "enabled": true,
+                    "provider": {
+                      "type": "cloudflare"
+                    }
+                  },
+                  "otp_form": "link"
+                }
+              ],
+              "type": "create_authenticator_data"
+            }
+          }
+        }
+  - action: input
+    input: |
+      {
+        "authentication": "secondary_oob_otp_email",
+        "target": "signup_bp@example.com",
+        "bot_protection": {
+          "type": "cloudflare",
+          "response": "fail"
+        }
+      }
+    output: 
+      error: |
+        {
+          "name": "Forbidden",
+          "reason": "BotProtectionVerificationFailed",
+          "message": "bot protection verification failed",
+          "code": 403
+        }

--- a/e2e/tests/bot_protection/signup/create_authenticator/secondary_oob_otp_email/sucess.test.yaml
+++ b/e2e/tests/bot_protection/signup/create_authenticator/secondary_oob_otp_email/sucess.test.yaml
@@ -124,3 +124,4 @@ steps:
             }
           }
         }
+# TODO: Finish this flow when verify_login_link action is supported

--- a/e2e/tests/bot_protection/signup/create_authenticator/secondary_oob_otp_email/sucess.test.yaml
+++ b/e2e/tests/bot_protection/signup/create_authenticator/secondary_oob_otp_email/sucess.test.yaml
@@ -1,0 +1,126 @@
+name: Signup with Bot Protection - Create Authenticator - Secondary OOB OTP Email - Bot Protection Verification Success
+authgear.yaml:
+  override: |
+    bot_protection:
+      enabled: true
+      provider:
+        type: cloudflare
+        site_key: dummy
+    authentication_flow:
+      signup_flows:
+      - name: f1
+        steps:
+        - name: signup_identify
+          type: identify
+          one_of:
+          - identification: username
+            steps:
+            - name: authenticate_primary_username
+              type: create_authenticator
+              one_of:
+              - authentication: primary_password
+            - name: authenticate_secondary_email
+              type: create_authenticator
+              one_of:
+              - authentication: secondary_oob_otp_email
+                bot_protection:
+                  mode: always
+                  provider: 
+                    type: cloudflare
+steps:
+  - action: "create"
+    input: |
+      {
+        "type": "signup",
+        "name": "f1"
+      }
+    output:
+      result: |
+        {
+          "action": {
+            "type": "identify",
+            "data": {
+              "options": [
+                "[[arrayof]]",
+                {
+                  "identification": "username"
+                }
+              ]
+            }
+          }
+        }
+  - action: input
+    input: |
+      {
+        "identification": "username",
+        "login_id": "signup_bp_username"
+      }
+    output: 
+      result: |
+        {
+          "action": {
+            "type": "create_authenticator",
+            "data": {
+              "options": [
+                "[[arrayof]]",
+                {
+                  "authentication": "primary_password"
+                }
+              ]
+            }
+          }
+        }
+  - action: input
+    input: |
+      {
+        "authentication": "primary_password",
+        "new_password": "signup_bp_primary_pwd"
+      }
+    output: 
+      result: |
+        {
+          "action": {
+            "type": "create_authenticator",
+            "data": {
+              "options": [
+                "[[arrayof]]",
+                {
+                  "authentication": "secondary_oob_otp_email",
+                  "bot_protection": {
+                    "enabled": true,
+                    "provider": {
+                      "type": "cloudflare"
+                    }
+                  },
+                  "otp_form": "link"
+                }
+              ],
+              "type": "create_authenticator_data"
+            }
+          }
+        }
+  - action: input
+    input: |
+      {
+        "authentication": "secondary_oob_otp_email",
+        "target": "signup_bp@example.com",
+        "bot_protection": {
+          "type": "cloudflare",
+          "response": "pass"
+        }
+      }
+    output: 
+      result: |
+        {
+          "action": {
+            "type": "create_authenticator",
+            "authentication": "secondary_oob_otp_email",
+            "data": {
+              "channel": "email",
+              "code_length": 32,
+              "masked_claim_value": "sign*****@example.com",
+              "otp_form": "link",
+              "type": "verify_oob_otp_data"
+            }
+          }
+        }

--- a/e2e/tests/bot_protection/signup/create_authenticator/secondary_oob_otp_sms/error_missing_required_field.test.yaml
+++ b/e2e/tests/bot_protection/signup/create_authenticator/secondary_oob_otp_sms/error_missing_required_field.test.yaml
@@ -1,0 +1,134 @@
+name: Signup with Bot Protection - Create Authenticator - Secondary OOB OTP SMS - Missing Bot Protection Required Field
+authgear.yaml:
+  override: |
+    bot_protection:
+      enabled: true
+      provider:
+        type: cloudflare
+        site_key: dummy
+    authentication_flow:
+      signup_flows:
+      - name: f1
+        steps:
+        - name: signup_identify
+          type: identify
+          one_of:
+          - identification: username
+            steps:
+            - name: authenticate_primary_username
+              type: create_authenticator
+              one_of:
+              - authentication: primary_password
+            - name: authenticate_secondary_sms
+              type: create_authenticator
+              one_of:
+              - authentication: secondary_oob_otp_sms
+                bot_protection:
+                  mode: always
+                  provider: 
+                    type: cloudflare
+steps:
+  - action: "create"
+    input: |
+      {
+        "type": "signup",
+        "name": "f1"
+      }
+    output:
+      result: |
+        {
+          "action": {
+            "type": "identify",
+            "data": {
+              "options": [
+                "[[arrayof]]",
+                {
+                  "identification": "username"
+                }
+              ]
+            }
+          }
+        }
+  - action: input
+    input: |
+      {
+        "identification": "username",
+        "login_id": "signup_bp_username"
+      }
+    output: 
+      result: |
+        {
+          "action": {
+            "type": "create_authenticator",
+            "data": {
+              "options": [
+                "[[arrayof]]",
+                {
+                  "authentication": "primary_password"
+                }
+              ]
+            }
+          }
+        }
+  - action: input
+    input: |
+      {
+        "authentication": "primary_password",
+        "new_password": "signup_bp_primary_pwd"
+      }
+    output: 
+      result: |
+        {
+          "action": {
+            "type": "create_authenticator",
+            "data": {
+              "options": [
+                "[[arrayof]]",
+                {
+                  "authentication": "secondary_oob_otp_sms",
+                  "bot_protection": {
+                    "enabled": true,
+                    "provider": {
+                      "type": "cloudflare"
+                    }
+                  },
+                  "otp_form": "code"
+                }
+              ],
+              "type": "create_authenticator_data"
+            }
+          }
+        }
+  - action: input
+    input: |
+      {
+        "authentication": "secondary_oob_otp_sms",
+        "target": "+85292078677",
+        "bot_protection": {
+          "invalid_field": "invalid_value"
+        }
+      }
+    output: 
+      error: |
+        {
+          "name": "Invalid",
+          "reason": "ValidationFailed",
+          "message": "invalid value",
+          "code": 400,
+          "info": {
+            "causes": [
+              "[[arrayof]]",
+              {
+                "details": {
+                  "actual": [
+                    "[[arrayof]]",
+                    "invalid_field"
+                  ],
+                  "missing": "[[array]]"
+                },
+                "kind": "required",
+                "location": "/bot_protection"
+              }
+            ]
+          }
+        }

--- a/e2e/tests/bot_protection/signup/create_authenticator/secondary_oob_otp_sms/fail.test.yaml
+++ b/e2e/tests/bot_protection/signup/create_authenticator/secondary_oob_otp_sms/fail.test.yaml
@@ -1,0 +1,119 @@
+name: Signup with Bot Protection - Create Authenticator - Secondary OOB OTP SMS - Verification Fail
+authgear.yaml:
+  override: |
+    bot_protection:
+      enabled: true
+      provider:
+        type: cloudflare
+        site_key: dummy
+    authentication_flow:
+      signup_flows:
+      - name: f1
+        steps:
+        - name: signup_identify
+          type: identify
+          one_of:
+          - identification: username
+            steps:
+            - name: authenticate_primary_username
+              type: create_authenticator
+              one_of:
+              - authentication: primary_password
+            - name: authenticate_secondary_sms
+              type: create_authenticator
+              one_of:
+              - authentication: secondary_oob_otp_sms
+                bot_protection:
+                  mode: always
+                  provider: 
+                    type: cloudflare
+steps:
+  - action: "create"
+    input: |
+      {
+        "type": "signup",
+        "name": "f1"
+      }
+    output:
+      result: |
+        {
+          "action": {
+            "type": "identify",
+            "data": {
+              "options": [
+                "[[arrayof]]",
+                {
+                  "identification": "username"
+                }
+              ]
+            }
+          }
+        }
+  - action: input
+    input: |
+      {
+        "identification": "username",
+        "login_id": "signup_bp_username"
+      }
+    output: 
+      result: |
+        {
+          "action": {
+            "type": "create_authenticator",
+            "data": {
+              "options": [
+                "[[arrayof]]",
+                {
+                  "authentication": "primary_password"
+                }
+              ]
+            }
+          }
+        }
+  - action: input
+    input: |
+      {
+        "authentication": "primary_password",
+        "new_password": "signup_bp_primary_pwd"
+      }
+    output: 
+      result: |
+        {
+          "action": {
+            "type": "create_authenticator",
+            "data": {
+              "options": [
+                "[[arrayof]]",
+                {
+                  "authentication": "secondary_oob_otp_sms",
+                  "bot_protection": {
+                    "enabled": true,
+                    "provider": {
+                      "type": "cloudflare"
+                    }
+                  },
+                  "otp_form": "code"
+                }
+              ],
+              "type": "create_authenticator_data"
+            }
+          }
+        }
+  - action: input
+    input: |
+      {
+        "authentication": "secondary_oob_otp_sms",
+        "target": "+85292078677",
+        "bot_protection": {
+          "type": "cloudflare",
+          "response": "fail"
+        }
+      }
+    output: 
+      error: |
+        {
+          "name": "Forbidden",
+          "reason": "BotProtectionVerificationFailed",
+          "message": "bot protection verification failed",
+          "code": 403
+        }

--- a/e2e/tests/bot_protection/signup/create_authenticator/secondary_oob_otp_sms/sucess.test.yaml
+++ b/e2e/tests/bot_protection/signup/create_authenticator/secondary_oob_otp_sms/sucess.test.yaml
@@ -1,0 +1,124 @@
+name: Signup with Bot Protection - Create Authenticator - Secondary OOB OTP SMS - Verification Success
+authgear.yaml:
+  override: |
+    bot_protection:
+      enabled: true
+      provider:
+        type: cloudflare
+        site_key: dummy
+    authentication_flow:
+      signup_flows:
+      - name: f1
+        steps:
+        - name: signup_identify
+          type: identify
+          one_of:
+          - identification: username
+            steps:
+            - name: authenticate_primary_username
+              type: create_authenticator
+              one_of:
+              - authentication: primary_password
+            - name: authenticate_secondary_sms
+              type: create_authenticator
+              one_of:
+              - authentication: secondary_oob_otp_sms
+                bot_protection:
+                  mode: always
+                  provider: 
+                    type: cloudflare
+steps:
+  - action: "create"
+    input: |
+      {
+        "type": "signup",
+        "name": "f1"
+      }
+    output:
+      result: |
+        {
+          "action": {
+            "type": "identify",
+            "data": {
+              "options": [
+                "[[arrayof]]",
+                {
+                  "identification": "username"
+                }
+              ]
+            }
+          }
+        }
+  - action: input
+    input: |
+      {
+        "identification": "username",
+        "login_id": "signup_bp_username"
+      }
+    output: 
+      result: |
+        {
+          "action": {
+            "type": "create_authenticator",
+            "data": {
+              "options": [
+                "[[arrayof]]",
+                {
+                  "authentication": "primary_password"
+                }
+              ]
+            }
+          }
+        }
+  - action: input
+    input: |
+      {
+        "authentication": "primary_password",
+        "new_password": "signup_bp_primary_pwd"
+      }
+    output: 
+      result: |
+        {
+          "action": {
+            "type": "create_authenticator",
+            "data": {
+              "options": [
+                "[[arrayof]]",
+                {
+                  "authentication": "secondary_oob_otp_sms",
+                  "bot_protection": {
+                    "enabled": true,
+                    "provider": {
+                      "type": "cloudflare"
+                    }
+                  },
+                  "otp_form": "code"
+                }
+              ],
+              "type": "create_authenticator_data"
+            }
+          }
+        }
+  - action: input
+    input: |
+      {
+        "authentication": "secondary_oob_otp_sms",
+        "target": "+85292078677",
+        "bot_protection": {
+          "type": "cloudflare",
+          "response": "pass"
+        }
+      }
+    output: 
+      result: |
+        {
+          "action": {
+            "type": "create_authenticator",
+            "authentication": "secondary_oob_otp_sms",
+            "data": {
+              "channels": "[[array]]",
+              "masked_claim_value": "+8529207****",
+              "type": "select_oob_otp_channels_data"
+            }
+          }
+        }

--- a/e2e/tests/bot_protection/signup/create_authenticator/secondary_oob_otp_sms/sucess.test.yaml
+++ b/e2e/tests/bot_protection/signup/create_authenticator/secondary_oob_otp_sms/sucess.test.yaml
@@ -122,3 +122,36 @@ steps:
             }
           }
         }
+  - action: input
+    input: |
+      {
+        "channel": "sms"
+      }
+    output: 
+      result: |
+        {
+          "action": {
+            "type": "create_authenticator",
+            "authentication": "secondary_oob_otp_sms",
+            "data": {
+              "channel": "sms",
+              "code_length": 6,
+              "failed_attempt_rate_limit_exceeded": false,
+              "masked_claim_value": "+8529207****",
+              "otp_form": "code",
+              "type": "verify_oob_otp_data"
+            }
+          }
+        }
+  - action: input
+    input: |
+      {
+        "code": "111111"
+      }
+    output: 
+      result: |
+        {
+          "action": {
+            "type": "finished"
+          }
+        }

--- a/pkg/lib/authenticationflow/declarative/data_create_authenticator_option.go
+++ b/pkg/lib/authenticationflow/declarative/data_create_authenticator_option.go
@@ -164,3 +164,14 @@ func NewCreateAuthenticationOptions(
 	}
 	return options, nil
 }
+
+func (o *CreateAuthenticatorOption) isBotProtectionRequired() bool {
+	if o.BotProtection == nil {
+		return false
+	}
+	if o.BotProtection.Enabled != nil && *o.BotProtection.Enabled && o.BotProtection.Provider != nil && o.BotProtection.Provider.Type != "" {
+		return true
+	}
+
+	return false
+}

--- a/pkg/lib/authenticationflow/declarative/input_signup_flow_step_create_authenticator_test.go
+++ b/pkg/lib/authenticationflow/declarative/input_signup_flow_step_create_authenticator_test.go
@@ -25,9 +25,10 @@ func TestInputSchemaSignupFlowStepCreateAuthenticator(t *testing.T) {
 			},
 		}
 
-		var dummyBotProtectionData = &config.AuthenticationFlowBotProtection{
-			Mode: config.AuthenticationFlowBotProtectionModeAlways,
-			Provider: &config.AuthenticationFlowBotProtectionProvider{
+		var varTrue = true
+		dummyBotProtection := &BotProtectionData{
+			Enabled: &varTrue,
+			Provider: &BotProtectionDataProvider{
 				Type: config.BotProtectionProviderTypeCloudflare,
 			},
 		}
@@ -35,17 +36,20 @@ func TestInputSchemaSignupFlowStepCreateAuthenticator(t *testing.T) {
 		test((&InputSchemaSignupFlowStepCreateAuthenticator{
 			ShouldBypassBotProtection: false,
 			BotProtectionCfg:          dummyBotProtectionCfg,
-			OneOf: []*config.AuthenticationFlowSignupFlowOneOf{
+			Options: []CreateAuthenticatorOption{
 				{
 					Authentication: config.AuthenticationFlowAuthenticationPrimaryPassword,
 				},
 				{
 					Authentication: config.AuthenticationFlowAuthenticationPrimaryOOBOTPEmail,
-					BotProtection:  dummyBotProtectionData,
+					BotProtection:  dummyBotProtection,
 				},
 				{
 					Authentication: config.AuthenticationFlowAuthenticationPrimaryOOBOTPSMS,
-					TargetStep:     "step",
+					Target: &CreateAuthenticatorTarget{
+						MaskedDisplayName:    "test",
+						VerificationRequired: true,
+					},
 				},
 				{
 					Authentication: config.AuthenticationFlowAuthenticationSecondaryPassword,

--- a/pkg/lib/authenticationflow/declarative/input_signup_flow_step_create_authenticator_test.go
+++ b/pkg/lib/authenticationflow/declarative/input_signup_flow_step_create_authenticator_test.go
@@ -18,13 +18,30 @@ func TestInputSchemaSignupFlowStepCreateAuthenticator(t *testing.T) {
 			So(string(bytes), ShouldEqualJSON, expected)
 		}
 
+		var dummyBotProtectionCfg = &config.BotProtectionConfig{
+			Enabled: true,
+			Provider: &config.BotProtectionProvider{
+				Type: config.BotProtectionProviderTypeCloudflare,
+			},
+		}
+
+		var dummyBotProtectionData = &config.AuthenticationFlowBotProtection{
+			Mode: config.AuthenticationFlowBotProtectionModeAlways,
+			Provider: &config.AuthenticationFlowBotProtectionProvider{
+				Type: config.BotProtectionProviderTypeCloudflare,
+			},
+		}
+
 		test((&InputSchemaSignupFlowStepCreateAuthenticator{
+			ShouldBypassBotProtection: false,
+			BotProtectionCfg:          dummyBotProtectionCfg,
 			OneOf: []*config.AuthenticationFlowSignupFlowOneOf{
 				{
 					Authentication: config.AuthenticationFlowAuthenticationPrimaryPassword,
 				},
 				{
 					Authentication: config.AuthenticationFlowAuthenticationPrimaryOOBOTPEmail,
+					BotProtection:  dummyBotProtectionData,
 				},
 				{
 					Authentication: config.AuthenticationFlowAuthenticationPrimaryOOBOTPSMS,
@@ -72,13 +89,29 @@ func TestInputSchemaSignupFlowStepCreateAuthenticator(t *testing.T) {
                 "authentication": {
                     "const": "primary_oob_otp_email"
                 },
+                "bot_protection": {
+                    "properties": {
+                    "response": {
+                        "type": "string"
+                    },
+                    "type": {
+                        "const": "cloudflare"
+                    }
+                    },
+                    "required": [
+                    "type",
+                    "response"
+                    ],
+                    "type": "object"
+                },
                 "target": {
                     "type": "string"
                 }
             },
             "required": [
                 "authentication",
-                "target"
+                "target",
+                "bot_protection"
             ]
         },
         {

--- a/pkg/lib/authenticationflow/declarative/intent_signup_flow_step_create_authenticator.go
+++ b/pkg/lib/authenticationflow/declarative/intent_signup_flow_step_create_authenticator.go
@@ -115,7 +115,7 @@ func (i *IntentSignupFlowStepCreateAuthenticator) CanReactTo(ctx context.Context
 		}
 	}
 
-	internalOptions, err := i.getOptions(ctx, deps, flows)
+	internalOptions, err := i.getInternalOptions(ctx, deps, flows)
 	if err != nil {
 		return nil, err
 	}
@@ -242,7 +242,7 @@ func (i *IntentSignupFlowStepCreateAuthenticator) ReactTo(ctx context.Context, d
 }
 
 func (i *IntentSignupFlowStepCreateAuthenticator) OutputData(ctx context.Context, deps *authflow.Dependencies, flows authflow.Flows) (authflow.Data, error) {
-	internalOptions, err := i.getOptions(ctx, deps, flows)
+	internalOptions, err := i.getInternalOptions(ctx, deps, flows)
 	if err != nil {
 		return nil, err
 	}
@@ -335,7 +335,7 @@ func (i *IntentSignupFlowStepCreateAuthenticator) findAuthenticatorOfSameType(de
 	return existing, nil
 }
 
-func (i *IntentSignupFlowStepCreateAuthenticator) getOptions(ctx context.Context, deps *authflow.Dependencies, flows authflow.Flows) ([]CreateAuthenticatorOptionInternal, error) {
+func (i *IntentSignupFlowStepCreateAuthenticator) getInternalOptions(ctx context.Context, deps *authflow.Dependencies, flows authflow.Flows) ([]CreateAuthenticatorOptionInternal, error) {
 	current, err := i.currentFlowObject(deps)
 	if err != nil {
 		return nil, err
@@ -389,7 +389,7 @@ func (i *IntentSignupFlowStepCreateAuthenticator) findSkippableOption(
 		return nil, -1, nil, err
 	}
 	// For each option, see if any existing identities can be reused
-	options, err := i.getOptions(ctx, deps, flows)
+	options, err := i.getInternalOptions(ctx, deps, flows)
 	if err != nil {
 		return nil, -1, nil, err
 	}

--- a/pkg/lib/authenticationflow/declarative/intent_signup_flow_step_create_authenticator.go
+++ b/pkg/lib/authenticationflow/declarative/intent_signup_flow_step_create_authenticator.go
@@ -130,17 +130,17 @@ func (i *IntentSignupFlowStepCreateAuthenticator) CanReactTo(ctx context.Context
 		if err != nil {
 			return nil, err
 		}
-		current, err := authflow.FlowObject(flowRootObject, i.JSONPointer)
+
+		options, err := i.getOptions(ctx, deps, flows)
 		if err != nil {
 			return nil, err
 		}
-		step := i.step(current)
 
 		shouldBypassBotProtection := ShouldExistingResultBypassBotProtectionRequirement(ctx)
 		return &InputSchemaSignupFlowStepCreateAuthenticator{
 			FlowRootObject:            flowRootObject,
 			JSONPointer:               i.JSONPointer,
-			OneOf:                     step.OneOf,
+			Options:                   options,
 			ShouldBypassBotProtection: shouldBypassBotProtection,
 			BotProtectionCfg:          deps.Config.BotProtection,
 		}, nil
@@ -346,6 +346,17 @@ func (i *IntentSignupFlowStepCreateAuthenticator) getInternalOptions(ctx context
 		return nil, err
 	}
 	return options, nil
+}
+
+func (i *IntentSignupFlowStepCreateAuthenticator) getOptions(ctx context.Context, deps *authflow.Dependencies, flows authflow.Flows) ([]CreateAuthenticatorOption, error) {
+	internalOptions, err := i.getInternalOptions(ctx, deps, flows)
+	if err != nil {
+		return nil, err
+	}
+
+	return slice.Map(internalOptions, func(o CreateAuthenticatorOptionInternal) CreateAuthenticatorOption {
+		return o.CreateAuthenticatorOption
+	}), nil
 }
 
 func (i *IntentSignupFlowStepCreateAuthenticator) reactToExistingAuthenticator(ctx context.Context, deps *authflow.Dependencies, flows authflow.Flows, option CreateAuthenticatorOptionInternal, authn *authenticator.Info, idx int) (*authflow.Node, error) {

--- a/pkg/lib/authenticationflow/declarative/intent_signup_flow_step_create_authenticator.go
+++ b/pkg/lib/authenticationflow/declarative/intent_signup_flow_step_create_authenticator.go
@@ -135,10 +135,14 @@ func (i *IntentSignupFlowStepCreateAuthenticator) CanReactTo(ctx context.Context
 			return nil, err
 		}
 		step := i.step(current)
+
+		shouldBypassBotProtection := ShouldExistingResultBypassBotProtectionRequirement(ctx)
 		return &InputSchemaSignupFlowStepCreateAuthenticator{
-			FlowRootObject: flowRootObject,
-			JSONPointer:    i.JSONPointer,
-			OneOf:          step.OneOf,
+			FlowRootObject:            flowRootObject,
+			JSONPointer:               i.JSONPointer,
+			OneOf:                     step.OneOf,
+			ShouldBypassBotProtection: shouldBypassBotProtection,
+			BotProtectionCfg:          deps.Config.BotProtection,
 		}, nil
 	}
 

--- a/pkg/lib/authenticationflow/declarative/utils_bot_protection.go
+++ b/pkg/lib/authenticationflow/declarative/utils_bot_protection.go
@@ -11,7 +11,7 @@ import (
 	"github.com/authgear/authgear-server/pkg/lib/config"
 )
 
-func isConfigBotProtectionRequired(authflowCfg *config.AuthenticationFlowBotProtection, appCfg *config.BotProtectionConfig) bool {
+func IsConfigBotProtectionRequired(authflowCfg *config.AuthenticationFlowBotProtection, appCfg *config.BotProtectionConfig) bool {
 	data := GetBotProtectionData(authflowCfg, appCfg)
 	return data != nil
 }
@@ -31,7 +31,7 @@ func isNodeBotProtectionRequired(ctx context.Context, deps *authflow.Dependencie
 		return false, authflow.ErrInvalidJSONPointer
 	}
 
-	return isConfigBotProtectionRequired(currentBranch.GetBotProtectionConfig(), deps.Config.BotProtection), nil
+	return IsConfigBotProtectionRequired(currentBranch.GetBotProtectionConfig(), deps.Config.BotProtection), nil
 }
 
 func IsBotProtectionRequired(ctx context.Context, flowRootObject config.AuthenticationFlowObject, oneOfJSONPointer jsonpointer.T) (bool, error) {
@@ -61,7 +61,7 @@ func isInputBotProtectionRequired(flowRootObject config.AuthenticationFlowObject
 		return false, nil
 	}
 
-	return isConfigBotProtectionRequired(currentBranch.GetBotProtectionConfig(), nil), nil
+	return IsConfigBotProtectionRequired(currentBranch.GetBotProtectionConfig(), nil), nil
 }
 
 func ShouldExistingResultBypassBotProtectionRequirement(ctx context.Context) bool {

--- a/pkg/lib/authenticationflow/declarative/utils_bot_protection.go
+++ b/pkg/lib/authenticationflow/declarative/utils_bot_protection.go
@@ -11,7 +11,7 @@ import (
 	"github.com/authgear/authgear-server/pkg/lib/config"
 )
 
-func IsConfigBotProtectionRequired(authflowCfg *config.AuthenticationFlowBotProtection, appCfg *config.BotProtectionConfig) bool {
+func isConfigBotProtectionRequired(authflowCfg *config.AuthenticationFlowBotProtection, appCfg *config.BotProtectionConfig) bool {
 	data := GetBotProtectionData(authflowCfg, appCfg)
 	return data != nil
 }
@@ -31,7 +31,7 @@ func isNodeBotProtectionRequired(ctx context.Context, deps *authflow.Dependencie
 		return false, authflow.ErrInvalidJSONPointer
 	}
 
-	return IsConfigBotProtectionRequired(currentBranch.GetBotProtectionConfig(), deps.Config.BotProtection), nil
+	return isConfigBotProtectionRequired(currentBranch.GetBotProtectionConfig(), deps.Config.BotProtection), nil
 }
 
 func IsBotProtectionRequired(ctx context.Context, flowRootObject config.AuthenticationFlowObject, oneOfJSONPointer jsonpointer.T) (bool, error) {
@@ -61,7 +61,7 @@ func isInputBotProtectionRequired(flowRootObject config.AuthenticationFlowObject
 		return false, nil
 	}
 
-	return IsConfigBotProtectionRequired(currentBranch.GetBotProtectionConfig(), nil), nil
+	return isConfigBotProtectionRequired(currentBranch.GetBotProtectionConfig(), nil), nil
 }
 
 func ShouldExistingResultBypassBotProtectionRequirement(ctx context.Context) bool {


### PR DESCRIPTION
## Blocked by

- #4512 
## What's in this PR?

DEV-1608 requires captcha in `signup > create_authenticator`, which is not supported yet. It is added in this PR

## Uncertainties

1. Only supports `create_authenticator_oob_otp` ? -  asked in https://github.com/authgear/authgear-server/pull/4282#discussion_r1695145534
    - yes
2. Only supports `secondary_oob_otp`? Both in authflow/authUI, I cannot observe when will `create_authenticator > primary_oob_otp` take place
    - no, also need `primary_oob_otp` & `verify`, will also implement in this PR