### PR TITLE
Allow variable NPM_AUDIT_LEVEL in authui-test & portal-test

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -23,7 +23,15 @@ jobs:
         node-version-file: "./.tool-versions"
     - run: npm ci
       working-directory: ./authui
-    - run: npm audit
+    - name: npm audit
+      env:
+        AUDIT_LEVEL: ${{ vars.NPM_AUDIT_LEVEL }}
+      run: |
+        if [ -z "${AUDIT_LEVEL}" ]; then
+          npm audit
+        else
+          npm audit --audit-level="${AUDIT_LEVEL}"
+        fi
       working-directory: ./authui
       if: ${{ !cancelled() }}
     - run: npm run typecheck
@@ -56,7 +64,15 @@ jobs:
         node-version-file: "./.tool-versions"
     - run: npm ci
       working-directory: ./portal
-    - run: npm audit
+    - name: npm audit
+      env:
+        AUDIT_LEVEL: ${{ vars.NPM_AUDIT_LEVEL }}
+      run: |
+        if [ -z "${AUDIT_LEVEL}" ]; then
+          npm audit
+        else
+          npm audit --audit-level="${AUDIT_LEVEL}"
+        fi
       working-directory: ./portal
       if: ${{ !cancelled() }}
     - run: npm run typecheck


### PR DESCRIPTION
Usually I test ci by creating a `test-ci-<ISSUE_NUMBER>` branch in main repo (`authgear/authgear-server` here).

But since I am not allowed to do that, maybe @louischan-oursky can help create `test-ci-DEV-1791` for me? 🙏 Then we

1. make this PR target `test-ci-DEV-1791`, merge it
2. confirm `NPM_AUDIT_LEVEL` works
3. make another PR from `test-ci-DEV-1791` to `main`?

Please advise if otherwise~

P.S. or maybe the script is simple enough that we are confident to merge to main directly 👍 