### PR TITLE
Redact `x_bot_protection_provider_response` in error cookie

### DIFF
--- a/pkg/util/strings/substring.go
+++ b/pkg/util/strings/substring.go
@@ -1,0 +1,12 @@
+package strings
+
+func GetFirstN(str string, n int) string {
+	if n < 0 {
+		panic("n must be >= 0")
+	}
+	v := []rune(str)
+	if n >= len(v) {
+		return str
+	}
+	return string(v[:n])
+}

--- a/pkg/util/strings/substring_test.go
+++ b/pkg/util/strings/substring_test.go
@@ -1,0 +1,25 @@
+package strings
+
+import (
+	"testing"
+
+	. "github.com/smartystreets/goconvey/convey"
+)
+
+func TestSubstring(t *testing.T) {
+	Convey("GetFirstN", t, func() {
+		original := "abcdefghijklmnopqrstuvwxyz"
+
+		negative := func() { GetFirstN(original, -999) }
+		empty := GetFirstN(original, 0)
+		untilJ := GetFirstN(original, 10)
+		untilZ := GetFirstN(original, 26)
+		overflow := GetFirstN(original, 9999)
+
+		So(negative, ShouldPanicWith, "n must be >= 0")
+		So(empty, ShouldResemble, "")
+		So(untilJ, ShouldResemble, "abcdefghij")
+		So(untilZ, ShouldResemble, "abcdefghijklmnopqrstuvwxyz")
+		So(overflow, ShouldResemble, "abcdefghijklmnopqrstuvwxyz")
+	})
+}


### PR DESCRIPTION
## What's in this PR
Before this PR, all error response from POST requests with bot protection token will return **_entire_** token, which takes up about `0.5-1kb` in response header. (for cloudflare turnstile, recaptcha token size might vary)

This PR attempts to redact that very long token, and show only the first 10 characters + some `*` chars

| Before | After |
| ------  | ----- |
| `"x_bot_protection_provider_response":["0.Q2cFtWTwiarQUS87fbxZ-i-LjJ_88P6bbtREwNklJoaRnspvcjm9DBfzhKUWUJYpl4T2K7z99eBbjXR0MUJqf54iog4AkNMo8-bdpWZuPjB9G_ltIfDFpGHuLpiM6kgtJkz3ru7YiMNHdI46kBHbek7XHyuXsd3SK6qSfRSs02fENxioOX9TqqICO_VY36K8dF7Fk_SXxXTWni1diRZ5KKtFBr7r-gmvbUGrhk8EabxwqbcBK9OvhB9zMnmMnpFW8jptZWObcu6d7LNdLd8QHlNRTNsp4ivhxx9FrFjhaRkzsxnJDd0s-CpUZKOLuse3WGJZ4zcSayGJ8UPaCFhg8WYb6Wo6gv7f5otmDCPpqT2Fsda-o9FrxELJ9Fe01FRVNJG_xW2N2LI9VRnBspx495eKwjscnuMFqQgETatSYC3-f7G_CzWfRTNEgz8mGqdH.MzLfOXkVtwuSWZSS5fcXqg.66fe503a07d73b74945840726d4dd9e253629d21d6724654dfb4cbbd613db298"]`        | `"x_bot_protection_provider_response":["0.2Moo0Wj3**********"]`     |


## Why this PR?

It is an attempt to make `response headers` smaller. Local experiment shows that 0.7 kb is saved

<details>

<summary> Before: 3.856 kb </summary>

<img width="732" alt="image" src="https://github.com/user-attachments/assets/cc3c984f-0eb9-475c-b0c7-8dadf2584253">

