### PR TITLE
Remove non-existing $.HasUnknownError in wechat.html

### DIFF
--- a/resources/authgear/templates/en/web/authflowv2/wechat.html
+++ b/resources/authgear/templates/en/web/authflowv2/wechat.html
@@ -1,10 +1,6 @@
 {{ template "authflowv2/__page_frame.html" . }}
 
 {{ define "page-content" }}
-{{ $unknown_error_message := "" }}
-{{ if $.HasUnknownError }}
-  {{ $unknown_error_message = (include "authflowv2/__error.html" .) }}
-{{ end }}
 
 {{ if $.IsNativePlatform }}
 {{ if $.WechatRedirectURI }}
@@ -21,7 +17,7 @@
       (dict
         "Type" "error"
         "Classname" "mt-4"
-        "Message" $unknown_error_message
+        "Message" (include "authflowv2/__error.html" .)
       )
     }}
   </header>


### PR DESCRIPTION
Found this weird behavior when working on PR #4705 

- `wechat.html` is referencing `$.HasUnknownError`
- If you do a global search `HasUnknownError`, it is only returned by SSR in password pages and ldap_login
   - [`wechat.go`](https://github.com/authgear/authgear-server/blob/main/pkg/auth/handler/webapp/authflowv2/wechat.go#L54-L55) only use [base view model, which does not have HasUnknownError](https://github.com/authgear/authgear-server/blob/main/pkg/auth/handler/webapp/viewmodels/base.go)
   - i.e. `$.HasUnknownError` is always nil in`wechat.html`

Not sure if expected, maybe need to introduce back the wechat unknown error somehow?