### PR TITLE
Do not cache `prettier:format` in portal

### DIFF
--- a/authui/package-lock.json
+++ b/authui/package-lock.json
@@ -43,7 +43,7 @@
         "parcel": "2.10.2",
         "parcel-reporter-static-files-copy": "1.5.3",
         "postcss": "8.4.31",
-        "prettier": "3.1.0",
+        "prettier": "2.8.8",
         "stylelint": "14.16.1",
         "tailwindcss": "3.3.5",
         "ts-jest": "29.1.1",
@@ -11652,15 +11652,15 @@
       }
     },
     "node_modules/prettier": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.1.0.tgz",
-      "integrity": "sha512-TQLvXjq5IAibjh8EpBIkNKxO749UEWABoiIZehEPiY4GNpVdhaFKqSTu+QrlU6D2dPAfubRmtJTi4K4YkQ5eXw==",
+      "version": "2.8.8",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.8.tgz",
+      "integrity": "sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==",
       "dev": true,
       "bin": {
-        "prettier": "bin/prettier.cjs"
+        "prettier": "bin-prettier.js"
       },
       "engines": {
-        "node": ">=14"
+        "node": ">=10.13.0"
       },
       "funding": {
         "url": "https://github.com/prettier/prettier?sponsor=1"
@@ -22172,9 +22172,9 @@
       "dev": true
     },
     "prettier": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.1.0.tgz",
-      "integrity": "sha512-TQLvXjq5IAibjh8EpBIkNKxO749UEWABoiIZehEPiY4GNpVdhaFKqSTu+QrlU6D2dPAfubRmtJTi4K4YkQ5eXw==",
+      "version": "2.8.8",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.8.tgz",
+      "integrity": "sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==",
       "dev": true
     },
     "pretty-format": {

--- a/authui/package.json
+++ b/authui/package.json
@@ -48,7 +48,7 @@
     "parcel": "2.10.2",
     "parcel-reporter-static-files-copy": "1.5.3",
     "postcss": "8.4.31",
-    "prettier": "3.1.0",
+    "prettier": "2.8.8",
     "stylelint": "14.16.1",
     "tailwindcss": "3.3.5",
     "ts-jest": "29.1.1",

--- a/authui/package.json
+++ b/authui/package.json
@@ -10,7 +10,7 @@
     "prettier:format": "prettier --cache --write --list-different ./src ./packages",
     "eslint:format": "eslint --cache --fix './src/**/*.{js,ts}'",
     "stylelint:format": "stylelint --cache --fix './src/**/*.{css,scss}'",
-    "prettier": "prettier --cache --write --list-different ./src ./packages",
+    "prettier": "prettier --cache --list-different ./src ./packages",
     "eslint": "eslint --cache './src/**/*.{js,ts}'",
     "stylelint": "stylelint --cache './src/**/*.{css,scss}'",
     "build": "parcel build --no-cache 'src/*.html' --dist-dir ../resources/authgear/generated",

--- a/authui/src/authflowv2/icons/material-symbols.css
+++ b/authui/src/authflowv2/icons/material-symbols.css
@@ -3,8 +3,7 @@
   font-style: normal;
   font-weight: 400;
   font-display: block;
-  src:
-    url("./icons/material-symbols-outlined-subset.woff2") format("woff2"),
+  src: url("./icons/material-symbols-outlined-subset.woff2") format("woff2"),
     url("./icons/material-symbols-outlined-subset.ttf") format("truetype");
 }
 

--- a/authui/src/authflowv2/icons/twemoji-countries.css
+++ b/authui/src/authflowv2/icons/twemoji-countries.css
@@ -4,8 +4,7 @@
   font-style: normal;
   font-weight: 400;
   font-display: swap;
-  src:
-    url("./icons/Twemoji.Mozilla-subset.woff2") format("woff2"),
+  src: url("./icons/Twemoji.Mozilla-subset.woff2") format("woff2"),
     url("./icons/Twemoji.Mozilla-subset.ttf") format("truetype");
 }
 
