### PR TITLE
Fix pipes nested in templates not traversed in validateHTMLTemplate

### DIFF
--- a/pkg/util/template/validation.go
+++ b/pkg/util/template/validation.go
@@ -216,7 +216,14 @@ func traverseTreeVisit(
 				}
 			}
 		}
-	case *parse.TemplateNode, *parse.TextNode:
+	case *parse.TemplateNode:
+		if n.Pipe != nil {
+			if cont = traverseTreeVisit(n.Pipe, depth+1, fn); !cont {
+				break
+			}
+		}
+
+	case *parse.TextNode:
 		break
 	default:
 		panic("unknown node type")

--- a/pkg/util/template/validation.go
+++ b/pkg/util/template/validation.go
@@ -178,6 +178,7 @@ func traverseTreeVisitBranch(n *parse.BranchNode, depth int, fn func(n parse.Nod
 	return
 }
 
+//nolint:gocognit
 func traverseTreeVisit(
 	n parse.Node,
 	depth int,

--- a/pkg/util/template/validation_test.go
+++ b/pkg/util/template/validation_test.go
@@ -98,5 +98,13 @@ func TestTemplateValidation(t *testing.T) {
 			err = v.ValidateHTMLTemplate(template(`{{ range . }}{{ end }}`))
 			So(err, ShouldBeNil)
 		})
+
+		Convey("should traverse into template nodes pipe", func() {
+			var err error
+			v := NewValidator(AllowTemplateNode(true))
+
+			err = v.ValidateHTMLTemplate((template(`{{ template "name" js (js (js (js (js "\\")))) }}`)))
+			So(err, ShouldBeError, "email:1:31: template nested too deep")
+		})
 	})
 }


### PR DESCRIPTION
cc @kiootic or was it intentional not to traverse into `TemplateNode.Pipe`?