### PR TITLE
Fix users list page size not equal to search result size

### DIFF
--- a/portal/src/graphql/adminapi/UsersList.tsx
+++ b/portal/src/graphql/adminapi/UsersList.tsx
@@ -12,6 +12,7 @@ import {
   PersonaSize,
   Text,
   MessageBar,
+  IListProps,
 } from "@fluentui/react";
 import { Context, FormattedMessage } from "@oursky/react-messageformat";
 import { Link, useParams } from "react-router-dom";
@@ -34,6 +35,10 @@ import useDelayedValue from "../../hook/useDelayedValue";
 import TextCell from "../../components/roles-and-groups/list/common/TextCell";
 import ActionButtonCell from "../../components/roles-and-groups/list/common/ActionButtonCell";
 import BaseCell from "../../components/roles-and-groups/list/common/BaseCell";
+
+function onShouldVirtualize(_: IListProps): boolean {
+  return false;
+}
 
 interface UsersListProps {
   className?: string;
@@ -460,6 +465,8 @@ const UsersList: React.VFC<UsersListProps> = function UsersList(props) {
             layoutMode={DetailsListLayoutMode.justified}
             columns={columns}
             items={items}
+            // UserList always render fixed number of items, which is not infinite scroll, so no need virtualization
+            onShouldVirtualize={onShouldVirtualize}
           />
         </div>
         {!isSearch ? (


### PR DESCRIPTION
ref dev-1788

I also try fixing this by changing `IListProps.renderedWindowsAhead = 3`, which _does_ fix the problem. But passing a correct page size seems a more proper fix.

ref https://github.com/microsoft/fluentui/blob/07f70bdc0c1d0718ff35b3aef8f7ac87635520e3/packages/react/src/components/List/List.tsx#L37

## Preview

https://github.com/user-attachments/assets/cd0ab173-43bf-496a-8471-7e5bb409103a


