### PR TITLE
Remove bot protection `provider` from authflow

### DIFF
--- a/e2e/tests/bot_protection/general/already_success.test.yaml
+++ b/e2e/tests/bot_protection/general/already_success.test.yaml
@@ -30,8 +30,6 @@ authgear.yaml:
           - identification: email
             bot_protection:
               mode: always
-              provider:
-                type: cloudflare
             steps:
             - name: authenticate_primary_email
               type: authenticate
@@ -39,8 +37,6 @@ authgear.yaml:
               - authentication: primary_password
                 bot_protection:
                   mode: always
-                  provider:
-                    type: cloudflare
 before:
   - type: user_import
     user_import: users.json

--- a/e2e/tests/bot_protection/login/authenticate/oobotp/error_missing_input.test.yaml
+++ b/e2e/tests/bot_protection/login/authenticate/oobotp/error_missing_input.test.yaml
@@ -33,8 +33,6 @@ authgear.yaml:
               - authentication: primary_oob_otp_email
                 bot_protection:
                   mode: always
-                  provider:
-                    type: cloudflare
                 target_step: login_identify
 before:
   - type: user_import

--- a/e2e/tests/bot_protection/login/authenticate/oobotp/fail.test.yaml
+++ b/e2e/tests/bot_protection/login/authenticate/oobotp/fail.test.yaml
@@ -33,8 +33,6 @@ authgear.yaml:
               - authentication: primary_oob_otp_email
                 bot_protection:
                   mode: always
-                  provider:
-                    type: cloudflare
                 target_step: login_identify
 before:
   - type: user_import

--- a/e2e/tests/bot_protection/login/authenticate/oobotp/success.test.yaml
+++ b/e2e/tests/bot_protection/login/authenticate/oobotp/success.test.yaml
@@ -33,8 +33,6 @@ authgear.yaml:
               - authentication: primary_oob_otp_email
                 bot_protection:
                   mode: always
-                  provider:
-                    type: cloudflare
                 target_step: login_identify
 before:
   - type: user_import

--- a/e2e/tests/bot_protection/login/authenticate/password/error_missing_input.test.yaml
+++ b/e2e/tests/bot_protection/login/authenticate/password/error_missing_input.test.yaml
@@ -32,8 +32,6 @@ authgear.yaml:
                 - authentication: primary_password
                   bot_protection:
                     mode: always
-                    provider:
-                      type: cloudflare
                 type: authenticate
 before:
   - type: user_import

--- a/e2e/tests/bot_protection/login/authenticate/password/fail.test.yaml
+++ b/e2e/tests/bot_protection/login/authenticate/password/fail.test.yaml
@@ -32,8 +32,6 @@ authgear.yaml:
                 - authentication: primary_password
                   bot_protection:
                     mode: always
-                    provider:
-                      type: cloudflare
                 type: authenticate
 before:
   - type: user_import

--- a/e2e/tests/bot_protection/login/authenticate/password/success.test.yaml
+++ b/e2e/tests/bot_protection/login/authenticate/password/success.test.yaml
@@ -32,8 +32,6 @@ authgear.yaml:
                 - authentication: primary_password
                   bot_protection:
                     mode: always
-                    provider:
-                      type: cloudflare
                 type: authenticate
 before:
   - type: user_import

--- a/e2e/tests/bot_protection/signup/create_authenticator/primary_oob_otp_email/error_missing_required_field.test.yaml
+++ b/e2e/tests/bot_protection/signup/create_authenticator/primary_oob_otp_email/error_missing_required_field.test.yaml
@@ -21,8 +21,6 @@ authgear.yaml:
               - authentication: primary_oob_otp_email
                 bot_protection:
                   mode: always
-                  provider: 
-                    type: cloudflare
 steps:
   - action: "create"
     input: |

--- a/e2e/tests/bot_protection/signup/create_authenticator/primary_oob_otp_email/fail.test.yaml
+++ b/e2e/tests/bot_protection/signup/create_authenticator/primary_oob_otp_email/fail.test.yaml
@@ -21,8 +21,6 @@ authgear.yaml:
               - authentication: primary_oob_otp_email
                 bot_protection:
                   mode: always
-                  provider: 
-                    type: cloudflare
 steps:
   - action: "create"
     input: |

--- a/e2e/tests/bot_protection/signup/create_authenticator/primary_oob_otp_email/sucess.test.yaml
+++ b/e2e/tests/bot_protection/signup/create_authenticator/primary_oob_otp_email/sucess.test.yaml
@@ -21,8 +21,6 @@ authgear.yaml:
               - authentication: primary_oob_otp_email
                 bot_protection:
                   mode: always
-                  provider: 
-                    type: cloudflare
 steps:
   - action: "create"
     input: |

--- a/e2e/tests/bot_protection/signup/create_authenticator/primary_oob_otp_sms/error_missing_required_field.test.yaml
+++ b/e2e/tests/bot_protection/signup/create_authenticator/primary_oob_otp_sms/error_missing_required_field.test.yaml
@@ -21,8 +21,6 @@ authgear.yaml:
               - authentication: primary_oob_otp_sms
                 bot_protection:
                   mode: always
