### PR TITLE
Remove csp `script-src` with Nonce

### DIFF
--- a/pkg/auth/webapp/dynamic_csp_middleware_test.go
+++ b/pkg/auth/webapp/dynamic_csp_middleware_test.go
@@ -44,7 +44,7 @@ func TestDynamicCSPMiddleware(t *testing.T) {
 					AllowFrameAncestorsFromCustomUI: true,
 					ExpectedHeaders: map[string][]string{
 						"Content-Security-Policy": {
-							"default-src 'self'; script-src 'unsafe-inline' www.googletagmanager.com eu-assets.i.posthog.com challenges.cloudflare.com www.google.com https://browser.sentry-cdn.com 'self' http://cdn.authgear.com; frame-src www.googletagmanager.com challenges.cloudflare.com www.google.com 'self'; font-src cdnjs.cloudflare.com static2.sharepointonline.com fonts.googleapis.com fonts.gstatic.com 'self' http://cdn.authgear.com; style-src 'unsafe-inline' cdnjs.cloudflare.com www.googletagmanager.com fonts.googleapis.com 'self' http://cdn.authgear.com; img-src http: https: data: 'self' http://cdn.authgear.com; object-src 'none'; base-uri 'none'; connect-src 'self' https://www.google-analytics.com ws://authgear.com wss://authgear.com; block-all-mixed-content; frame-ancestors http://authgearportal.com http://customui.com",
+							"default-src 'self'; script-src 'unsafe-inline' eu-assets.i.posthog.com https://browser.sentry-cdn.com 'self' http://cdn.authgear.com; frame-src www.googletagmanager.com challenges.cloudflare.com www.google.com 'self'; font-src cdnjs.cloudflare.com static2.sharepointonline.com fonts.googleapis.com fonts.gstatic.com 'self' http://cdn.authgear.com; style-src 'unsafe-inline' cdnjs.cloudflare.com www.googletagmanager.com fonts.googleapis.com 'self' http://cdn.authgear.com; img-src http: https: data: 'self' http://cdn.authgear.com; object-src 'none'; base-uri 'none'; connect-src 'self' https://www.google-analytics.com ws://authgear.com wss://authgear.com; block-all-mixed-content; frame-ancestors http://authgearportal.com http://customui.com",
 						},
 					},
 				},
@@ -62,7 +62,7 @@ func TestDynamicCSPMiddleware(t *testing.T) {
 					AllowFrameAncestorsFromCustomUI: false,
 					ExpectedHeaders: map[string][]string{
 						"Content-Security-Policy": {
-							"default-src 'self'; script-src 'unsafe-inline' www.googletagmanager.com eu-assets.i.posthog.com challenges.cloudflare.com www.google.com https://browser.sentry-cdn.com 'self' http://cdn.authgear.com; frame-src www.googletagmanager.com challenges.cloudflare.com www.google.com 'self'; font-src cdnjs.cloudflare.com static2.sharepointonline.com fonts.googleapis.com fonts.gstatic.com 'self' http://cdn.authgear.com; style-src 'unsafe-inline' cdnjs.cloudflare.com www.googletagmanager.com fonts.googleapis.com 'self' http://cdn.authgear.com; img-src http: https: data: 'self' http://cdn.authgear.com; object-src 'none'; base-uri 'none'; connect-src 'self' https://www.google-analytics.com ws://authgear.com wss://authgear.com; block-all-mixed-content; frame-ancestors http://authgearportal.com",
+							"default-src 'self'; script-src 'unsafe-inline' eu-assets.i.posthog.com https://browser.sentry-cdn.com 'self' http://cdn.authgear.com; frame-src www.googletagmanager.com challenges.cloudflare.com www.google.com 'self'; font-src cdnjs.cloudflare.com static2.sharepointonline.com fonts.googleapis.com fonts.gstatic.com 'self' http://cdn.authgear.com; style-src 'unsafe-inline' cdnjs.cloudflare.com www.googletagmanager.com fonts.googleapis.com 'self' http://cdn.authgear.com; img-src http: https: data: 'self' http://cdn.authgear.com; object-src 'none'; base-uri 'none'; connect-src 'self' https://www.google-analytics.com ws://authgear.com wss://authgear.com; block-all-mixed-content; frame-ancestors http://authgearportal.com",
 						},
 					},
 				},
