### PR TITLE
Fix import api failed to handle email username with upper cases

### DIFF
--- a/e2e/tests/issue_DEV_1458_import_uppercase/case_insensitive/email/test.yaml
+++ b/e2e/tests/issue_DEV_1458_import_uppercase/case_insensitive/email/test.yaml
@@ -1,0 +1,41 @@
+# https://linear.app/authgear/issue/DEV-1458/import-api-failed-to-handle-email-username-with-upper-cases
+
+name: If case_insensitive, import user with uppercase email should become lowercase 
+authgear.yaml:
+  override: |
+    authentication:
+      identities:
+      - login_id
+      primary_authenticators:
+      - password
+    identity:
+      login_id:
+        keys:
+        - create_disabled: false
+          delete_disabled: false
+          key: email
+          max_length: 320
+          type: email
+          update_disabled: false
+        types:
+          email:
+            case_sensitive: false
+before:
+  - type: user_import
+    user_import: user.json
+# Note "lowerUPPER@ca.se" is imported as "lowerupper@ca.se"
+steps:
+  - action: query
+    query: |
+      SELECT *
+      FROM _auth_user 
+      WHERE app_id = '{{ .AppID }}'
+      AND standard_attributes ->> 'email' = 'lowerupper@ca.se';
+    query_output:
+      rows: |
+        [
+          {
+            "id": "[[string]]",
+            "standard_attributes": "{\"email\": \"lowerupper@ca.se\"}"
+          }
+        ]

--- a/e2e/tests/issue_DEV_1458_import_uppercase/case_insensitive/email/user.json
+++ b/e2e/tests/issue_DEV_1458_import_uppercase/case_insensitive/email/user.json
@@ -1,0 +1,12 @@
+{
+  "identifier": "email",
+  "records": [
+    {
+      "email": "lowerUPPER@ca.se",
+      "password": {
+        "type": "bcrypt",
+        "password_hash": "$2y$10$/wLavnCmYGP/zzpw/mR1iOK5y5hGyrEFJtmaIbvFf9VA6l2O4NMKO"
+      }
+    }
+  ]
+}

--- a/e2e/tests/issue_DEV_1458_import_uppercase/case_insensitive/username/test.yaml
+++ b/e2e/tests/issue_DEV_1458_import_uppercase/case_insensitive/username/test.yaml
@@ -1,0 +1,41 @@
+# https://linear.app/authgear/issue/DEV-1458/import-api-failed-to-handle-email-username-with-upper-cases
+
+name: If case_insensitive, import user with uppercase username should become lowercase 
+authgear.yaml:
+  override: |
+    authentication:
+      identities:
+      - login_id
+      primary_authenticators:
+      - password
+    identity:
+      login_id:
+        keys:
+        - create_disabled: false
+          delete_disabled: false
+          key: username
+          max_length: 40
+          type: username
+          update_disabled: false
+        types:
+          username:
+            case_sensitive: false
+before:
+  - type: user_import
+    user_import: user.json
+steps:
+  - action: query
+    query: |
+      SELECT *
+      FROM _auth_user 
+      WHERE app_id = '{{ .AppID }}'
+      AND standard_attributes ->> 'preferred_username' = 'lowerupper';
+    # Note how `lowerUPPER` is imported as `lowerupper`
+    query_output:
+      rows: |
+        [
+          {
+            "id": "[[string]]",
+            "standard_attributes": "{\"preferred_username\": \"lowerupper\"}"
+          }
+        ]

--- a/e2e/tests/issue_DEV_1458_import_uppercase/case_insensitive/username/user.json
+++ b/e2e/tests/issue_DEV_1458_import_uppercase/case_insensitive/username/user.json
@@ -1,0 +1,12 @@
+{
+  "identifier": "preferred_username",
+  "records": [
+    {
+      "preferred_username": "lowerUPPER",
+      "password": {
+        "type": "bcrypt",
+        "password_hash": "$2y$10$/wLavnCmYGP/zzpw/mR1iOK5y5hGyrEFJtmaIbvFf9VA6l2O4NMKO"
+      }
+    }
+  ]
+}

