### PR TITLE
Fix app logo background when there is a uploaded logo

### DIFF
--- a/portal/src/components/design/AppLogoPicker.tsx
+++ b/portal/src/components/design/AppLogoPicker.tsx
@@ -51,7 +51,7 @@ const AppLogoPicker: React.VFC<AppLogoPickerProps> = function AppLogoPicker(
               "justify-center",
               "h-30",
               "w-30",
-              "bg-neutral-light",
+              imagePreviewData != null ? "bg-white" : "bg-neutral-light",
               "rounded",
               "border",
               "border-solid",


### PR DESCRIPTION
### No logo
<img width="1646" alt="Screenshot 2024-08-29 at 7 21 51 PM" src="https://github.com/user-attachments/assets/9220335b-21c0-4eab-b952-6b0518d87020">

### Uploaded logo
<img width="1644" alt="Screenshot 2024-08-29 at 7 21 34 PM" src="https://github.com/user-attachments/assets/b48be435-3be4-48ad-9f14-ba2323a1b3e4">

### Showing fallback logo
<img width="1650" alt="Screenshot 2024-08-29 at 7 21 41 PM" src="https://github.com/user-attachments/assets/4e23cbc6-f577-4c1e-a2ef-7121d92623b3">

