### PR TITLE
Remove `ON CONFLICT DO NOTHING` clause in e2e custom sqls

### DIFF
--- a/e2e/tests/login/totp_recovery/totp_user.sql
+++ b/e2e/tests/login/totp_recovery/totp_user.sql
@@ -37,7 +37,7 @@ VALUES
     NULL,
     NOW(),
     NOW()
-  ) ON CONFLICT DO NOTHING;
+  );
 INSERT INTO
   _auth_identity (
     "id",
@@ -55,7 +55,7 @@ VALUES
     'cb3a2f82-cbed-471b-aa42-0bf8da2b74cb',
     NOW(),
     NOW()
-  ) ON CONFLICT DO NOTHING;
+  );
 INSERT INTO
   _auth_authenticator (
     "id",
@@ -87,7 +87,7 @@ VALUES
     NOW(),
     't',
     'secondary'
-  ) ON CONFLICT DO NOTHING;
+  );
 INSERT INTO
   _auth_authenticator_password ("id", "app_id", "password_hash", "expire_after")
 VALUES
@@ -96,7 +96,7 @@ VALUES
     '{{ .AppID }}',
     '$bcrypt-sha512$$2a$10$TsJ6RYa.EL46SbDLGQnwTeFYi.3gdBiPWtO.J05zo0zm1yuNO6/6K',
     NULL
-  ) ON CONFLICT DO NOTHING;
+  );
 INSERT INTO
   _auth_authenticator_totp ("id", "app_id", "secret", "display_name")
 VALUES
@@ -105,7 +105,7 @@ VALUES
     '{{ .AppID }}',
     '3I526Y3Y7GSXO34RTFEEFXCJM6Y4VZXR',
     'TOTP @ 2024-06-26T15:11:48Z'
-  ) ON CONFLICT DO NOTHING;
+  );
 INSERT INTO
   _auth_identity_login_id (
     "id",
@@ -127,7 +127,7 @@ VALUES
     'signup@example.com',
     'signup@example.com',
     'email'
-  ) ON CONFLICT DO NOTHING;
+  );
 INSERT INTO
   _auth_password_history (
     "id",
@@ -143,7 +143,7 @@ VALUES
     NOW(),
     'cb3a2f82-cbed-471b-aa42-0bf8da2b74cb',
     '$bcrypt-sha512$$2a$10$TsJ6RYa.EL46SbDLGQnwTeFYi.3gdBiPWtO.J05zo0zm1yuNO6/6K'
-  ) ON CONFLICT DO NOTHING;
+  );
 INSERT INTO
   _auth_recovery_code (
     "id",
@@ -298,4 +298,4 @@ VALUES
     NOW(),
     'f',
     NOW()
-  ) ON CONFLICT DO NOTHING;
+  );

--- a/e2e/tests/reauth/reauth_user.sql
+++ b/e2e/tests/reauth/reauth_user.sql
@@ -1,8 +1,8 @@
 INSERT INTO _auth_user ("id", "app_id", "created_at", "updated_at", "last_login_at", "login_at", "is_disabled", "disable_reason", "standard_attributes", "custom_attributes", "is_deactivated", "delete_at", "is_anonymized", "anonymize_at", "anonymized_at", "last_indexed_at", "require_reindex_after") VALUES
-('ecaad8f0-74aa-4d6f-8d7f-f4edcb0c43c8', '{{ .AppID }}', '2024-06-27 07:51:42.040683', '2024-06-27 07:51:42.056654', NULL, NULL, 'f', NULL, '{"email": "e2e_reauth_primary_password@example.com", "preferred_username": "e2e_reauth_primary_password"}', '{}', 'f', NULL, 'f', NULL, NULL, '2024-06-27 07:51:42.079532', '2024-06-27 07:51:42.059056') ON CONFLICT DO NOTHING;
+('ecaad8f0-74aa-4d6f-8d7f-f4edcb0c43c8', '{{ .AppID }}', '2024-06-27 07:51:42.040683', '2024-06-27 07:51:42.056654', NULL, NULL, 'f', NULL, '{"email": "e2e_reauth_primary_password@example.com", "preferred_username": "e2e_reauth_primary_password"}', '{}', 'f', NULL, 'f', NULL, NULL, '2024-06-27 07:51:42.079532', '2024-06-27 07:51:42.059056');
 
 INSERT INTO _auth_authenticator ("id", "app_id", "type", "user_id", "created_at", "updated_at", "is_default", "kind") VALUES
