### PR TITLE
Implement new mobile layout for audit log filters

### DIFF
--- a/portal/src/components/audit-log/ActivityTypeFilterDropdown.tsx
+++ b/portal/src/components/audit-log/ActivityTypeFilterDropdown.tsx
@@ -1,0 +1,86 @@
+import React, { useCallback, useContext, useMemo } from "react";
+import { Context as MessageContext } from "@oursky/react-messageformat";
+import { IContextualMenuItem, IContextualMenuProps } from "@fluentui/react";
+import CommandBarButton from "../../CommandBarButton";
+import { AuditLogActivityType } from "../../graphql/adminapi/globalTypes.generated";
+
+export type AuditLogActivityTypeAll = "ALL";
+export const ACTIVITY_TYPE_ALL: AuditLogActivityTypeAll = "ALL";
+
+export type ActivityTypeFilterDropdownOptionKey =
+  | AuditLogActivityType
+  | AuditLogActivityTypeAll;
+
+interface ActivityTypeDropdownOption {
+  key: ActivityTypeFilterDropdownOptionKey;
+  text: string;
+}
+
+interface ActivityTypeFilterDropdownProps {
+  className?: string;
+  value: ActivityTypeFilterDropdownOptionKey;
+  onChange: (newValue: ActivityTypeFilterDropdownOptionKey) => void;
+  availableActivityTypes: AuditLogActivityType[];
+}
+
+export const ActivityTypeFilterDropdown: React.VFC<ActivityTypeFilterDropdownProps> =
+  function ActivityTypeFilterDropdown({
+    className,
+    value,
+    onChange,
+    availableActivityTypes,
+  }: ActivityTypeFilterDropdownProps) {
+    const { renderToString } = useContext(MessageContext);
+
+    const activityTypeOptions = useMemo<ActivityTypeDropdownOption[]>(() => {
+      const options: ActivityTypeDropdownOption[] = [
+        {
+          key: ACTIVITY_TYPE_ALL,
+          text: renderToString("AuditLogActivityType.ALL"),
+        },
+      ];
+      for (const key of availableActivityTypes) {
+        options.push({
+          key: key,
+          text: renderToString("AuditLogActivityType." + key),
+        });
+      }
+      return options;
+    }, [availableActivityTypes, renderToString]);
+
+    const placeholder = useMemo(() => {
+      return activityTypeOptions.find((option) => option.key === value)!.text;
+    }, [activityTypeOptions, value]);
+
+    const onClickOption = useCallback(
+      (
+        _event?:
+          | React.MouseEvent<HTMLElement>
+          | React.KeyboardEvent<HTMLElement>,
+        item?: IContextualMenuItem
+      ) => {
+        onChange(item?.key as ActivityTypeFilterDropdownOptionKey);
+      },
+      [onChange]
+    );
+
+    const menuProps = useMemo<IContextualMenuProps>(() => {
+      return {
+        items: activityTypeOptions.map((option) => ({
+          key: option.key,
+          text: option.text,
+          onClick: onClickOption,
+        })),
+      };
+    }, [activityTypeOptions, onClickOption]);
+
+    return (
+      <CommandBarButton
+        className={className}
+        key="activityTypes"
+        iconProps={{ iconName: "PC1" }}
+        menuProps={menuProps}
+        text={placeholder}
+      />
+    );
+  };

--- a/portal/src/components/audit-log/ActivityTypeFilterDropdown.tsx
+++ b/portal/src/components/audit-log/ActivityTypeFilterDropdown.tsx
@@ -1,8 +1,14 @@
 import React, { useCallback, useContext, useMemo } from "react";
 import { Context as MessageContext } from "@oursky/react-messageformat";
-import { IContextualMenuItem, IContextualMenuProps } from "@fluentui/react";
+import {
+  Dropdown,
+  IContextualMenuItem,
+  IContextualMenuProps,
+  IDropdownOption,
+} from "@fluentui/react";
 import CommandBarButton from "../../CommandBarButton";
 import { AuditLogActivityType } from "../../graphql/adminapi/globalTypes.generated";
+import { useScreenBreakpoint } from "../../hook/useScreenBreakpoint";
 
 export type AuditLogActivityTypeAll = "ALL";
 export const ACTIVITY_TYPE_ALL: AuditLogActivityTypeAll = "ALL";
@@ -23,8 +29,8 @@ interface ActivityTypeFilterDropdownProps {
   availableActivityTypes: AuditLogActivityType[];
 }
 
