### PR TITLE
Stricten user import schema

### DIFF
--- a/pkg/lib/authn/stdattrs/validate.go
+++ b/pkg/lib/authn/stdattrs/validate.go
@@ -188,68 +188,68 @@ func SchemaBuilderForPointerString(ptrStr string) (validation.SchemaBuilder, boo
 }
 
 func SchemaBuilderEmail() validation.SchemaBuilder {
-	return schemaBuilderEmail.Copy()
+	return schemaBuilderEmail.Clone()
 }
 func SchemaBuilderPhoneNumber() validation.SchemaBuilder {
-	return schemaBuilderPhoneNumber.Copy()
+	return schemaBuilderPhoneNumber.Clone()
 }
 func SchemaBuilderPreferredUsername() validation.SchemaBuilder {
-	return schemaBuilderPreferredUsername.Copy()
+	return schemaBuilderPreferredUsername.Clone()
 }
 func SchemaBuilderFamilyName() validation.SchemaBuilder {
-	return schemaBuilderFamilyName.Copy()
+	return schemaBuilderFamilyName.Clone()
 }
 func SchemaBuilderGivenName() validation.SchemaBuilder {
-	return schemaBuilderGivenName.Copy()
+	return schemaBuilderGivenName.Clone()
 }
 func SchemaBuilderMiddleName() validation.SchemaBuilder {
-	return schemaBuilderMiddleName.Copy()
+	return schemaBuilderMiddleName.Clone()
 }
 func SchemaBuilderName() validation.SchemaBuilder {
-	return schemaBuilderName.Copy()
+	return schemaBuilderName.Clone()
 }
 func SchemaBuilderNickName() validation.SchemaBuilder {
-	return schemaBuilderNickName.Copy()
+	return schemaBuilderNickName.Clone()
 }
 func SchemaBuilderPicture() validation.SchemaBuilder {
-	return schemaBuilderPicture.Copy()
+	return schemaBuilderPicture.Clone()
 }
 func SchemaBuilderProfile() validation.SchemaBuilder {
-	return schemaBuilderProfile.Copy()
+	return schemaBuilderProfile.Clone()
 }
 func SchemaBuilderWebsite() validation.SchemaBuilder {
-	return schemaBuilderWebsite.Copy()
+	return schemaBuilderWebsite.Clone()
 }
 func SchemaBuilderGender() validation.SchemaBuilder {
-	return schemaBuilderGender.Copy()
+	return schemaBuilderGender.Clone()
 }
 func SchemaBuilderBirthdate() validation.SchemaBuilder {
-	return schemaBuilderBirthdate.Copy()
+	return schemaBuilderBirthdate.Clone()
 }
 func SchemaBuilderZoneinfo() validation.SchemaBuilder {
-	return schemaBuilderZoneinfo.Copy()
+	return schemaBuilderZoneinfo.Clone()
 }
 func SchemaBuilderLocale() validation.SchemaBuilder {
-	return schemaBuilderLocale.Copy()
+	return schemaBuilderLocale.Clone()
 }
 func SchemaBuilderAddress() validation.SchemaBuilder {
-	return schemaBuilderAddress.Copy()
+	return schemaBuilderAddress.Clone()
 }
 func SchemaBuilderAddressFormatted() validation.SchemaBuilder {
-	return schemaBuilderAddressFormatted.Copy()
+	return schemaBuilderAddressFormatted.Clone()
 }
 func SchemaBuilderAddressStreetAddress() validation.SchemaBuilder {
-	return schemaBuilderAddressStreetAddress.Copy()
+	return schemaBuilderAddressStreetAddress.Clone()
 }
 func SchemaBuilderAddressLocality() validation.SchemaBuilder {
-	return schemaBuilderAddressLocality.Copy()
+	return schemaBuilderAddressLocality.Clone()
 }
 func SchemaBuilderAddressRegion() validation.SchemaBuilder {
-	return schemaBuilderAddressRegion.Copy()
+	return schemaBuilderAddressRegion.Clone()
 }
 func SchemaBuilderAddressPostalCode() validation.SchemaBuilder {
-	return schemaBuilderAddressPostalCode.Copy()
+	return schemaBuilderAddressPostalCode.Clone()
 }
 func SchemaBuilderAddressCountry() validation.SchemaBuilder {
-	return schemaBuilderAddressCountry.Copy()
+	return schemaBuilderAddressCountry.Clone()
 }