--- a/e2e/tests/issue_DEV_1458_import_uppercase/case_sensitive/email/test.yaml
+++ b/e2e/tests/issue_DEV_1458_import_uppercase/case_sensitive/email/test.yaml
@@ -1,0 +1,41 @@
+# https://linear.app/authgear/issue/DEV-1458/import-api-failed-to-handle-email-username-with-upper-cases
+
+name: If case_sensitive, import user with uppercase email should be exact match
+authgear.yaml:
+  override: |
+    authentication:
+      identities:
+      - login_id
+      primary_authenticators:
+      - password
+    identity:
+      login_id:
+        keys:
+        - create_disabled: false
+          delete_disabled: false
+          key: email
+          max_length: 320
+          type: email
+          update_disabled: false
+        types:
+          email:
+            case_sensitive: true
+before:
+  - type: user_import
+    user_import: user.json
+# Note how `lowerUPPER@ca.se` is imported as is.
+steps:
+  - action: query
+    query: |
+      SELECT *
+      FROM _auth_user 
+      WHERE app_id = '{{ .AppID }}'
+      AND standard_attributes ->> 'email' = 'lowerUPPER@ca.se';
+    query_output:
+      rows: |
+        [
+          {
+            "id": "[[string]]",
+            "standard_attributes": "{\"email\": \"lowerUPPER@ca.se\"}"
+          }
+        ]

--- a/e2e/tests/issue_DEV_1458_import_uppercase/case_sensitive/email/user.json
+++ b/e2e/tests/issue_DEV_1458_import_uppercase/case_sensitive/email/user.json
@@ -1,0 +1,13 @@
+{
+  "identifier": "email",
+  "records": [
+    {
+      "email": "lowerUPPER@ca.se",
+
+      "password": {
+        "type": "bcrypt",
+        "password_hash": "$2y$10$/wLavnCmYGP/zzpw/mR1iOK5y5hGyrEFJtmaIbvFf9VA6l2O4NMKO"
+      }
+    }
+  ]
+}

--- a/e2e/tests/issue_DEV_1458_import_uppercase/case_sensitive/username/test.yaml
+++ b/e2e/tests/issue_DEV_1458_import_uppercase/case_sensitive/username/test.yaml
@@ -1,0 +1,41 @@
+# https://linear.app/authgear/issue/DEV-1458/import-api-failed-to-handle-email-username-with-upper-cases
+
+name: If case_sensitive, import user with uppercase username should be exact match
+authgear.yaml:
+  override: |
+    authentication:
+      identities:
+      - login_id
+      primary_authenticators:
+      - password
+    identity:
+      login_id:
+        keys:
+        - create_disabled: false
+          delete_disabled: false
+          key: username
+          max_length: 40
+          type: username
+          update_disabled: false
+        types:
+          username:
+            case_sensitive: true
+before:
+  - type: user_import
+    user_import: user.json
+# Note how `lowerUPPER` is imported as is.
+steps:
+  - action: query
+    query: |
+      SELECT *
+      FROM _auth_user 
+      WHERE app_id = '{{ .AppID }}'
+      AND standard_attributes ->> 'preferred_username' = 'lowerUPPER';
+    query_output:
+      rows: |
+        [
+          {
+            "id": "[[string]]",
+            "standard_attributes": "{\"preferred_username\": \"lowerUPPER\"}"
+          }
+        ]

--- a/e2e/tests/issue_DEV_1458_import_uppercase/case_sensitive/username/user.json
+++ b/e2e/tests/issue_DEV_1458_import_uppercase/case_sensitive/username/user.json
@@ -1,0 +1,13 @@
+{
+  "identifier": "preferred_username",
+  "records": [
+    {
+      "preferred_username": "lowerUPPER",
+
+      "password": {
+        "type": "bcrypt",
+        "password_hash": "$2y$10$/wLavnCmYGP/zzpw/mR1iOK5y5hGyrEFJtmaIbvFf9VA6l2O4NMKO"
+      }
+    }
+  ]
+}

