### PR TITLE
Replace GMT string in datetime string to UTC

### DIFF
--- a/portal/src/util/formatDatetime.ts
+++ b/portal/src/util/formatDatetime.ts
@@ -28,5 +28,7 @@ export function formatDatetime(
   }
 
   datetime = datetime.setLocale(locale);
-  return datetime.toLocaleString(dateTimeWithTimezoneFormatOption);
+  return datetime
+    .toLocaleString(dateTimeWithTimezoneFormatOption)
+    .replace("GMT+", "UTC+");
 }


### PR DESCRIPTION
As https://tc39.es/ecma402/#table-datetimeformat-components
doesnt have options to control whether display `GMT` or `UTC`, added a replace for this purpose

Preview:

<img width="1082" alt="Screenshot 2024-09-09 at 2 43 34 PM" src="https://github.com/user-attachments/assets/ddfb6ea7-74f7-4642-a746-cfe299965610">