-                  provider: 
-                    type: cloudflare
 steps:
   - action: "create"
     input: |

--- a/e2e/tests/bot_protection/signup/create_authenticator/primary_oob_otp_sms/fail.test.yaml
+++ b/e2e/tests/bot_protection/signup/create_authenticator/primary_oob_otp_sms/fail.test.yaml
@@ -21,8 +21,6 @@ authgear.yaml:
               - authentication: primary_oob_otp_sms
                 bot_protection:
                   mode: always
-                  provider: 
-                    type: cloudflare
 steps:
   - action: "create"
     input: |

--- a/e2e/tests/bot_protection/signup/create_authenticator/primary_oob_otp_sms/sucess.test.yaml
+++ b/e2e/tests/bot_protection/signup/create_authenticator/primary_oob_otp_sms/sucess.test.yaml
@@ -21,8 +21,6 @@ authgear.yaml:
               - authentication: primary_oob_otp_sms
                 bot_protection:
                   mode: always
-                  provider: 
-                    type: cloudflare
 steps:
   - action: "create"
     input: |

--- a/e2e/tests/bot_protection/signup/create_authenticator/secondary_oob_otp_email/error_missing_required_field.test.yaml
+++ b/e2e/tests/bot_protection/signup/create_authenticator/secondary_oob_otp_email/error_missing_required_field.test.yaml
@@ -25,8 +25,6 @@ authgear.yaml:
               - authentication: secondary_oob_otp_email
                 bot_protection:
                   mode: always
-                  provider: 
-                    type: cloudflare
 steps:
   - action: "create"
     input: |

--- a/e2e/tests/bot_protection/signup/create_authenticator/secondary_oob_otp_email/fail.test.yaml
+++ b/e2e/tests/bot_protection/signup/create_authenticator/secondary_oob_otp_email/fail.test.yaml
@@ -25,8 +25,6 @@ authgear.yaml:
               - authentication: secondary_oob_otp_email
                 bot_protection:
                   mode: always
-                  provider: 
-                    type: cloudflare
 steps:
   - action: "create"
     input: |

--- a/e2e/tests/bot_protection/signup/create_authenticator/secondary_oob_otp_email/sucess.test.yaml
+++ b/e2e/tests/bot_protection/signup/create_authenticator/secondary_oob_otp_email/sucess.test.yaml
@@ -25,8 +25,6 @@ authgear.yaml:
               - authentication: secondary_oob_otp_email
                 bot_protection:
                   mode: always
-                  provider: 
-                    type: cloudflare
 steps:
   - action: "create"
     input: |

--- a/e2e/tests/bot_protection/signup/create_authenticator/secondary_oob_otp_sms/error_missing_required_field.test.yaml
+++ b/e2e/tests/bot_protection/signup/create_authenticator/secondary_oob_otp_sms/error_missing_required_field.test.yaml
@@ -25,8 +25,6 @@ authgear.yaml:
               - authentication: secondary_oob_otp_sms
                 bot_protection:
                   mode: always
-                  provider: 
-                    type: cloudflare
 steps:
   - action: "create"
     input: |

--- a/e2e/tests/bot_protection/signup/create_authenticator/secondary_oob_otp_sms/fail.test.yaml
+++ b/e2e/tests/bot_protection/signup/create_authenticator/secondary_oob_otp_sms/fail.test.yaml
@@ -25,8 +25,6 @@ authgear.yaml:
               - authentication: secondary_oob_otp_sms
                 bot_protection:
                   mode: always
-                  provider: 
-                    type: cloudflare
 steps:
   - action: "create"
     input: |

--- a/e2e/tests/bot_protection/signup/create_authenticator/secondary_oob_otp_sms/sucess.test.yaml
+++ b/e2e/tests/bot_protection/signup/create_authenticator/secondary_oob_otp_sms/sucess.test.yaml
@@ -25,8 +25,6 @@ authgear.yaml:
               - authentication: secondary_oob_otp_sms
                 bot_protection:
                   mode: always
-                  provider: 
-                    type: cloudflare
 steps:
   - action: "create"
     input: |

--- a/e2e/tests/bot_protection/signup_login/switchflow/login_no_need_verify_again.test.yaml
+++ b/e2e/tests/bot_protection/signup_login/switchflow/login_no_need_verify_again.test.yaml
@@ -24,8 +24,6 @@ authgear.yaml:
               - authentication: primary_password
                 bot_protection:
                   mode: always
-                  provider:
-                    type: cloudflare
 # Note bot protection is required above
 before:
   - type: user_import