--- a/pkg/lib/userimport/model.go
+++ b/pkg/lib/userimport/model.go
@@ -124,9 +124,7 @@ func init() {
 }
 
 var standardAttributeKeys []string = []string{
-	"preferred_username",
-	"email",
-	"phone_number",
+	// Note we don't need IdentityAware stdAttr ["email", "phone", "preferred_username"] here, since they are already populated in StdAttrsService
 	"name",
 	"given_name",
 	"family_name",

--- a/pkg/lib/userimport/model.go
+++ b/pkg/lib/userimport/model.go
@@ -123,7 +123,7 @@ func init() {
 	RecordSchemaForIdentifierPreferredUsername = preferredUsername.ToSimpleSchema()
 }
 
-var standardAttributeKeys []string = []string{
+var nonIdentityAwareStandardAttributeKeys []string = []string{
 	// Note we don't need IdentityAware stdAttr ["email", "phone", "preferred_username"] here, since they are already populated in StdAttrsService
 	"name",
 	"given_name",
@@ -322,10 +322,10 @@ func (m Record) PhoneNumberVerified() (bool, bool) {
 	return mapGetNonNull[Record, bool](m, "phone_number_verified")
 }
 
-func (m Record) standardAttributes() (map[string]interface{}, bool) {
+func (m Record) nonIdentityAwareStandardAttributes() (map[string]interface{}, bool) {
 	attrs := make(map[string]interface{})
 	for key := range m {
-		for _, k := range standardAttributeKeys {
+		for _, k := range nonIdentityAwareStandardAttributeKeys {
 			if key == k {
 				attrs[key] = m[key]
 			}
@@ -337,8 +337,8 @@ func (m Record) standardAttributes() (map[string]interface{}, bool) {
 	return nil, false
 }
 
-func (m Record) StandardAttributesList() (attrsList attrs.List) {
-	stdAttrs, ok := m.standardAttributes()
+func (m Record) NonIdentityAwareStandardAttributesList() (attrsList attrs.List) {
+	stdAttrs, ok := m.nonIdentityAwareStandardAttributes()
 	if !ok {
 		return
 	}

--- a/pkg/lib/userimport/model_test.go
+++ b/pkg/lib/userimport/model_test.go
@@ -263,7 +263,7 @@ func TestRecord(t *testing.T) {
 		Convey("standard_attributes", func() {
 			r := Record{}
 
-			l := r.StandardAttributesList()
+			l := r.NonIdentityAwareStandardAttributesList()
 			So(l, ShouldBeEmpty)
 
 			recordString := `
@@ -328,8 +328,8 @@ func TestRecord(t *testing.T) {
 			err := json.Unmarshal([]byte(recordString), &r)
 			So(err, ShouldBeNil)
 
-			l = r.StandardAttributesList()
-			So(len(l), ShouldEqual, 16)
+			l = r.NonIdentityAwareStandardAttributesList()
+			So(len(l), ShouldEqual, 13)
 		})
 
 		Convey("custom_attributes", func() {

--- a/pkg/lib/userimport/service.go
+++ b/pkg/lib/userimport/service.go
@@ -492,7 +492,7 @@ func (s *UserImportService) insertVerifiedClaimsInTxn(ctx context.Context, detai
 }
 
 func (s *UserImportService) insertStandardAttributesInTxn(ctx context.Context, detail *Detail, record Record, u *user.User) (err error) {
-	stdAttrsList := record.StandardAttributesList()
+	stdAttrsList := record.NonIdentityAwareStandardAttributesList()
 
 	stdAttrs, err := stdattrs.T(u.StandardAttributes).MergedWithList(stdAttrsList)
 	if err != nil {


### PR DESCRIPTION
## Blocked by
- #4522 
- #4568 

## What's in this PR?
Fix a bug where 
if
- `authgear.yaml` has `username/email.case_sensitive=false`

then
- import username/email with uppercase with fail
 
## Question
On 2nd thought, maybe the expected behavior is to skip these `invalid uppercase` imports and show error message?