--- a/pkg/lib/authn/stdattrs/validate.go
+++ b/pkg/lib/authn/stdattrs/validate.go
@@ -139,50 +139,117 @@ func Validate(t T) error {
 func SchemaBuilderForPointerString(ptrStr string) (validation.SchemaBuilder, bool) {
 	switch ptrStr {
 	case "/email":
-		return schemaBuilderEmail, true
+		return SchemaBuilderEmail(), true
 	case "/phone_number":
-		return schemaBuilderPhoneNumber, true
+		return SchemaBuilderPhoneNumber(), true
 	case "/preferred_username":
-		return schemaBuilderPreferredUsername, true
+		return SchemaBuilderPreferredUsername(), true
 	case "/family_name":
-		return schemaBuilderFamilyName, true
+		return SchemaBuilderFamilyName(), true
 	case "/given_name":
-		return schemaBuilderGivenName, true
+		return SchemaBuilderGivenName(), true
 	case "/middle_name":
-		return schemaBuilderMiddleName, true
+		return SchemaBuilderMiddleName(), true
 	case "/name":
-		return schemaBuilderName, true
+		return SchemaBuilderName(), true
 	case "/nickname":
-		return schemaBuilderNickName, true
+		return SchemaBuilderNickName(), true
 	case "/picture":
-		return schemaBuilderPicture, true
+		return SchemaBuilderPicture(), true
 	case "/profile":
-		return schemaBuilderProfile, true
+		return SchemaBuilderProfile(), true
 	case "/website":
-		return schemaBuilderWebsite, true
+		return SchemaBuilderWebsite(), true
 	case "/gender":
-		return schemaBuilderGender, true
+		return SchemaBuilderGender(), true
 	case "/birthdate":
-		return schemaBuilderBirthdate, true
+		return SchemaBuilderBirthdate(), true
 	case "/zoneinfo":
-		return schemaBuilderZoneinfo, true
+		return SchemaBuilderZoneinfo(), true
 	case "/locale":
-		return schemaBuilderLocale, true
+		return SchemaBuilderLocale(), true
 	case "/address":
-		return schemaBuilderAddress, true
+		return SchemaBuilderAddress(), true
 	case "/address/formatted":
-		return schemaBuilderAddressFormatted, true
+		return SchemaBuilderAddressFormatted(), true
 	case "/address/street_address":
-		return schemaBuilderAddressStreetAddress, true
+		return SchemaBuilderAddressStreetAddress(), true
 	case "/address/locality":
-		return schemaBuilderAddressLocality, true
+		return SchemaBuilderAddressLocality(), true
 	case "/address/region":
-		return schemaBuilderAddressRegion, true
+		return SchemaBuilderAddressRegion(), true
 	case "/address/postal_code":
-		return schemaBuilderAddressPostalCode, true
+		return SchemaBuilderAddressPostalCode(), true
 	case "/address/country":
-		return schemaBuilderAddressCountry, true
+		return SchemaBuilderAddressCountry(), true
 	default:
 		return nil, false
 	}
+}
+
+func SchemaBuilderEmail() validation.SchemaBuilder {
+	return schemaBuilderEmail.Copy()
+}
+func SchemaBuilderPhoneNumber() validation.SchemaBuilder {
+	return schemaBuilderPhoneNumber.Copy()
+}
+func SchemaBuilderPreferredUsername() validation.SchemaBuilder {
+	return schemaBuilderPreferredUsername.Copy()
+}
+func SchemaBuilderFamilyName() validation.SchemaBuilder {
+	return schemaBuilderFamilyName.Copy()
+}
+func SchemaBuilderGivenName() validation.SchemaBuilder {
+	return schemaBuilderGivenName.Copy()
+}
+func SchemaBuilderMiddleName() validation.SchemaBuilder {
+	return schemaBuilderMiddleName.Copy()
+}
+func SchemaBuilderName() validation.SchemaBuilder {
+	return schemaBuilderName.Copy()
+}
+func SchemaBuilderNickName() validation.SchemaBuilder {
+	return schemaBuilderNickName.Copy()
+}
+func SchemaBuilderPicture() validation.SchemaBuilder {
+	return schemaBuilderPicture.Copy()
+}
+func SchemaBuilderProfile() validation.SchemaBuilder {
+	return schemaBuilderProfile.Copy()
+}
+func SchemaBuilderWebsite() validation.SchemaBuilder {
+	return schemaBuilderWebsite.Copy()
+}
+func SchemaBuilderGender() validation.SchemaBuilder {
+	return schemaBuilderGender.Copy()
+}
+func SchemaBuilderBirthdate() validation.SchemaBuilder {
+	return schemaBuilderBirthdate.Copy()
+}
+func SchemaBuilderZoneinfo() validation.SchemaBuilder {
+	return schemaBuilderZoneinfo.Copy()
+}
+func SchemaBuilderLocale() validation.SchemaBuilder {
+	return schemaBuilderLocale.Copy()
+}
+func SchemaBuilderAddress() validation.SchemaBuilder {
+	return schemaBuilderAddress.Copy()
+}
+func SchemaBuilderAddressFormatted() validation.SchemaBuilder {
+	return schemaBuilderAddressFormatted.Copy()
+}
+func SchemaBuilderAddressStreetAddress() validation.SchemaBuilder {
+	return schemaBuilderAddressStreetAddress.Copy()
+}
+func SchemaBuilderAddressLocality() validation.SchemaBuilder {
+	return schemaBuilderAddressLocality.Copy()
+}
+func SchemaBuilderAddressRegion() validation.SchemaBuilder {
+	return schemaBuilderAddressRegion.Copy()
+}
+func SchemaBuilderAddressPostalCode() validation.SchemaBuilder {
+	return schemaBuilderAddressPostalCode.Copy()
+}
+func SchemaBuilderAddressCountry() validation.SchemaBuilder {
+	return schemaBuilderAddressCountry.Copy()
 }

--- a/pkg/lib/authn/stdattrs/validate.go
+++ b/pkg/lib/authn/stdattrs/validate.go
@@ -4,181 +4,184 @@ import (
 	"github.com/authgear/authgear-server/pkg/util/validation"
 )
 
+// SchemaBuilders in this file should be private to avoid unexpected mutation,
+// due to the fact that SchemaBuilder is just a map
+// We only expose public functions to create SchemaBuilder
 func init() {
-	SchemaBuilderAddress = validation.SchemaBuilder{}.
+	schemaBuilderAddress = validation.SchemaBuilder{}.
 		Type(validation.TypeObject)
-	addressProperties := SchemaBuilderAddress.Properties()
-	addressProperties.Property("formatted", SchemaBuilderAddressFormatted)
-	addressProperties.Property("street_address", SchemaBuilderAddressStreetAddress)
-	addressProperties.Property("locality", SchemaBuilderAddressLocality)
-	addressProperties.Property("region", SchemaBuilderAddressRegion)
-	addressProperties.Property("postal_code", SchemaBuilderAddressPostalCode)
-	addressProperties.Property("country", SchemaBuilderAddressCountry)
+	addressProperties := schemaBuilderAddress.Properties()
+	addressProperties.Property("formatted", schemaBuilderAddressFormatted)
+	addressProperties.Property("street_address", schemaBuilderAddressStreetAddress)
+	addressProperties.Property("locality", schemaBuilderAddressLocality)
+	addressProperties.Property("region", schemaBuilderAddressRegion)
+	addressProperties.Property("postal_code", schemaBuilderAddressPostalCode)
+	addressProperties.Property("country", schemaBuilderAddressCountry)
 
-	SchemaBuilder = validation.SchemaBuilder{}.
+	schemaBuilder = validation.SchemaBuilder{}.
 		Type(validation.TypeObject).
 		AdditionalPropertiesFalse()
 
-	schemaProperties := SchemaBuilder.Properties()
-	schemaProperties.Property("email", SchemaBuilderEmail)
-	schemaProperties.Property("phone_number", SchemaBuilderPhoneNumber)
-	schemaProperties.Property("preferred_username", SchemaBuilderPreferredUsername)
-	schemaProperties.Property("family_name", SchemaBuilderFamilyName)
-	schemaProperties.Property("given_name", SchemaBuilderGivenName)
-	schemaProperties.Property("middle_name", SchemaBuilderMiddleName)
-	schemaProperties.Property("name", SchemaBuilderName)
-	schemaProperties.Property("nickname", SchemaBuilderNickName)
-	schemaProperties.Property("picture", SchemaBuilderPicture)
-	schemaProperties.Property("profile", SchemaBuilderProfile)
-	schemaProperties.Property("website", SchemaBuilderWebsite)
-	schemaProperties.Property("gender", SchemaBuilderGender)
-	schemaProperties.Property("birthdate", SchemaBuilderBirthdate)
-	schemaProperties.Property("zoneinfo", SchemaBuilderZoneinfo)
-	schemaProperties.Property("locale", SchemaBuilderLocale)
-	schemaProperties.Property("address", SchemaBuilderAddress)
+	schemaProperties := schemaBuilder.Properties()
+	schemaProperties.Property("email", schemaBuilderEmail)
+	schemaProperties.Property("phone_number", schemaBuilderPhoneNumber)
+	schemaProperties.Property("preferred_username", schemaBuilderPreferredUsername)
+	schemaProperties.Property("family_name", schemaBuilderFamilyName)
+	schemaProperties.Property("given_name", schemaBuilderGivenName)
+	schemaProperties.Property("middle_name", schemaBuilderMiddleName)
+	schemaProperties.Property("name", schemaBuilderName)
+	schemaProperties.Property("nickname", schemaBuilderNickName)
+	schemaProperties.Property("picture", schemaBuilderPicture)
+	schemaProperties.Property("profile", schemaBuilderProfile)
+	schemaProperties.Property("website", schemaBuilderWebsite)
+	schemaProperties.Property("gender", schemaBuilderGender)
+	schemaProperties.Property("birthdate", schemaBuilderBirthdate)
+	schemaProperties.Property("zoneinfo", schemaBuilderZoneinfo)
+	schemaProperties.Property("locale", schemaBuilderLocale)
+	schemaProperties.Property("address", schemaBuilderAddress)
 
-	Schema = SchemaBuilder.ToSimpleSchema()
+	schema = schemaBuilder.ToSimpleSchema()
 }
 
-var SchemaBuilderAddress validation.SchemaBuilder
-var SchemaBuilder validation.SchemaBuilder
-var Schema *validation.SimpleSchema
+var schemaBuilderAddress validation.SchemaBuilder
+var schemaBuilder validation.SchemaBuilder
+var schema *validation.SimpleSchema
 
-var SchemaBuilderEmail = validation.SchemaBuilder{}.
+var schemaBuilderEmail = validation.SchemaBuilder{}.
 	Type(validation.TypeString).
 	Format("email")
 
-var SchemaBuilderPhoneNumber = validation.SchemaBuilder{}.
+var schemaBuilderPhoneNumber = validation.SchemaBuilder{}.
 	Type(validation.TypeString).
 	Format("phone")
 
-var SchemaBuilderPreferredUsername = validation.SchemaBuilder{}.
+var schemaBuilderPreferredUsername = validation.SchemaBuilder{}.
 	Type(validation.TypeString).
 	MinLength(1)
 
-var SchemaBuilderFamilyName = validation.SchemaBuilder{}.
+var schemaBuilderFamilyName = validation.SchemaBuilder{}.
 	Type(validation.TypeString).
 	MinLength(1)
 
-var SchemaBuilderGivenName = validation.SchemaBuilder{}.
+var schemaBuilderGivenName = validation.SchemaBuilder{}.
 	Type(validation.TypeString).
 	MinLength(1)
 
-var SchemaBuilderMiddleName = validation.SchemaBuilder{}.
+var schemaBuilderMiddleName = validation.SchemaBuilder{}.
 	Type(validation.TypeString).
 	MinLength(1)
 
-var SchemaBuilderName = validation.SchemaBuilder{}.
+var schemaBuilderName = validation.SchemaBuilder{}.
 	Type(validation.TypeString).
 	MinLength(1)
 
-var SchemaBuilderNickName = validation.SchemaBuilder{}.
+var schemaBuilderNickName = validation.SchemaBuilder{}.
 	Type(validation.TypeString).
 	MinLength(1)
 
-var SchemaBuilderPicture = validation.SchemaBuilder{}.
+var schemaBuilderPicture = validation.SchemaBuilder{}.
 	Type(validation.TypeString).
 	Format("x_picture")
 
-var SchemaBuilderProfile = validation.SchemaBuilder{}.
+var schemaBuilderProfile = validation.SchemaBuilder{}.
 	Type(validation.TypeString).
 	Format("uri")
 
-var SchemaBuilderWebsite = validation.SchemaBuilder{}.
+var schemaBuilderWebsite = validation.SchemaBuilder{}.
 	Type(validation.TypeString).
 	Format("uri")
 
-var SchemaBuilderGender = validation.SchemaBuilder{}.
+var schemaBuilderGender = validation.SchemaBuilder{}.
 	Type(validation.TypeString).
 	MinLength(1)
 
-var SchemaBuilderBirthdate = validation.SchemaBuilder{}.
+var schemaBuilderBirthdate = validation.SchemaBuilder{}.
 	Type(validation.TypeString).
 	Format("birthdate")
 
-var SchemaBuilderZoneinfo = validation.SchemaBuilder{}.
+var schemaBuilderZoneinfo = validation.SchemaBuilder{}.
 	Type(validation.TypeString).
 	Format("timezone")
 
-var SchemaBuilderLocale = validation.SchemaBuilder{}.
+var schemaBuilderLocale = validation.SchemaBuilder{}.
 	Type(validation.TypeString).
 	Format("bcp47")
 
-var SchemaBuilderAddressFormatted = validation.SchemaBuilder{}.
+var schemaBuilderAddressFormatted = validation.SchemaBuilder{}.
 	Type(validation.TypeString).
 	MinLength(1)
 
-var SchemaBuilderAddressStreetAddress = validation.SchemaBuilder{}.
+var schemaBuilderAddressStreetAddress = validation.SchemaBuilder{}.
 	Type(validation.TypeString).
 	MinLength(1)
 
-var SchemaBuilderAddressLocality = validation.SchemaBuilder{}.
+var schemaBuilderAddressLocality = validation.SchemaBuilder{}.
 	Type(validation.TypeString).
 	MinLength(1)
 
-var SchemaBuilderAddressRegion = validation.SchemaBuilder{}.
+var schemaBuilderAddressRegion = validation.SchemaBuilder{}.
 	Type(validation.TypeString).
 	MinLength(1)
 
-var SchemaBuilderAddressPostalCode = validation.SchemaBuilder{}.
+var schemaBuilderAddressPostalCode = validation.SchemaBuilder{}.
 	Type(validation.TypeString).
 	MinLength(1)
 
-var SchemaBuilderAddressCountry = validation.SchemaBuilder{}.
+var schemaBuilderAddressCountry = validation.SchemaBuilder{}.
 	Type(validation.TypeString).
 	MinLength(1)
 
 func Validate(t T) error {
 	a := t.ToClaims()
-	return Schema.Validator().ValidateValue(a)
+	return schema.Validator().ValidateValue(a)
 }
 
 func SchemaBuilderForPointerString(ptrStr string) (validation.SchemaBuilder, bool) {
 	switch ptrStr {
 	case "/email":
-		return SchemaBuilderEmail, true
+		return schemaBuilderEmail, true
 	case "/phone_number":
-		return SchemaBuilderPhoneNumber, true
+		return schemaBuilderPhoneNumber, true
 	case "/preferred_username":
-		return SchemaBuilderPreferredUsername, true
+		return schemaBuilderPreferredUsername, true
 	case "/family_name":
-		return SchemaBuilderFamilyName, true
+		return schemaBuilderFamilyName, true
 	case "/given_name":
-		return SchemaBuilderGivenName, true
+		return schemaBuilderGivenName, true
 	case "/middle_name":
-		return SchemaBuilderMiddleName, true
+		return schemaBuilderMiddleName, true
 	case "/name":
-		return SchemaBuilderName, true
+		return schemaBuilderName, true
 	case "/nickname":
-		return SchemaBuilderNickName, true
+		return schemaBuilderNickName, true
 	case "/picture":
-		return SchemaBuilderPicture, true
+		return schemaBuilderPicture, true
 	case "/profile":
-		return SchemaBuilderProfile, true
+		return schemaBuilderProfile, true
 	case "/website":
-		return SchemaBuilderWebsite, true
+		return schemaBuilderWebsite, true
 	case "/gender":
-		return SchemaBuilderGender, true
+		return schemaBuilderGender, true
 	case "/birthdate":
-		return SchemaBuilderBirthdate, true
+		return schemaBuilderBirthdate, true
 	case "/zoneinfo":
-		return SchemaBuilderZoneinfo, true
+		return schemaBuilderZoneinfo, true
 	case "/locale":
-		return SchemaBuilderLocale, true
+		return schemaBuilderLocale, true
 	case "/address":
-		return SchemaBuilderAddress, true
+		return schemaBuilderAddress, true
 	case "/address/formatted":
-		return SchemaBuilderAddressFormatted, true
+		return schemaBuilderAddressFormatted, true
 	case "/address/street_address":
-		return SchemaBuilderAddressStreetAddress, true
+		return schemaBuilderAddressStreetAddress, true
 	case "/address/locality":
-		return SchemaBuilderAddressLocality, true
+		return schemaBuilderAddressLocality, true
 	case "/address/region":
-		return SchemaBuilderAddressRegion, true
+		return schemaBuilderAddressRegion, true
 	case "/address/postal_code":
-		return SchemaBuilderAddressPostalCode, true
+		return schemaBuilderAddressPostalCode, true
 	case "/address/country":
-		return SchemaBuilderAddressCountry, true
+		return schemaBuilderAddressCountry, true
 	default:
 		return nil, false
 	}

--- a/pkg/lib/authn/stdattrs/validate_test.go
+++ b/pkg/lib/authn/stdattrs/validate_test.go
@@ -136,7 +136,7 @@ func TestSchema(t *testing.T) {
 	}
 }
 `
-		bytes, err := json.Marshal(SchemaBuilder)
+		bytes, err := json.Marshal(schemaBuilder)
 		So(err, ShouldBeNil)
 		So(string(bytes), ShouldEqualJSON, expected)
 	})

--- a/pkg/lib/userimport/model.go
+++ b/pkg/lib/userimport/model.go
@@ -24,8 +24,7 @@ var RecordSchemaForIdentifierPhoneNumber *validation.SimpleSchema
 var RecordSchemaForIdentifierPreferredUsername *validation.SimpleSchema
 
 func init() {
-	nullString := validation.SchemaBuilder{}.
-		Types(validation.TypeString, validation.TypeNull)
+	reusedSchemaBuilders := reuseSchemaBuilders()
 	str := validation.SchemaBuilder{}.
 		Type(validation.TypeString)
 
@@ -34,9 +33,6 @@ func init() {
 	makeBase := func() validation.SchemaBuilder {
 		boolean := validation.SchemaBuilder{}.
 			Type(validation.TypeBoolean)
-
-		nullObject := validation.SchemaBuilder{}.
-			Types(validation.TypeObject, validation.TypeNull)
 
 		customAttributes := validation.SchemaBuilder{}.
 			Type(validation.TypeObject)
@@ -65,8 +61,8 @@ func init() {
 			Type(validation.TypeObject).
 			AdditionalPropertiesFalse()
 		mfa.Properties().
-			Property("email", nullString).
-			Property("phone_number", nullString).
+			Property("email", reusedSchemaBuilders.Email.Nullable()).
+			Property("phone_number", reusedSchemaBuilders.PhoneNumber.Nullable()).
 			Property("password", password).
 			Property("totp", totp)
 
@@ -78,19 +74,19 @@ func init() {
 			Property("disabled", boolean).
 			Property("email_verified", boolean).
 			Property("phone_number_verified", boolean).
-			Property("name", nullString).
-			Property("given_name", nullString).
-			Property("family_name", nullString).
-			Property("middle_name", nullString).
-			Property("nickname", nullString).
-			Property("profile", nullString).
-			Property("picture", nullString).
-			Property("website", nullString).
-			Property("gender", nullString).
-			Property("birthdate", nullString).
-			Property("zoneinfo", nullString).
-			Property("locale", nullString).
-			Property("address", nullObject).
+			Property("name", reusedSchemaBuilders.Name.Nullable()).
+			Property("given_name", reusedSchemaBuilders.GivenName.Nullable()).
+			Property("family_name", reusedSchemaBuilders.FamilyName.Nullable()).
+			Property("middle_name", reusedSchemaBuilders.MiddleName.Nullable()).
+			Property("nickname", reusedSchemaBuilders.Nickname.Nullable()).
+			Property("profile", reusedSchemaBuilders.Profile.Nullable()).
+			Property("picture", reusedSchemaBuilders.Picture.Nullable()).
+			Property("website", reusedSchemaBuilders.Website.Nullable()).
+			Property("gender", reusedSchemaBuilders.Gender.Nullable()).
+			Property("birthdate", reusedSchemaBuilders.Birthdate.Nullable()).
+			Property("zoneinfo", reusedSchemaBuilders.Zoneinfo.Nullable()).
+			Property("locale", reusedSchemaBuilders.Locale.Nullable()).
+			Property("address", reusedSchemaBuilders.Address.Nullable()).
 			Property("custom_attributes", customAttributes).
 			Property("roles", rolesOrGroups).
 			Property("groups", rolesOrGroups).
@@ -103,25 +99,25 @@ func init() {
 	email := makeBase().
 		Required("email")
 	email.Properties().
-		Property("email", minLenStr).
-		Property("phone_number", nullString).
-		Property("preferred_username", nullString)
+		Property("email", reusedSchemaBuilders.Email).
+		Property("phone_number", reusedSchemaBuilders.PhoneNumber.Nullable()).
+		Property("preferred_username", reusedSchemaBuilders.PreferredUsername.Nullable())
 	RecordSchemaForIdentifierEmail = email.ToSimpleSchema()
 
 	phoneNumber := makeBase().
 		Required("phone_number")
 	phoneNumber.Properties().
-		Property("phone_number", minLenStr).
-		Property("email", nullString).
-		Property("preferred_username", nullString)
+		Property("phone_number", reusedSchemaBuilders.PhoneNumber).
+		Property("email", reusedSchemaBuilders.Email.Nullable()).
+		Property("preferred_username", reusedSchemaBuilders.PreferredUsername.Nullable())
 	RecordSchemaForIdentifierPhoneNumber = phoneNumber.ToSimpleSchema()
 
 	preferredUsername := makeBase().
 		Required("preferred_username")
 	preferredUsername.Properties().
-		Property("preferred_username", minLenStr).
-		Property("email", nullString).
-		Property("phone_number", nullString)
+		Property("preferred_username", reusedSchemaBuilders.PreferredUsername).
+		Property("email", reusedSchemaBuilders.Email.Nullable()).
+		Property("phone_number", reusedSchemaBuilders.PhoneNumber.Nullable())
 	RecordSchemaForIdentifierPreferredUsername = preferredUsername.ToSimpleSchema()
 }
 

--- a/pkg/lib/userimport/model.go
+++ b/pkg/lib/userimport/model.go
@@ -29,6 +29,8 @@ func init() {
 	str := validation.SchemaBuilder{}.
 		Type(validation.TypeString)
 
+	minLenStr := str.MinLength(1)
+
 	makeBase := func() validation.SchemaBuilder {
 		boolean := validation.SchemaBuilder{}.
 			Type(validation.TypeBoolean)
@@ -41,7 +43,7 @@ func init() {
 
 		rolesOrGroups := validation.SchemaBuilder{}.
 			Type(validation.TypeArray).
-			Items(str)
+			Items(minLenStr)
 
 		password := validation.SchemaBuilder{}.
 			Type(validation.TypeObject).
@@ -49,7 +51,7 @@ func init() {
 			Required("type", "password_hash")
 		password.Properties().
 			Property("type", validation.SchemaBuilder{}.Type(validation.TypeString).Enum("bcrypt")).
-			Property("password_hash", str).
+			Property("password_hash", minLenStr).
 			Property("expire_after", validation.SchemaBuilder{}.Type(validation.TypeString).Format("date-time"))
 
 		totp := validation.SchemaBuilder{}.
@@ -57,7 +59,7 @@ func init() {
 			AdditionalPropertiesFalse().
 			Required("secret")
 		totp.Properties().
-			Property("secret", str)
+			Property("secret", minLenStr)
 
 		mfa := validation.SchemaBuilder{}.
 			Type(validation.TypeObject).
@@ -101,7 +103,7 @@ func init() {
 	email := makeBase().
 		Required("email")
 	email.Properties().
-		Property("email", str).
+		Property("email", minLenStr).
 		Property("phone_number", nullString).
 		Property("preferred_username", nullString)
 	RecordSchemaForIdentifierEmail = email.ToSimpleSchema()
@@ -109,7 +111,7 @@ func init() {
 	phoneNumber := makeBase().
 		Required("phone_number")
 	phoneNumber.Properties().
-		Property("phone_number", str).
+		Property("phone_number", minLenStr).
 		Property("email", nullString).
 		Property("preferred_username", nullString)
 	RecordSchemaForIdentifierPhoneNumber = phoneNumber.ToSimpleSchema()
@@ -117,7 +119,7 @@ func init() {
 	preferredUsername := makeBase().
 		Required("preferred_username")
 	preferredUsername.Properties().
-		Property("preferred_username", str).
+		Property("preferred_username", minLenStr).
 		Property("email", nullString).
 		Property("phone_number", nullString)
 	RecordSchemaForIdentifierPreferredUsername = preferredUsername.ToSimpleSchema()

--- a/pkg/lib/userimport/model.go
+++ b/pkg/lib/userimport/model.go
@@ -61,8 +61,8 @@ func init() {
 			Type(validation.TypeObject).
 			AdditionalPropertiesFalse()
 		mfa.Properties().
-			Property("email", reusedSchemaBuilders.Email.Nullable()).
-			Property("phone_number", reusedSchemaBuilders.PhoneNumber.Nullable()).
+			Property("email", reusedSchemaBuilders.Email.AddTypeNull()).
+			Property("phone_number", reusedSchemaBuilders.PhoneNumber.AddTypeNull()).
 			Property("password", password).
 			Property("totp", totp)
 
@@ -74,19 +74,19 @@ func init() {
 			Property("disabled", boolean).
 			Property("email_verified", boolean).
 			Property("phone_number_verified", boolean).
-			Property("name", reusedSchemaBuilders.Name.Nullable()).
-			Property("given_name", reusedSchemaBuilders.GivenName.Nullable()).
-			Property("family_name", reusedSchemaBuilders.FamilyName.Nullable()).
-			Property("middle_name", reusedSchemaBuilders.MiddleName.Nullable()).
-			Property("nickname", reusedSchemaBuilders.Nickname.Nullable()).
-			Property("profile", reusedSchemaBuilders.Profile.Nullable()).
-			Property("picture", reusedSchemaBuilders.Picture.Nullable()).
-			Property("website", reusedSchemaBuilders.Website.Nullable()).
-			Property("gender", reusedSchemaBuilders.Gender.Nullable()).
-			Property("birthdate", reusedSchemaBuilders.Birthdate.Nullable()).
-			Property("zoneinfo", reusedSchemaBuilders.Zoneinfo.Nullable()).
-			Property("locale", reusedSchemaBuilders.Locale.Nullable()).
-			Property("address", reusedSchemaBuilders.Address.Nullable()).
+			Property("name", reusedSchemaBuilders.Name.AddTypeNull()).
+			Property("given_name", reusedSchemaBuilders.GivenName.AddTypeNull()).
+			Property("family_name", reusedSchemaBuilders.FamilyName.AddTypeNull()).
+			Property("middle_name", reusedSchemaBuilders.MiddleName.AddTypeNull()).
+			Property("nickname", reusedSchemaBuilders.Nickname.AddTypeNull()).
+			Property("profile", reusedSchemaBuilders.Profile.AddTypeNull()).
+			Property("picture", reusedSchemaBuilders.Picture.AddTypeNull()).
+			Property("website", reusedSchemaBuilders.Website.AddTypeNull()).
+			Property("gender", reusedSchemaBuilders.Gender.AddTypeNull()).
+			Property("birthdate", reusedSchemaBuilders.Birthdate.AddTypeNull()).
+			Property("zoneinfo", reusedSchemaBuilders.Zoneinfo.AddTypeNull()).
+			Property("locale", reusedSchemaBuilders.Locale.AddTypeNull()).
+			Property("address", reusedSchemaBuilders.Address.AddTypeNull()).
 			Property("custom_attributes", customAttributes).
 			Property("roles", rolesOrGroups).
 			Property("groups", rolesOrGroups).
@@ -100,24 +100,24 @@ func init() {
 		Required("email")
 	email.Properties().
 		Property("email", reusedSchemaBuilders.Email).
-		Property("phone_number", reusedSchemaBuilders.PhoneNumber.Nullable()).
-		Property("preferred_username", reusedSchemaBuilders.PreferredUsername.Nullable())
+		Property("phone_number", reusedSchemaBuilders.PhoneNumber.AddTypeNull()).
+		Property("preferred_username", reusedSchemaBuilders.PreferredUsername.AddTypeNull())
 	RecordSchemaForIdentifierEmail = email.ToSimpleSchema()
 
 	phoneNumber := makeBase().
 		Required("phone_number")
 	phoneNumber.Properties().
 		Property("phone_number", reusedSchemaBuilders.PhoneNumber).
-		Property("email", reusedSchemaBuilders.Email.Nullable()).
-		Property("preferred_username", reusedSchemaBuilders.PreferredUsername.Nullable())
+		Property("email", reusedSchemaBuilders.Email.AddTypeNull()).
+		Property("preferred_username", reusedSchemaBuilders.PreferredUsername.AddTypeNull())
 	RecordSchemaForIdentifierPhoneNumber = phoneNumber.ToSimpleSchema()
 
 	preferredUsername := makeBase().
 		Required("preferred_username")
 	preferredUsername.Properties().
 		Property("preferred_username", reusedSchemaBuilders.PreferredUsername).
-		Property("email", reusedSchemaBuilders.Email.Nullable()).
-		Property("phone_number", reusedSchemaBuilders.PhoneNumber.Nullable())
+		Property("email", reusedSchemaBuilders.Email.AddTypeNull()).
+		Property("phone_number", reusedSchemaBuilders.PhoneNumber.AddTypeNull())
 	RecordSchemaForIdentifierPreferredUsername = preferredUsername.ToSimpleSchema()
 }
 

--- a/pkg/lib/userimport/model_test.go
+++ b/pkg/lib/userimport/model_test.go
@@ -919,8 +919,8 @@ func TestRecordSchema(t *testing.T) {
 				}
 			}
 		}`, `invalid request body:
-/email: minLength
-  map[actual:0 expected:1]
+/email: format
+  map[error:invalid email address: mail: no address format:email]
 /mfa/password/password_hash: minLength
   map[actual:0 expected:1]
 /mfa/totp/secret: minLength
@@ -1012,8 +1012,8 @@ func TestRecordSchema(t *testing.T) {
   map[actual:0 expected:1]
 /password/password_hash: minLength
   map[actual:0 expected:1]
-/phone_number: minLength
-  map[actual:0 expected:1]`)
+/phone_number: format
+  map[error:not in E.164 format format:phone]`)
 	})
 
 	Convey("Record JSON Schema for preferred_username", t, func() {

--- a/pkg/lib/userimport/model_test.go
+++ b/pkg/lib/userimport/model_test.go
@@ -784,6 +784,16 @@ func TestRecordSchema(t *testing.T) {
 /password: required
   map[actual:[unknown] expected:[password_hash type] missing:[password_hash type]]
 /password/unknown: `)