-('70f573c9-90e6-4d5e-8b94-5cb6b3331fda', '{{ .AppID }}', 'password', 'ecaad8f0-74aa-4d6f-8d7f-f4edcb0c43c8', '2024-06-27 07:51:42.057486', '2024-06-27 07:51:42.057486', 't', 'primary') ON CONFLICT DO NOTHING;
+('70f573c9-90e6-4d5e-8b94-5cb6b3331fda', '{{ .AppID }}', 'password', 'ecaad8f0-74aa-4d6f-8d7f-f4edcb0c43c8', '2024-06-27 07:51:42.057486', '2024-06-27 07:51:42.057486', 't', 'primary');
 
 INSERT INTO
   _auth_authenticator_password ("id", "app_id", "password_hash", "expire_after")
@@ -12,18 +12,18 @@ VALUES
     '{{ .AppID }}',
     '$bcrypt-sha512$$2a$10$20bGr8PamvoeIhOmPAEcDuSnWTcBDTJ/eJFh/SwAeVeUBCBhbx2u2',
     NULL
-  ) ON CONFLICT DO NOTHING;
+  );
 
 INSERT INTO _auth_identity ("id", "app_id", "type", "user_id", "created_at", "updated_at") VALUES
 ('258c5774-46f9-4cad-baa2-dbaeac59e6f8', '{{ .AppID }}', 'login_id', 'ecaad8f0-74aa-4d6f-8d7f-f4edcb0c43c8', '2024-06-27 07:51:42.051107', '2024-06-27 07:51:42.051107'),
-('4b0665ff-b910-49b4-ab17-cd1c7c18de3e', '{{ .AppID }}', 'login_id', 'ecaad8f0-74aa-4d6f-8d7f-f4edcb0c43c8', '2024-06-27 07:51:42.046545', '2024-06-27 07:51:42.046545') ON CONFLICT DO NOTHING;
+('4b0665ff-b910-49b4-ab17-cd1c7c18de3e', '{{ .AppID }}', 'login_id', 'ecaad8f0-74aa-4d6f-8d7f-f4edcb0c43c8', '2024-06-27 07:51:42.046545', '2024-06-27 07:51:42.046545');
 
 INSERT INTO _auth_identity_login_id ("id", "app_id", "login_id_key", "login_id", "claims", "original_login_id", "unique_key", "login_id_type") VALUES
 ('258c5774-46f9-4cad-baa2-dbaeac59e6f8', '{{ .AppID }}', 'username', 'e2e_reauth_primary_password', '{"preferred_username": "e2e_reauth_primary_password"}', 'e2e_reauth_primary_password', 'e2e_reauth_primary_password', 'username'),
-('4b0665ff-b910-49b4-ab17-cd1c7c18de3e', '{{ .AppID }}', 'email', 'e2e_reauth_primary_password@example.com', '{"email": "e2e_reauth_primary_password@example.com"}', 'e2e_reauth_primary_password@example.com', 'e2e_reauth_primary_password@example.com', 'email') ON CONFLICT DO NOTHING;
+('4b0665ff-b910-49b4-ab17-cd1c7c18de3e', '{{ .AppID }}', 'email', 'e2e_reauth_primary_password@example.com', '{"email": "e2e_reauth_primary_password@example.com"}', 'e2e_reauth_primary_password@example.com', 'e2e_reauth_primary_password@example.com', 'email');
 
 INSERT INTO _auth_password_history ("id", "app_id", "created_at", "user_id", "password") VALUES
-('00699609-e17f-471a-a0ed-07251c0fbb4f', '{{ .AppID }}', '2024-06-27 07:51:42.058464', 'ecaad8f0-74aa-4d6f-8d7f-f4edcb0c43c8', '$2y$10$/wLavnCmYGP/zzpw/mR1iOK5y5hGyrEFJtmaIbvFf9VA6l2O4NMKO') ON CONFLICT DO NOTHING;
+('00699609-e17f-471a-a0ed-07251c0fbb4f', '{{ .AppID }}', '2024-06-27 07:51:42.058464', 'ecaad8f0-74aa-4d6f-8d7f-f4edcb0c43c8', '$2y$10$/wLavnCmYGP/zzpw/mR1iOK5y5hGyrEFJtmaIbvFf9VA6l2O4NMKO');
 
 
 


### PR DESCRIPTION
I found the issue was not

> error not thrown

Instead, it is

> database did not throw error when inserting duplicate primary key records

Which is caused by `ON CONFLICT DO NOTHING` clause in custom sql.

I will remove all `ON CONFLICT DO NOTHING` clauses as a fix 🙏 Since UUID() will be introduced in [DEV-1765](https://linear.app/authgear/issue/DEV-1765/add-generateuuid-to-e2e-template)