### PR TITLE
Add translation key rule to gotemplate linter

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -70,7 +70,7 @@ lint:
 	-go run ./devtools/importlinter worker api lib util >> .make-lint-expect 2>&1
 	-go run ./devtools/bandimportlinter ./pkg ./cmd >> .make-lint-expect 2>&1
 	git diff --exit-code .make-lint-expect > /dev/null 2>&1
-	go run ./devtools/gotemplatelinter --path ./resources/authgear/templates/en/web/authflowv2 --ignore-rules translationKey
+	go run ./devtools/gotemplatelinter --path ./resources/authgear/templates/en/web/authflowv2 --ignore-rules translation-key
 
 .PHONY: fmt
 fmt:

--- a/Makefile
+++ b/Makefile
@@ -53,7 +53,7 @@ test:
 
 .PHONY: lint-translation-keys
 lint-translation-keys:
-	go run ./devtools/gotemplatelinter --path ./resources/authgear/templates/en/web/authflowv2 --ignore-rule indentation --ignore-rule eol-at-eof
+	go run ./devtools/gotemplatelinter --ignore-rule indentation --ignore-rule eol-at-eof ./resources/authgear/templates/en/web/authflowv2
 
 .PHONY: lint
 lint:
@@ -70,7 +70,7 @@ lint:
 	-go run ./devtools/importlinter worker api lib util >> .make-lint-expect 2>&1
 	-go run ./devtools/bandimportlinter ./pkg ./cmd >> .make-lint-expect 2>&1
 	git diff --exit-code .make-lint-expect > /dev/null 2>&1
-	go run ./devtools/gotemplatelinter --path ./resources/authgear/templates/en/web/authflowv2 --ignore-rule translation-key
+	go run ./devtools/gotemplatelinter --ignore-rule translation-key ./resources/authgear/templates/en/web/authflowv2
 
 .PHONY: fmt
 fmt:

--- a/Makefile
+++ b/Makefile
@@ -66,7 +66,7 @@ lint:
 	-go run ./devtools/importlinter worker api lib util >> .make-lint-expect 2>&1
 	-go run ./devtools/bandimportlinter ./pkg ./cmd >> .make-lint-expect 2>&1
 	git diff --exit-code .make-lint-expect > /dev/null 2>&1
-	go run ./devtools/gotemplatelinter ./resources/authgear/templates/en/web/authflowv2
+	go run ./devtools/gotemplatelinter --path ./resources/authgear/templates/en/web/authflowv2 --ignore-rules translationKey
 
 .PHONY: fmt
 fmt:

--- a/Makefile
+++ b/Makefile
@@ -53,7 +53,7 @@ test:
 
 .PHONY: lint-translation-keys
 lint-translation-keys:
-	go run ./devtools/gotemplatelinter --path ./resources/authgear/templates/en/web/authflowv2 --ignore-rules indentation --ignore-rules eol-at-eof
+	go run ./devtools/gotemplatelinter --path ./resources/authgear/templates/en/web/authflowv2 --ignore-rule indentation --ignore-rule eol-at-eof
 
 .PHONY: lint
 lint:
@@ -70,7 +70,7 @@ lint:
 	-go run ./devtools/importlinter worker api lib util >> .make-lint-expect 2>&1
 	-go run ./devtools/bandimportlinter ./pkg ./cmd >> .make-lint-expect 2>&1
 	git diff --exit-code .make-lint-expect > /dev/null 2>&1
-	go run ./devtools/gotemplatelinter --path ./resources/authgear/templates/en/web/authflowv2 --ignore-rules translation-key
+	go run ./devtools/gotemplatelinter --path ./resources/authgear/templates/en/web/authflowv2 --ignore-rule translation-key
 
 .PHONY: fmt
 fmt:

--- a/Makefile
+++ b/Makefile
@@ -53,7 +53,7 @@ test:
 
 .PHONY: lint-translation-keys
 lint-translation-keys:
-	go run ./devtools/gotemplatelinter --path ./resources/authgear/templates/en/web/authflowv2 --ignore-rules indentation --ignore-rules finalNewline
+	go run ./devtools/gotemplatelinter --path ./resources/authgear/templates/en/web/authflowv2 --ignore-rules indentation --ignore-rules eol-at-eof
 
 .PHONY: lint
 lint:

--- a/Makefile
+++ b/Makefile
@@ -51,6 +51,10 @@ test:
 	$(MAKE) -C ./k6 go-test
 	go test ./cmd/... ./pkg/... -timeout 1m30s
 
+.PHONY: lint-translation-keys
+lint-translation-keys:
+	go run ./devtools/gotemplatelinter --path ./resources/authgear/templates/en/web/authflowv2 --ignore-rules indentation --ignore-rules finalNewline
+
 .PHONY: lint
 lint:
 	golangci-lint run ./cmd/... ./pkg/... --timeout 7m

--- a/devtools/gotemplatelinter/args_flags.go
+++ b/devtools/gotemplatelinter/args_flags.go
@@ -5,22 +5,21 @@ import (
 	"strings"
 )
 