+
+		test(`{
+			"email": "user@example.com",
+			"password": {
+				"type": "bcrypt",
+				"password_hash": ""
+			}
+		}`, `invalid request body:
+/password/password_hash: minLength
+  map[actual:0 expected:1]`)
 	})
 
 	Convey("Record JSON schema for mfa", t, func() {
@@ -819,6 +829,17 @@ func TestRecordSchema(t *testing.T) {
 			}
 		}`, `invalid request body:
 /mfa/totp/unknown: `)
+
+		test(`{
+			"email": "user@example.com",
+			"mfa": {
+				"totp": {
+					"secret": ""
+				}
+			}
+		}`, `invalid request body:
+/mfa/totp/secret: minLength
+  map[actual:0 expected:1]`)
 	})
 
 	Convey("Record JSON Schema for email", t, func() {
@@ -881,6 +902,31 @@ func TestRecordSchema(t *testing.T) {
   map[actual:<nil> expected:[secret] missing:[secret]]
 /password: required
   map[actual:<nil> expected:[password_hash type] missing:[password_hash type]]`)
+
+		test(`{
+			"email": "",
+			"password": {
+				"type": "bcrypt",
+				"password_hash": ""
+			},
+			"mfa": {
+				"password": {
+					"type": "bcrypt",
+					"password_hash": ""
+				},
+				"totp": {
+					"secret": ""
+				}
+			}
+		}`, `invalid request body:
+/email: minLength
+  map[actual:0 expected:1]
+/mfa/password/password_hash: minLength
+  map[actual:0 expected:1]
+/mfa/totp/secret: minLength
+  map[actual:0 expected:1]
+/password/password_hash: minLength
+  map[actual:0 expected:1]`)
 	})
 
 	Convey("Record JSON Schema for phone_number", t, func() {
@@ -943,6 +989,31 @@ func TestRecordSchema(t *testing.T) {
   map[actual:<nil> expected:[secret] missing:[secret]]
 /password: required
   map[actual:<nil> expected:[password_hash type] missing:[password_hash type]]`)
+
+		test(`{
+			"phone_number": "",
+			"password": {
+				"type": "bcrypt",
+				"password_hash": ""
+			},
+			"mfa": {
+				"password": {
+					"type": "bcrypt",
+					"password_hash": ""
+				},
+				"totp": {
+					"secret": ""
+				}
+			}
+		}`, `invalid request body:
+/mfa/password/password_hash: minLength
+  map[actual:0 expected:1]
+/mfa/totp/secret: minLength
+  map[actual:0 expected:1]
+/password/password_hash: minLength
+  map[actual:0 expected:1]
+/phone_number: minLength
+  map[actual:0 expected:1]`)
 	})
 
 	Convey("Record JSON Schema for preferred_username", t, func() {
@@ -1005,5 +1076,30 @@ func TestRecordSchema(t *testing.T) {
   map[actual:<nil> expected:[secret] missing:[secret]]
 /password: required
   map[actual:<nil> expected:[password_hash type] missing:[password_hash type]]`)
+
+		test(`{
+			"preferred_username": "",
+			"password": {
+				"type": "bcrypt",
+				"password_hash": ""
+			},
+			"mfa": {
+				"password": {
+					"type": "bcrypt",
+					"password_hash": ""
+				},
+				"totp": {
+					"secret": ""
+				}
+			}
+		}`, `invalid request body:
+/mfa/password/password_hash: minLength
+  map[actual:0 expected:1]
+/mfa/totp/secret: minLength
+  map[actual:0 expected:1]
+/password/password_hash: minLength
+  map[actual:0 expected:1]
+/preferred_username: minLength
+  map[actual:0 expected:1]`)
 	})
 }

