### PR TITLE
Use geo-ip for country code in onboarding survey

### DIFF
--- a/portal/src/OnboardingSurveyScreen.tsx
+++ b/portal/src/OnboardingSurveyScreen.tsx
@@ -485,6 +485,9 @@ function Step2(_props: StepProps) {
 }
 
 function Step3Team(_props: StepProps) {
+  const { viewer } = useViewerQuery();
+  const { geoIPCountryCode } = viewer ?? {};
+
   const prefix = "step3team";
   const companyNameFromLocalStorage = getFromLocalStorage("company_name");
   const [companyName, setCompanyName] = useState(
@@ -603,6 +606,7 @@ function Step3Team(_props: StepProps) {
               "OnboardingSurveyScreen.step3-team.phone.label"
             )}
             inputValue={companyPhone.rawInputValue}
+            initialCountry={geoIPCountryCode ?? undefined}
             onChange={(v) => setCompanyPhone(v)}
           />
         </FormProvider>

--- a/portal/src/PhoneTextField.tsx
+++ b/portal/src/PhoneTextField.tsx
@@ -61,7 +61,9 @@ export default class PhoneTextField extends React.Component<PhoneTextFieldProps>
       formatOnDisplay: false,
     };
     if (this.props.initialCountry != null) {
-      options.initialCountry = this.props.initialCountry;
+      // seems IntlTelInputInitOptions.initialCountry must be lowercase
+      // https://github.com/jackocnr/intl-tel-input/blob/c53a32b4f39996d50cde4ffa0df37726e8435ec2/src/spec/tests/options/initialCountry.js#L15
+      options.initialCountry = this.props.initialCountry.toLowerCase();
     }
     if (this.props.allowlist != null) {
       options.onlyCountries = [...this.props.allowlist];


### PR DESCRIPTION
ref DEV-1647

Note below previews are achieved by hard-coding `ip-address` server side

## Preview
| UK          | Japan                                   |
|---------------------|------------------------------------------|
| <img width="512" alt="image" src="https://github.com/user-attachments/assets/1dcc7253-2228-4696-b4f6-6efb8eb4ae2c">                | <img width="501" alt="image" src="https://github.com/user-attachments/assets/0ab74d11-9546-4c7a-abf7-84951d906733">                           |



