### PR TITLE
Fix portal & server generate password test sometimes fail

### DIFF
--- a/cmd/authgear/background/wire_gen.go
+++ b/cmd/authgear/background/wire_gen.go
@@ -800,8 +800,10 @@ func newUserService(ctx context.Context, p *deps.BackgroundProvider, appID strin
 	}
 	accountDeletionConfig := appConfig.AccountDeletion
 	accountAnonymizationConfig := appConfig.AccountAnonymization
+	maxTrials := _wireMaxTrialsValue
 	passwordRand := password.NewRandSource()
 	generator := &password.Generator{
+		MaxTrials:      maxTrials,
 		Checker:        passwordChecker,
 		Rand:           passwordRand,
 		PasswordConfig: authenticatorPasswordConfig,
@@ -840,5 +842,6 @@ func newUserService(ctx context.Context, p *deps.BackgroundProvider, appID strin
 }
 
 var (
-	_wireRandValue = idpsession.Rand(rand.SecureRand)
+	_wireRandValue      = idpsession.Rand(rand.SecureRand)
+	_wireMaxTrialsValue = password.DefaultMaxTrials
 )

--- a/e2e/cmd/e2e/pkg/wire_gen.go
+++ b/e2e/cmd/e2e/pkg/wire_gen.go
@@ -773,8 +773,10 @@ func newUserImport(p *deps.AppProvider, c context.Context) *userimport.UserImpor
 	}
 	accountDeletionConfig := appConfig.AccountDeletion
 	accountAnonymizationConfig := appConfig.AccountAnonymization