-type Flags struct {
-	Path          string
+type ArgsFlags struct {
+	Paths         []string
 	RulesToIgnore []string
 }
 
-func ParseFlags() Flags {
-	var path string
-	flag.StringVar(&path, "path", "", "path to go templates htmls")
-
+func ParseArgsFlags() ArgsFlags {
 	var rulesToIgnore RulesToIgnoreFlags
 	flag.Var(&rulesToIgnore, "ignore-rule", "rules to ignore, repeat this flag to ignore more rules")
 
 	flag.Parse()
 
-	return Flags{
-		Path:          path,
+	paths := flag.Args()
+
+	return ArgsFlags{
+		Paths:         paths,
 		RulesToIgnore: rulesToIgnore,
 	}
 }

--- a/devtools/gotemplatelinter/final_newline_rule.go
+++ b/devtools/gotemplatelinter/final_newline_rule.go
@@ -6,6 +6,8 @@ import (
 
 type FinalNewlineRule struct{}
 
+var _ Rule = FinalNewlineRule{}
+
 func (r FinalNewlineRule) Check(content string, path string) LintViolations {
 	var violations LintViolations
 	lines := strings.Split(content, "\n")
@@ -20,4 +22,8 @@ func (r FinalNewlineRule) Check(content string, path string) LintViolations {
 		})
 	}
 	return violations
+}
+
+func (r FinalNewlineRule) Key() string {
+	return "finalNewline"
 }

--- a/devtools/gotemplatelinter/final_newline_rule.go
+++ b/devtools/gotemplatelinter/final_newline_rule.go
@@ -4,11 +4,11 @@ import (
 	"strings"
 )
 
-type FinalNewlineRule struct{}
+type EOLAtEOFRule struct{}
 
-var _ Rule = FinalNewlineRule{}
+var _ Rule = EOLAtEOFRule{}
 
-func (r FinalNewlineRule) Check(content string, path string) LintViolations {
+func (r EOLAtEOFRule) Check(content string, path string) LintViolations {
 	var violations LintViolations
 	lines := strings.Split(content, "\n")
 	if len(content) > 0 && !strings.HasSuffix(content, "\n") {
@@ -24,6 +24,6 @@ func (r FinalNewlineRule) Check(content string, path string) LintViolations {
 	return violations
 }
 
-func (r FinalNewlineRule) Key() string {
-	return "finalNewline"
+func (r EOLAtEOFRule) Key() string {
+	return "eol-at-eof"
 }

--- a/devtools/gotemplatelinter/final_newline_rule_test.go
+++ b/devtools/gotemplatelinter/final_newline_rule_test.go
@@ -6,10 +6,10 @@ import (
 	. "github.com/smartystreets/goconvey/convey"
 )
 
-func TestFinalNewlineRule(t *testing.T) {
+func TestEOLAtEOFRule(t *testing.T) {
 	Convey("Given a empty file", t, func() {
 		html := ``
-		violations := FinalNewlineRule{}.Check(html, "test.html")
+		violations := EOLAtEOFRule{}.Check(html, "test.html")
 		Convey("Then I expect to see a lint violation", func() {
 			So(len(violations), ShouldEqual, 0)
 		})
@@ -17,7 +17,7 @@ func TestFinalNewlineRule(t *testing.T) {
 
 	Convey("Given a file with a single line", t, func() {
 		html := `<!DOCTYPE html><html lang="en"><head><title>Test</title></head><body><p>Test</p></body></html>`
-		violations := FinalNewlineRule{}.Check(html, "test.html")
+		violations := EOLAtEOFRule{}.Check(html, "test.html")
 		Convey("Then I expect to see a lint violation", func() {
 			So(len(violations), ShouldEqual, 1)
 			So(violations[0].Path, ShouldEqual, "test.html")
@@ -30,7 +30,7 @@ func TestFinalNewlineRule(t *testing.T) {
 	Convey("Given a file with a single line and a newline", t, func() {
 		html := `<!DOCTYPE html><html lang="en"><head><title>Test</title></head><body><p>Test</p></body></html>
 `
-		violations := FinalNewlineRule{}.Check(html, "test.html")
+		violations := EOLAtEOFRule{}.Check(html, "test.html")
 		Convey("Then I expect to see no violation", func() {
 			So(len(violations), ShouldEqual, 0)
 		})
@@ -39,7 +39,7 @@ func TestFinalNewlineRule(t *testing.T) {
 	Convey("Given a file with a single character and a newline", t, func() {
 		html := `A
 `
-		violations := FinalNewlineRule{}.Check(html, "test.html")
+		violations := EOLAtEOFRule{}.Check(html, "test.html")
 		Convey("Then I expect to see no violation", func() {
 			So(len(violations), ShouldEqual, 0)
 		})
@@ -55,7 +55,7 @@ func TestFinalNewlineRule(t *testing.T) {
 <p>Test</p>
 </body>
 </html>`
-		violations := FinalNewlineRule{}.Check(html, "test.html")
+		violations := EOLAtEOFRule{}.Check(html, "test.html")
 		Convey("Then I expect to see a lint violation", func() {
 			So(len(violations), ShouldEqual, 1)
 			So(violations[0].Path, ShouldEqual, "test.html")

--- a/devtools/gotemplatelinter/flags.go
+++ b/devtools/gotemplatelinter/flags.go
@@ -1,0 +1,40 @@
+package main
+
+import (
+	"flag"
+	"strings"
+)
+
+type Flags struct {
+	Path          string
+	RulesToIgnore []string
+}
+
+func ParseFlags() Flags {
+	var path string
+	flag.StringVar(&path, "path", "", "path to go templates htmls")
+
+	var rulesToIgnore RulesToIgnoreFlags
+	flag.Var(&rulesToIgnore, "ignore-rules", "rules to ignore")
+
+	flag.Parse()
+
+	return Flags{
+		Path:          path,
+		RulesToIgnore: rulesToIgnore,
+	}
+}
+
+type RulesToIgnoreFlags []string
+
+func (rs *RulesToIgnoreFlags) String() string {
+	if rs == nil {
+		return ""
+	}
+	return strings.Join(*rs, ",")
+}
+
+func (rs *RulesToIgnoreFlags) Set(value string) error {
+	*rs = append(*rs, value)
+	return nil
+}

--- a/devtools/gotemplatelinter/flags.go
+++ b/devtools/gotemplatelinter/flags.go
@@ -15,7 +15,7 @@ func ParseFlags() Flags {
 	flag.StringVar(&path, "path", "", "path to go templates htmls")
 
 	var rulesToIgnore RulesToIgnoreFlags
-	flag.Var(&rulesToIgnore, "ignore-rules", "rules to ignore")
+	flag.Var(&rulesToIgnore, "ignore-rule", "rules to ignore, repeat this flag to ignore more rules")
 
 	flag.Parse()
 

--- a/devtools/gotemplatelinter/indent_rule.go
+++ b/devtools/gotemplatelinter/indent_rule.go
@@ -7,6 +7,8 @@ import (
 
 type IndentationRule struct{}
 
+var _ Rule = IndentationRule{}
+
 func (r IndentationRule) Check(content string, path string) LintViolations {
 	var violations LintViolations
 	lines := strings.Split(content, "\n")
@@ -23,4 +25,8 @@ func (r IndentationRule) Check(content string, path string) LintViolations {
 		}
 	}
 	return violations
+}
+
+func (r IndentationRule) Key() string {
+	return "indentation"
 }

--- a/devtools/gotemplatelinter/main.go
+++ b/devtools/gotemplatelinter/main.go
@@ -103,11 +103,11 @@ func (l *Linter) LintFile(path string, info os.FileInfo) (violations LintViolati
 
 func constructRules(rulesToIgnore []string) []Rule {
 	indentationRule := IndentationRule{}
-	finalNewlineRule := FinalNewlineRule{}
+	EOLAtEOFRule := EOLAtEOFRule{}
 	translationKeyRule := TranslationKeyRule{}
 	rules := []Rule{
 		indentationRule,
-		finalNewlineRule,
+		EOLAtEOFRule,
 		translationKeyRule,
 	}
 	ignoreRuleFn := func(rule Rule) {
@@ -119,8 +119,8 @@ func constructRules(rulesToIgnore []string) []Rule {
 		switch ruleToIgnore {
 		case indentationRule.Key():
 			ignoreRuleFn(indentationRule)
-		case finalNewlineRule.Key():
-			ignoreRuleFn(finalNewlineRule)
+		case EOLAtEOFRule.Key():
+			ignoreRuleFn(EOLAtEOFRule)
 		case translationKeyRule.Key():
 			ignoreRuleFn(translationKeyRule)
 		}

--- a/devtools/gotemplatelinter/main.go
+++ b/devtools/gotemplatelinter/main.go
@@ -111,6 +111,7 @@ func doMain() (violations LintViolations, err error) {
 		Rules: []Rule{
 			IndentationRule{},
 			FinalNewlineRule{},
+			TranslationKeyRule{},
 		},
 		Path: path,
 	}

--- a/devtools/gotemplatelinter/main.go
+++ b/devtools/gotemplatelinter/main.go
@@ -131,7 +131,7 @@ func constructRules(rulesToIgnore []string) []Rule {
 
 func doMain() (violations LintViolations, err error) {
 	if len(os.Args) < 2 {
-		err = fmt.Errorf("usage: gotemplatelinter --path <path/to/htmls> --ignore-rules rule1ToIgnore --ignore-rules rule2ToIgnore")
+		err = fmt.Errorf("usage: gotemplatelinter --path <path/to/htmls> --ignore-rule rule1ToIgnore --ignore-rule rule2ToIgnore")
 		return
 	}
 	flags := ParseFlags()

--- a/devtools/gotemplatelinter/main.go
+++ b/devtools/gotemplatelinter/main.go
@@ -10,6 +10,7 @@ import (
 
 type Rule interface {
 	Check(content string, path string) LintViolations
+	Key() string
 }
 
 type LintViolation struct {

--- a/devtools/gotemplatelinter/transation_key_rule_check_include.go
+++ b/devtools/gotemplatelinter/transation_key_rule_check_include.go
@@ -19,8 +19,7 @@ func CheckCommandInclude(includeNode *parse.CommandNode) (err error) {
 			}
 			err = CheckTranslationKeyNode(arg)
 			if err != nil {
-				// return fmt.Errorf("invalid 2nd arg of `include`: %w", err)
-				err = nil
+				return err
 			}
 		}
 

--- a/devtools/gotemplatelinter/transation_key_rule_check_include.go
+++ b/devtools/gotemplatelinter/transation_key_rule_check_include.go
@@ -1,0 +1,38 @@
+package main
+
+import (
+	"strings"
+	"text/template/parse"
+)
+
+// validate `include` command
+//
+// e.g. (include "v2-error-screen-title" nil)
+// e.g. (include (printf "v2-oauth-branding-%s" .provider_type) nil)
+// e.g. (include $description_key nil)
+func CheckCommandInclude(includeNode *parse.CommandNode) (err error) {
+	// 2nd arg should be translation key
+	for idx, arg := range includeNode.Args {
+		if idx == 1 {
+			if isHTMLInclude(arg) { // false positive
+				break
+			}
+			err = CheckTranslationKeyNode(arg)
+			if err != nil {
+				// return fmt.Errorf("invalid 2nd arg of `include`: %w", err)
+				err = nil
+			}
+		}
+
+	}
+	return
+}
+
+func isHTMLInclude(arg parse.Node) bool {
+	if str, ok := arg.(*parse.StringNode); ok {
+		if strings.Contains(str.Text, ".html") {
+			return true
+		}
+	}
+	return false
+}

--- a/devtools/gotemplatelinter/transation_key_rule_check_template.go
+++ b/devtools/gotemplatelinter/transation_key_rule_check_template.go
@@ -1,0 +1,28 @@
+package main
+
+import (
+	"fmt"
+	"strings"
+	"text/template/parse"
+)
+
+// validate `{{ template }}` nodes
+//
+// e.g. {{template "setup-totp-get-google-authenticator-description"}}
+// e.g. {{template "setup-totp-raw-secret" (dict "secret" $.Secret)}}
+// e.g. {{template "settings-totp-item-description" (dict "time" .CreatedAt "rfc3339" (rfc3339 .CreatedAt))}}
+func CheckTemplate(templateNode *parse.TemplateNode) (err error) {
+	if isHTMLTemplate(templateNode) { // false positive
+		return
+	}
+	translationKey := templateNode.Name
+	err = CheckTranslationKey(translationKey)
+	if err != nil {
+		return fmt.Errorf("invalid template name: %w", err)
+	}
+	return
+}
+
+func isHTMLTemplate(templateNode *parse.TemplateNode) bool {
+	return strings.Contains(templateNode.Name, ".html")
+}

--- a/devtools/gotemplatelinter/transation_key_rule_check_template.go
+++ b/devtools/gotemplatelinter/transation_key_rule_check_template.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"fmt"
 	"strings"
 	"text/template/parse"
 )
@@ -18,7 +17,7 @@ func CheckTemplate(templateNode *parse.TemplateNode) (err error) {
 	translationKey := templateNode.Name
 	err = CheckTranslationKey(translationKey)
 	if err != nil {
-		return fmt.Errorf("invalid template name: %w", err)
+		return err
 	}
 	return
 }

--- a/devtools/gotemplatelinter/transation_key_rule_check_template.go
+++ b/devtools/gotemplatelinter/transation_key_rule_check_template.go
@@ -15,7 +15,7 @@ func CheckTemplate(templateNode *parse.TemplateNode) (err error) {
 		return
 	}
 	translationKey := templateNode.Name
-	err = CheckTranslationKey(translationKey)
+	err = CheckTranslationKeyPattern(translationKey)
 	if err != nil {
 		return err
 	}

--- a/devtools/gotemplatelinter/transation_key_rule_check_translate.go
+++ b/devtools/gotemplatelinter/transation_key_rule_check_translate.go
@@ -1,0 +1,23 @@
+package main
+
+import (
+	"fmt"
+	"text/template/parse"
+)
+
+// validate `translate` command
+//
+// e.g. (translate "app.name" nil)
+func CheckCommandTranslate(translateNode *parse.CommandNode) (err error) {
+	// 2nd arg should be translation key
+	for idx, arg := range translateNode.Args {
+		if idx == 1 {
+			err = CheckTranslationKeyNode(arg)
+			if err != nil {
+				return fmt.Errorf("invalid 2nd arg of `translate`: %w", err)
+			}
+		}
+
+	}
+	return
+}

--- a/devtools/gotemplatelinter/transation_key_rule_check_translate.go
+++ b/devtools/gotemplatelinter/transation_key_rule_check_translate.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"fmt"
 	"text/template/parse"
 )
 
@@ -14,7 +13,7 @@ func CheckCommandTranslate(translateNode *parse.CommandNode) (err error) {
 		if idx == 1 {
 			err = CheckTranslationKeyNode(arg)
 			if err != nil {
-				return fmt.Errorf("invalid 2nd arg of `translate`: %w", err)
+				return err
 			}
 		}
 

--- a/devtools/gotemplatelinter/transation_key_rule_check_translations_render_text.go
+++ b/devtools/gotemplatelinter/transation_key_rule_check_translations_render_text.go
@@ -1,0 +1,24 @@
+package main
+
+import (
+	"fmt"
+	"text/template/parse"
+)
+
+// validate commands with variable `$.Translations.RenderText` or field `.Translations.RenderText`
+//
+// example: `($.Translations.RenderText "customer-support-link" nil)`
+// example: (.Translations.RenderText "terms-of-service-link" nil)
+func CheckCommandTranslationsRenderText(node *parse.CommandNode) (err error) {
+	// 2nd arg should be translation key
+	for idx, arg := range node.Args {
+		if idx == 1 {
+			err = CheckTranslationKeyNode(arg)
+			if err != nil {
+				return fmt.Errorf("invalid 2nd arg of `%v`: %w", node.Args[0], err)
+			}
+		}
+
+	}
+	return
+}

--- a/devtools/gotemplatelinter/transation_key_rule_check_translations_render_text.go
+++ b/devtools/gotemplatelinter/transation_key_rule_check_translations_render_text.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"fmt"
 	"text/template/parse"
 )
 
@@ -15,7 +14,7 @@ func CheckCommandTranslationsRenderText(node *parse.CommandNode) (err error) {
 		if idx == 1 {
 			err = CheckTranslationKeyNode(arg)
 			if err != nil {
-				return fmt.Errorf("invalid 2nd arg of `%v`: %w", node.Args[0], err)
+				return err
 			}
 		}
 

--- a/devtools/gotemplatelinter/translation_key_rule.go
+++ b/devtools/gotemplatelinter/translation_key_rule.go
@@ -80,7 +80,8 @@ func validateTree(tree *parse.Tree, path string) LintViolations {
 				if ident, ok := arg.(*parse.IdentifierNode); ok {
 					switch ident.String() {
 					case "include":
-						// TODO: handle include fn
+						err = CheckCommandInclude(n)
+						handleNodeErrFn(n, err)
 					case "translate":
 						err = CheckCommandTranslate(n)
 						handleNodeErrFn(n, err)

--- a/devtools/gotemplatelinter/translation_key_rule.go
+++ b/devtools/gotemplatelinter/translation_key_rule.go
@@ -17,7 +17,7 @@ func (r TranslationKeyRule) Check(content string, path string) LintViolations {
 }
 
 func (r TranslationKeyRule) Key() string {
-	return "translationKey"
+	return "translation-key"
 }
 
 func (r TranslationKeyRule) check(content string, path string) LintViolations {

--- a/devtools/gotemplatelinter/translation_key_rule.go
+++ b/devtools/gotemplatelinter/translation_key_rule.go
@@ -1,0 +1,76 @@
+package main
+
+import (
+	htmltemplate "html/template"
+	"sort"
+	"text/template/parse"
+
+	authgearutiltemplate "github.com/authgear/authgear-server/pkg/util/template"
+)
+
+type TranslationKeyRule struct{}
+
+func (r TranslationKeyRule) Check(content string, path string) LintViolations {
+	return r.check(content, path)
+}
+
+func (r TranslationKeyRule) check(content string, path string) LintViolations {
+	var violations LintViolations
+	t := r.makeTemplate(content)
+
+	r.validateHTMLTemplate(t)
+
+	// TODO: add violations
+	return violations
+}
+
+func (r TranslationKeyRule) makeTemplate(content string) *htmltemplate.Template {
+	t := htmltemplate.New("")
+	funcMap := authgearutiltemplate.MakeTemplateFuncMap(t)
+	t.Funcs(funcMap)
+	parsed := htmltemplate.Must(t.Parse(content))
+	return parsed
+}
+
+func (r TranslationKeyRule) validateHTMLTemplate(template *htmltemplate.Template) error {
+	tpls := template.Templates()
+
+	sort.Slice(tpls, func(i, j int) bool {
+		return tpls[i].Name() < tpls[j].Name()
+	})
+
+	for _, tpl := range tpls {
+		if tpl.Tree == nil {
+			continue
+		}
+		if err := validateTree(tpl.Tree); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func validateTree(tree *parse.Tree) (err error) {
+	validateFn := func(n parse.Node, depth int) (cont bool) {
+		switch n := n.(type) {
+		case *parse.CommandNode:
+			for _, arg := range n.Args {
+				if ident, ok := arg.(*parse.IdentifierNode); ok {
+					switch ident.String() {
+					case "include":
+						// TODO: handle include fn
+					case "translate":
+						// TODO: handle translate fn
+					}
+				}
+			}
+		case *parse.TemplateNode:
+			// TODO: handle template node
+		}
+
+		return err == nil
+	}
+
+	TraverseTree(tree, validateFn)
+	return
+}

--- a/devtools/gotemplatelinter/translation_key_rule.go
+++ b/devtools/gotemplatelinter/translation_key_rule.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	htmltemplate "html/template"
-	"sort"
 	"text/template/parse"
 
 	authgearutiltemplate "github.com/authgear/authgear-server/pkg/util/template"
@@ -39,9 +38,6 @@ func (r TranslationKeyRule) validateHTMLTemplate(template *htmltemplate.Template
 	tpls := template.Templates()
 
 	var violations LintViolations
-	sort.Slice(tpls, func(i, j int) bool {
-		return tpls[i].Name() < tpls[j].Name()
-	})
 
 	for _, tpl := range tpls {
 		if tpl.Tree == nil {

--- a/devtools/gotemplatelinter/translation_key_rule.go
+++ b/devtools/gotemplatelinter/translation_key_rule.go
@@ -70,10 +70,12 @@ func validateTree(tree *parse.Tree, path string) LintViolations {
 		case *parse.CommandNode:
 			for _, arg := range n.Args {
 				if variable, ok := arg.(*parse.VariableNode); ok && variable.String() == "$.Translations.RenderText" {
-					// TODO: handle $.Translations.RenderText
+					err = CheckCommandTranslationsRenderText(n)
+					handleNodeErrFn(n, err)
 				}
 				if field, ok := arg.(*parse.FieldNode); ok && field.String() == ".Translations.RenderText" {
-					// TODO: handle .Translations.RenderText
+					err = CheckCommandTranslationsRenderText(n)
+					handleNodeErrFn(n, err)
 				}
 				if ident, ok := arg.(*parse.IdentifierNode); ok {
 					switch ident.String() {

--- a/devtools/gotemplatelinter/translation_key_rule.go
+++ b/devtools/gotemplatelinter/translation_key_rule.go
@@ -10,8 +10,14 @@ import (
 
 type TranslationKeyRule struct{}
 
+var _ Rule = TranslationKeyRule{}
+
 func (r TranslationKeyRule) Check(content string, path string) LintViolations {
 	return r.check(content, path)
+}
+
+func (r TranslationKeyRule) Key() string {
+	return "translationKey"
 }
 
 func (r TranslationKeyRule) check(content string, path string) LintViolations {

--- a/devtools/gotemplatelinter/translation_key_rule.go
+++ b/devtools/gotemplatelinter/translation_key_rule.go
@@ -89,7 +89,8 @@ func validateTree(tree *parse.Tree, path string) LintViolations {
 				}
 			}
 		case *parse.TemplateNode:
-			// TODO: handle template node
+			err = CheckTemplate(n)
+			handleNodeErrFn(n, err)
 		}
 
 		// always continue to traverse

--- a/devtools/gotemplatelinter/translation_key_rule.go
+++ b/devtools/gotemplatelinter/translation_key_rule.go
@@ -55,6 +55,12 @@ func validateTree(tree *parse.Tree) (err error) {
 		switch n := n.(type) {
 		case *parse.CommandNode:
 			for _, arg := range n.Args {
+				if variable, ok := arg.(*parse.VariableNode); ok && variable.String() == "$.Translations.RenderText" {
+					// TODO: handle $.Translations.RenderText
+				}
+				if field, ok := arg.(*parse.FieldNode); ok && field.String() == ".Translations.RenderText" {
+					// TODO: handle .Translations.RenderText
+				}
 				if ident, ok := arg.(*parse.IdentifierNode); ok {
 					switch ident.String() {
 					case "include":

--- a/devtools/gotemplatelinter/translation_key_rule_check_translation_key.go
+++ b/devtools/gotemplatelinter/translation_key_rule_check_translation_key.go
@@ -4,7 +4,17 @@ import (
 	"fmt"
 	"regexp"
 	"strings"
+	"text/template/parse"
 )
+
+func CheckTranslationKeyNode(translationKeyNode parse.Node) (err error) {
+	switch translationKeyNode.Type() {
+	case parse.NodeString:
+		return CheckTranslationKey(translationKeyNode.(*parse.StringNode).Text)
+	default:
+		return fmt.Errorf("expected: *parse.StringNode, got: %T", translationKeyNode)
+	}
+}
 
 const TranslationKeyPattern = `(v2)\.(page|component)\.([-a-z]+)\.(default)\.([-a-z]+)`
 

--- a/devtools/gotemplatelinter/translation_key_rule_check_translation_key.go
+++ b/devtools/gotemplatelinter/translation_key_rule_check_translation_key.go
@@ -51,7 +51,7 @@ func CheckTranslationKeyPattern(translationKey string) (err error) {
 		return fmt.Errorf("translation key not defined: \"%v\"", key)
 	}
 
-	if !validKey.MatchString(key) || !validErrKey.MatchString(key) {
+	if !validKey.MatchString(key) && !validErrKey.MatchString(key) {
 		return fmt.Errorf("invalid translation key: \"%v\"", key)
 	}
 

--- a/devtools/gotemplatelinter/translation_key_rule_check_translation_key.go
+++ b/devtools/gotemplatelinter/translation_key_rule_check_translation_key.go
@@ -27,7 +27,7 @@ func CheckTranslationKey(translationKey string) (err error) {
 
 	var validKey = regexp.MustCompile(TranslationKeyPattern)
 	if ok := validKey.MatchString(key); !ok {
-		return fmt.Errorf("invalid translation key, please follow format: `v2.page.my-page.default.my-descriptor`")
+		return fmt.Errorf("invalid translation key: \"%v\" -- please follow format: `v2.page.my-page.default.my-descriptor`", key)
 	}
 
 	return

--- a/devtools/gotemplatelinter/translation_key_rule_check_translation_key.go
+++ b/devtools/gotemplatelinter/translation_key_rule_check_translation_key.go
@@ -7,6 +7,14 @@ import (
 	"text/template/parse"
 )
 
+const TranslationKeyPattern = `(v2)\.(page|component)\.([-a-z]+)\.(default)\.([-a-z]+)`
+
+var validKey *regexp.Regexp
+
+func init() {
+	validKey = regexp.MustCompile(TranslationKeyPattern)
+}
+
 func CheckTranslationKeyNode(translationKeyNode parse.Node) (err error) {
 	switch translationKeyNode.Type() {
 	case parse.NodeString:
@@ -22,8 +30,6 @@ func CheckTranslationKeyNode(translationKeyNode parse.Node) (err error) {
 	}
 }
 
-const TranslationKeyPattern = `(v2)\.(page|component)\.([-a-z]+)\.(default)\.([-a-z]+)`
-
 func CheckTranslationKeyPattern(translationKey string) (err error) {
 	key := strings.Trim(translationKey, "\"")
 
@@ -31,7 +37,6 @@ func CheckTranslationKeyPattern(translationKey string) (err error) {
 		return fmt.Errorf("translation key is empty")
 	}
 
-	var validKey = regexp.MustCompile(TranslationKeyPattern)
 	if ok := validKey.MatchString(key); !ok {
 		return fmt.Errorf("invalid translation key: \"%v\"", key)
 	}

--- a/devtools/gotemplatelinter/translation_key_rule_check_translation_key.go
+++ b/devtools/gotemplatelinter/translation_key_rule_check_translation_key.go
@@ -7,7 +7,7 @@ import (
 	"text/template/parse"
 )
 
-const TranslationKeyPattern = `(v2)\.(page|component)\.([-a-z]+)\.(default)\.([-a-z]+)`
+const TranslationKeyPattern = `^(v2)\.(page|component)\.([-a-z]+)\.(default)\.([-a-z]+)$`
 
 var validKey *regexp.Regexp
 

--- a/devtools/gotemplatelinter/translation_key_rule_check_translation_key.go
+++ b/devtools/gotemplatelinter/translation_key_rule_check_translation_key.go
@@ -9,7 +9,9 @@ import (
 	"text/template/parse"
 )
 
-const TranslationKeyPattern = `^(v2)\.(page|component)\.([-a-z]+)\.(default)\.([-a-z]+)$`
+// v2.page.<page>.<state>.<descriptor>
+// v2.component.<component>.<state>.<descriptor>
+const TranslationKeyPattern = `^(v2)\.(page|component)\.([-a-z]+)\.([-a-z]+)\.([-a-z]+)$`
 const ErrTranslationKeyPattern = `^(v2)\.(error)\.([-a-z]+)$`
 const enTranslationJSONPath = "resources/authgear/templates/en/translation.json"
 

--- a/devtools/gotemplatelinter/translation_key_rule_check_translation_key.go
+++ b/devtools/gotemplatelinter/translation_key_rule_check_translation_key.go
@@ -10,13 +10,16 @@ import (
 )
 
 const TranslationKeyPattern = `^(v2)\.(page|component)\.([-a-z]+)\.(default)\.([-a-z]+)$`
+const ErrTranslationKeyPattern = `^(v2)\.(error)\.([-a-z]+)$`
 const enTranslationJSONPath = "resources/authgear/templates/en/translation.json"
 
 var validKey *regexp.Regexp
+var validErrKey *regexp.Regexp
 var translationKeys []string
 
 func init() {
 	validKey = regexp.MustCompile(TranslationKeyPattern)
+	validErrKey = regexp.MustCompile(ErrTranslationKeyPattern)
 	translationKeys = getEnJSONTranslationKeys()
 }
 
@@ -46,7 +49,7 @@ func CheckTranslationKeyPattern(translationKey string) (err error) {
 		return fmt.Errorf("translation key not defined: \"%v\"", key)
 	}
 
-	if ok := validKey.MatchString(key); !ok {
+	if !validKey.MatchString(key) || !validErrKey.MatchString(key) {
 		return fmt.Errorf("invalid translation key: \"%v\"", key)
 	}
 

--- a/devtools/gotemplatelinter/translation_key_rule_check_translation_key.go
+++ b/devtools/gotemplatelinter/translation_key_rule_check_translation_key.go
@@ -33,7 +33,7 @@ func CheckTranslationKey(translationKey string) (err error) {
 
 	var validKey = regexp.MustCompile(TranslationKeyPattern)
 	if ok := validKey.MatchString(key); !ok {
-		return fmt.Errorf("invalid translation key: \"%v\" -- please follow format: `v2.page.my-page.default.my-descriptor`", key)
+		return fmt.Errorf("invalid translation key: \"%v\"", key)
 	}
 
 	return

--- a/devtools/gotemplatelinter/translation_key_rule_check_translation_key.go
+++ b/devtools/gotemplatelinter/translation_key_rule_check_translation_key.go
@@ -1,0 +1,24 @@
+package main
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+)
+
+const TranslationKeyPattern = `(v2)\.(page|component)\.([-a-z]+)\.(default)\.([-a-z]+)`
+
+func CheckTranslationKey(translationKey string) (err error) {
+	key := strings.Trim(translationKey, "\"")
+
+	if key == "" {
+		return fmt.Errorf("translation key is empty")
+	}
+
+	var validKey = regexp.MustCompile(TranslationKeyPattern)
+	if ok := validKey.MatchString(key); !ok {
+		return fmt.Errorf("invalid translation key, please follow format: `v2.page.my-page.default.my-descriptor`")
+	}
+
+	return
+}

--- a/devtools/gotemplatelinter/translation_key_rule_check_translation_key.go
+++ b/devtools/gotemplatelinter/translation_key_rule_check_translation_key.go
@@ -11,8 +11,14 @@ func CheckTranslationKeyNode(translationKeyNode parse.Node) (err error) {
 	switch translationKeyNode.Type() {
 	case parse.NodeString:
 		return CheckTranslationKey(translationKeyNode.(*parse.StringNode).Text)
+	case parse.NodeVariable:
+		// FIXME: support variable, like $label, $label_key, $variant_label_key
+		fallthrough
+	case parse.NodePipe:
+		// FIXME: support pipe, like (printf "territory-%s" $.AddressCountry)
+		fallthrough
 	default:
-		return fmt.Errorf("expected: *parse.StringNode, got: %T", translationKeyNode)
+		return fmt.Errorf("expected: *parse.StringNode, got: %T \n\t\t concerning node: %v", translationKeyNode, translationKeyNode)
 	}
 }
 

--- a/devtools/gotemplatelinter/translation_key_rule_check_translation_key.go
+++ b/devtools/gotemplatelinter/translation_key_rule_check_translation_key.go
@@ -10,7 +10,7 @@ import (
 func CheckTranslationKeyNode(translationKeyNode parse.Node) (err error) {
 	switch translationKeyNode.Type() {
 	case parse.NodeString:
-		return CheckTranslationKey(translationKeyNode.(*parse.StringNode).Text)
+		return CheckTranslationKeyPattern(translationKeyNode.(*parse.StringNode).Text)
 	case parse.NodeVariable:
 		// FIXME: support variable, like $label, $label_key, $variant_label_key
 		fallthrough
@@ -24,7 +24,7 @@ func CheckTranslationKeyNode(translationKeyNode parse.Node) (err error) {
 
 const TranslationKeyPattern = `(v2)\.(page|component)\.([-a-z]+)\.(default)\.([-a-z]+)`
 
-func CheckTranslationKey(translationKey string) (err error) {
+func CheckTranslationKeyPattern(translationKey string) (err error) {
 	key := strings.Trim(translationKey, "\"")
 
 	if key == "" {

--- a/devtools/gotemplatelinter/translation_key_rule_check_translation_key.go
+++ b/devtools/gotemplatelinter/translation_key_rule_check_translation_key.go
@@ -26,7 +26,7 @@ func CheckTranslationKeyNode(translationKeyNode parse.Node) (err error) {
 		// FIXME: support pipe, like (printf "territory-%s" $.AddressCountry)
 		fallthrough
 	default:
-		return fmt.Errorf("expected: *parse.StringNode, got: %T \n\t\t concerning node: %v", translationKeyNode, translationKeyNode)
+		return fmt.Errorf("invalid translation key: \"%v\"", translationKeyNode.String())
 	}
 }
 

--- a/devtools/gotemplatelinter/translation_key_rule_traverse_tree.go
+++ b/devtools/gotemplatelinter/translation_key_rule_traverse_tree.go
@@ -2,6 +2,8 @@
 package main
 
 import (
+	"strconv"
+	"strings"
 	"text/template/parse"
 )
 
@@ -67,6 +69,22 @@ func traverseTreeVisit(n parse.Node, depth int, fn func(n parse.Node, depth int)
 				break
 			}
 		}
+	}
+
+	return
+}
+
+func TreeErrorContext(tree *parse.Tree, n parse.Node) (line int, col int, ctx string) {
+	location, ctx := tree.ErrorContext(n)
+	locationInfo := strings.Split(location, ":") // location is of %s:%d:%d
+
+	line, err := strconv.Atoi(locationInfo[1])
+	if err != nil {
+		line = 0
+	}
+	col, err = strconv.Atoi(locationInfo[2])
+	if err != nil {
+		col = 0
 	}
 
 	return

--- a/devtools/gotemplatelinter/translation_key_rule_traverse_tree.go
+++ b/devtools/gotemplatelinter/translation_key_rule_traverse_tree.go
@@ -1,0 +1,67 @@
+// This file is mostly copied from pkg/util/template/validation.go
+package main
+
+import (
+	"text/template/parse"
+)
+
+func TraverseTree(tree *parse.Tree, fn func(n parse.Node, depth int) (cont bool)) {
+	traverseTreeVisit(tree.Root, 0, fn)
+}
+
+func traverseTreeVisitBranch(n *parse.BranchNode, depth int, fn func(n parse.Node, depth int) (cont bool)) (cont bool) {
+	if cont = traverseTreeVisit(n.Pipe, depth, fn); !cont {
+		return
+	}
+	if cont = traverseTreeVisit(n.List, depth, fn); !cont {
+		return
+	}
+	if n.ElseList != nil {
+		if cont = traverseTreeVisit(n.ElseList, depth, fn); !cont {
+			return false
+		}
+	}
+	return
+}
+
+func traverseTreeVisit(n parse.Node, depth int, fn func(n parse.Node, depth int) (cont bool)) (cont bool) {
+	cont = fn(n, depth)
+	if !cont {
+		return
+	}
+
+	switch n := n.(type) {
+	case *parse.PipeNode:
+		for _, cmd := range n.Cmds {
+			if cont = traverseTreeVisit(cmd, depth, fn); !cont {
+				break
+			}
+		}
+	case *parse.CommandNode:
+		for _, arg := range n.Args {
+			if pipe, ok := arg.(*parse.PipeNode); ok {
+				if cont = traverseTreeVisit(pipe, depth+1, fn); !cont {
+					break
+				}
+			}
+		}
+	case *parse.ActionNode:
+		cont = traverseTreeVisit(n.Pipe, depth, fn)
+	case *parse.TemplateNode, *parse.TextNode:
+		break
+	case *parse.IfNode:
+		cont = traverseTreeVisitBranch(&n.BranchNode, depth, fn)
+	case *parse.RangeNode:
+		cont = traverseTreeVisitBranch(&n.BranchNode, depth, fn)
+	case *parse.WithNode:
+		cont = traverseTreeVisitBranch(&n.BranchNode, depth, fn)
+	case *parse.ListNode:
+		for _, n := range n.Nodes {
+			if cont = traverseTreeVisit(n, depth+1, fn); !cont {
+				break
+			}
+		}
+	}
+
+	return
+}

--- a/devtools/gotemplatelinter/translation_key_rule_traverse_tree.go
+++ b/devtools/gotemplatelinter/translation_key_rule_traverse_tree.go
@@ -47,7 +47,13 @@ func traverseTreeVisit(n parse.Node, depth int, fn func(n parse.Node, depth int)
 		}
 	case *parse.ActionNode:
 		cont = traverseTreeVisit(n.Pipe, depth, fn)
-	case *parse.TemplateNode, *parse.TextNode:
+	case *parse.TemplateNode:
+		if n.Pipe != nil {
+			if cont = traverseTreeVisit(n.Pipe, depth+1, fn); !cont {
+				break
+			}
+		}
+	case *parse.TextNode:
 		break
 	case *parse.IfNode:
 		cont = traverseTreeVisitBranch(&n.BranchNode, depth, fn)


### PR DESCRIPTION
@louischan-oursky Seems unable to reuse code in `pkg/util/template/validation.go` inside `devtools/`.

I plan to duplicate the template validation into `devtools/gotemplatetranslationlinter/validation.go`. Any thoughts?