### PR TITLE
Fix regression due to TakeBranchResultInput variable wrong reference

### DIFF
--- a/pkg/auth/webapp/session_authflow.go
+++ b/pkg/auth/webapp/session_authflow.go
@@ -362,7 +362,7 @@ func (TakeBranchResultSimple) takeBranchResult() {}
 type TakeBranchResultInputRetryHandler func(err error) (nextInput interface{})
 
 type TakeBranchResultInput struct {
-	Input                 interface{}
+	Input                 map[string]interface{}
 	NewAuthflowScreenFull func(flowResponse *authflow.FlowResponse, retriedForError error) *AuthflowScreenWithFlowResponse
 	OnRetry               *TakeBranchResultInputRetryHandler
 }

--- a/pkg/auth/webapp/session_authflow.go
+++ b/pkg/auth/webapp/session_authflow.go
@@ -837,7 +837,7 @@ func (s *AuthflowScreenWithFlowResponse) takeBranchCreateAuthenticator(input *Ta
 			options.DisableFallbackToSMS,
 		)
 		return TakeBranchResultInput{
-			Input: input,
+			Input: resultInput,
 			NewAuthflowScreenFull: func(flowResponse *authflow.FlowResponse, retriedForError error) *AuthflowScreenWithFlowResponse {
 				isContinuation := func(flowResponse *authflow.FlowResponse) bool {
 					return flowResponse.Action.Type == authflow.FlowActionType(config.AuthenticationFlowSignupFlowStepTypeCreateAuthenticator) &&


### PR DESCRIPTION
## Context
My refactoring in #4602 did not update with @IniZio changes in #4555 

- the input type is `interface{}`
- there is no merge conflict 

Thanks @louischan-oursky for helping me fix this