@@ -36,8 +35,7 @@
 @supports (-webkit-appearance: none) and (stroke-color: transparent) {
   @font-face {
     font-family: "twemoji-countries";
-    src:
-      url("./icons/twemoji-color-subset.woff2") format("woff2"),
+    src: url("./icons/twemoji-color-subset.woff2") format("woff2"),
       url("./icons/twemoji-color-subset.ttf") format("truetype");
   }
 

--- a/authui/src/base64.ts
+++ b/authui/src/base64.ts
@@ -4,14 +4,14 @@ function b64ToUint6(nChr: number): number {
   return nChr > 64 && nChr < 91
     ? nChr - 65
     : nChr > 96 && nChr < 123
-      ? nChr - 71
-      : nChr > 47 && nChr < 58
-        ? nChr + 4
-        : nChr === 43
-          ? 62
-          : nChr === 47
-            ? 63
-            : 0;
+    ? nChr - 71
+    : nChr > 47 && nChr < 58
+    ? nChr + 4
+    : nChr === 43
+    ? 62
+    : nChr === 47
+    ? 63
+    : 0;
 }
 
 export function base64DecToArr(
@@ -49,14 +49,14 @@ function uint6ToB64(nUint6: number) {
   return nUint6 < 26
     ? nUint6 + 65
     : nUint6 < 52
-      ? nUint6 + 71
-      : nUint6 < 62
-        ? nUint6 - 4
-        : nUint6 === 62
-          ? 43
-          : nUint6 === 63
-            ? 47
-            : 65;
+    ? nUint6 + 71
+    : nUint6 < 62
+    ? nUint6 - 4
+    : nUint6 === 62
+    ? 43
+    : nUint6 === 63
+    ? 47
+    : 65;
 }
 
 export function base64EncArr(aBytes: Uint8Array) {

--- a/authui/src/build-authflowv2.html
+++ b/authui/src/build-authflowv2.html
@@ -1,4 +1,4 @@
-<!doctype html>
+<!DOCTYPE html>
 <html lang="en">
   <head>
     <script type="module" src="authflowv2.ts"></script>

--- a/authui/src/build-dummy.html
+++ b/authui/src/build-dummy.html
@@ -1,4 +1,4 @@
-<!doctype html>
+<!DOCTYPE html>
 <html lang="en">
   <head>
     <script type="module" src="dummy.ts"></script>

--- a/authui/src/build.html
+++ b/authui/src/build.html
@@ -1,4 +1,4 @@
-<!doctype html>
+<!DOCTYPE html>
 <html lang="en">
   <head>
     <link

--- a/authui/src/icons/authgear-icons.css
+++ b/authui/src/icons/authgear-icons.css
@@ -5,8 +5,7 @@
 @font-face {
   font-family: "authgear-icons";
   src: url("./authgear-icons.eot");
-  src:
-    url("./authgear-icons.eot") format("embedded-opentype"),
+  src: url("./authgear-icons.eot") format("embedded-opentype"),
     url("./authgear-icons.woff") format("woff"),
     url("./authgear-icons.ttf") format("truetype"),
     url("./authgear-icons.svg") format("svg");

--- a/authui/src/tailwind.css
+++ b/authui/src/tailwind.css
@@ -31,16 +31,8 @@
   }
 
   body {
-    font-family:
-      "Segoe UI Web",
-      -apple-system,
-      BlinkMacSystemFont,
-      "Segoe UI",
-      "Helvetica",
-      "Arial",
-      sans-serif,
-      "Apple Color Emoji",
-      "Segoe UI Emoji";
+    font-family: "Segoe UI Web", -apple-system, BlinkMacSystemFont, "Segoe UI",
+      "Helvetica", "Arial", sans-serif, "Apple Color Emoji", "Segoe UI Emoji";
   }
 
   /* NOTE(1) */
@@ -595,9 +587,7 @@
   #loading-progress-bar {
     @apply fixed block top-0 left-0 h-[3px] z-[9999] opacity-0;
     background-color: var(--color-primary-unshaded);
-    transition:
-      width 300ms ease-out,
-      opacity 150ms 150ms ease-in;
+    transition: width 300ms ease-out, opacity 150ms 150ms ease-in;
     transform: translate3d(0, 0, 0);
   }
   .turbo-progress-bar {

--- a/portal/package-lock.json
+++ b/portal/package-lock.json
@@ -72,7 +72,7 @@
         "parcel": "2.10.2",
         "parcel-resolver-authgear": "1.0.0",
         "parcel-resolver-ignore": "2.2.0",
-        "prettier": "2.7.1",
+        "prettier": "2.8.8",
         "stylelint": "14.11.0",
         "tailwindcss": "3.3.5",
         "ts-jest": "29.1.1",
@@ -14279,9 +14279,9 @@
       }
     },
     "node_modules/prettier": {
-      "version": "2.7.1",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.7.1.tgz",
-      "integrity": "sha512-ujppO+MkdPqoVINuDFDRLClm7D78qbDt0/NR+wp5FqEZOoTNAjPHWj17QRhu7geIHJfcNhRk1XVQmF8Bp3ye+g==",
+      "version": "2.8.8",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.8.tgz",
+      "integrity": "sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==",
       "dev": true,
       "bin": {
         "prettier": "bin-prettier.js"
@@ -27099,9 +27099,9 @@
       "dev": true
     },
     "prettier": {
-      "version": "2.7.1",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.7.1.tgz",
-      "integrity": "sha512-ujppO+MkdPqoVINuDFDRLClm7D78qbDt0/NR+wp5FqEZOoTNAjPHWj17QRhu7geIHJfcNhRk1XVQmF8Bp3ye+g==",
+      "version": "2.8.8",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.8.tgz",
+      "integrity": "sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==",
       "dev": true
     },
     "pretty-format": {

--- a/portal/package.json
+++ b/portal/package.json
@@ -51,7 +51,7 @@
     "parcel": "2.10.2",
     "parcel-resolver-authgear": "1.0.0",
     "parcel-resolver-ignore": "2.2.0",
-    "prettier": "2.7.1",
+    "prettier": "2.8.8",
     "stylelint": "14.11.0",
     "tailwindcss": "3.3.5",
     "ts-jest": "29.1.1",

--- a/portal/package.json
+++ b/portal/package.json
@@ -10,7 +10,7 @@
     "build": "PARCEL_BUNDLE_ANALYZER=1 parcel build --no-cache --no-scope-hoist './src/*.html'",
     "clean": "rm -rf ./dist/ ./parcel-bundle-reports/ && mkdir ./dist/ && touch ./dist/.gitkeep",
     "typecheck": "tsc",
-    "prettier:format": "prettier --list-different --write './src/**/*.{js,ts,jsx,tsx,css,scss,html}'",
+    "prettier:format": "prettier --list-different --write --cache './src/**/*.{js,ts,jsx,tsx,css,scss,html}'",
     "eslint:format": "eslint --cache --fix './src/**/*.{js,ts,jsx,tsx}'",
     "stylelint:format": "stylelint --cache --fix './src/**/*.{css,scss}'",
     "prettier": "prettier --list-different --cache './src/**/*.{js,ts,jsx,tsx,css,scss,html}'",

--- a/portal/package.json
+++ b/portal/package.json
@@ -10,7 +10,7 @@
     "build": "PARCEL_BUNDLE_ANALYZER=1 parcel build --no-cache --no-scope-hoist './src/*.html'",
     "clean": "rm -rf ./dist/ ./parcel-bundle-reports/ && mkdir ./dist/ && touch ./dist/.gitkeep",
     "typecheck": "tsc",
-    "prettier:format": "prettier --list-different --write --cache './src/**/*.{js,ts,jsx,tsx,css,scss,html}'",
+    "prettier:format": "prettier --list-different --write './src/**/*.{js,ts,jsx,tsx,css,scss,html}'",
     "eslint:format": "eslint --cache --fix './src/**/*.{js,ts,jsx,tsx}'",
     "stylelint:format": "stylelint --cache --fix './src/**/*.{css,scss}'",
     "prettier": "prettier --list-different --cache './src/**/*.{js,ts,jsx,tsx,css,scss,html}'",

--- a/portal/src/graphql/adminapi/UserDetailsConnectedIdentities.tsx
+++ b/portal/src/graphql/adminapi/UserDetailsConnectedIdentities.tsx
@@ -75,7 +75,7 @@ interface UserDetailsConnectedIdentitiesProps {
 }
 
 const loginIdIdentityTypes = ["email", "phone", "username"] as const;
-type LoginIDIdentityType = typeof loginIdIdentityTypes[number];
+type LoginIDIdentityType = (typeof loginIdIdentityTypes)[number];
 type IdentityType = "login_id" | "oauth" | "biometric" | "anonymous" | "siwe";
 
 type IdentityListItem =

--- a/portal/src/graphql/portal/PhoneInputListWidget.tsx
+++ b/portal/src/graphql/portal/PhoneInputListWidget.tsx
@@ -48,7 +48,7 @@ interface ListItem {
   disabled: boolean;
 }
 
-type Country = typeof ALL_COUNTRIES[number];
+type Country = (typeof ALL_COUNTRIES)[number];
 type CountryMap = Record<string, Country>;
 
 const COUNTRY_MAP: CountryMap = ALL_COUNTRIES.reduce<CountryMap>(

--- a/portal/src/model/themeAuthFlowV2.ts
+++ b/portal/src/model/themeAuthFlowV2.ts
@@ -52,7 +52,7 @@ export const enum CSSVariable {
 export type CSSColor = string;
 
 export const AllAlignments = ["start", "center", "end"] as const;
-export type Alignment = typeof AllAlignments[number];
+export type Alignment = (typeof AllAlignments)[number];
 
 export type Hidden = "hidden";
 
@@ -61,7 +61,7 @@ export const AllBorderRadiusStyleTypes = [
   "rounded",
   "rounded-full",
 ] as const;
-export type BorderRadiusStyleType = typeof AllBorderRadiusStyleTypes[number];
+export type BorderRadiusStyleType = (typeof AllBorderRadiusStyleTypes)[number];
 
 export type BorderRadiusStyle =
   | {

--- a/portal/src/types.ts
+++ b/portal/src/types.ts
@@ -24,7 +24,7 @@ export interface RateLimitConfig {
 // LoginIDKeyConfig
 
 export const loginIDKeyTypes = ["email", "phone", "username"] as const;
-export type LoginIDKeyType = typeof loginIDKeyTypes[number];
+export type LoginIDKeyType = (typeof loginIDKeyTypes)[number];
 
 export interface LoginIDKeyConfig {
   type: LoginIDKeyType;
@@ -74,9 +74,9 @@ export const oauthSSOProviderTypes = [
   "adfs",
   "wechat",
 ] as const;
-export type OAuthSSOProviderType = typeof oauthSSOProviderTypes[number];
+export type OAuthSSOProviderType = (typeof oauthSSOProviderTypes)[number];
 export const oauthSSOWeChatAppType = ["mobile", "web"] as const;
-export type OAuthSSOWeChatAppType = typeof oauthSSOWeChatAppType[number];
+export type OAuthSSOWeChatAppType = (typeof oauthSSOWeChatAppType)[number];
 export interface OAuthClaimConfig {
   required?: boolean;
 }
@@ -112,7 +112,7 @@ export const oauthSSOProviderItemKeys = [
   "wechat.mobile",
   "wechat.web",
 ] as const;
-export type OAuthSSOProviderItemKey = typeof oauthSSOProviderItemKeys[number];
+export type OAuthSSOProviderItemKey = (typeof oauthSSOProviderItemKeys)[number];
 
 export const createOAuthSSOProviderItemKey = (
   type: OAuthSSOProviderType,
@@ -145,7 +145,7 @@ export interface OAuthSSOConfig {
 // IdentityConflictConfig
 export const promotionConflictBehaviours = ["error", "login"] as const;
 export type PromotionConflictBehaviour =
-  typeof promotionConflictBehaviours[number];
+  (typeof promotionConflictBehaviours)[number];
 export const isPromotionConflictBehaviour = (
   value: unknown
 ): value is PromotionConflictBehaviour => {
@@ -177,7 +177,7 @@ export interface IdentityConfig {
 
 export const passwordPolicyGuessableLevels = [0, 1, 2, 3, 4, 5] as const;
 export type PasswordPolicyGuessableLevel =
-  typeof passwordPolicyGuessableLevels[number];
+  (typeof passwordPolicyGuessableLevels)[number];
 export const isPasswordPolicyGuessableLevel = (
   value: unknown
 ): value is PasswordPolicyGuessableLevel => {
@@ -267,7 +267,8 @@ export const primaryAuthenticatorTypes = [
   "oob_otp_sms",
   "passkey",
 ] as const;
-export type PrimaryAuthenticatorType = typeof primaryAuthenticatorTypes[number];
+export type PrimaryAuthenticatorType =
+  (typeof primaryAuthenticatorTypes)[number];
 export function isPrimaryAuthenticatorType(
   type: any
 ): type is PrimaryAuthenticatorType {
@@ -281,7 +282,7 @@ export const secondaryAuthenticatorTypes = [
   "totp",
 ] as const;
 export type SecondaryAuthenticatorType =
-  typeof secondaryAuthenticatorTypes[number];
+  (typeof secondaryAuthenticatorTypes)[number];
 export function isSecondaryAuthenticatorType(
   type: any
 ): type is SecondaryAuthenticatorType {
@@ -296,7 +297,7 @@ export const identityTypes = [
   "passkey",
   "siwe",
 ] as const;
-export type IdentityType = typeof identityTypes[number];
+export type IdentityType = (typeof identityTypes)[number];
 
 export const secondaryAuthenticationModes = [
   "disabled",
@@ -304,7 +305,7 @@ export const secondaryAuthenticationModes = [
   "required",
 ] as const;
 export type SecondaryAuthenticationMode =
-  typeof secondaryAuthenticationModes[number];
+  (typeof secondaryAuthenticationModes)[number];
 
 export interface RecoveryCodeConfig {
   disabled?: boolean;
@@ -338,11 +339,11 @@ export interface VerificationClaimsConfig {
 }
 
 export const verificationCriteriaList = ["any", "all"] as const;
-export type VerificationCriteria = typeof verificationCriteriaList[number];
+export type VerificationCriteria = (typeof verificationCriteriaList)[number];
 
 export const authenticatorEmailOTPModeList = ["code", "login_link"] as const;
 export type AuthenticatorEmailOTPMode =
-  typeof authenticatorEmailOTPModeList[number];
+  (typeof authenticatorEmailOTPModeList)[number];
 
 export const authenticatorPhoneOTPModeList = [
   "sms",
@@ -350,7 +351,7 @@ export const authenticatorPhoneOTPModeList = [
   "whatsapp",
 ] as const;
 export type AuthenticatorPhoneOTPMode =
-  typeof authenticatorPhoneOTPModeList[number];
+  (typeof authenticatorPhoneOTPModeList)[number];
 
 export const authenticatorPhoneOTPSMSModeList = ["sms", "whatsapp_sms"];
 
@@ -476,7 +477,7 @@ export const applicationTypes = [
   "confidential",
   "third_party_app",
 ] as const;
-export type ApplicationType = typeof applicationTypes[number];
+export type ApplicationType = (typeof applicationTypes)[number];
 
 // OAuthConfig
 export interface OAuthClientConfig {
@@ -578,7 +579,7 @@ export const customAttributeTypes = [
   "url",
   "country_code",
 ] as const;
-export type CustomAttributeType = typeof customAttributeTypes[number];
+export type CustomAttributeType = (typeof customAttributeTypes)[number];
 export function isCustomAttributeType(v: unknown): v is CustomAttributeType {
   // @ts-expect-error
   return typeof v === "string" && customAttributeTypes.includes(v);
@@ -1033,6 +1034,6 @@ export const botProtectionProviderTypes = [
   "recaptchav2",
 ] as const;
 export type BotProtectionProviderType =
-  typeof botProtectionProviderTypes[number];
+  (typeof botProtectionProviderTypes)[number];
 
 export type UIImplementation = "interaction" | "authflow" | "authflowv2";


### PR DESCRIPTION
## What's in this PR?
It fixes below problem. Now at step 3, the mal-formatted files will be formatted
## Problem

1. run `npm run prettier`
2. mal-formatted files are cached in `./node_modules/.cache/prettier/.prettier-cache` 
    ref https://prettier.io/docs/en/cli.html#--cache
3. run `npm run prettier:format`

At 3, the mal-formatted files will NOT be formatted, which is unexpected