@@ -80,7 +80,7 @@ func TestDynamicCSPMiddleware(t *testing.T) {
 					AllowFrameAncestorsFromCustomUI: true,
 					ExpectedHeaders: map[string][]string{
 						"Content-Security-Policy": {
-							"default-src 'self'; script-src 'unsafe-inline' www.googletagmanager.com eu-assets.i.posthog.com challenges.cloudflare.com www.google.com https://browser.sentry-cdn.com 'self' http://cdn.authgear.com; frame-src www.googletagmanager.com challenges.cloudflare.com www.google.com 'self'; font-src cdnjs.cloudflare.com static2.sharepointonline.com fonts.googleapis.com fonts.gstatic.com 'self' http://cdn.authgear.com; style-src 'unsafe-inline' cdnjs.cloudflare.com www.googletagmanager.com fonts.googleapis.com 'self' http://cdn.authgear.com; img-src http: https: data: 'self' http://cdn.authgear.com; object-src 'none'; base-uri 'none'; connect-src 'self' https://www.google-analytics.com ws://authgear.com wss://authgear.com; block-all-mixed-content; frame-ancestors http://customui.com",
+							"default-src 'self'; script-src 'unsafe-inline' eu-assets.i.posthog.com https://browser.sentry-cdn.com 'self' http://cdn.authgear.com; frame-src www.googletagmanager.com challenges.cloudflare.com www.google.com 'self'; font-src cdnjs.cloudflare.com static2.sharepointonline.com fonts.googleapis.com fonts.gstatic.com 'self' http://cdn.authgear.com; style-src 'unsafe-inline' cdnjs.cloudflare.com www.googletagmanager.com fonts.googleapis.com 'self' http://cdn.authgear.com; img-src http: https: data: 'self' http://cdn.authgear.com; object-src 'none'; base-uri 'none'; connect-src 'self' https://www.google-analytics.com ws://authgear.com wss://authgear.com; block-all-mixed-content; frame-ancestors http://customui.com",
 						},
 					},
 				},