-export const ActivityTypeFilterDropdown: React.VFC<ActivityTypeFilterDropdownProps> =
-  function ActivityTypeFilterDropdown({
+const DesktopActivityTypeFilterDropdown: React.VFC<ActivityTypeFilterDropdownProps> =
+  function DesktopActivityTypeFilterDropdown({
     className,
     value,
     onChange,
@@ -83,4 +89,61 @@ export const ActivityTypeFilterDropdown: React.VFC<ActivityTypeFilterDropdownPro
         text={placeholder}
       />
     );
+  };
+
+const MobileActivityTypeFilterDropdown: React.VFC<ActivityTypeFilterDropdownProps> =
+  function MobileActivityTypeFilterDropdown({
+    className,
+    value,
+    onChange,
+    availableActivityTypes,
+  }: ActivityTypeFilterDropdownProps) {
+    const { renderToString } = useContext(MessageContext);
+
+    const options = useMemo<IDropdownOption[]>(() => {
+      const options: IDropdownOption[] = [
+        {
+          key: ACTIVITY_TYPE_ALL,
+          text: renderToString("AuditLogActivityType.ALL"),
+        },
+      ];
+      for (const key of availableActivityTypes) {
+        options.push({
+          key: key,
+          text: renderToString("AuditLogActivityType." + key),
+        });
+      }
+      return options;
+    }, [availableActivityTypes, renderToString]);
+
+    const onChangeOption = useCallback(
+      (_e: unknown, option?: IDropdownOption) => {
+        if (option == null) {
+          return;
+        }
+        onChange(option.key as ActivityTypeFilterDropdownOptionKey);
+      },
+      [onChange]
+    );
+    return (
+      <Dropdown
+        className={className}
+        selectedKey={value}
+        options={options}
+        onChange={onChangeOption}
+      />
+    );
+  };
+
+export const ActivityTypeFilterDropdown: React.VFC<ActivityTypeFilterDropdownProps> =
+  function ActivityTypeFilterDropdown(props: ActivityTypeFilterDropdownProps) {
+    const screenBreakpoint = useScreenBreakpoint();
+
+    switch (screenBreakpoint) {
+      case "desktop":
+        return <DesktopActivityTypeFilterDropdown {...props} />;
+      case "mobile":
+      case "tablet":
+        return <MobileActivityTypeFilterDropdown {...props} />;
+    }
   };

--- a/portal/src/components/audit-log/AuditLogFilterBar.module.css
+++ b/portal/src/components/audit-log/AuditLogFilterBar.module.css
@@ -5,6 +5,10 @@
   /* Align the first item with the screen title. */
   @apply px-3.5;
 
+  @apply tablet:flex tablet:flex-col;
+  @apply tablet:h-auto;
+  @apply tablet:px-4;
+
   /* Mimick command bar bottom border */
   border-bottom: 1px solid #edebe9;
 }
@@ -12,23 +16,42 @@
 .filterContainer {
   @apply flex items-center;
   @apply h-full;
-  @apply flex-1-0-auto;
+
+  @apply tablet:grid tablet:grid-cols-2 tablet:gap-4;
+  @apply tablet:h-auto tablet:w-full;
 }
 
 .searchBox {
-  @apply w-[300px] flex-none;
-  @apply mobile:w-full;
+  @apply w-[300px] flex-1-0-auto;
   @apply mx-4;
+
+  @apply tablet:w-full;
+  @apply tablet:col-span-2;
+  @apply tablet:mx-0;
 }
 
 .dateRangeFilter {
-  @apply h-full;
+  @apply h-full tablet:h-11;
 }
 
 .activityTypeFilter {
+  @apply h-full tablet:h-11;
+}
+
+.filterActionContainer {
   @apply h-full;
+  @apply flex items-center;
+  @apply flex-1-0-auto;
+
+  @apply tablet:h-auto;
+  @apply tablet:w-full;
+}
+
+.clearAllButtonContainer {
+  @apply h-full;
+  @apply flex-1-0-auto;
 }
 
 .clearAllButton {
-  @apply h-full;
+  @apply h-full tablet:h-11;
 }

--- a/portal/src/components/audit-log/AuditLogFilterBar.module.css
+++ b/portal/src/components/audit-log/AuditLogFilterBar.module.css
@@ -6,6 +6,12 @@
   @apply px-3.5;
 }
 
