### PR TITLE
SAML: Add client_id to service provider

### DIFF
--- a/pkg/auth/handler/saml/login.go
+++ b/pkg/auth/handler/saml/login.go
@@ -113,12 +113,12 @@ func (h *LoginHandler) ServeHTTP(rw http.ResponseWriter, r *http.Request) {
 	switch parseResult := parseResult.(type) {
 	case *samlbinding.SAMLBindingHTTPRedirectParseResult:
 		relayState = parseResult.RelayState
-		err = h.SAMLService.ValidateAuthnRequest(sp.ID, parseResult.AuthnRequest)
+		err = h.SAMLService.ValidateAuthnRequest(sp.GetID(), parseResult.AuthnRequest)
 		// TODO(saml): Validate the signature in parseResult
 		authnRequest = parseResult.AuthnRequest
 	case *samlbinding.SAMLBindingHTTPPostParseResult:
 		relayState = parseResult.RelayState
-		err = h.SAMLService.ValidateAuthnRequest(sp.ID, parseResult.AuthnRequest)
+		err = h.SAMLService.ValidateAuthnRequest(sp.GetID(), parseResult.AuthnRequest)
 		// TODO(saml): Validate the signature in AuthnRequest
 		authnRequest = parseResult.AuthnRequest
 	default:
@@ -224,7 +224,7 @@ func (h *LoginHandler) startSSOFlow(
 	issuer := h.SAMLService.IdpEntityID()
 
 	samlSessionEntry := &samlsession.SAMLSessionEntry{
-		ServiceProviderID: sp.ID,
+		ServiceProviderID: sp.GetID(),
 		AuthnRequestXML:   authnRequestXML,
 		CallbackURL:       callbackURL,
 		RelayState:        relayState,

--- a/pkg/lib/config/config.go
+++ b/pkg/lib/config/config.go
@@ -357,6 +357,22 @@ func (c *AppConfig) validateSAML(ctx *validation.Context) {
 				"actual":   0,
 			})
 		}
+
+		for idx, sp := range c.SAML.ServiceProviders {
+			if sp.ClientID != "" {
+				found := false
+				for _, oauthClient := range c.OAuth.Clients {
+					if sp.ClientID == oauthClient.ClientID {
+						found = true
+						break
+					}
+				}
+				if !found {
+					ctx.Child("saml", "service_providers", strconv.Itoa(idx), "client_id").
+						EmitErrorMessage("client_id does not exist in /oauth/clients")
+				}
+			}
+		}
 	}
 }
 

--- a/pkg/lib/config/saml.go
+++ b/pkg/lib/config/saml.go
@@ -37,7 +37,15 @@ var _ = Schema.Add("SAMLServiceProviderConfig", `
 		"audience": { "type": "string", "format": "uri" },
 		"assertion_valid_duration":  { "$ref": "#/$defs/DurationString" }
 	},
-	"required": ["acs_urls"]
+	"required": ["acs_urls"],
+	"anyOf": [
+		{
+			"required": ["id"]
+		},
+		{
+			"required": ["client_id"]
+		}
+	]
 }
 `)
 