@@ -98,7 +98,7 @@ func TestDynamicCSPMiddleware(t *testing.T) {
 					AllowFrameAncestorsFromCustomUI: false,
 					ExpectedHeaders: map[string][]string{
 						"Content-Security-Policy": {
-							"default-src 'self'; script-src 'unsafe-inline' www.googletagmanager.com eu-assets.i.posthog.com challenges.cloudflare.com www.google.com https://browser.sentry-cdn.com 'self' http://cdn.authgear.com; frame-src www.googletagmanager.com challenges.cloudflare.com www.google.com 'self'; font-src cdnjs.cloudflare.com static2.sharepointonline.com fonts.googleapis.com fonts.gstatic.com 'self' http://cdn.authgear.com; style-src 'unsafe-inline' cdnjs.cloudflare.com www.googletagmanager.com fonts.googleapis.com 'self' http://cdn.authgear.com; img-src http: https: data: 'self' http://cdn.authgear.com; object-src 'none'; base-uri 'none'; connect-src 'self' https://www.google-analytics.com ws://authgear.com wss://authgear.com; block-all-mixed-content; frame-ancestors 'none'",
+							"default-src 'self'; script-src 'unsafe-inline' eu-assets.i.posthog.com https://browser.sentry-cdn.com 'self' http://cdn.authgear.com; frame-src www.googletagmanager.com challenges.cloudflare.com www.google.com 'self'; font-src cdnjs.cloudflare.com static2.sharepointonline.com fonts.googleapis.com fonts.gstatic.com 'self' http://cdn.authgear.com; style-src 'unsafe-inline' cdnjs.cloudflare.com www.googletagmanager.com fonts.googleapis.com 'self' http://cdn.authgear.com; img-src http: https: data: 'self' http://cdn.authgear.com; object-src 'none'; base-uri 'none'; connect-src 'self' https://www.google-analytics.com ws://authgear.com wss://authgear.com; block-all-mixed-content; frame-ancestors 'none'",
 						},
 						"X-Frame-Options": {"DENY"},
 					},
@@ -117,7 +117,7 @@ func TestDynamicCSPMiddleware(t *testing.T) {
 					AllowFrameAncestorsFromCustomUI: true,
 					ExpectedHeaders: map[string][]string{
 						"Content-Security-Policy": {
-							"default-src 'self'; script-src 'strict-dynamic' 'nonce-' www.googletagmanager.com eu-assets.i.posthog.com challenges.cloudflare.com www.google.com https://browser.sentry-cdn.com 'self' http://cdn.authgear.com; frame-src www.googletagmanager.com challenges.cloudflare.com www.google.com 'self'; font-src cdnjs.cloudflare.com static2.sharepointonline.com fonts.googleapis.com fonts.gstatic.com 'self' http://cdn.authgear.com; style-src 'unsafe-inline' cdnjs.cloudflare.com www.googletagmanager.com fonts.googleapis.com 'self' http://cdn.authgear.com; img-src http: https: data: 'self' http://cdn.authgear.com; object-src 'none'; base-uri 'none'; connect-src 'self' https://www.google-analytics.com ws://authgear.com wss://authgear.com; block-all-mixed-content; frame-ancestors http://authgearportal.com http://customui.com",
+							"default-src 'self'; script-src 'strict-dynamic' 'nonce-' eu-assets.i.posthog.com https://browser.sentry-cdn.com 'self' http://cdn.authgear.com; frame-src www.googletagmanager.com challenges.cloudflare.com www.google.com 'self'; font-src cdnjs.cloudflare.com static2.sharepointonline.com fonts.googleapis.com fonts.gstatic.com 'self' http://cdn.authgear.com; style-src 'unsafe-inline' cdnjs.cloudflare.com www.googletagmanager.com fonts.googleapis.com 'self' http://cdn.authgear.com; img-src http: https: data: 'self' http://cdn.authgear.com; object-src 'none'; base-uri 'none'; connect-src 'self' https://www.google-analytics.com ws://authgear.com wss://authgear.com; block-all-mixed-content; frame-ancestors http://authgearportal.com http://customui.com",
 						},
 					},
 				},
@@ -135,7 +135,7 @@ func TestDynamicCSPMiddleware(t *testing.T) {
 					AllowFrameAncestorsFromCustomUI: false,
 					ExpectedHeaders: map[string][]string{
 						"Content-Security-Policy": {
-							"default-src 'self'; script-src 'strict-dynamic' 'nonce-' www.googletagmanager.com eu-assets.i.posthog.com challenges.cloudflare.com www.google.com https://browser.sentry-cdn.com 'self' http://cdn.authgear.com; frame-src www.googletagmanager.com challenges.cloudflare.com www.google.com 'self'; font-src cdnjs.cloudflare.com static2.sharepointonline.com fonts.googleapis.com fonts.gstatic.com 'self' http://cdn.authgear.com; style-src 'unsafe-inline' cdnjs.cloudflare.com www.googletagmanager.com fonts.googleapis.com 'self' http://cdn.authgear.com; img-src http: https: data: 'self' http://cdn.authgear.com; object-src 'none'; base-uri 'none'; connect-src 'self' https://www.google-analytics.com ws://authgear.com wss://authgear.com; block-all-mixed-content; frame-ancestors http://authgearportal.com",
+							"default-src 'self'; script-src 'strict-dynamic' 'nonce-' eu-assets.i.posthog.com https://browser.sentry-cdn.com 'self' http://cdn.authgear.com; frame-src www.googletagmanager.com challenges.cloudflare.com www.google.com 'self'; font-src cdnjs.cloudflare.com static2.sharepointonline.com fonts.googleapis.com fonts.gstatic.com 'self' http://cdn.authgear.com; style-src 'unsafe-inline' cdnjs.cloudflare.com www.googletagmanager.com fonts.googleapis.com 'self' http://cdn.authgear.com; img-src http: https: data: 'self' http://cdn.authgear.com; object-src 'none'; base-uri 'none'; connect-src 'self' https://www.google-analytics.com ws://authgear.com wss://authgear.com; block-all-mixed-content; frame-ancestors http://authgearportal.com",
 						},
 					},
 				},
@@ -153,7 +153,7 @@ func TestDynamicCSPMiddleware(t *testing.T) {
 					AllowFrameAncestorsFromCustomUI: true,
 					ExpectedHeaders: map[string][]string{
 						"Content-Security-Policy": {
-							"default-src 'self'; script-src 'strict-dynamic' 'nonce-' www.googletagmanager.com eu-assets.i.posthog.com challenges.cloudflare.com www.google.com https://browser.sentry-cdn.com 'self' http://cdn.authgear.com; frame-src www.googletagmanager.com challenges.cloudflare.com www.google.com 'self'; font-src cdnjs.cloudflare.com static2.sharepointonline.com fonts.googleapis.com fonts.gstatic.com 'self' http://cdn.authgear.com; style-src 'unsafe-inline' cdnjs.cloudflare.com www.googletagmanager.com fonts.googleapis.com 'self' http://cdn.authgear.com; img-src http: https: data: 'self' http://cdn.authgear.com; object-src 'none'; base-uri 'none'; connect-src 'self' https://www.google-analytics.com ws://authgear.com wss://authgear.com; block-all-mixed-content; frame-ancestors http://customui.com",
+							"default-src 'self'; script-src 'strict-dynamic' 'nonce-' eu-assets.i.posthog.com https://browser.sentry-cdn.com 'self' http://cdn.authgear.com; frame-src www.googletagmanager.com challenges.cloudflare.com www.google.com 'self'; font-src cdnjs.cloudflare.com static2.sharepointonline.com fonts.googleapis.com fonts.gstatic.com 'self' http://cdn.authgear.com; style-src 'unsafe-inline' cdnjs.cloudflare.com www.googletagmanager.com fonts.googleapis.com 'self' http://cdn.authgear.com; img-src http: https: data: 'self' http://cdn.authgear.com; object-src 'none'; base-uri 'none'; connect-src 'self' https://www.google-analytics.com ws://authgear.com wss://authgear.com; block-all-mixed-content; frame-ancestors http://customui.com",
 						},
 					},
 				},
@@ -171,20 +171,7 @@ func TestDynamicCSPMiddleware(t *testing.T) {
 					AllowFrameAncestorsFromCustomUI: false,
 					ExpectedHeaders: map[string][]string{
 						"Content-Security-Policy": {
-							"default-src 'self'; script-src 'strict-dynamic' 'nonce-' www.googletagmanager.com eu-assets.i.posthog.com challenges.cloudflare.com www.google.com https://browser.sentry-cdn.com 'self' http://cdn.authgear.com; frame-src www.googletagmanager.com challenges.cloudflare.com www.google.com 'self'; font-src cdnjs.cloudflare.com static2.sharepointonline.com fonts.googleapis.com fonts.gstatic.com 'self' http://cdn.authgear.com; style-src 'unsafe-inline' cdnjs.cloudflare.com www.googletagmanager.com fonts.googleapis.com 'self' http://cdn.authgear.com; img-src http: https: data: 'self' http://cdn.authgear.com; object-src 'none'; base-uri 'none'; connect-src 'self' https://www.google-analytics.com ws://authgear.com wss://authgear.com; block-all-mixed-content; frame-ancestors 'none'",
-						},
-						"X-Frame-Options": {"DENY"},
-					},
-				},
-				{
-					AllowedFrameAncestorsFromEnv:    config.AllowedFrameAncestors{},
-					OAuthConfig:                     &config.OAuthConfig{},
-					AllowInlineScript:               true,
-					AllowFrameAncestorsFromEnv:      true,
-					AllowFrameAncestorsFromCustomUI: true,
-					ExpectedHeaders: map[string][]string{
-						"Content-Security-Policy": {
-							"default-src 'self'; script-src 'unsafe-inline' www.googletagmanager.com eu-assets.i.posthog.com challenges.cloudflare.com www.google.com https://browser.sentry-cdn.com 'self' http://cdn.authgear.com; frame-src www.googletagmanager.com challenges.cloudflare.com www.google.com 'self'; font-src cdnjs.cloudflare.com static2.sharepointonline.com fonts.googleapis.com fonts.gstatic.com 'self' http://cdn.authgear.com; style-src 'unsafe-inline' cdnjs.cloudflare.com www.googletagmanager.com fonts.googleapis.com 'self' http://cdn.authgear.com; img-src http: https: data: 'self' http://cdn.authgear.com; object-src 'none'; base-uri 'none'; connect-src 'self' https://www.google-analytics.com ws://authgear.com wss://authgear.com; block-all-mixed-content; frame-ancestors 'none'",
+							"default-src 'self'; script-src 'strict-dynamic' 'nonce-' eu-assets.i.posthog.com https://browser.sentry-cdn.com 'self' http://cdn.authgear.com; frame-src www.googletagmanager.com challenges.cloudflare.com www.google.com 'self'; font-src cdnjs.cloudflare.com static2.sharepointonline.com fonts.googleapis.com fonts.gstatic.com 'self' http://cdn.authgear.com; style-src 'unsafe-inline' cdnjs.cloudflare.com www.googletagmanager.com fonts.googleapis.com 'self' http://cdn.authgear.com; img-src http: https: data: 'self' http://cdn.authgear.com; object-src 'none'; base-uri 'none'; connect-src 'self' https://www.google-analytics.com ws://authgear.com wss://authgear.com; block-all-mixed-content; frame-ancestors 'none'",
 						},
 						"X-Frame-Options": {"DENY"},
 					},
@@ -193,11 +180,24 @@ func TestDynamicCSPMiddleware(t *testing.T) {
 					AllowedFrameAncestorsFromEnv:    config.AllowedFrameAncestors{},
 					OAuthConfig:                     &config.OAuthConfig{},
 					AllowInlineScript:               true,
+					AllowFrameAncestorsFromEnv:      true,
+					AllowFrameAncestorsFromCustomUI: true,
+					ExpectedHeaders: map[string][]string{
+						"Content-Security-Policy": {
+							"default-src 'self'; script-src 'unsafe-inline' eu-assets.i.posthog.com https://browser.sentry-cdn.com 'self' http://cdn.authgear.com; frame-src www.googletagmanager.com challenges.cloudflare.com www.google.com 'self'; font-src cdnjs.cloudflare.com static2.sharepointonline.com fonts.googleapis.com fonts.gstatic.com 'self' http://cdn.authgear.com; style-src 'unsafe-inline' cdnjs.cloudflare.com www.googletagmanager.com fonts.googleapis.com 'self' http://cdn.authgear.com; img-src http: https: data: 'self' http://cdn.authgear.com; object-src 'none'; base-uri 'none'; connect-src 'self' https://www.google-analytics.com ws://authgear.com wss://authgear.com; block-all-mixed-content; frame-ancestors 'none'",
+						},
+						"X-Frame-Options": {"DENY"},
+					},
+				},
+				{
+					AllowedFrameAncestorsFromEnv:    config.AllowedFrameAncestors{},
+					OAuthConfig:                     &config.OAuthConfig{},
+					AllowInlineScript:               true,
 					AllowFrameAncestorsFromEnv:      false,
 					AllowFrameAncestorsFromCustomUI: false,
 					ExpectedHeaders: map[string][]string{
 						"Content-Security-Policy": {
-							"default-src 'self'; script-src 'unsafe-inline' www.googletagmanager.com eu-assets.i.posthog.com challenges.cloudflare.com www.google.com https://browser.sentry-cdn.com 'self' http://cdn.authgear.com; frame-src www.googletagmanager.com challenges.cloudflare.com www.google.com 'self'; font-src cdnjs.cloudflare.com static2.sharepointonline.com fonts.googleapis.com fonts.gstatic.com 'self' http://cdn.authgear.com; style-src 'unsafe-inline' cdnjs.cloudflare.com www.googletagmanager.com fonts.googleapis.com 'self' http://cdn.authgear.com; img-src http: https: data: 'self' http://cdn.authgear.com; object-src 'none'; base-uri 'none'; connect-src 'self' https://www.google-analytics.com ws://authgear.com wss://authgear.com; block-all-mixed-content; frame-ancestors 'none'",
+							"default-src 'self'; script-src 'unsafe-inline' eu-assets.i.posthog.com https://browser.sentry-cdn.com 'self' http://cdn.authgear.com; frame-src www.googletagmanager.com challenges.cloudflare.com www.google.com 'self'; font-src cdnjs.cloudflare.com static2.sharepointonline.com fonts.googleapis.com fonts.gstatic.com 'self' http://cdn.authgear.com; style-src 'unsafe-inline' cdnjs.cloudflare.com www.googletagmanager.com fonts.googleapis.com 'self' http://cdn.authgear.com; img-src http: https: data: 'self' http://cdn.authgear.com; object-src 'none'; base-uri 'none'; connect-src 'self' https://www.google-analytics.com ws://authgear.com wss://authgear.com; block-all-mixed-content; frame-ancestors 'none'",
 						},
 						"X-Frame-Options": {"DENY"},
 					},

--- a/pkg/lib/web/csp.go
+++ b/pkg/lib/web/csp.go
@@ -216,10 +216,7 @@ func CSPDirectives(opts CSPDirectivesOptions) ([]string, error) {
 	}
 	scriptSrc = append(
 		scriptSrc,
-		wwwgoogletagmanagercom,
 		euassetsiposthogcom,
-		challengescloudflarecom,
-		wwwgooglecom,
 		CSPHostSource{
 			Scheme: "https",
 			Host:   "browser.sentry-cdn.com",

--- a/pkg/lib/web/csp_test.go
+++ b/pkg/lib/web/csp_test.go
@@ -21,7 +21,7 @@ func TestCSPDirectives(t *testing.T) {
 			AllowInlineScript: false,
 		}, []string{
 			"default-src 'self'",
-			"script-src 'strict-dynamic' 'nonce-N0NC5' www.googletagmanager.com eu-assets.i.posthog.com challenges.cloudflare.com www.google.com https://browser.sentry-cdn.com 'self'",
+			"script-src 'strict-dynamic' 'nonce-N0NC5' eu-assets.i.posthog.com https://browser.sentry-cdn.com 'self'",
 			"frame-src www.googletagmanager.com challenges.cloudflare.com www.google.com 'self'",
 			"font-src cdnjs.cloudflare.com static2.sharepointonline.com fonts.googleapis.com fonts.gstatic.com 'self'",
 			"style-src 'unsafe-inline' cdnjs.cloudflare.com www.googletagmanager.com fonts.googleapis.com 'self'",
@@ -40,7 +40,7 @@ func TestCSPDirectives(t *testing.T) {
 			AllowInlineScript: false,
 		}, []string{
 			"default-src 'self'",
-			"script-src 'strict-dynamic' 'nonce-N0NC5' www.googletagmanager.com eu-assets.i.posthog.com challenges.cloudflare.com www.google.com https://browser.sentry-cdn.com 'self' cdn.localhost:3000",
+			"script-src 'strict-dynamic' 'nonce-N0NC5' eu-assets.i.posthog.com https://browser.sentry-cdn.com 'self' cdn.localhost:3000",
 			"frame-src www.googletagmanager.com challenges.cloudflare.com www.google.com 'self'",
 			"font-src cdnjs.cloudflare.com static2.sharepointonline.com fonts.googleapis.com fonts.gstatic.com 'self' cdn.localhost:3000",
 			"style-src 'unsafe-inline' cdnjs.cloudflare.com www.googletagmanager.com fonts.googleapis.com 'self' cdn.localhost:3000",
@@ -59,7 +59,7 @@ func TestCSPDirectives(t *testing.T) {
 			AllowInlineScript: true,
 		}, []string{
 			"default-src 'self'",
-			"script-src 'unsafe-inline' www.googletagmanager.com eu-assets.i.posthog.com challenges.cloudflare.com www.google.com https://browser.sentry-cdn.com 'self' cdn.localhost:3000",
+			"script-src 'unsafe-inline' eu-assets.i.posthog.com https://browser.sentry-cdn.com 'self' cdn.localhost:3000",
 			"frame-src www.googletagmanager.com challenges.cloudflare.com www.google.com 'self'",
 			"font-src cdnjs.cloudflare.com static2.sharepointonline.com fonts.googleapis.com fonts.gstatic.com 'self' cdn.localhost:3000",
 			"style-src 'unsafe-inline' cdnjs.cloudflare.com www.googletagmanager.com fonts.googleapis.com 'self' cdn.localhost:3000",
@@ -79,7 +79,7 @@ func TestCSPDirectives(t *testing.T) {
 			FrameAncestors:    []string{"http://remote.localhost"},
 		}, []string{
 			"default-src 'self'",
-			"script-src 'strict-dynamic' 'nonce-N0NC5' www.googletagmanager.com eu-assets.i.posthog.com challenges.cloudflare.com www.google.com https://browser.sentry-cdn.com 'self' cdn.localhost:3000",
+			"script-src 'strict-dynamic' 'nonce-N0NC5' eu-assets.i.posthog.com https://browser.sentry-cdn.com 'self' cdn.localhost:3000",
 			"frame-src www.googletagmanager.com challenges.cloudflare.com www.google.com 'self'",
 			"font-src cdnjs.cloudflare.com static2.sharepointonline.com fonts.googleapis.com fonts.gstatic.com 'self' cdn.localhost:3000",
 			"style-src 'unsafe-inline' cdnjs.cloudflare.com www.googletagmanager.com fonts.googleapis.com 'self' cdn.localhost:3000",
@@ -99,7 +99,7 @@ func TestCSPDirectives(t *testing.T) {
 			AuthUISentryDSN:   "https://examplePublicKey@o0.ingest.sentry.io/0",
 		}, []string{
 			"default-src 'self'",
-			"script-src 'strict-dynamic' 'nonce-N0NC5' www.googletagmanager.com eu-assets.i.posthog.com challenges.cloudflare.com www.google.com https://browser.sentry-cdn.com 'self'",
+			"script-src 'strict-dynamic' 'nonce-N0NC5' eu-assets.i.posthog.com https://browser.sentry-cdn.com 'self'",
 			"frame-src www.googletagmanager.com challenges.cloudflare.com www.google.com 'self'",
 			"font-src cdnjs.cloudflare.com static2.sharepointonline.com fonts.googleapis.com fonts.gstatic.com 'self'",
 			"style-src 'unsafe-inline' cdnjs.cloudflare.com www.googletagmanager.com fonts.googleapis.com 'self'",


### PR DESCRIPTION
Note at CSP3, nonce- is supported over script-src per endpoint config

## Why this PR?

It is an attempt to make `response headers` smaller. But it doesn't seem very effective - only shrinked 0.066 kb

Still, this PR helps remove obsolete/unused/ineffective code

<details>

<summary> Before: 3.856 kb </summary>

<img width="773" alt="image" src="https://github.com/user-attachments/assets/425f1cac-e473-4f62-ba43-8f2e64f2ef25">


```
HTTP/1.1 302 Found
Server: nginx/1.18.0
Date: Mon, 26 Aug 2024 17:42:46 GMT
Content-Length: 0
Connection: keep-alive
Cache-Control: no-store
Content-Security-Policy: default-src 'self'; script-src 'strict-dynamic' 'nonce-1HY3G7TDAKE3V6M2JNNGHRXRC0R3KY7X' www.googletagmanager.com eu-assets.i.posthog.com challenges.cloudflare.com www.google.com https://browser.sentry-cdn.com 'self'; frame-src www.googletagmanager.com challenges.cloudflare.com www.google.com 'self'; font-src cdnjs.cloudflare.com static2.sharepointonline.com fonts.googleapis.com fonts.gstatic.com 'self'; style-src 'unsafe-inline' cdnjs.cloudflare.com www.googletagmanager.com fonts.googleapis.com 'self'; img-src http: https: data: 'self'; object-src 'none'; base-uri 'none'; connect-src 'self' https://www.google-analytics.com ws://accounts.portal.localhost:3100 wss://accounts.portal.localhost:3100; block-all-mixed-content; frame-ancestors http://portal.localhost:8000
Location: /signup?q_login_id_input_type=text&q_login_id_key=email
Permissions-Policy: accelerometer=(), ambient-light-sensor=(), autoplay=*, battery=(), bluetooth=(), browsing-topics=(), camera=(), display-capture=(), document-domain=(), encrypted-media=(), execution-while-not-rendered=*, execution-while-out-of-viewport=*, fullscreen=*, gamepad=(), geolocation=(), gyroscope=(), hid=(), identity-credentials-get=(), idle-detection=(), local-fonts=(), magnetometer=(), microphone=(), midi=(), otp-credentials=(), payment=(), picture-in-picture=(), publickey-credentials-create=(self), publickey-credentials-get=(self), screen-wake-lock=(), serial=(), speaker-selection=(), storage-access=(), usb=(), web-share=(), window-management=(), xr-spatial-tracking=()
Pragma: no-cache
Set-Cookie: debug_csrf_same_site_omit=exists; Path=/; Domain=portal.localhost; Max-Age=1200; HttpOnly
Set-Cookie: debug_csrf_same_site_none=exists; Path=/; Domain=portal.localhost; Max-Age=1200; HttpOnly
Set-Cookie: debug_csrf_same_site_lax=exists; Path=/; Domain=portal.localhost; Max-Age=1200; HttpOnly; SameSite=Lax
Set-Cookie: debug_csrf_same_site_strict=exists; Path=/; Domain=portal.localhost; Max-Age=1200; HttpOnly; SameSite=Strict
Set-Cookie: web_err=eyJGb3JtIjp7ImdvcmlsbGEuY3NyZi5Ub2tlbiI6WyI2cnZpT0FxVjVidXVVdnZTb0JwSG9Vc2g0QWIzVDZndHd3N3ArV1pqNHZ4dEl6U29jdXpyZDd5ZU8ySkNKQTR1S1pnYUFVelJYMll6Z043MUhVanJrdz09Il0sInFfbG9naW5faWQiOlsicGtvbmd6QG91cnNreS5jb20iXSwicV9sb2dpbl9pZF9pbnB1dF90eXBlIjpbInRleHQiXSwicV9sb2dpbl9pZF9rZXkiOlsiZW1haWwiLCJlbWFpbCJdLCJxX2xvZ2luX2lkX3R5cGUiOlsiZW1haWwiXSwieF9hY3Rpb24iOlsibG9naW5faWQiXSwieF9ib3RfcHJvdGVjdGlvbl9wcm92aWRlcl9yZXNwb25zZSI6WyIwLlViLUZJLVNKM3ZxOEdZZW5USldpa08wQmd4U1puM2c1ZHAzSHVrWFdBS24xa3UxR2VVSEg0S2o3VFItbWVZTG0wbXVkVGFPV1l5eGhZbEFsMmEyc09mZ1czQ25CQ0dmQWp2NGJzajEtYmtVeHNpU2xXa1BqTGVCQ2podHVQQXY5TnBlXzg4MVZ6NU9ZY29SeHRLSDdWSHVoNVZMUHBSeVZ6THZxTml3UWFGOXFDaVIxQTlweUJHeUtMb1lFTHF4M09zNFJfcmFZdmlNWU5Iak1RdW0zbU54SHY2dEV3ekRwOTExaFgxM1pUQUxKbGZzc2xFX1FRdDUxU21hOEhPdFRJeVFBSW02QzNtbWtpazRCZkpBN25LM21td3pwdHpBQ0tHUlBzNERCZTdkZWFGS0RiRzg5RWM4S2R2R0RkMWQxRm5aeFh6bFQyR3N4dUR0ZXVOb2d6SjgzSktwUGJFYWNCdTZCNzFsNlh5QnZUY25RMW53RXYtVVI4Y01nRVpraWRMb01Dc2pDOERqNkNYRzBSVWhPU1hvWnU3VVZWV1RRSm5sR3JFeVhmT19qX2tUNFhBdVBfd3VwSnlqSllINnAuWjctN2ZfRVhSWHZKcmt5WlV3TUJYdy42NDc4ZmJjNDQ4MTc4ZWZjMGJjNTA3ZTVkYWZhOTU1MjBhY2FjNzQ2YjNlY2I1NjQwYWZhNzNmODQyZDQxZGM2Il0sInhfYm90X3Byb3RlY3Rpb25fcHJvdmlkZXJfdHlwZSI6WyJjbG91ZGZsYXJlIl19LCJFcnJvciI6eyJuYW1lIjoiSW52YWxpZCIsInJlYXNvbiI6IkludmFyaWFudFZpb2xhdGVkIiwibWVzc2FnZSI6ImlkZW50aXR5IGFscmVhZHkgZXhpc3RzIiwiY29kZSI6NDAwLCJpbmZvIjp7IkZsb3dUeXBlIjoic2lnbnVwIiwiSWRlbnRpdHlUeXBlRXhpc3RpbmciOiJsb2dpbl9pZCIsIklkZW50aXR5VHlwZUluY29taW5nIjoibG9naW5faWQiLCJMb2dpbklEVHlwZUV4aXN0aW5nIjoiZW1haWwiLCJMb2dpbklEVHlwZUluY29taW5nIjoiZW1haWwiLCJjYXVzZSI6eyJraW5kIjoiRHVwbGljYXRlZElkZW50aXR5In19fX0; Path=/; Domain=portal.localhost; HttpOnly; SameSite=Lax
Vary: Cookie
X-Content-Type-Options: nosniff
```

</details>

<details>

<summary> After : 3.790 kb</summary>

<img width="771" alt="image" src="https://github.com/user-attachments/assets/cb9e9bbb-95f9-4390-b01a-67f6f4846645">


```
TTP/1.1 302 Found
Server: nginx/1.18.0
Date: Mon, 26 Aug 2024 17:36:56 GMT
Content-Length: 0
Connection: keep-alive
Cache-Control: no-store
Content-Security-Policy: default-src 'self'; script-src 'strict-dynamic' 'nonce-1HY3G7TDAKE3V6M2JNNGHRXRC0R3KY7X' eu-assets.i.posthog.com https://browser.sentry-cdn.com 'self'; frame-src www.googletagmanager.com challenges.cloudflare.com www.google.com 'self'; font-src cdnjs.cloudflare.com static2.sharepointonline.com fonts.googleapis.com fonts.gstatic.com 'self'; style-src 'unsafe-inline' cdnjs.cloudflare.com www.googletagmanager.com fonts.googleapis.com 'self'; img-src http: https: data: 'self'; object-src 'none'; base-uri 'none'; connect-src 'self' https://www.google-analytics.com ws://accounts.portal.localhost:3100 wss://accounts.portal.localhost:3100; block-all-mixed-content; frame-ancestors http://portal.localhost:8000
Location: /signup?q_login_id_input_type=text&q_login_id_key=email
Permissions-Policy: accelerometer=(), ambient-light-sensor=(), autoplay=*, battery=(), bluetooth=(), browsing-topics=(), camera=(), display-capture=(), document-domain=(), encrypted-media=(), execution-while-not-rendered=*, execution-while-out-of-viewport=*, fullscreen=*, gamepad=(), geolocation=(), gyroscope=(), hid=(), identity-credentials-get=(), idle-detection=(), local-fonts=(), magnetometer=(), microphone=(), midi=(), otp-credentials=(), payment=(), picture-in-picture=(), publickey-credentials-create=(self), publickey-credentials-get=(self), screen-wake-lock=(), serial=(), speaker-selection=(), storage-access=(), usb=(), web-share=(), window-management=(), xr-spatial-tracking=()
Pragma: no-cache
Set-Cookie: debug_csrf_same_site_omit=exists; Path=/; Domain=portal.localhost; Max-Age=1200; HttpOnly
Set-Cookie: debug_csrf_same_site_none=exists; Path=/; Domain=portal.localhost; Max-Age=1200; HttpOnly
Set-Cookie: debug_csrf_same_site_lax=exists; Path=/; Domain=portal.localhost; Max-Age=1200; HttpOnly; SameSite=Lax
Set-Cookie: debug_csrf_same_site_strict=exists; Path=/; Domain=portal.localhost; Max-Age=1200; HttpOnly; SameSite=Strict
Set-Cookie: web_err=eyJGb3JtIjp7ImdvcmlsbGEuY3NyZi5Ub2tlbiI6WyJ5dXNibFlGdzhPVktPcFVuaE9BWW5INS9UdjhDR2FHMG9kWVF3cXk5RTAxTmM4MEYrUW4rS1ZqMlZaZG0zbEVUSE1hMCtMbUhWdjlSV0NmTzE1WWFJZz09Il0sInFfbG9naW5faWQiOlsicGtvbmd6QG91cnNreS5jb20iXSwicV9sb2dpbl9pZF9pbnB1dF90eXBlIjpbInRleHQiXSwicV9sb2dpbl9pZF9rZXkiOlsiZW1haWwiLCJlbWFpbCJdLCJxX2xvZ2luX2lkX3R5cGUiOlsiZW1haWwiXSwieF9hY3Rpb24iOlsibG9naW5faWQiXSwieF9ib3RfcHJvdGVjdGlvbl9wcm92aWRlcl9yZXNwb25zZSI6WyIwLnNMZ24zTDFfaVpmcWxmLW54TC1wUk5WbUNKWkhNQzd0ZlhWVDRjMWsyTk1RdGIwUEVja0pHZlA0b2U3bHE1aU9FMTdsNzBHZmNiQURIMG5lTHp1R2wtSnNxdVpaeGVQcXBkbVpaMFpJRDRiVWhaemtKWWpuRkpySHJwZkpmMzZBbXAwTzhZOVFjNVpRc0NFZ0YyVlppRE5jdDdfaE1FcldaelE3Zm9nX3FRemMtSENVRjVUSGtrMHpfZkxqVVZyalY5MV9kcDRnTE12d1NvQWU1cTJaTGhmMDBRZVgyelh5Q3pkMU1aUHdwNFpRTDg4b1VidUFaUW8tQmpaNThjdEYzWnhuRlZnMzBzUzJXenNrbVRWM0dscnp0bDZaaS1iSlp6MUZYZGZJeVpqQkMzVDd1Qmkwc1pHTDhvWmxJdXRvX2VKQmZ3dTFYc0V1Mi10TXVsMlhrZkF3TFVieUViSlBvNmNzeEVLRFRoVUNIUFgxd1V1MWlvckkxU1BfSmFubm5TNnpQY3hmVi1RRFAyZHdIQ254Ti02STA3bFNETVdrLXVrMVU1REdHWU1OdnFuZlY3ZlZIbmNMbXJlMlVIaGQuNkx1V3daYVdrTkNsMVZIVWxTb3F5QS5mN2FjMTYzZDBkMWQ0Nzk1N2U1NDJlMzVmYjllMTU4N2IxNDJjZmZjYjVmNTI2YTBjZDBlZTE1OTQ2NWI3MThiIl0sInhfYm90X3Byb3RlY3Rpb25fcHJvdmlkZXJfdHlwZSI6WyJjbG91ZGZsYXJlIl19LCJFcnJvciI6eyJuYW1lIjoiSW52YWxpZCIsInJlYXNvbiI6IkludmFyaWFudFZpb2xhdGVkIiwibWVzc2FnZSI6ImlkZW50aXR5IGFscmVhZHkgZXhpc3RzIiwiY29kZSI6NDAwLCJpbmZvIjp7IkZsb3dUeXBlIjoic2lnbnVwIiwiSWRlbnRpdHlUeXBlRXhpc3RpbmciOiJsb2dpbl9pZCIsIklkZW50aXR5VHlwZUluY29taW5nIjoibG9naW5faWQiLCJMb2dpbklEVHlwZUV4aXN0aW5nIjoiZW1haWwiLCJMb2dpbklEVHlwZUluY29taW5nIjoiZW1haWwiLCJjYXVzZSI6eyJraW5kIjoiRHVwbGljYXRlZElkZW50aXR5In19fX0; Path=/; Domain=portal.localhost; HttpOnly; SameSite=Lax
Vary: Cookie
X-Content-Type-Options: nosniff
```

</details>



## Any regression?
Cloudflare still renders, which is allowed by nonce

<img width="446" alt="image" src="https://github.com/user-attachments/assets/9f5b8f64-05a7-480f-a558-9700ed4282ef">