--- a/pkg/lib/authenticationflow/declarative/data_bot_protection.go
+++ b/pkg/lib/authenticationflow/declarative/data_bot_protection.go
@@ -27,8 +27,7 @@ func GetBotProtectionData(authflowCfg *config.AuthenticationFlowBotProtection, a
 	if authflowCfg == nil {
 		return nil
 	}
-	// appCfg as optional parameter
-	if appCfg != nil && (!appCfg.Enabled || appCfg.Provider == nil) {
+	if appCfg == nil || !appCfg.Enabled || appCfg.Provider == nil || appCfg.Provider.Type == "" {
 		return nil
 	}
 
@@ -36,7 +35,7 @@ func GetBotProtectionData(authflowCfg *config.AuthenticationFlowBotProtection, a
 	case config.BotProtectionRiskModeNever:
 		break
 	case config.BotProtectionRiskModeAlways:
-		return NewBotProtectionData(authflowCfg.Provider.Type)
+		return NewBotProtectionData(appCfg.Provider.Type)
 	}
 	return nil
 }

--- a/pkg/lib/authenticationflow/declarative/generate_config_account_recovery_flow_test.go
+++ b/pkg/lib/authenticationflow/declarative/generate_config_account_recovery_flow_test.go
@@ -176,8 +176,6 @@ steps:
   - identification: email
     bot_protection:
       mode: always
-      provider: 
-        type: recaptchav2
     on_failure: ignore
     steps:
       - type: select_destination
@@ -187,8 +185,6 @@ steps:
   - identification: phone
     bot_protection:
       mode: always
-      provider: 
-        type: recaptchav2
     on_failure: ignore
     steps:
       - type: select_destination

--- a/pkg/lib/authenticationflow/declarative/generate_config_bot_protection.go
+++ b/pkg/lib/authenticationflow/declarative/generate_config_bot_protection.go
@@ -14,9 +14,6 @@ func getBotProtectionRequirementsSignupOrLogin(cfg *config.AppConfig) (botProtec
 	}
 	return &config.AuthenticationFlowBotProtection{
 		Mode: cfg.BotProtection.Requirements.SignupOrLogin.Mode,
-		Provider: &config.AuthenticationFlowBotProtectionProvider{
-			Type: cfg.BotProtection.Provider.Type,
-		},
 	}
 }
 
@@ -29,9 +26,6 @@ func getBotProtectionRequirementsAccountRecovery(cfg *config.AppConfig) (botProt
 	}
 	return &config.AuthenticationFlowBotProtection{
 		Mode: cfg.BotProtection.Requirements.AccountRecovery.Mode,
-		Provider: &config.AuthenticationFlowBotProtectionProvider{
-			Type: cfg.BotProtection.Provider.Type,
-		},
 	}
 }
 func getBotProtectionRequirementsPassword(cfg *config.AppConfig) (botProtection *config.AuthenticationFlowBotProtection) {
@@ -43,9 +37,6 @@ func getBotProtectionRequirementsPassword(cfg *config.AppConfig) (botProtection 
 	}
 	return &config.AuthenticationFlowBotProtection{
 		Mode: cfg.BotProtection.Requirements.Password.Mode,
-		Provider: &config.AuthenticationFlowBotProtectionProvider{
-			Type: cfg.BotProtection.Provider.Type,
-		},
 	}
 }
 func getBotProtectionRequirementsOOBOTPEmail(cfg *config.AppConfig) (botProtection *config.AuthenticationFlowBotProtection) {
@@ -57,9 +48,6 @@ func getBotProtectionRequirementsOOBOTPEmail(cfg *config.AppConfig) (botProtecti
 	}
 	return &config.AuthenticationFlowBotProtection{
 		Mode: cfg.BotProtection.Requirements.OOBOTPEmail.Mode,
-		Provider: &config.AuthenticationFlowBotProtectionProvider{
-			Type: cfg.BotProtection.Provider.Type,
-		},
 	}
 }
 func getBotProtectionRequirementsOOBOTPSMS(cfg *config.AppConfig) (botProtection *config.AuthenticationFlowBotProtection) {
@@ -71,8 +59,5 @@ func getBotProtectionRequirementsOOBOTPSMS(cfg *config.AppConfig) (botProtection
 	}
 	return &config.AuthenticationFlowBotProtection{
 		Mode: cfg.BotProtection.Requirements.OOBOTPSMS.Mode,
-		Provider: &config.AuthenticationFlowBotProtectionProvider{
-			Type: cfg.BotProtection.Provider.Type,
-		},
 	}
 }

--- a/pkg/lib/authenticationflow/declarative/generate_config_login_flow_test.go
+++ b/pkg/lib/authenticationflow/declarative/generate_config_login_flow_test.go
@@ -564,8 +564,6 @@ steps:
   - identification: email
     bot_protection:
       mode: always
-      provider: 
-        type: recaptchav2
     steps:
     - name: authenticate_primary_email
       type: authenticate
@@ -625,8 +623,6 @@ steps:
   one_of:
   - bot_protection:
       mode: always
-      provider:
-        type: recaptchav2
     identification: email
     steps:
     - name: authenticate_primary_email
@@ -635,26 +631,18 @@ steps:
       - authentication: primary_password
         bot_protection:
           mode: never
-          provider:
-            type: recaptchav2
         steps:
         - name: authenticate_secondary_email
           one_of:
           - authentication: secondary_oob_otp_email
             bot_protection:
               mode: always
