### PR TITLE
Fix VerifyWithSpec is not updated to include Form

### DIFF
--- a/pkg/latte/node_authenticate_oob_otp_phone.go
+++ b/pkg/latte/node_authenticate_oob_otp_phone.go
@@ -63,6 +63,7 @@ func (n *NodeAuthenticateOOBOTPPhone) ReactTo(ctx context.Context, deps *workflo
 				Code: inputTakeOOBOTPCode.GetCode(),
 			},
 		}, &facade.VerifyOptions{
+			Form: otp.FormCode,
 			AuthenticationDetails: facade.NewAuthenticationDetails(
 				info.UserID,
 				authn.AuthenticationStagePrimary,

--- a/pkg/lib/interaction/nodes/authn_oob.go
+++ b/pkg/lib/interaction/nodes/authn_oob.go
@@ -6,6 +6,7 @@ import (
 	"github.com/authgear/authgear-server/pkg/api/model"
 	"github.com/authgear/authgear-server/pkg/lib/authn"
 	"github.com/authgear/authgear-server/pkg/lib/authn/authenticator"
+	"github.com/authgear/authgear-server/pkg/lib/authn/otp"
 	"github.com/authgear/authgear-server/pkg/lib/facade"
 	"github.com/authgear/authgear-server/pkg/lib/interaction"
 )
@@ -36,6 +37,7 @@ func (e *EdgeAuthenticationOOB) Instantiate(ctx *interaction.Context, graph *int
 			Code: input.GetOOBOTP(),
 		},
 	}, &facade.VerifyOptions{
+		Form: otp.FormCode,
 		AuthenticationDetails: facade.NewAuthenticationDetails(
 			info.UserID,
 			e.Stage,

--- a/pkg/lib/interaction/nodes/authn_whatsapp.go
+++ b/pkg/lib/interaction/nodes/authn_whatsapp.go
@@ -4,6 +4,7 @@ import (
 	"github.com/authgear/authgear-server/pkg/api/model"
 	"github.com/authgear/authgear-server/pkg/lib/authn"
 	"github.com/authgear/authgear-server/pkg/lib/authn/authenticator"
+	"github.com/authgear/authgear-server/pkg/lib/authn/otp"
 	"github.com/authgear/authgear-server/pkg/lib/facade"
 	"github.com/authgear/authgear-server/pkg/lib/interaction"
 )
@@ -34,6 +35,7 @@ func (e *EdgeAuthenticationWhatsapp) Instantiate(ctx *interaction.Context, graph
 			Code: code,
 		},
 	}, &facade.VerifyOptions{
+		Form:       otp.FormCode,
 		OOBChannel: &channel,
 		AuthenticationDetails: facade.NewAuthenticationDetails(
 			graph.MustGetUserID(),

--- a/pkg/lib/interaction/nodes/create_authenticator_whatsapp_otp.go
+++ b/pkg/lib/interaction/nodes/create_authenticator_whatsapp_otp.go
@@ -4,6 +4,7 @@ import (
 	"github.com/authgear/authgear-server/pkg/api/model"
 	"github.com/authgear/authgear-server/pkg/lib/authn"
 	"github.com/authgear/authgear-server/pkg/lib/authn/authenticator"
+	"github.com/authgear/authgear-server/pkg/lib/authn/otp"
 	"github.com/authgear/authgear-server/pkg/lib/facade"
 	"github.com/authgear/authgear-server/pkg/lib/interaction"
 )
@@ -33,6 +34,7 @@ func (e *EdgeCreateAuthenticatorWhatsappOTP) Instantiate(ctx *interaction.Contex
 			Code: code,
 		},
 	}, &facade.VerifyOptions{
+		Form:       otp.FormCode,
 		OOBChannel: &channel,
 	})
 	if err != nil {


### PR DESCRIPTION
In #4487, we require VerifyOptions to have Form if verifying OOB OTP. But we only updated VerifyOneWithSpec.

ref DEV-1680