### PR TITLE
Fix bot protection input channel not inherited from previous screen

### DIFF
--- a/pkg/auth/webapp/session_authflow.go
+++ b/pkg/auth/webapp/session_authflow.go
@@ -501,6 +501,10 @@ func (s *AuthflowScreenWithFlowResponse) takeBranchLoginAuthenticate(input *Take
 			// Below clause takes place only when index=0 branch is OOBOTP, and bot protection not in input
 			// otherwise, the bot protection is fed to auto-taken OOBOTP branch too
 			if option.BotProtection.IsRequired() && !input.HasBotProtectionInput() {
+				// Make sure bot protection input is fed with default channel
+				if input.Channel == "" {
+					input.Channel = channel
+				}
 				return s.takeBranchResultSimple(input, true)
 			}
 

--- a/pkg/auth/webapp/session_authflow.go
+++ b/pkg/auth/webapp/session_authflow.go
@@ -434,16 +434,15 @@ func (s *AuthflowScreenWithFlowResponse) takeBranchSignupPromote(input *TakeBran
 	case config.AuthenticationFlowStepTypeVerify:
 		// If we ever reach here, this means we have to choose channels.
 		data := s.StateTokenFlowResponse.Action.Data.(declarative.SelectOOBOTPChannelsData)
-		channel := input.Channel
-		if channel == "" {
-			channel = data.Channels[0]
+		if input.Channel == "" {
+			input.Channel = data.Channels[0]
 		}
 		inputFactory := func(c model.AuthenticatorOOBChannel) map[string]interface{} {
 			return map[string]interface{}{
 				"channel": c,
 			}
 		}
-		resultInput := inputFactory(channel)
+		resultInput := inputFactory(input.Channel)
 		onFailureHandler := s.makeFallbackToSMSFromWhatsappRetryHandler(
 			inputFactory,
 			data.Channels,
@@ -456,7 +455,7 @@ func (s *AuthflowScreenWithFlowResponse) takeBranchSignupPromote(input *TakeBran
 				isContinuation := func(flowResponse *authflow.FlowResponse) bool {
 					return flowResponse.Action.Type == authflow.FlowActionType(config.AuthenticationFlowSignupFlowStepTypeVerify)
 				}
-				takenChannel := channel
+				takenChannel := input.Channel
 				if d, ok := flowResponse.Action.Data.(declarative.VerifyOOBOTPData); ok {
 					takenChannel = d.Channel
 				}
@@ -494,17 +493,12 @@ func (s *AuthflowScreenWithFlowResponse) takeBranchLoginAuthenticate(input *Take
 			fallthrough
 		case config.AuthenticationFlowAuthenticationSecondaryOOBOTPSMS:
 			// This branch requires input to take.
-			channel := input.Channel
-			if channel == "" {
-				channel = option.Channels[0]
+			if input.Channel == "" {
+				input.Channel = option.Channels[0]
 			}
 			// Below clause takes place only when index=0 branch is OOBOTP, and bot protection not in input
 			// otherwise, the bot protection is fed to auto-taken OOBOTP branch too
 			if option.BotProtection.IsRequired() && !input.HasBotProtectionInput() {
-				// Make sure bot protection input is fed with default channel
-				if input.Channel == "" {
-					input.Channel = channel
-				}
 				return s.takeBranchResultSimple(input, true)
 			}
 
@@ -523,7 +517,7 @@ func (s *AuthflowScreenWithFlowResponse) takeBranchLoginAuthenticate(input *Take
 				}
 				return out
 			}
-			resultInput := inputFactory(channel)
+			resultInput := inputFactory(input.Channel)
 			onFailureHandler := s.makeFallbackToSMSFromWhatsappRetryHandler(
 				inputFactory,
 				option.Channels,
@@ -536,7 +530,7 @@ func (s *AuthflowScreenWithFlowResponse) takeBranchLoginAuthenticate(input *Take
 					isContinuation := func(flowResponse *authflow.FlowResponse) bool {
 						return flowResponse.Action.Type == authflow.FlowActionType(config.AuthenticationFlowLoginFlowStepTypeAuthenticate) && flowResponse.Action.Authentication == option.Authentication
 					}
-					takenChannel := channel
+					takenChannel := input.Channel
 					switch d := flowResponse.Action.Data.(type) {
 					case declarative.VerifyOOBOTPData:
 						takenChannel = d.Channel
@@ -610,9 +604,8 @@ func (s *AuthflowScreenWithFlowResponse) takeBranchReauth(input *TakeBranchInput
 			fallthrough
 		case config.AuthenticationFlowAuthenticationSecondaryOOBOTPSMS:
 			// This branch requires input to take.
-			channel := input.Channel
-			if channel == "" {
-				channel = option.Channels[0]
+			if input.Channel == "" {
+				input.Channel = option.Channels[0]
 			}
 
 			if option.BotProtection.IsRequired() {
@@ -626,7 +619,7 @@ func (s *AuthflowScreenWithFlowResponse) takeBranchReauth(input *TakeBranchInput
 					"channel":        c,
 				}
 			}
-			resultInput := inputFactory(channel)
+			resultInput := inputFactory(input.Channel)
 			onFailureHandler := s.makeFallbackToSMSFromWhatsappRetryHandler(
 				inputFactory,
 				option.Channels,
@@ -639,7 +632,7 @@ func (s *AuthflowScreenWithFlowResponse) takeBranchReauth(input *TakeBranchInput
 					isContinuation := func(flowResponse *authflow.FlowResponse) bool {
 						return flowResponse.Action.Type == authflow.FlowActionType(config.AuthenticationFlowStepTypeAuthenticate) && flowResponse.Action.Authentication == option.Authentication
 					}
-					takenChannel := channel
+					takenChannel := input.Channel
 					switch d := flowResponse.Action.Data.(type) {
 					case declarative.VerifyOOBOTPData:
 						takenChannel = d.Channel
@@ -824,9 +817,8 @@ func (s *AuthflowScreenWithFlowResponse) takeBranchCreateAuthenticator(input *Ta
 	case config.AuthenticationFlowAuthenticationPrimaryOOBOTPEmail:
 		fallthrough
 	case config.AuthenticationFlowAuthenticationPrimaryOOBOTPSMS:
-		channel := input.Channel
-		if channel == "" {
-			channel = option.Channels[0]
+		if input.Channel == "" {
+			input.Channel = option.Channels[0]
 		}
 		inputFactory := func(c model.AuthenticatorOOBChannel) map[string]interface{} {
 			return map[string]interface{}{
@@ -834,7 +826,7 @@ func (s *AuthflowScreenWithFlowResponse) takeBranchCreateAuthenticator(input *Ta
 				"channel":        c,
 			}
 		}
-		resultInput := inputFactory(channel)
+		resultInput := inputFactory(input.Channel)
 		onFailureHandler := s.makeFallbackToSMSFromWhatsappRetryHandler(
 			inputFactory,
 			option.Channels,
@@ -847,7 +839,7 @@ func (s *AuthflowScreenWithFlowResponse) takeBranchCreateAuthenticator(input *Ta
 					return flowResponse.Action.Type == authflow.FlowActionType(config.AuthenticationFlowSignupFlowStepTypeCreateAuthenticator) &&
 						flowResponse.Action.Authentication == option.Authentication
 				}
-				takenChannel := channel
+				takenChannel := input.Channel
 				if d, ok := flowResponse.Action.Data.(declarative.VerifyOOBOTPData); ok {
 					takenChannel = d.Channel
 				}
@@ -861,13 +853,12 @@ func (s *AuthflowScreenWithFlowResponse) takeBranchCreateAuthenticator(input *Ta
 	case config.AuthenticationFlowAuthenticationSecondaryOOBOTPEmail:
 		fallthrough
 	case config.AuthenticationFlowAuthenticationSecondaryOOBOTPSMS:
-		channel := input.Channel
-		if channel == "" {
-			channel = option.Channels[0]
+		if input.Channel == "" {
+			input.Channel = option.Channels[0]
 		}
 		return s.takeBranchResultSimple(&TakeBranchInput{
 			Index:   input.Index,
-			Channel: channel,
+			Channel: input.Channel,
 		}, false)
 	default:
 		panic(fmt.Errorf("unexpected authentication: %v", option.Authentication))


### PR DESCRIPTION
ref DEV-1904

The problem was `channel` defaulted as `options[0].Channel` in `takeBranchLoginAuthenticate`, but this default channel is not inherited in the captcha redirect screen

Thought about adding test for this, but currently we don't have UI testing

## Preview 1 - setup to reproduce


https://github.com/user-attachments/assets/13faf110-48ab-4475-a089-b5f65efa8cac

## Preview 2 - verify fixed

https://github.com/user-attachments/assets/f0f9ddab-12ed-4484-8941-4c5077e4028a