+	maxTrials := _wireMaxTrialsValue
 	passwordRand := password.NewRandSource()
 	generator := &password.Generator{
+		MaxTrials:      maxTrials,
 		Checker:        passwordChecker,
 		Rand:           passwordRand,
 		PasswordConfig: authenticatorPasswordConfig,
@@ -840,7 +842,8 @@ func newUserImport(p *deps.AppProvider, c context.Context) *userimport.UserImpor
 }
 
 var (
-	_wireRandValue = idpsession.Rand(rand.SecureRand)
+	_wireRandValue      = idpsession.Rand(rand.SecureRand)
+	_wireMaxTrialsValue = password.DefaultMaxTrials
 )
 
 func newLoginIDSerivce(p *deps.AppProvider, c context.Context) *loginid.Provider {

--- a/pkg/admin/wire_gen.go
+++ b/pkg/admin/wire_gen.go
@@ -848,8 +848,10 @@ func newGraphQLHandler(p *deps.RequestProvider) http.Handler {
 	}
 	accountDeletionConfig := appConfig.AccountDeletion
 	accountAnonymizationConfig := appConfig.AccountAnonymization
+	maxTrials := _wireMaxTrialsValue
 	passwordRand := password.NewRandSource()
 	generator := &password.Generator{
+		MaxTrials:      maxTrials,
 		Checker:        passwordChecker,
 		Rand:           passwordRand,
 		PasswordConfig: authenticatorPasswordConfig,
@@ -1179,6 +1181,7 @@ func newGraphQLHandler(p *deps.RequestProvider) http.Handler {
 
 var (
 	_wireRandValue           = idpsession.Rand(rand.SecureRand)
+	_wireMaxTrialsValue      = password.DefaultMaxTrials
 	_wireTokenGeneratorValue = handler.TokenGenerator(oauth2.GenerateToken)
 )
 

--- a/pkg/lib/authn/authenticator/password/deps.go
+++ b/pkg/lib/authn/authenticator/password/deps.go
@@ -63,5 +63,6 @@ var DependencySet = wire.NewSet(
 	wire.Bind(new(CheckerHistoryStore), new(*HistoryStore)),
 	ProvideExpiry,
 	NewRandSource,
+	wire.Value(DefaultMaxTrials),
 	wire.Struct(new(Generator), "*"),
 )

--- a/pkg/lib/authn/authenticator/password/generator.go
+++ b/pkg/lib/authn/authenticator/password/generator.go
@@ -22,7 +22,7 @@ const (
 
 const (
 	// Max trials to generate a password that satisfies the checker.
-	MaxTrials = 10
+	DefaultMaxTrials MaxTrials = 10
 	// Default minimum length of a password, overrides min length in the policy if less than it.
 	DefaultMinLength = 8
 	// When min guessable level is > 0, the minimum length of a password.
@@ -87,7 +87,10 @@ type RandRand struct {
 
 var _ Rand = RandRand{}
 
+type MaxTrials int
+
 type Generator struct {
+	MaxTrials      MaxTrials
 	Checker        *Checker
 	Rand           Rand
 	PasswordConfig *config.AuthenticatorPasswordConfig
@@ -100,7 +103,7 @@ func (g *Generator) Generate() (string, error) {
 
 // generate generates a password that satisfies the checker
 func (g *Generator) generate() (string, int, error) {
-	for i := 0; i < MaxTrials; i++ {
+	for i := 0; i < int(g.MaxTrials); i++ {
 		password, err := g.generateOnce()
 		if err != nil {
 			return "", -1, err

--- a/pkg/lib/authn/authenticator/password/generator_test.go
+++ b/pkg/lib/authn/authenticator/password/generator_test.go
@@ -15,8 +15,9 @@ func newInt(v int) *int { return &v }
 func TestBasicPasswordGeneration(t *testing.T) {
 	Convey("Given a password generator with default settings", t, func() {
 		generator := &Generator{
-			Checker: &Checker{},
-			Rand:    NewRandSource(),
+			MaxTrials: DefaultMaxTrials,
+			Checker:   &Checker{},
+			Rand:      NewRandSource(),
 			PasswordConfig: &config.AuthenticatorPasswordConfig{
 				Policy: &config.PasswordPolicyConfig{
 					MinLength: newInt(8),
@@ -36,8 +37,9 @@ func TestBasicPasswordGeneration(t *testing.T) {
 func TestUppercaseRequirement(t *testing.T) {
 	Convey("Given a password generator requiring at least one uppercase letter", t, func() {
 		generator := &Generator{
-			Checker: &Checker{},
-			Rand:    NewRandSource(),
+			MaxTrials: DefaultMaxTrials,
+			Checker:   &Checker{},
+			Rand:      NewRandSource(),
 			PasswordConfig: &config.AuthenticatorPasswordConfig{
 				Policy: &config.PasswordPolicyConfig{
 					MinLength:         newInt(8),
@@ -58,8 +60,9 @@ func TestUppercaseRequirement(t *testing.T) {
 func TestLowercaseRequirement(t *testing.T) {
 	Convey("Given a password generator requiring at least one lowercase letter", t, func() {
 		generator := &Generator{
-			Checker: &Checker{},
-			Rand:    NewRandSource(),
+			MaxTrials: DefaultMaxTrials,
+			Checker:   &Checker{},
+			Rand:      NewRandSource(),
 			PasswordConfig: &config.AuthenticatorPasswordConfig{
 				Policy: &config.PasswordPolicyConfig{
 					MinLength:         newInt(8),
@@ -80,8 +83,9 @@ func TestLowercaseRequirement(t *testing.T) {
 func TestCombinedRequirements(t *testing.T) {
 	Convey("Given a password generator with multiple requirements", t, func() {
 		generator := &Generator{
-			Checker: &Checker{},
-			Rand:    NewRandSource(),
+			MaxTrials: DefaultMaxTrials,
+			Checker:   &Checker{},
+			Rand:      NewRandSource(),
 			PasswordConfig: &config.AuthenticatorPasswordConfig{
 				Policy: &config.PasswordPolicyConfig{
 					MinLength:         newInt(12),
@@ -109,8 +113,9 @@ func TestCombinedRequirements(t *testing.T) {
 func TestMinLengthRequirement(t *testing.T) {
 	Convey("Given a password generator with a minimum length requirement", t, func() {
 		generator := &Generator{
-			Checker: &Checker{},
-			Rand:    NewRandSource(),
+			MaxTrials: DefaultMaxTrials,
+			Checker:   &Checker{},
+			Rand:      NewRandSource(),
 			PasswordConfig: &config.AuthenticatorPasswordConfig{
 				Policy: &config.PasswordPolicyConfig{
 					MinLength: newInt(40),
@@ -130,8 +135,9 @@ func TestMinLengthRequirement(t *testing.T) {
 func TestMinGuessableLevelRequirement(t *testing.T) {
 	Convey("Given a password generator with a minimum guessable level requirement", t, func() {
 		generator := &Generator{
-			Checker: &Checker{},
-			Rand:    NewRandSource(),
+			MaxTrials: DefaultMaxTrials,
+			Checker:   &Checker{},
+			Rand:      NewRandSource(),
 			PasswordConfig: &config.AuthenticatorPasswordConfig{
 				Policy: &config.PasswordPolicyConfig{
 					MinLength:             newInt(8),
@@ -171,8 +177,10 @@ func (r *TestRand) Shuffle(n int, swap func(i, j int)) {
 
 func TestExcludedKeywordsRequirement(t *testing.T) {
 	Convey("Given a password generator with excluded keywords", t, func() {
+		const overriderMaxTrials MaxTrials = 25 // ref PR#4666
 		excluded := []string{"0"}
 		generator := &Generator{
+			MaxTrials: overriderMaxTrials,
 			Checker: &Checker{
 				PwExcludedKeywords: excluded,
 			},

--- a/pkg/redisqueue/wire_gen.go
+++ b/pkg/redisqueue/wire_gen.go
@@ -715,8 +715,10 @@ func newUserImportService(ctx context.Context, p *deps.AppProvider) *userimport.
 	}
 	accountDeletionConfig := appConfig.AccountDeletion
 	accountAnonymizationConfig := appConfig.AccountAnonymization
+	maxTrials := _wireMaxTrialsValue
 	passwordRand := password.NewRandSource()
 	generator := &password.Generator{
+		MaxTrials:      maxTrials,
 		Checker:        passwordChecker,
 		Rand:           passwordRand,
 		PasswordConfig: authenticatorPasswordConfig,
@@ -784,6 +786,7 @@ func newUserImportService(ctx context.Context, p *deps.AppProvider) *userimport.
 var (
 	_wireSystemClockValue = clock.NewSystemClock()
 	_wireRandValue        = idpsession.Rand(rand.SecureRand)
+	_wireMaxTrialsValue   = password.DefaultMaxTrials
 )
 
 func newElasticsearchService(ctx context.Context, p *deps.AppProvider) *elasticsearch.Service {

--- a/pkg/resolver/wire_gen.go
+++ b/pkg/resolver/wire_gen.go
@@ -784,8 +784,10 @@ func newSessionMiddleware(p *deps.RequestProvider) httproute.Middleware {
 	}
 	accountDeletionConfig := appConfig.AccountDeletion
 	accountAnonymizationConfig := appConfig.AccountAnonymization
+	maxTrials := _wireMaxTrialsValue
 	passwordRand := password.NewRandSource()
 	generator := &password.Generator{
+		MaxTrials:      maxTrials,
 		Checker:        passwordChecker,
 		Rand:           passwordRand,
 		PasswordConfig: authenticatorPasswordConfig,
@@ -867,6 +869,7 @@ func newSessionMiddleware(p *deps.RequestProvider) httproute.Middleware {
 var (
 	_wireSystemClockValue = clock.NewSystemClock()
 	_wireRandValue        = idpsession.Rand(rand.SecureRand)
+	_wireMaxTrialsValue   = password.DefaultMaxTrials
 )
 
 func newSessionResolveHandler(p *deps.RequestProvider) http.Handler {

--- a/portal/src/util/passwordGenerator.test.ts
+++ b/portal/src/util/passwordGenerator.test.ts
@@ -4,6 +4,7 @@ import {
   determineMinLength,
   generatePasswordWithSource,
   internalGeneratePasswordWithSource,
+  MaxTrials,
   prepareCharList,
   RandSource,
 } from "./passwordGenerator";
@@ -12,59 +13,87 @@ import { zxcvbnGuessableLevel } from "./zxcvbn";
 
 describe("passwordGenerator", () => {
   it("should generate a password with default settings", () => {
-    const password = generatePasswordWithSource(cryptoRandSource, {});
+    const password = generatePasswordWithSource(
+      cryptoRandSource,
+      {},
+      MaxTrials
+    );
     expect(password).not.toBeNull();
     expect(password!.length).toBeGreaterThanOrEqual(8);
   });
 
   it("should include at least one uppercase letter when required", () => {
-    const password = generatePasswordWithSource(cryptoRandSource, {
-      uppercase_required: true,
-    });
+    const password = generatePasswordWithSource(
+      cryptoRandSource,
+      {
+        uppercase_required: true,
+      },
+      MaxTrials
+    );
     expect(password).not.toBeNull();
     expect(password).toMatch(/[A-Z]/);
   });
 
   it("should include at least one lowercase letter when required", () => {
-    const password = generatePasswordWithSource(cryptoRandSource, {
-      lowercase_required: true,
-    });
+    const password = generatePasswordWithSource(
+      cryptoRandSource,
+      {
+        lowercase_required: true,
+      },
+      MaxTrials
+    );
     expect(password).not.toBeNull();
     expect(password).toMatch(/[a-z]/);
   });
 
   it("should include at least one digit when required", () => {
-    const password = generatePasswordWithSource(cryptoRandSource, {
-      digit_required: true,
-    });
+    const password = generatePasswordWithSource(
+      cryptoRandSource,
+      {
+        digit_required: true,
+      },
+      MaxTrials
+    );
     expect(password).not.toBeNull();
     expect(password).toMatch(/[0-9]/);
   });
 
   it("should include at least one special character when required", () => {
-    const password = generatePasswordWithSource(cryptoRandSource, {
-      symbol_required: true,
-    });
+    const password = generatePasswordWithSource(
+      cryptoRandSource,
+      {
+        symbol_required: true,
+      },
+      MaxTrials
+    );
     expect(password).not.toBeNull();
     expect(password).toMatch(/[^A-Za-z0-9]/);
   });
 
   it("should meet the minimum length requirement", () => {
-    const password = generatePasswordWithSource(cryptoRandSource, {
-      min_length: 40,
-    });
+    const password = generatePasswordWithSource(
+      cryptoRandSource,
+      {
+        min_length: 40,
+      },
+      MaxTrials
+    );
     expect(password).not.toBeNull();
     expect(password!.length).toBeGreaterThanOrEqual(40);
   });
 
   it("should meet all combined requirements", () => {
-    const password = generatePasswordWithSource(cryptoRandSource, {
-      uppercase_required: true,
-      lowercase_required: true,
-      digit_required: true,
-      symbol_required: true,
-      min_length: 12,
-    });
+    const password = generatePasswordWithSource(
+      cryptoRandSource,
+      {
+        uppercase_required: true,
+        lowercase_required: true,
+        digit_required: true,
+        symbol_required: true,
+        min_length: 12,
+      },
+      MaxTrials
+    );
     expect(password).not.toBeNull();
     expect(password).toMatch(/[A-Z]/);
     expect(password).toMatch(/[a-z]/);
@@ -74,9 +103,13 @@ describe("passwordGenerator", () => {
   });
 
   it("should meet the minimum guessable level requirement", () => {
-    const password = generatePasswordWithSource(cryptoRandSource, {
-      minimum_guessable_level: 4,
-    });
+    const password = generatePasswordWithSource(
+      cryptoRandSource,
+      {
+        minimum_guessable_level: 4,
+      },
+      MaxTrials
+    );
     expect(password).not.toBeNull();
     const guessableLevel = zxcvbnGuessableLevel(password);
     expect(password!.length).toBeGreaterThanOrEqual(32);
@@ -98,13 +131,14 @@ describe("passwordGenerator", () => {
         },
       };
     };
-
+    const OVERRIDE_MAX_TRIAL = 25; // ref PR#4666
     const [password, attempts] = internalGeneratePasswordWithSource(
       createRandSource(),
       {
         digit_required: true,
         excluded_keywords: ["0"],
-      }
+      },
+      OVERRIDE_MAX_TRIAL
     );
     expect(password).not.toBeNull();
     expect(password).not.toContain("0");

--- a/portal/src/util/passwordGenerator.ts
+++ b/portal/src/util/passwordGenerator.ts
@@ -18,7 +18,7 @@ const AllCharLists = [
   CharListSymbol,
 ];
 
-const MaxTrials = 25;
+export const MaxTrials = 10;
 const DefaultMinLength = 8;
 const GuessableEnabledMinLength = 32;
 
@@ -58,25 +58,31 @@ export const mathRandSource: RandSource = {
 export function generatePassword(policy: PasswordPolicyConfig): string | null {
   try {
     window.crypto.getRandomValues(new Uint8Array(1));
-    return generatePasswordWithSource(cryptoRandSource, policy);
+    return generatePasswordWithSource(cryptoRandSource, policy, MaxTrials);
   } catch {
-    return generatePasswordWithSource(mathRandSource, policy);
+    return generatePasswordWithSource(mathRandSource, policy, MaxTrials);
   }
 }
 
 export function generatePasswordWithSource(
   source: RandSource,
-  policy: PasswordPolicyConfig
+  policy: PasswordPolicyConfig,
+  maxTrials: number
 ): string | null {
-  const [password, _] = internalGeneratePasswordWithSource(source, policy);
+  const [password, _] = internalGeneratePasswordWithSource(
+    source,
+    policy,
+    maxTrials
+  );
   return password;
 }
 
 export function internalGeneratePasswordWithSource(
   source: RandSource,
-  policy: PasswordPolicyConfig
+  policy: PasswordPolicyConfig,
+  maxTrials: number
 ): [string | null, number] {
-  for (let i = 0; i < MaxTrials; i++) {
+  for (let i = 0; i < maxTrials; i++) {
     const password = generatePasswordOnce(source, policy);
     if (password !== null) {
       return [password, i];

--- a/portal/src/util/passwordGenerator.ts
+++ b/portal/src/util/passwordGenerator.ts
@@ -18,7 +18,7 @@ const AllCharLists = [
   CharListSymbol,
 ];
 
-const MaxTrials = 10;
+const MaxTrials = 25;
 const DefaultMinLength = 8;
 const GuessableEnabledMinLength = 32;
 


### PR DESCRIPTION
## Failing examples
- https://github.com/authgear/authgear-server/actions/runs/10572893051/job/29291367108
- https://github.com/authgear/authgear-server/actions/runs/10465349585/job/28980452492?pr=4619

## The math

### Why it happened

Think it happened at least 3 times since it got merged. Was curious why so I did some math.

```
all combinations of `[1-9]{8}` = 9^8
all combinations of `[0-9]{8}` = 10^8


P(1st trial fail) = 1
    because `if (!ranOnce) return 0`
P(2nd trial fail) = [1 - (9^8 / 10^8)] = 0.5695
P(3nd trial fail) = [1 - (9^8 / 10^8)]^2 = 0.5695^2 = 0.3243
...
P(10th trial fail) = [1 - (9^8 / 10^8)]^9 = 0.5695^9 = 0.00630
```

`0.00630` = `test will fail 6 times out of 1000 CI runs`, which is not that unlikely, so it failing 3 times is kind of expected.

### How to prevent

Say we aim for `only fail once in 100,000 CI runs`

```
[1 - (9^8 / 10^8)]^n <= 0.000001
n >= 24.53
```

Which gives the solution n = 25. So I increased to 25 here

## How do I know it works?

Ran below locally, let's see if it fails 🕵️ 

```
for i in {1..100000}; do npx jest passwordGenerator.test.ts --silent || (echo "Failed after $i attempts" && break); echo $i; done
```

EDIT2: ran to ~8167~10774 w/o failing, will stop for now

```
Test Suites: 1 passed, 1 total
Tests:       1 passed, 1 total
Snapshots:   0 total
Time:        1.534 s, estimated 2 s
10774
 PASS  src/util/passwordGenerator.test.ts
```