```
HTTP/1.1 302 Found
Server: nginx/1.18.0
Date: Mon, 26 Aug 2024 18:23:41 GMT
Content-Length: 0
Connection: keep-alive
Cache-Control: no-store
Content-Security-Policy: default-src 'self'; script-src 'strict-dynamic' 'nonce-1HY3G7TDAKE3V6M2JNNGHRXRC0R3KY7X' www.googletagmanager.com eu-assets.i.posthog.com challenges.cloudflare.com www.google.com https://browser.sentry-cdn.com 'self'; frame-src www.googletagmanager.com challenges.cloudflare.com www.google.com 'self'; font-src cdnjs.cloudflare.com static2.sharepointonline.com fonts.googleapis.com fonts.gstatic.com 'self'; style-src 'unsafe-inline' cdnjs.cloudflare.com www.googletagmanager.com fonts.googleapis.com 'self'; img-src http: https: data: 'self'; object-src 'none'; base-uri 'none'; connect-src 'self' https://www.google-analytics.com ws://accounts.portal.localhost:3100 wss://accounts.portal.localhost:3100; block-all-mixed-content; frame-ancestors http://portal.localhost:8000
Location: /signup?q_login_id_input_type=text&q_login_id_key=email
Permissions-Policy: accelerometer=(), ambient-light-sensor=(), autoplay=*, battery=(), bluetooth=(), browsing-topics=(), camera=(), display-capture=(), document-domain=(), encrypted-media=(), execution-while-not-rendered=*, execution-while-out-of-viewport=*, fullscreen=*, gamepad=(), geolocation=(), gyroscope=(), hid=(), identity-credentials-get=(), idle-detection=(), local-fonts=(), magnetometer=(), microphone=(), midi=(), otp-credentials=(), payment=(), picture-in-picture=(), publickey-credentials-create=(self), publickey-credentials-get=(self), screen-wake-lock=(), serial=(), speaker-selection=(), storage-access=(), usb=(), web-share=(), window-management=(), xr-spatial-tracking=()
Pragma: no-cache
Set-Cookie: debug_csrf_same_site_omit=exists; Path=/; Domain=portal.localhost; Max-Age=1200; HttpOnly
Set-Cookie: debug_csrf_same_site_none=exists; Path=/; Domain=portal.localhost; Max-Age=1200; HttpOnly
Set-Cookie: debug_csrf_same_site_lax=exists; Path=/; Domain=portal.localhost; Max-Age=1200; HttpOnly; SameSite=Lax
Set-Cookie: debug_csrf_same_site_strict=exists; Path=/; Domain=portal.localhost; Max-Age=1200; HttpOnly; SameSite=Strict
Set-Cookie: web_err=eyJGb3JtIjp7ImdvcmlsbGEuY3NyZi5Ub2tlbiI6WyJ4ZGQvM1FzYzRvNE1LeXhjM09yaGdYaWVpSnFoU0lmZ0orNDEreGluam9VdXhQYkJ5YlBiZmwveU5rSGtLV1Bvb0t2QTdtOWw4UjJZK2xJTkpuUmNQUT09Il0sInFfbG9naW5faWQiOlsicGtvbmd6QG91cnNreS5jb20iXSwicV9sb2dpbl9pZF9pbnB1dF90eXBlIjpbInRleHQiXSwicV9sb2dpbl9pZF9rZXkiOlsiZW1haWwiLCJlbWFpbCJdLCJxX2xvZ2luX2lkX3R5cGUiOlsiZW1haWwiXSwieF9hY3Rpb24iOlsibG9naW5faWQiXSwieF9ib3RfcHJvdGVjdGlvbl9wcm92aWRlcl9yZXNwb25zZSI6WyIwLlEyY0Z0V1R3aWFyUVVTODdmYnhaLWktTGpKXzg4UDZiYnRSRXdOa2xKb2FSbnNwdmNqbTlEQmZ6aEtVV1VKWXBsNFQySzd6OTllQmJqWFIwTVVKcWY1NGlvZzRBa05NbzgtYmRwV1p1UGpCOUdfbHRJZkRGcEdIdUxwaU02a2d0Smt6M3J1N1lpTU5IZEk0NmtCSGJlazdYSHl1WHNkM1NLNnFTZlJTczAyZkVOeGlvT1g5VHFxSUNPX1ZZMzZLOGRGN0ZrX1NYeFhUV25pMWRpUlo1S0t0RkJyN3ItZ212YlVHcmhrOEVhYnh3cWJjQks5T3ZoQjl6TW5tTW5wRlc4anB0WldPYmN1NmQ3TE5kTGQ4UUhsTlJUTnNwNGl2aHh4OUZyRmpoYVJrenN4bkpEZDBzLUNwVVpLT0x1c2UzV0dKWjR6Y1NheUdKOFVQYUNGaGc4V1liNldvNmd2N2Y1b3RtRENQcHFUMkZzZGEtbzlGcnhFTEo5RmUwMUZSVk5KR194VzJOMkxJOVZSbkJzcHg0OTVlS3dqc2NudU1GcVFnRVRhdFNZQzMtZjdHX0N6V2ZSVE5FZ3o4bUdxZEguTXpMZk9Ya1Z0d3VTV1pTUzVmY1hxZy42NmZlNTAzYTA3ZDczYjc0OTQ1ODQwNzI2ZDRkZDllMjUzNjI5ZDIxZDY3MjQ2NTRkZmI0Y2JiZDYxM2RiMjk4Il0sInhfYm90X3Byb3RlY3Rpb25fcHJvdmlkZXJfdHlwZSI6WyJjbG91ZGZsYXJlIl19LCJFcnJvciI6eyJuYW1lIjoiSW52YWxpZCIsInJlYXNvbiI6IkludmFyaWFudFZpb2xhdGVkIiwibWVzc2FnZSI6ImlkZW50aXR5IGFscmVhZHkgZXhpc3RzIiwiY29kZSI6NDAwLCJpbmZvIjp7IkZsb3dUeXBlIjoic2lnbnVwIiwiSWRlbnRpdHlUeXBlRXhpc3RpbmciOiJsb2dpbl9pZCIsIklkZW50aXR5VHlwZUluY29taW5nIjoibG9naW5faWQiLCJMb2dpbklEVHlwZUV4aXN0aW5nIjoiZW1haWwiLCJMb2dpbklEVHlwZUluY29taW5nIjoiZW1haWwiLCJjYXVzZSI6eyJraW5kIjoiRHVwbGljYXRlZElkZW50aXR5In19fX0; Path=/; Domain=portal.localhost; HttpOnly; SameSite=Lax
Vary: Cookie
X-Content-Type-Options: nosniff
```

