### PR TITLE
Fix incorrect error checking in user import

### DIFF
--- a/pkg/lib/userimport/service.go
+++ b/pkg/lib/userimport/service.go
@@ -1160,7 +1160,7 @@ func (s *UserImportService) upsertDisabledInTxn(ctx context.Context, detail *Det
 		var accountStatus *user.AccountStatus
 		// Treat invalid account status transition as warning.
 		accountStatus, accountStatusErr := u.AccountStatus().Reenable()
-		if err != accountStatusErr {
+		if accountStatusErr != nil {
 			detail.Warnings = append(detail.Warnings, Warning{
 				Message: accountStatusErr.Error(),
 			})


### PR DESCRIPTION
As `err` is always `nil` when executing this code, effectively it is having the same logic before the fix. But this looks like a mistake.