--- a/pkg/lib/userimport/reuseschema.go
+++ b/pkg/lib/userimport/reuseschema.go
@@ -1,0 +1,46 @@
+package userimport
+
+import (
+	"github.com/authgear/authgear-server/pkg/lib/authn/stdattrs"
+	"github.com/authgear/authgear-server/pkg/util/validation"
+)
+
+type ReusedSchemaBuilders struct {
+	Email             validation.SchemaBuilder
+	PhoneNumber       validation.SchemaBuilder
+	PreferredUsername validation.SchemaBuilder
+	FamilyName        validation.SchemaBuilder
+	GivenName         validation.SchemaBuilder
+	MiddleName        validation.SchemaBuilder
+	Name              validation.SchemaBuilder
+	Nickname          validation.SchemaBuilder
+	Picture           validation.SchemaBuilder
+	Profile           validation.SchemaBuilder
+	Website           validation.SchemaBuilder
+	Gender            validation.SchemaBuilder
+	Birthdate         validation.SchemaBuilder
+	Zoneinfo          validation.SchemaBuilder
+	Locale            validation.SchemaBuilder
+	Address           validation.SchemaBuilder
+}
+
+func reuseSchemaBuilders() ReusedSchemaBuilders {
+	return ReusedSchemaBuilders{
+		Email:             stdattrs.SchemaBuilderEmail(),
+		PhoneNumber:       stdattrs.SchemaBuilderPhoneNumber(),
+		PreferredUsername: stdattrs.SchemaBuilderPreferredUsername(),
+		FamilyName:        stdattrs.SchemaBuilderFamilyName(),
+		GivenName:         stdattrs.SchemaBuilderGivenName(),
+		MiddleName:        stdattrs.SchemaBuilderMiddleName(),
+		Name:              stdattrs.SchemaBuilderName(),
+		Nickname:          stdattrs.SchemaBuilderNickName(),
+		Picture:           stdattrs.SchemaBuilderPicture(),
+		Profile:           stdattrs.SchemaBuilderProfile(),
+		Website:           stdattrs.SchemaBuilderWebsite(),
+		Gender:            stdattrs.SchemaBuilderGender(),
+		Birthdate:         stdattrs.SchemaBuilderBirthdate(),
+		Zoneinfo:          stdattrs.SchemaBuilderZoneinfo(),
+		Locale:            stdattrs.SchemaBuilderLocale(),
+		Address:           stdattrs.SchemaBuilderAddress(),
+	}
+}