</details>

<details>

<summary> After: 3.165 kb </summary>

<img width="735" alt="image" src="https://github.com/user-attachments/assets/3113cf91-1f9e-4b60-b6c3-e5d18bd566ed">

```
HTTP/1.1 302 Found
Server: nginx/1.18.0
Date: Mon, 26 Aug 2024 18:18:38 GMT
Content-Length: 0
Connection: keep-alive
Cache-Control: no-store
Content-Security-Policy: default-src 'self'; script-src 'strict-dynamic' 'nonce-1HY3G7TDAKE3V6M2JNNGHRXRC0R3KY7X' www.googletagmanager.com eu-assets.i.posthog.com challenges.cloudflare.com www.google.com https://browser.sentry-cdn.com 'self'; frame-src www.googletagmanager.com challenges.cloudflare.com www.google.com 'self'; font-src cdnjs.cloudflare.com static2.sharepointonline.com fonts.googleapis.com fonts.gstatic.com 'self'; style-src 'unsafe-inline' cdnjs.cloudflare.com www.googletagmanager.com fonts.googleapis.com 'self'; img-src http: https: data: 'self'; object-src 'none'; base-uri 'none'; connect-src 'self' https://www.google-analytics.com ws://accounts.portal.localhost:3100 wss://accounts.portal.localhost:3100; block-all-mixed-content; frame-ancestors http://portal.localhost:8000
Location: /signup?q_login_id_input_type=text&q_login_id_key=email
Permissions-Policy: accelerometer=(), ambient-light-sensor=(), autoplay=*, battery=(), bluetooth=(), browsing-topics=(), camera=(), display-capture=(), document-domain=(), encrypted-media=(), execution-while-not-rendered=*, execution-while-out-of-viewport=*, fullscreen=*, gamepad=(), geolocation=(), gyroscope=(), hid=(), identity-credentials-get=(), idle-detection=(), local-fonts=(), magnetometer=(), microphone=(), midi=(), otp-credentials=(), payment=(), picture-in-picture=(), publickey-credentials-create=(self), publickey-credentials-get=(self), screen-wake-lock=(), serial=(), speaker-selection=(), storage-access=(), usb=(), web-share=(), window-management=(), xr-spatial-tracking=()
Pragma: no-cache
Set-Cookie: debug_csrf_same_site_omit=exists; Path=/; Domain=portal.localhost; Max-Age=1200; HttpOnly
Set-Cookie: debug_csrf_same_site_none=exists; Path=/; Domain=portal.localhost; Max-Age=1200; HttpOnly
Set-Cookie: debug_csrf_same_site_lax=exists; Path=/; Domain=portal.localhost; Max-Age=1200; HttpOnly; SameSite=Lax
Set-Cookie: debug_csrf_same_site_strict=exists; Path=/; Domain=portal.localhost; Max-Age=1200; HttpOnly; SameSite=Strict
Set-Cookie: web_err=eyJGb3JtIjp7ImdvcmlsbGEuY3NyZi5Ub2tlbiI6WyJJMWNNRkt2T2hvd0M3eitwRlhNUlZvdFoyeXY5OFJmRzRibGFQN01RMkVUSVJJVUlhV0cvZkZFMkpiUXRzSk0vVTJ5VFh6UGNZVHRlclQzSmpjTUsvQT09Il0sInFfbG9naW5faWQiOlsicGtvbmd6QG91cnNreS5jb20iXSwicV9sb2dpbl9pZF9pbnB1dF90eXBlIjpbInRleHQiXSwicV9sb2dpbl9pZF9rZXkiOlsiZW1haWwiLCJlbWFpbCJdLCJxX2xvZ2luX2lkX3R5cGUiOlsiZW1haWwiXSwieF9hY3Rpb24iOlsibG9naW5faWQiXSwieF9ib3RfcHJvdGVjdGlvbl9wcm92aWRlcl9yZXNwb25zZSI6WyIwLjJNb28wV2ozKioqKioqKioqKiJdLCJ4X2JvdF9wcm90ZWN0aW9uX3Byb3ZpZGVyX3R5cGUiOlsiY2xvdWRmbGFyZSJdfSwiRXJyb3IiOnsibmFtZSI6IkludmFsaWQiLCJyZWFzb24iOiJJbnZhcmlhbnRWaW9sYXRlZCIsIm1lc3NhZ2UiOiJpZGVudGl0eSBhbHJlYWR5IGV4aXN0cyIsImNvZGUiOjQwMCwiaW5mbyI6eyJGbG93VHlwZSI6InNpZ251cCIsIklkZW50aXR5VHlwZUV4aXN0aW5nIjoibG9naW5faWQiLCJJZGVudGl0eVR5cGVJbmNvbWluZyI6ImxvZ2luX2lkIiwiTG9naW5JRFR5cGVFeGlzdGluZyI6ImVtYWlsIiwiTG9naW5JRFR5cGVJbmNvbWluZyI6ImVtYWlsIiwiY2F1c2UiOnsia2luZCI6IkR1cGxpY2F0ZWRJZGVudGl0eSJ9fX19; Path=/; Domain=portal.localhost; HttpOnly; SameSite=Lax
Vary: Cookie
```

</details>
