### PR TITLE
Make user screen page size as 50

### DIFF
--- a/portal/src/graphql/adminapi/UsersScreen.tsx
+++ b/portal/src/graphql/adminapi/UsersScreen.tsx
@@ -37,8 +37,8 @@ import {
 
 const pageSize = 10;
 // We have performance problem on the users query
-// limit to 10 items for now
-const searchResultSize = 10;
+// limit to 50 items for now
+const searchResultSize = 50;
 
 function useRemoteData(options: {
   filters: UsersFilter;

--- a/portal/src/locale-data/en.json
+++ b/portal/src/locale-data/en.json
@@ -293,7 +293,7 @@
 
   "UsersScreen.title": "Users",
   "UsersScreen.add-user": "Create User",
-  "UsersScreen.search.resultLimited": "Only showing top 10 results, please refine the search query if you can't find what you want.",
+  "UsersScreen.search.resultLimited": "Only showing top 50 results, please refine the search query if you can't find what you want.",
   "UsersScreen.filters.groups.placeholder": "Groups",
   "UsersScreen.filters.roles.placeholder": "Roles",
 


### PR DESCRIPTION
- Seems previously the page size is intentionally set to 10 due to performance problem in [Issue #3176](https://github.com/authgear/authgear-server/issues/3176) 

- Then, the performance problem is fixed in [Issue #3233](https://github.com/authgear/authgear-server/issues/3233)

I tried increasing page size, seems no significant load speed difference (locally)

Maybe need to test on staging before/after, see if 50-page-size cause performance issue