+.filterContainer {
+  @apply flex items-center;
+  @apply h-full;
+  @apply flex-1-0-auto;
+}
+
 .searchBox {
   @apply w-[300px] flex-none;
   @apply mobile:w-full;

--- a/portal/src/components/audit-log/AuditLogFilterBar.module.css
+++ b/portal/src/components/audit-log/AuditLogFilterBar.module.css
@@ -19,3 +19,7 @@
 .activityTypeFilter {
   @apply h-full;
 }
+
+.clearAllButton {
+  @apply h-full;
+}

--- a/portal/src/components/audit-log/AuditLogFilterBar.module.css
+++ b/portal/src/components/audit-log/AuditLogFilterBar.module.css
@@ -1,5 +1,5 @@
 .root {
-  @apply flex gap-4 items-center flex-wrap;
+  @apply flex items-center flex-wrap;
   @apply h-11;
 
   /* Align the first item with the screen title. */
@@ -9,6 +9,7 @@
 .searchBox {
   @apply w-[300px] flex-none;
   @apply mobile:w-full;
+  @apply mx-4;
 }
 
 .dateRangeFilter {

--- a/portal/src/components/audit-log/AuditLogFilterBar.module.css
+++ b/portal/src/components/audit-log/AuditLogFilterBar.module.css
@@ -1,5 +1,5 @@
 .root {
-  @apply flex flex-wrap;
+  @apply flex gap-4 items-center flex-wrap;
   /* imitate command bar height ref https://github.com/microsoft/fluentui/blob/master/packages/azure-themes/src/azure/styles/CommandBar.styles.ts#L14 */
   @apply h-9; 
 
@@ -10,4 +10,8 @@
 .searchBox {
   @apply w-[300px] flex-none;
   @apply mobile:w-full;
+}
+
+.dateRangeFilter {
+  @apply h-11;
 }

--- a/portal/src/components/audit-log/AuditLogFilterBar.module.css
+++ b/portal/src/components/audit-log/AuditLogFilterBar.module.css
@@ -1,0 +1,13 @@
+.root {
+  @apply flex flex-wrap;
+  /* imitate command bar height ref https://github.com/microsoft/fluentui/blob/master/packages/azure-themes/src/azure/styles/CommandBar.styles.ts#L14 */
+  @apply h-9; 
+
+  /* Align the first item with the screen title. */
+  @apply px-3.5;
+}
+
+.searchBox {
+  @apply w-[300px] flex-none;
+  @apply mobile:w-full;
+}

--- a/portal/src/components/audit-log/AuditLogFilterBar.module.css
+++ b/portal/src/components/audit-log/AuditLogFilterBar.module.css
@@ -1,7 +1,6 @@
 .root {
   @apply flex gap-4 items-center flex-wrap;
-  /* imitate command bar height ref https://github.com/microsoft/fluentui/blob/master/packages/azure-themes/src/azure/styles/CommandBar.styles.ts#L14 */
-  @apply h-9; 
+  @apply h-11;
 
   /* Align the first item with the screen title. */
   @apply px-3.5;
@@ -13,5 +12,9 @@
 }
 
 .dateRangeFilter {
-  @apply h-11;
+  @apply h-full;
+}
+
+.activityTypeFilter {
+  @apply h-full;
 }

--- a/portal/src/components/audit-log/AuditLogFilterBar.module.css
+++ b/portal/src/components/audit-log/AuditLogFilterBar.module.css
@@ -4,6 +4,9 @@
 
   /* Align the first item with the screen title. */
   @apply px-3.5;
+
+  /* Mimick command bar bottom border */
+  border-bottom: 1px solid #edebe9;
 }
 
 .filterContainer {

--- a/portal/src/components/audit-log/AuditLogFilterBar.tsx
+++ b/portal/src/components/audit-log/AuditLogFilterBar.tsx
@@ -1,0 +1,54 @@
+import React, { useCallback } from "react";
+import cn from "classnames";
+import styles from "./AuditLogFilterBar.module.css";
+import { ISearchBoxProps, SearchBox } from "@fluentui/react";
+
+export interface AuditLogFilter {
+  searchKeyword: string;
+  // TODO: add below
+  // dateRange: DateRangeDropdownOption | null;
+  // activityType: ActivityTypeDropdownOption | null;
+}
+
+interface AuditLogFilterBarProps {
+  className?: string;
+  filters: AuditLogFilter;
+  onFilterChange: (fn: (prevValue: AuditLogFilter) => AuditLogFilter) => void;
+  searchBoxProps?: ISearchBoxProps;
+}
+
+export const AuditLogFilterBar: React.VFC<AuditLogFilterBarProps> =
+  function AuditLogFilterBar({
+    className,
+    filters,
+    onFilterChange,
+    searchBoxProps,
+  }) {
+    const onChangeSearchKeyword = useCallback(
+      (e?: React.ChangeEvent<HTMLInputElement>) => {
+        if (e === undefined) {
+          return;
+        }
+        onFilterChange((prev) => ({
+          ...prev,
+          searchKeyword: e.currentTarget.value,
+        }));
+      },
+      [onFilterChange]
+    );
+    const onClearSearchKeyword = useCallback(() => {
+      onFilterChange((prev) => ({ ...prev, searchKeyword: "" }));
+    }, [onFilterChange]);
+
+    return (
+      <div className={cn(styles.root, className)}>
+        <SearchBox
+          className={styles.searchBox}
+          value={filters.searchKeyword}
+          onChange={onChangeSearchKeyword}
+          onClear={onClearSearchKeyword}
+          {...searchBoxProps}
+        />
+      </div>
+    );
+  };

--- a/portal/src/components/audit-log/AuditLogFilterBar.tsx
+++ b/portal/src/components/audit-log/AuditLogFilterBar.tsx
@@ -11,6 +11,7 @@ import {
   ActivityTypeFilterDropdownOptionKey,
 } from "./ActivityTypeFilterDropdown";
 import { AuditLogActivityType } from "../../graphql/adminapi/globalTypes.generated";
+import { ClearAllButton } from "./ClearAllButton";
 
 export interface AuditLogFilter {
   searchKeyword: string;
@@ -31,6 +32,7 @@ interface AuditLogFilterBarProps {
   className?: string;
   filters: AuditLogFilter;
   onFilterChange: (fn: (prevValue: AuditLogFilter) => AuditLogFilter) => void;
+  onRemoveAllFilters: () => void;
   searchBoxProps?: ISearchBoxProps;
   dateRange: AuditLogFilterBarPropsDateRange;
   availableActivityTypes: AuditLogActivityType[];
@@ -41,6 +43,7 @@ export const AuditLogFilterBar: React.VFC<AuditLogFilterBarProps> =
     className,
     filters,
     onFilterChange,
+    onRemoveAllFilters,
     searchBoxProps,
     dateRange,
     availableActivityTypes,
@@ -87,6 +90,10 @@ export const AuditLogFilterBar: React.VFC<AuditLogFilterBarProps> =
           onChange={onChangeSearchKeyword}
           onClear={onClearSearchKeyword}
           {...searchBoxProps}
+        />
+        <ClearAllButton
+          className={styles.clearAllButton}
+          onClick={onRemoveAllFilters}
         />
       </div>
     );

--- a/portal/src/components/audit-log/AuditLogFilterBar.tsx
+++ b/portal/src/components/audit-log/AuditLogFilterBar.tsx
@@ -12,6 +12,7 @@ import {
 } from "./ActivityTypeFilterDropdown";
 import { AuditLogActivityType } from "../../graphql/adminapi/globalTypes.generated";
 import { ClearAllButton } from "./ClearAllButton";
+import { RefreshButton } from "./RefreshButton";
 
 export interface AuditLogFilter {
   searchKeyword: string;
@@ -33,9 +34,11 @@ interface AuditLogFilterBarProps {
   filters: AuditLogFilter;
   onFilterChange: (fn: (prevValue: AuditLogFilter) => AuditLogFilter) => void;
   onRemoveAllFilters: () => void;
+  onRefresh: () => void;
   searchBoxProps?: ISearchBoxProps;
   dateRange: AuditLogFilterBarPropsDateRange;
   availableActivityTypes: AuditLogActivityType[];
+  lastUpdatedAt: Date;
 }
 
 export const AuditLogFilterBar: React.VFC<AuditLogFilterBarProps> =
@@ -44,9 +47,11 @@ export const AuditLogFilterBar: React.VFC<AuditLogFilterBarProps> =
     filters,
     onFilterChange,
     onRemoveAllFilters,
+    onRefresh,
     searchBoxProps,
     dateRange,
     availableActivityTypes,
+    lastUpdatedAt,
   }) {
     const onChangeSearchKeyword = useCallback(
       (e?: React.ChangeEvent<HTMLInputElement>) => {
@@ -72,29 +77,33 @@ export const AuditLogFilterBar: React.VFC<AuditLogFilterBarProps> =
 
     return (
       <div className={cn(styles.root, className)}>
-        <DateRangeFilterDropdown
-          className={styles.dateRangeFilter}
-          value={dateRange.value}
-          onClickAllDateRange={dateRange.onClickAllDateRange}
-          onClickCustomDateRange={dateRange.onClickCustomDateRange}
-        />
-        <ActivityTypeFilterDropdown
-          className={styles.activityTypeFilter}
-          value={filters.activityType}
-          onChange={onChangeActivityType}
-          availableActivityTypes={availableActivityTypes}
-        />
-        <SearchBox
-          className={styles.searchBox}
-          value={filters.searchKeyword}
-          onChange={onChangeSearchKeyword}
-          onClear={onClearSearchKeyword}
-          {...searchBoxProps}
-        />
-        <ClearAllButton
-          className={styles.clearAllButton}
-          onClick={onRemoveAllFilters}
-        />
+        <div className={styles.filterContainer}>
+          <DateRangeFilterDropdown
+            className={styles.dateRangeFilter}
+            value={dateRange.value}
+            onClickAllDateRange={dateRange.onClickAllDateRange}
+            onClickCustomDateRange={dateRange.onClickCustomDateRange}
+          />
+          <ActivityTypeFilterDropdown
+            className={styles.activityTypeFilter}
+            value={filters.activityType}
+            onChange={onChangeActivityType}
+            availableActivityTypes={availableActivityTypes}
+          />
+          <SearchBox
+            className={styles.searchBox}
+            value={filters.searchKeyword}
+            onChange={onChangeSearchKeyword}
+            onClear={onClearSearchKeyword}
+            {...searchBoxProps}
+          />
+          <ClearAllButton
+            className={styles.clearAllButton}
+            onClick={onRemoveAllFilters}
+          />
+        </div>
+
+        <RefreshButton onClick={onRefresh} lastUpdatedAt={lastUpdatedAt} />
       </div>
     );
   };

--- a/portal/src/components/audit-log/AuditLogFilterBar.tsx
+++ b/portal/src/components/audit-log/AuditLogFilterBar.tsx
@@ -97,13 +97,16 @@ export const AuditLogFilterBar: React.VFC<AuditLogFilterBarProps> =
             onClear={onClearSearchKeyword}
             {...searchBoxProps}
           />
-          <ClearAllButton
-            className={styles.clearAllButton}
-            onClick={onRemoveAllFilters}
-          />
         </div>
-
-        <RefreshButton onClick={onRefresh} lastUpdatedAt={lastUpdatedAt} />
+        <div className={styles.filterActionContainer}>
+          <div className={styles.clearAllButtonContainer}>
+            <ClearAllButton
+              className={styles.clearAllButton}
+              onClick={onRemoveAllFilters}
+            />
+          </div>
+          <RefreshButton onClick={onRefresh} lastUpdatedAt={lastUpdatedAt} />
+        </div>
       </div>
     );
   };

--- a/portal/src/components/audit-log/AuditLogFilterBar.tsx
+++ b/portal/src/components/audit-log/AuditLogFilterBar.tsx
@@ -6,14 +6,18 @@ import {
   DateRangeFilterDropdown,
   DateRangeFilterDropdownOptionKey,
 } from "./DateRangeFilterDropdown";
+import {
+  ActivityTypeFilterDropdown,
+  ActivityTypeFilterDropdownOptionKey,
+} from "./ActivityTypeFilterDropdown";
+import { AuditLogActivityType } from "../../graphql/adminapi/globalTypes.generated";
 
 export interface AuditLogFilter {
   searchKeyword: string;
-  // TODO: add below
-  // activityType: ActivityTypeDropdownOption | null;
+  activityType: ActivityTypeFilterDropdownOptionKey;
 }
 
-interface AuditLogFilterBarPropsDateRange {
+export interface AuditLogFilterBarPropsDateRange {
   value: DateRangeFilterDropdownOptionKey;
   onClickAllDateRange: (
     e?: React.MouseEvent<unknown> | React.KeyboardEvent<unknown>
@@ -29,6 +33,7 @@ interface AuditLogFilterBarProps {
   onFilterChange: (fn: (prevValue: AuditLogFilter) => AuditLogFilter) => void;
   searchBoxProps?: ISearchBoxProps;
   dateRange: AuditLogFilterBarPropsDateRange;
+  availableActivityTypes: AuditLogActivityType[];
 }
 
 export const AuditLogFilterBar: React.VFC<AuditLogFilterBarProps> =
@@ -38,6 +43,7 @@ export const AuditLogFilterBar: React.VFC<AuditLogFilterBarProps> =
     onFilterChange,
     searchBoxProps,
     dateRange,
+    availableActivityTypes,
   }) {
     const onChangeSearchKeyword = useCallback(
       (e?: React.ChangeEvent<HTMLInputElement>) => {
@@ -48,6 +54,12 @@ export const AuditLogFilterBar: React.VFC<AuditLogFilterBarProps> =
           ...prev,
           searchKeyword: e.currentTarget.value,
         }));
+      },
+      [onFilterChange]
+    );
+    const onChangeActivityType = useCallback(
+      (newAT: ActivityTypeFilterDropdownOptionKey) => {
+        onFilterChange((prev) => ({ ...prev, activityType: newAT }));
       },
       [onFilterChange]
     );
@@ -62,6 +74,12 @@ export const AuditLogFilterBar: React.VFC<AuditLogFilterBarProps> =
           value={dateRange.value}
           onClickAllDateRange={dateRange.onClickAllDateRange}
           onClickCustomDateRange={dateRange.onClickCustomDateRange}
+        />
+        <ActivityTypeFilterDropdown
+          className={styles.activityTypeFilter}
+          value={filters.activityType}
+          onChange={onChangeActivityType}
+          availableActivityTypes={availableActivityTypes}
         />
         <SearchBox
           className={styles.searchBox}

--- a/portal/src/components/audit-log/AuditLogFilterBar.tsx
+++ b/portal/src/components/audit-log/AuditLogFilterBar.tsx
@@ -2,12 +2,25 @@ import React, { useCallback } from "react";
 import cn from "classnames";
 import styles from "./AuditLogFilterBar.module.css";
 import { ISearchBoxProps, SearchBox } from "@fluentui/react";
+import {
+  DateRangeFilterDropdown,
+  DateRangeFilterDropdownOptionKey,
+} from "./DateRangeFilterDropdown";
 
 export interface AuditLogFilter {
   searchKeyword: string;
   // TODO: add below
-  // dateRange: DateRangeDropdownOption | null;
   // activityType: ActivityTypeDropdownOption | null;
+}
+
+interface AuditLogFilterBarPropsDateRange {
+  value: DateRangeFilterDropdownOptionKey;
+  onClickAllDateRange: (
+    e?: React.MouseEvent<unknown> | React.KeyboardEvent<unknown>
+  ) => void;
+  onClickCustomDateRange: (
+    e?: React.MouseEvent<unknown> | React.KeyboardEvent<unknown>
+  ) => void;
 }
 
 interface AuditLogFilterBarProps {
@@ -15,6 +28,7 @@ interface AuditLogFilterBarProps {
   filters: AuditLogFilter;
   onFilterChange: (fn: (prevValue: AuditLogFilter) => AuditLogFilter) => void;
   searchBoxProps?: ISearchBoxProps;
+  dateRange: AuditLogFilterBarPropsDateRange;
 }
 
 export const AuditLogFilterBar: React.VFC<AuditLogFilterBarProps> =
@@ -23,6 +37,7 @@ export const AuditLogFilterBar: React.VFC<AuditLogFilterBarProps> =
     filters,
     onFilterChange,
     searchBoxProps,
+    dateRange,
   }) {
     const onChangeSearchKeyword = useCallback(
       (e?: React.ChangeEvent<HTMLInputElement>) => {
@@ -42,6 +57,12 @@ export const AuditLogFilterBar: React.VFC<AuditLogFilterBarProps> =
 
     return (
       <div className={cn(styles.root, className)}>
+        <DateRangeFilterDropdown
+          className={styles.dateRangeFilter}
+          value={dateRange.value}
+          onClickAllDateRange={dateRange.onClickAllDateRange}
+          onClickCustomDateRange={dateRange.onClickCustomDateRange}
+        />
         <SearchBox
           className={styles.searchBox}
           value={filters.searchKeyword}

--- a/portal/src/components/audit-log/ClearAllButton.tsx
+++ b/portal/src/components/audit-log/ClearAllButton.tsx
@@ -1,0 +1,24 @@
+import React, { useContext } from "react";
+import { Context as MessageContext } from "@oursky/react-messageformat";
+import CommandBarButton from "../../CommandBarButton";
+
+interface ClearAllButtonProps {
+  className?: string;
+  onClick: () => void;
+}
+
+export const ClearAllButton: React.VFC<ClearAllButtonProps> =
+  function ClearAllButton({ className, onClick }: ClearAllButtonProps) {
+    const { renderToString } = useContext(MessageContext);
+
+    return (
+      <CommandBarButton
+        className={className}
+        key="clear"
+        iconProps={{ iconName: "" }}
+        onClick={onClick}
+        text={renderToString("AuditLogScreen.clear-all-filters")}
+        styles={{ root: { color: "rgba(89, 86, 83, 0.4)" } }}
+      />
+    );
+  };

--- a/portal/src/components/audit-log/DateRangeFilterDropdown.tsx
+++ b/portal/src/components/audit-log/DateRangeFilterDropdown.tsx
@@ -1,0 +1,73 @@
+import React, { useContext, useMemo } from "react";
+import { Context as MessageContext } from "@oursky/react-messageformat";
+import { IContextualMenuProps } from "@fluentui/react";
+import CommandBarButton from "../../CommandBarButton";
+
+export type DateRangeFilterDropdownOptionKey =
+  | "allDateRange"
+  | "customDateRange";
+
+interface DateRangeFilterDropdownProps {
+  className?: string;
+  value: DateRangeFilterDropdownOptionKey;
+  onClickAllDateRange: (
+    e?: React.MouseEvent<unknown> | React.KeyboardEvent<unknown>
+  ) => void;
+  onClickCustomDateRange: (
+    e?: React.MouseEvent<unknown> | React.KeyboardEvent<unknown>
+  ) => void;
+}
+
+export const DateRangeFilterDropdown: React.VFC<DateRangeFilterDropdownProps> =
+  function DateRangeFilterDropdown({
+    className,
+    value,
+    onClickAllDateRange,
+    onClickCustomDateRange,
+  }: DateRangeFilterDropdownProps) {
+    const { renderToString } = useContext(MessageContext);
+    const allDateRangeLabel = renderToString("AuditLogScreen.date-range.all");
+    const customDateRangeLabel = renderToString(
+      "AuditLogScreen.date-range.custom"
+    );
+
+    const placeholder = useMemo(() => {
+      if (value === "customDateRange") {
+        return renderToString("AuditLogScreen.date-range.custom");
+      }
+
+      return renderToString("AuditLogScreen.date-range.all");
+    }, [renderToString, value]);
+
+    const menuProps = useMemo<IContextualMenuProps>(() => {
+      return {
+        items: [
+          {
+            key: "allDateRange",
+            text: allDateRangeLabel,
+            onClick: onClickAllDateRange,
+          },
+          {
+            key: "customDateRange",
+            text: customDateRangeLabel,
+            onClick: onClickCustomDateRange,
+          },
+        ],
+      };
+    }, [
+      allDateRangeLabel,
+      customDateRangeLabel,
+      onClickAllDateRange,
+      onClickCustomDateRange,
+    ]);
+
+    return (
+      <CommandBarButton
+        className={className}
+        key="dateRange"
+        iconProps={{ iconName: "Calendar" }}
+        menuProps={menuProps}
+        text={placeholder}
+      />
+    );
+  };

--- a/portal/src/components/audit-log/DateRangeFilterDropdown.tsx
+++ b/portal/src/components/audit-log/DateRangeFilterDropdown.tsx
@@ -1,7 +1,12 @@
-import React, { useContext, useMemo } from "react";
+import React, { useCallback, useContext, useMemo } from "react";
 import { Context as MessageContext } from "@oursky/react-messageformat";
-import { IContextualMenuProps } from "@fluentui/react";
+import {
+  Dropdown,
+  IContextualMenuProps,
+  IDropdownOption,
+} from "@fluentui/react";
 import CommandBarButton from "../../CommandBarButton";
+import { useScreenBreakpoint } from "../../hook/useScreenBreakpoint";
 
 export type DateRangeFilterDropdownOptionKey =
   | "allDateRange"
@@ -18,8 +23,8 @@ interface DateRangeFilterDropdownProps {
   ) => void;
 }
 
-export const DateRangeFilterDropdown: React.VFC<DateRangeFilterDropdownProps> =
-  function DateRangeFilterDropdown({
+const DesktopDateRangeFilterDropdown: React.VFC<DateRangeFilterDropdownProps> =
+  function DesktopDateRangeFilterDropdown({
     className,
     value,
     onClickAllDateRange,
@@ -70,4 +75,72 @@ export const DateRangeFilterDropdown: React.VFC<DateRangeFilterDropdownProps> =
         text={placeholder}
       />
     );
+  };
+
+const MobileDateRangeFilterDropdown: React.VFC<DateRangeFilterDropdownProps> =
+  function MobileDateRangeFilterDropdown({
+    className,
+    value,
+    onClickAllDateRange,
+    onClickCustomDateRange,
+  }: DateRangeFilterDropdownProps) {
+    const { renderToString } = useContext(MessageContext);
+    const allDateRangeLabel = renderToString("AuditLogScreen.date-range.all");
+    const customDateRangeLabel = renderToString(
+      "AuditLogScreen.date-range.custom"
+    );
+    const options = useMemo<IDropdownOption[]>(() => {
+      return [
+        {
+          key: "allDateRange",
+          text: allDateRangeLabel,
+        },
+        {
+          key: "customDateRange",
+          text: customDateRangeLabel,
+        },
+      ];
+    }, [allDateRangeLabel, customDateRangeLabel]);
+
+    const onChangeOption = useCallback(
+      (_e: unknown, option?: IDropdownOption) => {
+        if (option == null) {
+          return;
+        }
+        switch (option.key) {
+          case "allDateRange":
+            onClickAllDateRange();
+            break;
+          case "customDateRange":
+            onClickCustomDateRange();
+            break;
+          default:
+            console.error("Unexpected option key: ", option.key);
+            break;
+        }
+      },
+      [onClickAllDateRange, onClickCustomDateRange]
+    );
+
+    return (
+      <Dropdown
+        className={className}
+        selectedKey={value}
+        options={options}
+        onChange={onChangeOption}
+      />
+    );
+  };
+
+export const DateRangeFilterDropdown: React.VFC<DateRangeFilterDropdownProps> =
+  function DateRangeFilterDropdown(props: DateRangeFilterDropdownProps) {
+    const screenBreakpoint = useScreenBreakpoint();
+    switch (screenBreakpoint) {
+      case "desktop": {
+        return <DesktopDateRangeFilterDropdown {...props} />;
+      }
+      case "tablet":
+      case "mobile":
+        return <MobileDateRangeFilterDropdown {...props} />;
+    }
   };

--- a/portal/src/components/audit-log/RefreshButton.tsx
+++ b/portal/src/components/audit-log/RefreshButton.tsx
@@ -22,7 +22,10 @@ export const RefreshButton: React.VFC<RefreshButtonProps> =
         display: "flex",
         padding: "auto",
         height: "100%",
-        justifySelf: "flex-end",
+        // mobile
+        "@media(max-width: 640px)": {
+          height: "2.75rem", // 44px
+        },
       },
     };
     const tooltipId = useId("refreshTooltip");

--- a/portal/src/components/audit-log/RefreshButton.tsx
+++ b/portal/src/components/audit-log/RefreshButton.tsx
@@ -1,0 +1,68 @@
+import React, { useContext, useMemo } from "react";
+import { Context as MessageContext } from "@oursky/react-messageformat";
+import CommandBarButton from "../../CommandBarButton";
+import {
+  DirectionalHint,
+  ITooltipHostStyles,
+  ITooltipProps,
+  TooltipHost,
+} from "@fluentui/react";
+import { useId } from "@fluentui/react-hooks";
+import { DateTime } from "luxon";
+
+interface RefreshButtonProps {
+  onClick: () => void;
+  lastUpdatedAt: Date;
+}
+
+export const RefreshButton: React.VFC<RefreshButtonProps> =
+  function RefreshButton({ onClick, lastUpdatedAt }: RefreshButtonProps) {
+    const tooltipStyle: Partial<ITooltipHostStyles> = {
+      root: {
+        display: "flex",
+        padding: "auto",
+        height: "100%",
+        justifySelf: "flex-end",
+      },
+    };
+    const tooltipId = useId("refreshTooltip");
+    const tooltipCalloutProps = {
+      gapSpace: 0,
+    };
+
+    const { renderToString, locale } = useContext(MessageContext);
+
+    const tooltipProps: ITooltipProps = useMemo(() => {
+      return {
+        // eslint-disable-next-line react/no-unstable-nested-components
+        onRenderContent: () => {
+          const tooltipcontent = renderToString(
+            "AuditLogScreen.last-update-at",
+            {
+              datetime: DateTime.fromJSDate(lastUpdatedAt).toRelative({
+                locale,
+              }),
+            }
+          );
+          return <>{tooltipcontent}</>;
+        },
+      };
+    }, [lastUpdatedAt, locale, renderToString]);
+
+    return (
+      <TooltipHost
+        styles={tooltipStyle}
+        id={tooltipId}
+        calloutProps={tooltipCalloutProps}
+        directionalHint={DirectionalHint.bottomCenter}
+        tooltipProps={tooltipProps}
+      >
+        <CommandBarButton
+          key="refresh"
+          text={renderToString("AuditLogScreen.refresh")}
+          iconProps={{ iconName: "Sync" }}
+          onClick={onClick}
+        />
+      </TooltipHost>
+    );
+  };

--- a/portal/src/graphql/adminapi/AuditLogScreen.module.css
+++ b/portal/src/graphql/adminapi/AuditLogScreen.module.css
@@ -28,12 +28,6 @@
   padding-top: 16px;
 }
 
-.searchBox {
-  width: 300px;
-  align-self: center;
-  margin: 0 16px;
-}
-
 .list {
   flex: 1 1 0px;
 }

--- a/portal/src/graphql/adminapi/AuditLogScreen.tsx
+++ b/portal/src/graphql/adminapi/AuditLogScreen.tsx
@@ -10,18 +10,7 @@ import {
   useSearchParams,
   URLSearchParamsInit,
 } from "react-router-dom";
-import {
-  ICommandBarItemProps,
-  addDays,
-  TooltipHost,
-  ITooltipHostStyles,
-  ITooltipProps,
-  DirectionalHint,
-  Pivot,
-  PivotItem,
-  ISearchBoxProps,
-} from "@fluentui/react";
-import { useId } from "@fluentui/react-hooks";
+import { addDays, Pivot, PivotItem, ISearchBoxProps } from "@fluentui/react";
 import { FormattedMessage, Context } from "@oursky/react-messageformat";
 import { useQuery } from "@apollo/client";
 import { DateTime } from "luxon";
@@ -41,7 +30,6 @@ import { AuditLogActivityType, SortDirection } from "./globalTypes.generated";
 import styles from "./AuditLogScreen.module.css";
 import { useAppFeatureConfigQuery } from "../portal/query/appFeatureConfigQuery";
 import FeatureDisabledMessageBar from "../portal/FeatureDisabledMessageBar";
-import CommandBarButton from "../../CommandBarButton";
 import { useDebounced } from "../../hook/useDebounced";
 import { toTypedID } from "../../util/graphql";
 import { NodeType } from "./node";
@@ -74,45 +62,6 @@ enum AuditLogKind {
 }
 function isAuditLogKind(s: string): s is AuditLogKind {
   return Object.values(AuditLogKind).includes(s as AuditLogKind);
-}
-
-function _RefreshButton(props: ICommandBarItemProps) {
-  const tooltipStyle: Partial<ITooltipHostStyles> = {
-    root: { display: "inline-block" },
-  };
-  const tooltipId = useId("refreshTooltip");
-  const tooltipCalloutProps = {
-    gapSpace: 0,
-  };
-
-  const { renderToString, locale } = useContext(Context);
-
-  const tooltipProps: ITooltipProps = useMemo(() => {
-    return {
-      // eslint-disable-next-line react/no-unstable-nested-components
-      onRenderContent: () => {
-        const tooltipcontent = renderToString("AuditLogScreen.last-update-at", {
-          datetime: DateTime.fromJSDate(props.lastUpdatedAt).toRelative({
-            locale,
-          }),
-        });
-        return <>{tooltipcontent}</>;
-      },
-    };
-  }, [locale, props.lastUpdatedAt, renderToString]);
-
-  return (
-    <TooltipHost
-      styles={tooltipStyle}
-      id={tooltipId}
-      calloutProps={tooltipCalloutProps}
-      directionalHint={DirectionalHint.bottomCenter}
-      tooltipProps={tooltipProps}
-    >
-      {/* @ts-expect-error */}
-      <CommandBarButton {...props} />
-    </TooltipHost>
-  );
 }
 
 // eslint-disable-next-line complexity
@@ -501,7 +450,7 @@ const AuditLogScreen: React.VFC = function AuditLogScreen() {
     }));
   }, [onFilterChange, setRangeFromImmediately, setRangeToImmediately]);
 