-              provider:
-                type: recaptchav2
           - authentication: secondary_oob_otp_sms
             bot_protection:
               mode: always
-              provider:
-                type: recaptchav2
           - authentication: secondary_password
             bot_protection:
               mode: never
-              provider:
-                type: recaptchav2
           - authentication: recovery_code
           - authentication: device_token
           type: authenticate
@@ -664,8 +652,6 @@ steps:
         target_step: login_identify
         bot_protection:
           mode: always
-          provider:
-            type: recaptchav2
         steps:
         - name: authenticate_secondary_email
           type: authenticate
@@ -673,25 +659,17 @@ steps:
           - authentication: secondary_oob_otp_email
             bot_protection:
               mode: always
-              provider:
-                type: recaptchav2
           - authentication: secondary_oob_otp_sms
             bot_protection:
               mode: always
-              provider:
-                type: recaptchav2
           - authentication: secondary_password
             bot_protection:
               mode: never
-              provider:
-                type: recaptchav2
           - authentication: recovery_code
           - authentication: device_token
   - identification: phone
     bot_protection:
       mode: always
-      provider: 
-        type: recaptchav2
     steps:
     - name: authenticate_primary_phone
       type: authenticate
@@ -699,8 +677,6 @@ steps:
       - authentication: primary_password
         bot_protection:
           mode: never
-          provider:
-            type: recaptchav2
         steps:
         - name: authenticate_secondary_phone
           type: authenticate
@@ -708,18 +684,12 @@ steps:
           - authentication: secondary_oob_otp_email
             bot_protection:
               mode: always
-              provider:
-                type: recaptchav2
           - authentication: secondary_oob_otp_sms
             bot_protection:
               mode: always
-              provider:
-                type: recaptchav2
           - authentication: secondary_password
             bot_protection:
               mode: never
-              provider:
-                type: recaptchav2
           - authentication: recovery_code
           - authentication: device_token
         - target_step: authenticate_primary_phone
@@ -728,8 +698,6 @@ steps:
         target_step: login_identify
         bot_protection:
           mode: always
-          provider:
-            type: recaptchav2
         steps:
         - name: authenticate_secondary_phone
           type: authenticate
@@ -737,18 +705,12 @@ steps:
           - authentication: secondary_oob_otp_email
             bot_protection:
               mode: always
-              provider:
-                type: recaptchav2
           - authentication: secondary_oob_otp_sms
             bot_protection:
               mode: always
-              provider:
-                type: recaptchav2
           - authentication: secondary_password
             bot_protection:
               mode: never
-              provider:
-                type: recaptchav2
           - authentication: recovery_code
           - authentication: device_token
 - type: check_account_status

--- a/pkg/lib/authenticationflow/declarative/generate_config_signup_flow_test.go
+++ b/pkg/lib/authenticationflow/declarative/generate_config_signup_flow_test.go
@@ -358,23 +358,17 @@ steps:
   - identification: email
     bot_protection:
       mode: always
-      provider:
-        type: recaptchav2
     steps:
     - target_step: signup_identify
       type: verify
       bot_protection:
         mode: always
-        provider:
-          type: recaptchav2
     - name: authenticate_primary_email
       one_of:
       - authentication: primary_password
       - authentication: primary_oob_otp_email
         bot_protection:
           mode: always
-          provider:
-            type: recaptchav2
         target_step: signup_identify
       type: create_authenticator
     - name: authenticate_secondary_email
@@ -382,30 +376,22 @@ steps:
       - authentication: secondary_oob_otp_email
         bot_protection:
           mode: always
-          provider:
-            type: recaptchav2
         steps:
         - type: view_recovery_code
       - authentication: secondary_oob_otp_sms
         bot_protection:
           mode: always
-          provider:
-            type: recaptchav2
         steps:
         - type: view_recovery_code
       type: create_authenticator
   - identification: phone
     bot_protection:
       mode: always
-      provider:
-        type: recaptchav2
     steps:
     - target_step: signup_identify
       type: verify
       bot_protection:
         mode: always
-        provider:
-          type: recaptchav2
     - name: authenticate_primary_phone
       type: create_authenticator
       one_of:
@@ -414,30 +400,22 @@ steps:
         target_step: signup_identify
         bot_protection:
           mode: always
-          provider:
-            type: recaptchav2
     - name: authenticate_secondary_phone
       one_of:
       - authentication: secondary_oob_otp_email
         bot_protection:
           mode: always
-          provider:
-            type: recaptchav2
         steps:
         - type: view_recovery_code
       - authentication: secondary_oob_otp_sms
         bot_protection:
           mode: always
-          provider:
-            type: recaptchav2
         steps:
         - type: view_recovery_code
       type: create_authenticator
   - identification: username
     bot_protection:
       mode: always
-      provider:
-        type: recaptchav2
     steps:
     - name: authenticate_primary_username
       one_of:
@@ -448,15 +426,11 @@ steps:
       - authentication: secondary_oob_otp_email
         bot_protection:
           mode: always
-          provider:
-            type: recaptchav2
         steps:
         - type: view_recovery_code
       - authentication: secondary_oob_otp_sms
         bot_protection:
           mode: always