--- a/pkg/lib/config/saml.go
+++ b/pkg/lib/config/saml.go
@@ -47,8 +47,11 @@ type SAMLConfig struct {
 }
 
 func (c *SAMLConfig) ResolveProvider(id string) (*SAMLServiceProviderConfig, bool) {
+	if id == "" {
+		return nil, false
+	}
 	for _, sp := range c.ServiceProviders {
-		if sp.ID == id {
+		if sp.ID == id || sp.ClientID == id {
 			return sp, true
 		}
 	}
@@ -120,6 +123,16 @@ func (c *SAMLServiceProviderConfig) SetDefaults() {
 
 func (c *SAMLServiceProviderConfig) DefaultAcsURL() string {
 	return c.AcsURLs[0]
+}
+
+func (c *SAMLServiceProviderConfig) GetID() string {
+	if c.ID != "" {
+		return c.ID
+	}
+	if c.ClientID != "" {
+		return c.ClientID
+	}
+	panic("unexpected: service provider does not have id nor client id")
 }
 
 var _ = Schema.Add("SAMLSigningConfig", `

--- a/pkg/lib/config/saml.go
+++ b/pkg/lib/config/saml.go
@@ -51,7 +51,7 @@ func (c *SAMLConfig) ResolveProvider(id string) (*SAMLServiceProviderConfig, boo
 		return nil, false
 	}
 	for _, sp := range c.ServiceProviders {
-		if sp.ID == id || sp.ClientID == id {
+		if sp.Deprecated_ID == id || sp.ClientID == id {
 			return sp, true
 		}
 	}
@@ -96,7 +96,7 @@ func (p SAMLNameIDAttributePointer) MustGetJSONPointer() jsonpointer.T {
 }
 
 type SAMLServiceProviderConfig struct {
-	ID                     string                     `json:"id,omitempty"`
+	Deprecated_ID          string                     `json:"id,omitempty"`
 	ClientID               string                     `json:"client_id,omitempty"`
 	NameIDFormat           SAMLNameIDFormat           `json:"nameid_format,omitempty"`
 	NameIDAttributePointer SAMLNameIDAttributePointer `json:"nameid_attribute_pointer,omitempty"`
@@ -126,8 +126,8 @@ func (c *SAMLServiceProviderConfig) DefaultAcsURL() string {
 }
 
 func (c *SAMLServiceProviderConfig) GetID() string {
-	if c.ID != "" {
-		return c.ID
+	if c.Deprecated_ID != "" {
+		return c.Deprecated_ID
 	}
 	if c.ClientID != "" {
 		return c.ClientID

--- a/pkg/lib/config/saml.go
+++ b/pkg/lib/config/saml.go
@@ -24,6 +24,7 @@ var _ = Schema.Add("SAMLServiceProviderConfig", `
 	"additionalProperties": false,
 	"properties": {
 		"id": { "type": "string" },
+		"client_id": { "type": "string" },
 		"nameid_format": { "$ref": "#/$defs/SAMLNameIDFormat" },
 		"nameid_attribute_pointer": { "$ref": "#/$defs/SAMLNameIDAttributePointer" },
 		"acs_urls": {
@@ -36,7 +37,7 @@ var _ = Schema.Add("SAMLServiceProviderConfig", `
 		"audience": { "type": "string", "format": "uri" },
 		"assertion_valid_duration":  { "$ref": "#/$defs/DurationString" }
 	},
-	"required": ["id", "acs_urls"]
+	"required": ["acs_urls"]
 }
 `)
 
@@ -93,6 +94,7 @@ func (p SAMLNameIDAttributePointer) MustGetJSONPointer() jsonpointer.T {
 
 type SAMLServiceProviderConfig struct {
 	ID                     string                     `json:"id,omitempty"`
+	ClientID               string                     `json:"client_id,omitempty"`
 	NameIDFormat           SAMLNameIDFormat           `json:"nameid_format,omitempty"`
 	NameIDAttributePointer SAMLNameIDAttributePointer `json:"nameid_attribute_pointer,omitempty"`
 	AcsURLs                []string                   `json:"acs_urls,omitempty"`

--- a/pkg/lib/config/saml.go
+++ b/pkg/lib/config/saml.go
@@ -126,11 +126,11 @@ func (c *SAMLServiceProviderConfig) DefaultAcsURL() string {
 }
 
 func (c *SAMLServiceProviderConfig) GetID() string {
-	if c.Deprecated_ID != "" {
-		return c.Deprecated_ID
-	}
 	if c.ClientID != "" {
 		return c.ClientID
+	}
+	if c.Deprecated_ID != "" {
+		return c.Deprecated_ID
 	}
 	panic("unexpected: service provider does not have id nor client id")
 }

--- a/pkg/lib/config/testdata/config_tests.yaml
+++ b/pkg/lib/config/testdata/config_tests.yaml
@@ -1200,3 +1200,39 @@ config:
     signing:
       key_id: asdfasdf
       signature_method: http://www.w3.org/2001/04/xmldsig-more#rsa-sha256
+---
+name: saml-service-provider-missing-id
+error: |-
+  invalid configuration:
+  /saml/service_providers/0: required
+    map[actual:[acs_urls nameid_format] expected:[id] missing:[id]]
+  /saml/service_providers/0: required
+    map[actual:[acs_urls nameid_format] expected:[client_id] missing:[client_id]]
+config:
+  id: test
+  http:
+    public_origin: http://test
+  saml:
+    signing:
+      key_id: asdfasdf
+    service_providers:
+      - nameid_format: urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress
+        acs_urls:
+          - http://localhost:3000/acs
+---
+name: saml-service-provider-invalid-client-id
+error: |-
+  invalid configuration:
+  /saml/service_providers/0/client_id: client_id does not exist in /oauth/clients
+config:
+  id: test
+  http:
+    public_origin: http://test
+  saml:
+    signing:
+      key_id: asdfasdf
+    service_providers:
+      - client_id: notexist
+        nameid_format: urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress
+        acs_urls:
+          - http://localhost:3000/acs

--- a/pkg/lib/config/testdata/config_tests.yaml
+++ b/pkg/lib/config/testdata/config_tests.yaml
@@ -1212,11 +1212,27 @@ config:
   id: test
   http:
     public_origin: http://test
+  oauth:
+    clients:
+      - name: Test Client
+        client_id: testclient
+        redirect_uris:
+          - "https://example.com"
+        refresh_token_lifetime_seconds: 10
+        access_token_lifetime_seconds: 10000
   saml:
     signing:
       key_id: asdfasdf
     service_providers:
       - nameid_format: urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress
+        acs_urls:
+          - http://localhost:3000/acs
+      - id: someid
+        nameid_format: urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress
+        acs_urls:
+          - http://localhost:3000/acs
+      - client_id: testclient
+        nameid_format: urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress
         acs_urls:
           - http://localhost:3000/acs
 ---

--- a/pkg/lib/saml/service.go
+++ b/pkg/lib/saml/service.go
@@ -102,11 +102,11 @@ func (s *Service) IdpMetadata(serviceProviderId string) (*samlprotocol.Metadata,
 				SingleSignOnServices: []crewjamsaml.Endpoint{
 					{
 						Binding:  crewjamsaml.HTTPRedirectBinding,
-						Location: s.Endpoints.SAMLLoginURL(sp.ID).String(),
+						Location: s.Endpoints.SAMLLoginURL(sp.GetID()).String(),
 					},
 					{
 						Binding:  crewjamsaml.HTTPPostBinding,
-						Location: s.Endpoints.SAMLLoginURL(sp.ID).String(),
+						Location: s.Endpoints.SAMLLoginURL(sp.GetID()).String(),
 					},
 				},
 			},
@@ -128,11 +128,11 @@ func (s *Service) ValidateAuthnRequest(serviceProviderId string, authnRequest *s
 	}
 
 	if authnRequest.Destination != "" {
-		if authnRequest.Destination != s.Endpoints.SAMLLoginURL(sp.ID).String() {
+		if authnRequest.Destination != s.Endpoints.SAMLLoginURL(sp.GetID()).String() {
 			return &samlerror.InvalidRequestError{
 				Field:    "Destination",
 				Actual:   authnRequest.Destination,
-				Expected: []string{s.Endpoints.SAMLLoginURL(sp.ID).String()},
+				Expected: []string{s.Endpoints.SAMLLoginURL(sp.GetID()).String()},
 				Reason:   "unexpected Destination",
 			}
 		}

--- a/pkg/lib/saml/service_test.go
+++ b/pkg/lib/saml/service_test.go
@@ -33,7 +33,7 @@ func TestSAMLService(t *testing.T) {
 		SAMLConfig: &config.SAMLConfig{
 			ServiceProviders: []*config.SAMLServiceProviderConfig{
 				{
-					ID:           spID,
+					ClientID:     spID,
 					NameIDFormat: config.SAMLNameIDFormatEmailAddress,
 					AcsURLs: []string{
 						"http://localhost/saml-test",


### PR DESCRIPTION
ref DEV-2002

Steps to update existing configs:
1. Deploy the code in this pr
2. Add `client_id` in existing config. Old endpoints should still work, but metadata will be updated.
3. Switch to new endpoints.
4. Remove `id` from configs.
5. Remove `id` from code.