### PR TITLE
Fix captcha authflow signup login flow identify doesnt require captcha correctly

### DIFF
--- a/docs/specs/bot-protection.md
+++ b/docs/specs/bot-protection.md
@@ -322,6 +322,15 @@ Given `bot_protection.enabled=true`,
                 </ul>
               </ul>
             </li>
+            <li>
+              <code>signup_login</code>
+              <ul>
+                <li><code>identify</code></li>
+                <ul>
+                  <li><code>email</code></li>
+                </ul>
+              </ul>
+            </li>
           </ol>
       </td>
    </tr>
@@ -357,6 +366,15 @@ Given `bot_protection.enabled=true`,
                 <ul>
                   <li><code>primary_oob_otp_sms</code></li>
                   <li><code>secondary_oob_otp_sms</code></li>
+                </ul>
+              </ul>
+            </li>
+            <li>
+              <code>signup_login</code>
+              <ul>
+                <li><code>identify</code></li>
+                <ul>
+                  <li><code>phone</code></li>
                 </ul>
               </ul>
             </li>

--- a/pkg/lib/authenticationflow/declarative/generate_config_signup_login_flow_test.go
+++ b/pkg/lib/authenticationflow/declarative/generate_config_signup_login_flow_test.go
@@ -344,5 +344,76 @@ steps:
   - identification: passkey
     login_flow: default
 `)
+
+		// DEV-1972: bot_protection, depends on authenticator, oob_otp_email
+		test(`
+authentication:
+  identities:
+  - login_id
+  primary_authenticators:
+  - oob_otp_email
+identity:
+  login_id:
+    keys:
+    - type: email
+bot_protection:
+  enabled: true
+  provider:
+    type: recaptchav2
+    site_key: some-site-key
+  requirements:
+    oob_otp_email:
+      mode: always
+    oob_otp_sms:
+      mode: never
+    password:
+      mode: never
+`, `
+name: default
+steps:
+- name: signup_login_identify
+  type: identify
+  one_of:
+  - identification: email
+    bot_protection:
+      mode: always
+    signup_flow: default
+    login_flow: default
+`)
+		// DEV-1972: bot_protection, depends on authenticator, oob_otp_sms
+		test(`
+authentication:
+  identities:
+  - login_id
+  primary_authenticators:
+  - oob_otp_sms
+identity:
+  login_id:
+    keys:
+    - type: phone
+bot_protection:
+  enabled: true
+  provider:
+    type: recaptchav2
+    site_key: some-site-key
+  requirements:
+    oob_otp_email:
+      mode: never
+    oob_otp_sms:
+      mode: always
+    password:
+      mode: never
+`, `
+name: default
+steps:
+- name: signup_login_identify
+  type: identify
+  one_of:
+  - identification: phone
+    bot_protection:
+      mode: always
+    signup_flow: default
+    login_flow: default
+`)
 	})
 }


### PR DESCRIPTION
ref DEV-1972

## What's in this PR?
Previously we missed that signup_login identify should also requires bot_protection according to `requirements.___`
- `oob_otp_email` -> `signup_login > identify > email`
- `oob_otp_sms` -> `signup_login > identify > phone`

This PR added that back. Note the changes in `spec/bot-protection.md`

## Preview

https://github.com/user-attachments/assets/f9be9358-ffa6-4cc4-a36a-ec7042994f3d