--- a/pkg/util/validation/schema_builder.go
+++ b/pkg/util/validation/schema_builder.go
@@ -33,6 +33,30 @@ func (b SchemaBuilder) Types(ts ...Type) SchemaBuilder {
 	return b
 }
 
+func (b SchemaBuilder) AddTypeNull() SchemaBuilder {
+	bType, ok := b["type"]
+	if !ok {
+		b.Type(TypeNull)
+		return b
+	}
+
+	originals, ok := bType.([]Type)
+	if ok {
+		newTypes := append(originals, TypeNull)
+		b.Types(newTypes...)
+		return b
+	}
+
+	original, ok := bType.(Type)
+	if ok {
+		newTypes := []Type{original, TypeNull}
+		b.Types(newTypes...)
+		return b
+	}
+
+	panic("unexpected: schema builder has invalid type")
+}
+
 func (b SchemaBuilder) Properties() SchemaBuilder {
 	bb, ok := b["properties"].(SchemaBuilder)
 	if !ok {
@@ -165,22 +189,4 @@ func (b SchemaBuilder) Clone() SchemaBuilder {
 	}
 
 	return newB
-}
-
-func (b SchemaBuilder) Nullable() SchemaBuilder {
-	existingTypes := b["type"]
-
-	if existingTypes == nil {
-		b.Type(TypeNull)
-	}
-
-	if ts, ok := existingTypes.([]Type); ok {
-		b.Types(append(ts, TypeNull)...)
-	} else if t, ok := existingTypes.(Type); ok {
-		b.Types(t, TypeNull)
-	} else {
-		b.Type(TypeNull)
-	}
-
-	return b
 }

--- a/pkg/util/validation/schema_builder.go
+++ b/pkg/util/validation/schema_builder.go
@@ -153,12 +153,12 @@ func (b SchemaBuilder) ToSimpleSchema() *SimpleSchema {
 
 // This function allow copying the schema builder to a reference
 // Expected usage is to avoid mutating original schema builder
-func (b SchemaBuilder) Copy() SchemaBuilder {
+func (b SchemaBuilder) Clone() SchemaBuilder {
 	newB := make(SchemaBuilder)
 	for k, v := range b {
 		vb, ok := v.(SchemaBuilder)
 		if ok {
-			newB[k] = vb.Copy()
+			newB[k] = vb.Clone()
 		} else {
 			newB[k] = v
 		}

--- a/pkg/util/validation/schema_builder.go
+++ b/pkg/util/validation/schema_builder.go
@@ -166,3 +166,21 @@ func (b SchemaBuilder) Copy() SchemaBuilder {
 
 	return newB
 }
+
+func (b SchemaBuilder) Nullable() SchemaBuilder {
+	existingTypes := b["type"]
+
+	if existingTypes == nil {
+		b.Type(TypeNull)
+	}
+
+	if ts, ok := existingTypes.([]Type); ok {
+		b.Types(append(ts, TypeNull)...)
+	} else if t, ok := existingTypes.(Type); ok {
+		b.Types(t, TypeNull)
+	} else {
+		b.Type(TypeNull)
+	}
+
+	return b
+}

--- a/pkg/util/validation/schema_builder.go
+++ b/pkg/util/validation/schema_builder.go
@@ -150,3 +150,19 @@ func (b SchemaBuilder) ToSimpleSchema() *SimpleSchema {
 	}
 	return NewSimpleSchema(string(bytes))
 }
+
+// This function allow copying the schema builder to a reference
+// Expected usage is to avoid mutating original schema builder
+func (b SchemaBuilder) Copy() SchemaBuilder {
+	newB := make(SchemaBuilder)
+	for k, v := range b {
+		vb, ok := v.(SchemaBuilder)
+		if ok {
+			newB[k] = vb.Copy()
+		} else {
+			newB[k] = v
+		}
+	}
+
+	return newB
+}

--- a/pkg/util/validation/schema_builder_test.go
+++ b/pkg/util/validation/schema_builder_test.go
@@ -214,7 +214,7 @@ func TestSchemaBuilder(t *testing.T) {
 }
 `)
 		})
-		Convey("nullable should append type", func() {
+		Convey("AddTypeNull should append type", func() {
 			b := SchemaBuilder{}
 			b.Type(TypeObject).Required("channel")
 
@@ -239,7 +239,7 @@ func TestSchemaBuilder(t *testing.T) {
     }
 }
 `)
-			b.Nullable()
+			b.AddTypeNull()
 			test(b, `
 {
     "type": ["object", "null"],

--- a/pkg/util/validation/schema_builder_test.go
+++ b/pkg/util/validation/schema_builder_test.go
@@ -214,5 +214,50 @@ func TestSchemaBuilder(t *testing.T) {
 }
 `)
 		})
+		Convey("nullable should append type", func() {
+			b := SchemaBuilder{}
+			b.Type(TypeObject).Required("channel")
+
+			b.Properties().
+				Property("channel", SchemaBuilder{}.Type(TypeString).Enum("sms", "email", "whatsapp"))
+
+			test(b, `
+{
+    "type": "object",
+    "required": [
+        "channel"
+    ],
+    "properties": {
+        "channel": {
+            "type": "string",
+            "enum": [
+                "sms",
+                "email",
+                "whatsapp"
+            ]
+        }
+    }
+}
+`)
+			b.Nullable()
+			test(b, `
+{
+    "type": ["object", "null"],
+    "required": [
+        "channel"
+    ],
+    "properties": {
+        "channel": {
+            "type": "string",
+            "enum": [
+                "sms",
+                "email",
+                "whatsapp"
+            ]
+        }
+    }
+}
+`)
+		})
 	})
 }

