### PR TITLE
Fix sign up or login option wording

### DIFF
--- a/portal/src/locale-data/en.json
+++ b/portal/src/locale-data/en.json
@@ -1022,7 +1022,7 @@
   "DesignScreen.configuration.authgearBranding.disableAuthgearLogo.label": "Display Authgear logo in Sign in and Sign up page",
   "DesignScreen.configuration.fallback": "Leave unset to fallback to primary language settings - {fallbackLanguage}",
   "DesignScreen.preview.pages.title.Login": "Log In",
-  "DesignScreen.preview.pages.title.LoginAndSignUp": "Sign Up/Login",
+  "DesignScreen.preview.pages.title.LoginAndSignUp": "Sign Up or Log In",
   "DesignScreen.preview.pages.title.SignUp": "Sign Up",
   "DesignScreen.preview.pages.title.EnterPassword": "Enter Password",
   "DesignScreen.preview.pages.title.EnterOOBOTP": "Verification Code",


### PR DESCRIPTION
@louischan-oursky fixed combine sign up, login text wording

Preview:

<img width="517" alt="Screenshot 2024-09-09 at 2 48 20 PM" src="https://github.com/user-attachments/assets/910fcb78-9550-41f3-8be9-0691eded218e">