-          provider:
-            type: recaptchav2
         steps:
         - type: view_recovery_code
       type: create_authenticator

--- a/pkg/lib/authenticationflow/declarative/generate_config_signup_login_flow_test.go
+++ b/pkg/lib/authenticationflow/declarative/generate_config_signup_login_flow_test.go
@@ -252,8 +252,6 @@ steps:
   - identification: email
     bot_protection:
       mode: always
-      provider: 
-        type: recaptchav2
     signup_flow: default
     login_flow: default
 `)
@@ -301,22 +299,16 @@ steps:
   - identification: email
     bot_protection:
       mode: always
-      provider: 
-        type: recaptchav2
     signup_flow: default
     login_flow: default
   - identification: phone
     bot_protection:
       mode: always
-      provider: 
-        type: recaptchav2
     signup_flow: default
     login_flow: default
   - identification: username
     bot_protection:
       mode: always
-      provider: 
-        type: recaptchav2
     signup_flow: default
     login_flow: default
   - identification: oauth

--- a/pkg/lib/authenticationflow/declarative/intent_create_authenticator_oob_otp.go
+++ b/pkg/lib/authenticationflow/declarative/intent_create_authenticator_oob_otp.go
@@ -92,7 +92,7 @@ func (n *IntentCreateAuthenticatorOOBOTP) CanReactTo(ctx context.Context, deps *
 			return nil, nil
 		}
 
-		isBotProtectionRequired, err := IsBotProtectionRequired(ctx, flowRootObject, n.JSONPointer)
+		isBotProtectionRequired, err := IsBotProtectionRequired(ctx, deps, flows, n.JSONPointer)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/lib/authenticationflow/declarative/intent_create_identity_login_id.go
+++ b/pkg/lib/authenticationflow/declarative/intent_create_identity_login_id.go
@@ -60,7 +60,7 @@ func (n *IntentCreateIdentityLoginID) CanReactTo(ctx context.Context, deps *auth
 		return nil, err
 	}
 
-	isBotProtectionRequired, err := IsBotProtectionRequired(ctx, flowRootObject, n.JSONPointer)
+	isBotProtectionRequired, err := IsBotProtectionRequired(ctx, deps, flows, n.JSONPointer)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/lib/authenticationflow/declarative/intent_lookup_identity_login_id.go
+++ b/pkg/lib/authenticationflow/declarative/intent_lookup_identity_login_id.go
@@ -45,7 +45,7 @@ func (n *IntentLookupIdentityLoginID) CanReactTo(ctx context.Context, deps *auth
 		return nil, err
 	}
 
-	isBotProtectionRequired, err := IsBotProtectionRequired(ctx, flowRootObject, n.JSONPointer)
+	isBotProtectionRequired, err := IsBotProtectionRequired(ctx, deps, flows, n.JSONPointer)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/lib/authenticationflow/declarative/intent_lookup_identity_oauth.go
+++ b/pkg/lib/authenticationflow/declarative/intent_lookup_identity_oauth.go
@@ -48,7 +48,7 @@ func (i *IntentLookupIdentityOAuth) CanReactTo(ctx context.Context, deps *authfl
 		}
 
 		oauthOptions := NewIdentificationOptionsOAuth(deps.Config.Identity.OAuth, deps.FeatureConfig.Identity.OAuth.Providers, authflowCfg, deps.Config.BotProtection)
-		isBotProtectionRequired, err := IsBotProtectionRequired(ctx, flowRootObject, i.JSONPointer)
+		isBotProtectionRequired, err := IsBotProtectionRequired(ctx, deps, flows, i.JSONPointer)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/lib/authenticationflow/declarative/intent_lookup_identity_passkey.go
+++ b/pkg/lib/authenticationflow/declarative/intent_lookup_identity_passkey.go
@@ -45,7 +45,7 @@ func (n *IntentLookupIdentityPasskey) CanReactTo(ctx context.Context, deps *auth
 	if err != nil {
 		return nil, err
 	}
-	isBotProtectionRequired, err := IsBotProtectionRequired(ctx, flowRootObject, n.JSONPointer)
+	isBotProtectionRequired, err := IsBotProtectionRequired(ctx, deps, flows, n.JSONPointer)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/lib/authenticationflow/declarative/intent_oauth.go
+++ b/pkg/lib/authenticationflow/declarative/intent_oauth.go
@@ -66,7 +66,7 @@ func (i *IntentOAuth) CanReactTo(ctx context.Context, deps *authflow.Dependencie
 
 		oauthOptions := NewIdentificationOptionsOAuth(deps.Config.Identity.OAuth, deps.FeatureConfig.Identity.OAuth.Providers, authflowCfg, deps.Config.BotProtection)
 
-		isBotProtectionRequired, err := IsBotProtectionRequired(ctx, flowRootObject, i.JSONPointer)
+		isBotProtectionRequired, err := IsBotProtectionRequired(ctx, deps, flows, i.JSONPointer)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/lib/authenticationflow/declarative/intent_promote_identity_login_id.go
+++ b/pkg/lib/authenticationflow/declarative/intent_promote_identity_login_id.go
@@ -53,7 +53,7 @@ func (n *IntentPromoteIdentityLoginID) CanReactTo(ctx context.Context, deps *aut
 	if err != nil {
 		return nil, err
 	}
-	isBotProtectionRequired, err := IsBotProtectionRequired(ctx, flowRootObject, n.JSONPointer)
+	isBotProtectionRequired, err := IsBotProtectionRequired(ctx, deps, flows, n.JSONPointer)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/lib/authenticationflow/declarative/intent_promote_identity_oauth.go
+++ b/pkg/lib/authenticationflow/declarative/intent_promote_identity_oauth.go
@@ -53,7 +53,7 @@ func (i *IntentPromoteIdentityOAuth) CanReactTo(ctx context.Context, deps *authf
 		}
 		oauthOptions := NewIdentificationOptionsOAuth(deps.Config.Identity.OAuth, deps.FeatureConfig.Identity.OAuth.Providers, authflowCfg, deps.Config.BotProtection)
 
-		isBotProtectionRequired, err := IsBotProtectionRequired(ctx, flowRootObject, i.JSONPointer)
+		isBotProtectionRequired, err := IsBotProtectionRequired(ctx, deps, flows, i.JSONPointer)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/lib/authenticationflow/declarative/intent_use_account_recovery_identity.go
+++ b/pkg/lib/authenticationflow/declarative/intent_use_account_recovery_identity.go
@@ -44,7 +44,7 @@ func (n *IntentUseAccountRecoveryIdentity) CanReactTo(ctx context.Context, deps 
 	if err != nil {
 		return nil, err
 	}
-	isBotProtectionRequired, err := IsBotProtectionRequired(ctx, flowRootObject, n.JSONPointer)
+	isBotProtectionRequired, err := IsBotProtectionRequired(ctx, deps, flows, n.JSONPointer)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/lib/authenticationflow/declarative/intent_use_authenticator_passkey.go
+++ b/pkg/lib/authenticationflow/declarative/intent_use_authenticator_passkey.go
@@ -52,7 +52,7 @@ func (n *IntentUseAuthenticatorPasskey) CanReactTo(ctx context.Context, deps *au
 	if err != nil {
 		return nil, err
 	}
-	isBotProtectionRequired, err := IsBotProtectionRequired(ctx, flowRootObject, n.JSONPointer)
+	isBotProtectionRequired, err := IsBotProtectionRequired(ctx, deps, flows, n.JSONPointer)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/lib/authenticationflow/declarative/intent_use_authenticator_password.go
+++ b/pkg/lib/authenticationflow/declarative/intent_use_authenticator_password.go
@@ -51,7 +51,7 @@ func (n *IntentUseAuthenticatorPassword) CanReactTo(ctx context.Context, deps *a
 	if err != nil {
 		return nil, err
 	}
-	isBotProtectionRequired, err := IsBotProtectionRequired(ctx, flowRootObject, n.JSONPointer)
+	isBotProtectionRequired, err := IsBotProtectionRequired(ctx, deps, flows, n.JSONPointer)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/lib/authenticationflow/declarative/intent_use_authenticator_totp.go
+++ b/pkg/lib/authenticationflow/declarative/intent_use_authenticator_totp.go
@@ -52,7 +52,7 @@ func (n *IntentUseAuthenticatorTOTP) CanReactTo(ctx context.Context, deps *authf
 		return nil, err
 	}
 
-	isBotProtectionRequired, err := IsBotProtectionRequired(ctx, flowRootObject, n.JSONPointer)
+	isBotProtectionRequired, err := IsBotProtectionRequired(ctx, deps, flows, n.JSONPointer)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/lib/authenticationflow/declarative/intent_use_identity_login_id.go
+++ b/pkg/lib/authenticationflow/declarative/intent_use_identity_login_id.go
@@ -48,7 +48,7 @@ func (n *IntentUseIdentityLoginID) CanReactTo(ctx context.Context, deps *authflo
 		return nil, err
 	}
 
-	isBotProtectionRequired, err := IsBotProtectionRequired(ctx, flowRootObject, n.JSONPointer)
+	isBotProtectionRequired, err := IsBotProtectionRequired(ctx, deps, flows, n.JSONPointer)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/lib/authenticationflow/declarative/intent_use_identity_passkey.go
+++ b/pkg/lib/authenticationflow/declarative/intent_use_identity_passkey.go
@@ -53,7 +53,7 @@ func (n *IntentUseIdentityPasskey) CanReactTo(ctx context.Context, deps *authflo
 		return nil, err
 	}
 
-	isBotProtectionRequired, err := IsBotProtectionRequired(ctx, flowRootObject, n.JSONPointer)
+	isBotProtectionRequired, err := IsBotProtectionRequired(ctx, deps, flows, n.JSONPointer)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/lib/authenticationflow/declarative/intent_use_recovery_code.go
+++ b/pkg/lib/authenticationflow/declarative/intent_use_recovery_code.go
@@ -48,7 +48,7 @@ func (n *IntentUseRecoveryCode) CanReactTo(ctx context.Context, deps *authflow.D
 		return nil, err
 	}
 
-	isBotProtectionRequired, err := IsBotProtectionRequired(ctx, flowRootObject, n.JSONPointer)
+	isBotProtectionRequired, err := IsBotProtectionRequired(ctx, deps, flows, n.JSONPointer)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/lib/authenticationflow/declarative/utils_bot_protection.go
+++ b/pkg/lib/authenticationflow/declarative/utils_bot_protection.go
@@ -34,34 +34,14 @@ func isNodeBotProtectionRequired(ctx context.Context, deps *authflow.Dependencie
 	return isConfigBotProtectionRequired(currentBranch.GetBotProtectionConfig(), deps.Config.BotProtection), nil
 }
 
-func IsBotProtectionRequired(ctx context.Context, flowRootObject config.AuthenticationFlowObject, oneOfJSONPointer jsonpointer.T) (bool, error) {
-	required, err := isInputBotProtectionRequired(flowRootObject, oneOfJSONPointer)
+func IsBotProtectionRequired(ctx context.Context, deps *authflow.Dependencies, flows authflow.Flows, oneOfJSONPointer jsonpointer.T) (bool, error) {
+	required, err := isNodeBotProtectionRequired(ctx, deps, flows, oneOfJSONPointer)
 	if err != nil {
 		return false, err
 	}
 	shouldExistingBypassRequired := ShouldExistingResultBypassBotProtectionRequirement(ctx)
 
 	return required && !shouldExistingBypassRequired, nil
-}
-
-func isInputBotProtectionRequired(flowRootObject config.AuthenticationFlowObject, oneOfJSONPointer jsonpointer.T) (bool, error) {
-	current, err := authflow.FlowObject(flowRootObject, oneOfJSONPointer)
-	if err != nil {
-		return false, err
-	}
-
-	currentBranch, ok := current.(config.AuthenticationFlowObjectBotProtectionConfigProvider)
-	if !ok {
-		return false, authflow.ErrInvalidJSONPointer
-	}
-
-	authflowCfg := currentBranch.GetBotProtectionConfig()
-
-	if authflowCfg == nil {
-		return false, nil
-	}
-
-	return isConfigBotProtectionRequired(currentBranch.GetBotProtectionConfig(), nil), nil
 }
 
 func ShouldExistingResultBypassBotProtectionRequirement(ctx context.Context) bool {

--- a/pkg/lib/config/authentication_flow_bot_protection.go
+++ b/pkg/lib/config/authentication_flow_bot_protection.go
@@ -6,42 +6,11 @@ var _ = Schema.Add("AuthenticationFlowBotProtection", `
 	"additionalProperties": false,
 	"required": ["mode"],
 	"properties": {
-		"mode": { "$ref": "#/$defs/BotProtectionRiskMode" },
-		"provider": { "$ref": "#/$defs/AuthenticationFlowBotProtectionProvider" }
-	},
-	"allOf": [
-		{
-			"if": {
-				"required": ["mode"],
-				"properties": {
-					"mode": {
-						"enum": ["always"]
-					}
-				}
-			},
-			"then": {
-				"required": ["provider"]
-			}
-		}
-	]
-}
-`)
-
-var _ = Schema.Add("AuthenticationFlowBotProtectionProvider", `
-{
-	"type": "object",
-	"additionalProperties": false,
-	"required": ["type"],
-	"properties": {
-		"type": { "type": "string", "enum": ["cloudflare", "recaptchav2"] }
+		"mode": { "$ref": "#/$defs/BotProtectionRiskMode" }
 	}
 }
 `)
 
-type AuthenticationFlowBotProtectionProvider struct {
-	Type BotProtectionProviderType `json:"type,omitempty"`
-}
 type AuthenticationFlowBotProtection struct {
-	Mode     BotProtectionRiskMode                    `json:"mode,omitempty"`
-	Provider *AuthenticationFlowBotProtectionProvider `json:"provider,omitempty"`
+	Mode BotProtectionRiskMode `json:"mode,omitempty"`
 }

--- a/pkg/lib/config/testdata/login_flow_tests.yaml
+++ b/pkg/lib/config/testdata/login_flow_tests.yaml
@@ -76,11 +76,8 @@ value:
   - type: foobar
 ---
 part: AuthenticationFlowLoginFlow
-name: bot-protection-mode-always-but-missing-provider
-error: |-
-  invalid value:
-  /steps/0/one_of/0/bot_protection: required
-    map[actual:[mode] expected:[provider] missing:[provider]]
+name: bot-protection-mode-always
+error: null
 value:
   name: id
   steps:
@@ -90,34 +87,6 @@ value:
     - identification: email
       bot_protection:
         mode: always
-      steps:
-      - type: authenticate
-        one_of:
-        - authentication: primary_oob_otp_email
-          target_step: my_step
-      - type: authenticate
-        optional: true
-        one_of:
-        - authentication: secondary_totp
----
-part: AuthenticationFlowLoginFlow
-name: bot-protection-provider-missing-type
-error: |-
-  invalid value:
-  /steps/0/one_of/0/bot_protection/provider: required
-    map[actual:[nickname] expected:[type] missing:[type]]
-  /steps/0/one_of/0/bot_protection/provider/nickname: 
-value:
-  name: id
-  steps:
-  - type: identify
-    name: my_step
-    one_of:
-    - identification: email
-      bot_protection:
-        mode: always
-        provider:
-          nickname: wrong-key
       steps:
       - type: authenticate
         one_of:

--- a/pkg/lib/config/testdata/reauth_flow_tests.yaml
+++ b/pkg/lib/config/testdata/reauth_flow_tests.yaml
@@ -42,11 +42,8 @@ value:
         foobar: true
 ---
 part: AuthenticationFlowReauthFlow
-name: bot-protection-mode-always-but-missing-provider
-error: |-
-  invalid value:
-  /steps/0/one_of/0/bot_protection: required
-    map[actual:[mode] expected:[provider] missing:[provider]]
+name: bot-protection-mode-always
+error: null
 value:
   name: id
   steps:
@@ -55,28 +52,6 @@ value:
     - authentication: primary_password
       bot_protection:
         mode: always
-      steps:
-      - type: authenticate
-        one_of:
-        - authentication: secondary_totp
----
-part: AuthenticationFlowReauthFlow
-name: bot-protection-provider-missing-alias
-error: |-
-  invalid value:
-  /steps/0/one_of/0/bot_protection/provider: required
-    map[actual:[nickname] expected:[type] missing:[type]]
-  /steps/0/one_of/0/bot_protection/provider/nickname: 
-value:
-  name: id
-  steps:
-  - type: authenticate
-    one_of:
-    - authentication: primary_password
-      bot_protection:
-        mode: always
-        provider:
-          nickname: wrong-key
       steps:
       - type: authenticate
         one_of:

--- a/pkg/lib/config/testdata/signup_flow_tests.yaml
+++ b/pkg/lib/config/testdata/signup_flow_tests.yaml
@@ -62,11 +62,8 @@ value:
   - type: foobar
 ---
 part: AuthenticationFlowSignupFlow
-name: bot-protection-mode-always-but-missing-provider
-error: |-
-  invalid value:
-  /steps/0/one_of/0/bot_protection: required
-    map[actual:[mode] expected:[provider] missing:[provider]]
+name: bot-protection-mode-always
+error: null
 value:
   name: id
   steps:
@@ -76,36 +73,6 @@ value:
     - identification: email
       bot_protection:
         mode: always
-      steps:
-      - type: create_authenticator
-        one_of:
-        - authentication: primary_password
-  - type: verify
-    target_step: my_step
-  - type: fill_in_user_profile
-    user_profile:
-    - pointer: /given_name
-      required: true
-  - type: view_recovery_code
----
-part: AuthenticationFlowSignupFlow
-name: bot-protection-provider-missing-alias
-error: |-
-  invalid value:
-  /steps/0/one_of/0/bot_protection/provider: required
-    map[actual:[nickname] expected:[type] missing:[type]]
-  /steps/0/one_of/0/bot_protection/provider/nickname: 
-value:
-  name: id
-  steps:
-  - type: identify
-    name: my_step
-    one_of:
-    - identification: email
-      bot_protection:
-        mode: always
-        provider:
-          nickname: wrong-key
       steps:
       - type: create_authenticator
         one_of:

--- a/pkg/lib/config/testdata/signup_login_flow_tests.yaml
+++ b/pkg/lib/config/testdata/signup_login_flow_tests.yaml
@@ -39,11 +39,8 @@ value:
         foobar: true
 ---
 part: AuthenticationFlowSignupLoginFlow
-name: bot_protection-mode-always-but-missing-provider
-error: |-
-  invalid value:
-  /steps/0/one_of/0/bot_protection: required
-    map[actual:[mode] expected:[provider] missing:[provider]]
+name: bot_protection-mode-always
+error: null
 value:
   name: id
   steps:
@@ -52,25 +49,5 @@ value:
     - identification: email
       bot_protection:
         mode: always
-      signup_flow: a
-      login_flow: b
----
-part: AuthenticationFlowSignupLoginFlow
-name: bot-protection-provider-missing-alias
-error: |-
-  invalid value:
-  /steps/0/one_of/0/bot_protection/provider: required
-    map[actual:[nickname] expected:[type] missing:[type]]
-  /steps/0/one_of/0/bot_protection/provider/nickname: 
-value:
-  name: id
-  steps:
-  - type: identify
-    one_of:
-    - identification: email
-      bot_protection:
-        mode: always
-        provider:
-          nickname: wrong-key
       signup_flow: a
       login_flow: b


### PR DESCRIPTION
## What's in this PR?

In light of https://github.com/authgear/authgear-server/pull/4533#discussion_r1706495496, we decided to remove `provider.type` from authentication_flow

## Any regression?

bot protection e2e tests pass, should be okay 