--- a/pkg/util/validation/schema_builder_test.go
+++ b/pkg/util/validation/schema_builder_test.go
@@ -144,5 +144,75 @@ func TestSchemaBuilder(t *testing.T) {
 }
 `)
 		})
+
+		Convey("mutation on copied builder should not affect original builder", func() {
+			b := SchemaBuilder{}
+			b.Type(TypeObject).Required("channel")
+
+			b.Properties().
+				Property("channel", SchemaBuilder{}.Type(TypeString).Enum("sms", "email", "whatsapp"))
+
+			test(b, `
+{
+    "type": "object",
+    "required": [
+        "channel"
+    ],
+    "properties": {
+        "channel": {
+            "type": "string",
+            "enum": [
+                "sms",
+                "email",
+                "whatsapp"
+            ]
+        }
+    }
+}
+`)
+			newB := b.Copy()
+			So(newB, ShouldResemble, b)
+
+			newB.Properties().Property("myNewProperty", SchemaBuilder{}.Type(TypeString))
+			test(newB, `
+{
+    "type": "object",
+    "required": [
+        "channel"
+    ],
+    "properties": {
+        "channel": {
+            "type": "string",
+            "enum": [
+                "sms",
+                "email",
+                "whatsapp"
+            ]
+        },
+        "myNewProperty": {
+            "type": "string"
+        }
+    }
+}
+`)
+			test(b, `
+{
+    "type": "object",
+    "required": [
+        "channel"
+    ],
+    "properties": {
+        "channel": {
+            "type": "string",
+            "enum": [
+                "sms",
+                "email",
+                "whatsapp"
+            ]
+        }
+    }
+}
+`)
+		})
 	})
 }

--- a/pkg/util/validation/schema_builder_test.go
+++ b/pkg/util/validation/schema_builder_test.go
@@ -145,7 +145,7 @@ func TestSchemaBuilder(t *testing.T) {
 `)
 		})
 
-		Convey("mutation on copied builder should not affect original builder", func() {
+		Convey("mutation on cloned builder should not affect original builder", func() {
 			b := SchemaBuilder{}
 			b.Type(TypeObject).Required("channel")
 
@@ -170,7 +170,7 @@ func TestSchemaBuilder(t *testing.T) {
     }
 }
 `)
-			newB := b.Copy()
+			newB := b.Clone()
 			So(newB, ShouldResemble, b)
 
 			newB.Properties().Property("myNewProperty", SchemaBuilder{}.Type(TypeString))


### PR DESCRIPTION
ref DEV-1482

Some directions I thought of, but only implemented the checked ones
- [x] add `minLength: 1` to required string fields
- [ ] add regex to some expected fields, like email, phone number, birthdate
- [ ] add enum to expected fields, like zoneinfo, locale

ref https://docs.authgear.com/how-to-guide/user-management/import-users-using-user-import-api#input-format

@louischan-oursky see if you expected more strict rules? thanks 🙏 