### PR TITLE
Slightly optimize performance of translation key linter `is defined` logic

### DIFF
--- a/devtools/gotemplatelinter/translation_key_rule_check_translation_key.go
+++ b/devtools/gotemplatelinter/translation_key_rule_check_translation_key.go
@@ -3,7 +3,7 @@ package main
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"regexp"
 	"strings"
 	"text/template/parse"
@@ -68,7 +68,7 @@ func isTranslationKeyDefined(targetKey string) bool {
 }
 
 func getEnJSONTranslationKeys() []string {
-	bytes, err := ioutil.ReadFile(enTranslationJSONPath)
+	bytes, err := os.ReadFile(enTranslationJSONPath)
 	if err != nil {
 		panic(fmt.Errorf("failed to read %v: %w", enTranslationJSONPath, err))
 	}

--- a/devtools/gotemplatelinter/translation_key_rule_check_translation_key.go
+++ b/devtools/gotemplatelinter/translation_key_rule_check_translation_key.go
@@ -17,7 +17,7 @@ const enTranslationJSONPath = "resources/authgear/templates/en/translation.json"
 
 var validKey *regexp.Regexp
 var validErrKey *regexp.Regexp
-var translationKeys []string
+var translationKeys map[string]struct{}
 
 func init() {
 	validKey = regexp.MustCompile(TranslationKeyPattern)
@@ -59,15 +59,11 @@ func CheckTranslationKeyPattern(translationKey string) (err error) {
 }
 
 func isTranslationKeyDefined(targetKey string) bool {
-	for _, key := range translationKeys {
-		if key == targetKey {
-			return true
-		}
-	}
-	return false
+	_, ok := translationKeys[targetKey]
+	return ok
 }
 
-func getEnJSONTranslationKeys() []string {
+func getEnJSONTranslationKeys() map[string]struct{} {
 	bytes, err := os.ReadFile(enTranslationJSONPath)
 	if err != nil {
 		panic(fmt.Errorf("failed to read %v: %w", enTranslationJSONPath, err))
@@ -80,11 +76,9 @@ func getEnJSONTranslationKeys() []string {
 		panic(fmt.Errorf("failed to unmarshal %v: %w", enTranslationJSONPath, err))
 	}
 
-	keys := make([]string, len(translationData))
-	i := 0
+	keys := make(map[string]struct{})
 	for key := range translationData {
-		keys[i] = key
-		i++
+		keys[key] = struct{}{}
 	}
 	return keys
 


### PR DESCRIPTION
Use set over list. `find` time complexity became O(1)