### PR TITLE
Fix partial background image is shown in authui mobile layout

### DIFF
--- a/authui/src/authflowv2/components/layout.css
+++ b/authui/src/authflowv2/components/layout.css
@@ -23,10 +23,15 @@
     /* In non-mobile layout, we see the true background-color */
     @apply bg-[var(--color-surface-primary)] tablet:bg-[var(--layout\_\_bg-color)];
 
-    background-image: var(--layout__bg-image);
-    background-repeat: var(--layout__bg_repeat);
-    background-position: var(--layout__bg_position);
-    background-size: var(--layout__bg_size);
+    /* In mobile layout, we should never see the background image as well */
+    /* It should only show background-color that same as widget's background-color */
+    /* background-image should only be seen in non-mobile layout */
+    @media (min-width: theme("screens.tablet")) {
+      background-image: var(--layout__bg-image);
+      background-repeat: var(--layout__bg_repeat);
+      background-position: var(--layout__bg_position);
+      background-size: var(--layout__bg_size);
+    }
   }
 
   /* alignment-card */


### PR DESCRIPTION
#### Mobile layout

<img width="452" alt="Screenshot 2024-08-15 at 1 36 57 PM" src="https://github.com/user-attachments/assets/6ff81ea3-aba9-4532-a4a7-a697d4485213">

#### Tablet layout

<img width="663" alt="Screenshot 2024-08-15 at 1 36 49 PM" src="https://github.com/user-attachments/assets/e2497d3a-8803-4c64-912b-2614606cb1a3">

#### Desktop layout

<img width="1645" alt="Screenshot 2024-08-15 at 1 36 38 PM" src="https://github.com/user-attachments/assets/a1932d4b-a822-4248-9b02-a811804fd044">