-  const _onClickRefresh = useCallback(
+  const onClickRefresh = useCallback(
     (e?: React.MouseEvent<unknown> | React.KeyboardEvent<unknown>) => {
       e?.stopPropagation();
       setLastUpdatedAt(new Date());
@@ -636,6 +585,8 @@ const AuditLogScreen: React.VFC = function AuditLogScreen() {
           dateRange={filtersDateRange}
           availableActivityTypes={availableActivityTypes}
           onRemoveAllFilters={onRemoveAllFilters}
+          onRefresh={onClickRefresh}
+          lastUpdatedAt={lastUpdatedAt}
         />
         <div className={styles.listContainer}>
           <CommandBarContainer

--- a/portal/src/graphql/adminapi/AuditLogScreen.tsx
+++ b/portal/src/graphql/adminapi/AuditLogScreen.tsx
@@ -491,6 +491,16 @@ const AuditLogScreen: React.VFC = function AuditLogScreen() {
     [filters]
   );
 
+  const onRemoveAllFilters = useCallback(() => {
+    setOffset(0);
+    setRangeFromImmediately(null);
+    setRangeToImmediately(null);
+    onFilterChange(() => ({
+      searchKeyword: "",
+      activityType: ACTIVITY_TYPE_ALL,
+    }));
+  }, [onFilterChange, setRangeFromImmediately, setRangeToImmediately]);
+
   const _onClickRefresh = useCallback(
     (e?: React.MouseEvent<unknown> | React.KeyboardEvent<unknown>) => {
       e?.stopPropagation();
@@ -625,6 +635,7 @@ const AuditLogScreen: React.VFC = function AuditLogScreen() {
           searchBoxProps={searchBoxProps}
           dateRange={filtersDateRange}
           availableActivityTypes={availableActivityTypes}
+          onRemoveAllFilters={onRemoveAllFilters}
         />
         <div className={styles.listContainer}>
           <CommandBarContainer

--- a/portal/src/graphql/adminapi/AuditLogScreen.tsx
+++ b/portal/src/graphql/adminapi/AuditLogScreen.tsx
@@ -51,6 +51,7 @@ import { parsePhoneNumber } from "../../util/phone";
 import {
   AuditLogFilter,
   AuditLogFilterBar,
+  AuditLogFilterBarPropsDateRange,
 } from "../../components/audit-log/AuditLogFilterBar";
 
 const pageSize = 100;
@@ -158,7 +159,6 @@ const AuditLogScreen: React.VFC = function AuditLogScreen() {
 
   const [filters, setFilters] = useState<AuditLogFilter>({
     searchKeyword: "",
-    // dateRange: ...,
     // activityType: ...,
   });
 
@@ -228,7 +228,32 @@ const AuditLogScreen: React.VFC = function AuditLogScreen() {
     return lastUpdatedAt.toISOString();
   }, [rangeTo, lastUpdatedAt]);
 
-  const _isCustomDateRange = rangeFrom != null || rangeTo != null;
+  const isCustomDateRange = rangeFrom != null || rangeTo != null;
+
+  const onClickAllDateRange = useCallback(
+    (e?: React.MouseEvent<unknown> | React.KeyboardEvent<unknown>) => {
+      e?.stopPropagation();
+      setRangeFromImmediately(null);
+      setRangeToImmediately(null);
+    },
+    [setRangeFromImmediately, setRangeToImmediately]
+  );
+
+  const onClickCustomDateRange = useCallback(
+    (e?: React.MouseEvent<unknown> | React.KeyboardEvent<unknown>) => {
+      e?.stopPropagation();
+      setDateRangeDialogHidden(false);
+    },
+    []
+  );
+
+  const filtersDateRange = useMemo<AuditLogFilterBarPropsDateRange>(() => {
+    return {
+      value: isCustomDateRange ? "customDateRange" : "allDateRange",
+      onClickAllDateRange,
+      onClickCustomDateRange,
+    };
+  }, [isCustomDateRange, onClickAllDateRange, onClickCustomDateRange]);
 
   const availableActivityTypes = useMemo(() => {
     return activityKind === "admin"
@@ -480,23 +505,6 @@ const AuditLogScreen: React.VFC = function AuditLogScreen() {
     []
   );
 
-  const _onClickAllDateRange = useCallback(
-    (e?: React.MouseEvent<unknown> | React.KeyboardEvent<unknown>) => {
-      e?.stopPropagation();
-      setRangeFromImmediately(null);
-      setRangeToImmediately(null);
-    },
-    [setRangeFromImmediately, setRangeToImmediately]
-  );
-
-  const _onClickCustomDateRange = useCallback(
-    (e?: React.MouseEvent<unknown> | React.KeyboardEvent<unknown>) => {
-      e?.stopPropagation();
-      setDateRangeDialogHidden(false);
-    },
-    []
-  );
-
   const _onClickRefresh = useCallback(
     (e?: React.MouseEvent<unknown> | React.KeyboardEvent<unknown>) => {
       e?.stopPropagation();
@@ -629,6 +637,7 @@ const AuditLogScreen: React.VFC = function AuditLogScreen() {
           filters={filters}
           onFilterChange={setFilters}
           searchBoxProps={searchBoxProps}
+          dateRange={filtersDateRange}
         />
         <div className={styles.listContainer}>
           <CommandBarContainer

--- a/portal/src/graphql/adminapi/AuditLogScreen.tsx
+++ b/portal/src/graphql/adminapi/AuditLogScreen.tsx
@@ -275,6 +275,11 @@ const AuditLogScreen: React.VFC = function AuditLogScreen() {
 
   const [debouncedSearchQuery] = useDebounced(filters.searchKeyword, 300);
 
+  // Reset page to zero on search
+  useEffect(() => {
+    setOffset(0);
+  }, [debouncedSearchQuery]);
+
   const { renderToString } = useContext(Context);
 
   // When the page is refreshed, and it is on the first page,

--- a/portal/src/hook/useScreenBreakpoint.ts
+++ b/portal/src/hook/useScreenBreakpoint.ts
@@ -1,0 +1,14 @@
+import { useWindowSize } from "./useWindowSize";
+
+export type ScreenBreakpoint = "mobile" | "tablet" | "desktop";
+
+export function useScreenBreakpoint(): ScreenBreakpoint {
+  const { width } = useWindowSize();
+  // This should corresponds to tailwind.config.js
+  if (width <= 640) {
+    return "mobile";
+  } else if (width <= 1080) {
+    return "tablet";
+  }
+  return "desktop";
+}

--- a/portal/src/hook/useWindowSize.ts
+++ b/portal/src/hook/useWindowSize.ts
@@ -1,0 +1,33 @@
+import { useEffect, useState } from "react";
+
+interface WindowSize {
+  width: number;
+  height: number;
+}
+
+// https://usehooks.com/useWindowSize/
+export function useWindowSize(): WindowSize {
+  // Initialize state with undefined width/height so server and client renders match
+  // Learn more here: https://joshwcomeau.com/react/the-perils-of-rehydration/
+  const [windowSize, setWindowSize] = useState<WindowSize>({
+    width: 0,
+    height: 0,
+  });
+  useEffect(() => {
+    // Handler to call on window resize
+    function handleResize() {
+      // Set window width/height to state
+      setWindowSize({
+        width: window.innerWidth,
+        height: window.innerHeight,
+      });
+    }
+    // Add event listener
+    window.addEventListener("resize", handleResize);
+    // Call handler right away so state gets updated with initial window size
+    handleResize();
+    // Remove event listener on cleanup
+    return () => window.removeEventListener("resize", handleResize);
+  }, []); // Empty array ensures that effect is only run on mount
+  return windowSize;
+}


### PR DESCRIPTION
ref DEV-1462

## What's in this PR?
- Replace existing command bar as custom filter bar
- In mobile, render dropdown instead of command bar button with submenu items
- searchable dropdown for activity type

## Preview 1 - mobile layout in firefox responsive
https://github.com/user-attachments/assets/e003481e-dbce-4668-beb4-511958ed92b1


## Preview 2 - mobile layout in ios safri 
~Pending because xcode have problem on my machine :(~

https://github.com/user-attachments/assets/c72688a8-c5e1-47f2-8c7c-eac243fc254b



## Preview 3 - desktop UI unchanged

https://github.com/user-attachments/assets/64d970c8-1847-40a5-9a97-bc0de5de6c2b


