### PR TITLE
Change all `template "v2.___"` and `.Translations.RenderText` into `include`

### DIFF
--- a/.make-lint-translation-keys-expect
+++ b/.make-lint-translation-keys-expect
@@ -1,38 +1,38 @@
-resources/authgear/templates/en/web/authflowv2/__base_page_frame.html:43:12: translation key not defined: "page-frame-content"
+resources/authgear/templates/en/web/authflowv2/__base_page_frame.html:43:12: template translation is forbidden: `page-frame-content`
 resources/authgear/templates/en/web/authflowv2/__bot_protection_dialog.html:5:27: translation key not defined: "dialog-controller-str"
 resources/authgear/templates/en/web/authflowv2/__bot_protection_dialog.html:6:21: translation key not defined: "dialog-content"
-resources/authgear/templates/en/web/authflowv2/__bot_protection_dialog.html:19:14: translation key not defined: "dialog-close-btn"
+resources/authgear/templates/en/web/authflowv2/__bot_protection_dialog.html:19:14: template translation is forbidden: `dialog-close-btn`
 resources/authgear/templates/en/web/authflowv2/__country_input.html:6:16: invalid translation key: "$labelKey"
 resources/authgear/templates/en/web/authflowv2/__country_input.html:10:21: translation key not defined: "%s %s"
-resources/authgear/templates/en/web/authflowv2/__csrf_error_page_layout.html:28:18: translation key not defined: "page-content"
-resources/authgear/templates/en/web/authflowv2/__dialog.html:27:14: translation key not defined: "dialog-attr"
-resources/authgear/templates/en/web/authflowv2/__error.html:134:18: translation key not defined: "authflowv2/__error_account"
-resources/authgear/templates/en/web/authflowv2/__error.html:166:20: translation key not defined: "authflowv2/__error_account"
+resources/authgear/templates/en/web/authflowv2/__csrf_error_page_layout.html:28:18: template translation is forbidden: `page-content`
+resources/authgear/templates/en/web/authflowv2/__dialog.html:27:14: template translation is forbidden: `dialog-attr`
+resources/authgear/templates/en/web/authflowv2/__error.html:134:18: template translation is forbidden: `authflowv2/__error_account`
+resources/authgear/templates/en/web/authflowv2/__error.html:166:20: template translation is forbidden: `authflowv2/__error_account`
 resources/authgear/templates/en/web/authflowv2/__locale_input.html:6:16: invalid translation key: "$labelKey"
 resources/authgear/templates/en/web/authflowv2/__locale_input.html:10:21: translation key not defined: "%s %s"
 resources/authgear/templates/en/web/authflowv2/__new_password_field.html:38:33: translation key not defined: "%s %s"
 resources/authgear/templates/en/web/authflowv2/__new_password_field.html:62:38: translation key not defined: "%s %s"
-resources/authgear/templates/en/web/authflowv2/__page_frame.html:12:18: translation key not defined: "page-content"
+resources/authgear/templates/en/web/authflowv2/__page_frame.html:12:18: template translation is forbidden: `page-content`
 resources/authgear/templates/en/web/authflowv2/__password_field.html:10:20: translation key not defined: "%s %s"
-resources/authgear/templates/en/web/authflowv2/__settings_page_frame.html:46:15: translation key not defined: "page-navbar"
-resources/authgear/templates/en/web/authflowv2/__settings_page_frame.html:48:18: translation key not defined: "page-content"
+resources/authgear/templates/en/web/authflowv2/__settings_page_frame.html:46:15: template translation is forbidden: `page-navbar`
+resources/authgear/templates/en/web/authflowv2/__settings_page_frame.html:48:18: template translation is forbidden: `page-content`
 resources/authgear/templates/en/web/authflowv2/__settings_radio.html:16:16: translation key not defined: "radio-%s-%s"
 resources/authgear/templates/en/web/authflowv2/__timezone_input.html:8:21: translation key not defined: "%s %s"
 resources/authgear/templates/en/web/authflowv2/account_linking.html:90:33: translation key not defined: "%s-icon"
-resources/authgear/templates/en/web/authflowv2/forgot_password.html:109:30: translation key not defined: "__forgot_password_alternative"
-resources/authgear/templates/en/web/authflowv2/forgot_password.html:165:26: translation key not defined: "__forgot_password_alternative"
-resources/authgear/templates/en/web/authflowv2/layout.html:5:14: translation key not defined: "widget"
+resources/authgear/templates/en/web/authflowv2/forgot_password.html:109:30: template translation is forbidden: `__forgot_password_alternative`
+resources/authgear/templates/en/web/authflowv2/forgot_password.html:165:26: template translation is forbidden: `__forgot_password_alternative`
+resources/authgear/templates/en/web/authflowv2/layout.html:5:14: template translation is forbidden: `widget`
 resources/authgear/templates/en/web/authflowv2/login.html:252:37: translation key not defined: "%s-icon"
-resources/authgear/templates/en/web/authflowv2/settings_layout.html:3:14: translation key not defined: "widget"
-resources/authgear/templates/en/web/authflowv2/settings_profile.html:29:18: translation key not defined: "__settings_profile_item"
-resources/authgear/templates/en/web/authflowv2/settings_profile.html:51:18: translation key not defined: "__settings_profile_item"
+resources/authgear/templates/en/web/authflowv2/settings_layout.html:3:14: template translation is forbidden: `widget`
+resources/authgear/templates/en/web/authflowv2/settings_profile.html:29:18: template translation is forbidden: `__settings_profile_item`
+resources/authgear/templates/en/web/authflowv2/settings_profile.html:51:18: template translation is forbidden: `__settings_profile_item`
 resources/authgear/templates/en/web/authflowv2/settings_profile.html:68:22: translation key not defined: "__settings_profile_date_item"
-resources/authgear/templates/en/web/authflowv2/settings_profile.html:70:18: translation key not defined: "__settings_profile_item"
+resources/authgear/templates/en/web/authflowv2/settings_profile.html:70:18: template translation is forbidden: `__settings_profile_item`
 resources/authgear/templates/en/web/authflowv2/settings_profile.html:87:22: translation key not defined: "__settings_profile_address_item"
-resources/authgear/templates/en/web/authflowv2/settings_profile.html:89:18: translation key not defined: "__settings_profile_item"
-resources/authgear/templates/en/web/authflowv2/settings_profile.html:107:18: translation key not defined: "__settings_profile_item"
+resources/authgear/templates/en/web/authflowv2/settings_profile.html:89:18: template translation is forbidden: `__settings_profile_item`
+resources/authgear/templates/en/web/authflowv2/settings_profile.html:107:18: template translation is forbidden: `__settings_profile_item`
 resources/authgear/templates/en/web/authflowv2/settings_profile.html:123:23: translation key not defined: "__settings_profile_locale_item"
-resources/authgear/templates/en/web/authflowv2/settings_profile.html:125:18: translation key not defined: "__settings_profile_item"
+resources/authgear/templates/en/web/authflowv2/settings_profile.html:125:18: template translation is forbidden: `__settings_profile_item`
 resources/authgear/templates/en/web/authflowv2/settings_profile.html:174:22: invalid translation key: "$label"
 resources/authgear/templates/en/web/authflowv2/settings_profile_edit_gender.html:57:33: translation key not defined: "__settings_gender_edit_custom_gender_input"
 resources/authgear/templates/en/web/authflowv2/signup.html:237:35: translation key not defined: "%s-icon"

--- a/devtools/gotemplatelinter/transation_key_rule_check_template.go
+++ b/devtools/gotemplatelinter/transation_key_rule_check_template.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"fmt"
 	"strings"
 	"text/template/parse"
 )
@@ -14,12 +15,13 @@ func CheckTemplate(templateNode *parse.TemplateNode) (err error) {
 	if isHTMLTemplate(templateNode) { // false positive
 		return
 	}
-	translationKey := templateNode.Name
-	err = CheckTranslationKeyPattern(translationKey)
-	if err != nil {
-		return err
+
+	key := templateNode.Name
+	if IsSpecialCase(key) {
+		return
 	}
-	return
+
+	return fmt.Errorf("template translation is forbidden: `%s`", key)
 }
 
 func isHTMLTemplate(templateNode *parse.TemplateNode) bool {

--- a/devtools/gotemplatelinter/transation_key_rule_check_translations_render_text.go
+++ b/devtools/gotemplatelinter/transation_key_rule_check_translations_render_text.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"fmt"
 	"text/template/parse"
 )
 
@@ -9,15 +10,5 @@ import (
 // example: `($.Translations.RenderText "customer-support-link" nil)`
 // example: (.Translations.RenderText "terms-of-service-link" nil)
 func CheckCommandTranslationsRenderText(node *parse.CommandNode) (err error) {
-	// 2nd arg should be translation key
-	for idx, arg := range node.Args {
-		if idx == 1 {
-			err = CheckTranslationKeyNode(arg)
-			if err != nil {
-				return err
-			}
-		}
-
-	}
-	return
+	return fmt.Errorf("Translations.RenderText is forbidden: `%s`", node.String())
 }

--- a/resources/authgear/templates/en/web/authflowv2/__alert_message.html
+++ b/resources/authgear/templates/en/web/authflowv2/__alert_message.html
@@ -6,14 +6,14 @@
   {{ if eq $.Type "warning" }}alert-message--warning{{ end }}
   {{ $.Classname }}"
   data-controller="alert-message"
-  data-server-error-message="{{ template "v2.error.server" }}"
-  data-network-error-message="{{ template "v2.error.network" }}"
-  data-passkey-not-supported="{{ template "v2.error.passkey-not-supported" }}"
-  data-invalid-passkey-or-not-supported="{{ template "v2.error.invalid-passkey-or-not-supported" }}"
-  data-no-passkey="{{ template "v2.error.no-passkey" }}"
-  data-passkey-duplicate="{{ template "v2.error.passkey-duplicate" }}"
-  data-bot-protection-cloudflare="{{ template "v2.error.bot-protection-cloudflare" }}"
-  data-bot-protection-recaptcha-v2="{{ template "v2.error.bot-protection-recaptcha-v2" }}"
+  data-server-error-message="{{ include "v2.error.server" nil }}"
+  data-network-error-message="{{ include "v2.error.network" nil }}"
+  data-passkey-not-supported="{{ include "v2.error.passkey-not-supported" nil }}"
+  data-invalid-passkey-or-not-supported="{{ include "v2.error.invalid-passkey-or-not-supported" nil }}"
+  data-no-passkey="{{ include "v2.error.no-passkey" nil }}"
+  data-passkey-duplicate="{{ include "v2.error.passkey-duplicate" nil }}"
+  data-bot-protection-cloudflare="{{ include "v2.error.bot-protection-cloudflare" nil }}"
+  data-bot-protection-recaptcha-v2="{{ include "v2.error.bot-protection-recaptcha-v2" nil }}"
   {{ if $message }}
     data-error-message={{ $message }}
   {{ end }}

--- a/resources/authgear/templates/en/web/authflowv2/__authflow_branch.html
+++ b/resources/authgear/templates/en/web/authflowv2/__authflow_branch.html
@@ -22,7 +22,7 @@
         <input type="hidden" name="x_action" value="take_branch">
         <button class="secondary-btn w-full flex gap-x-2" type="submit">
           <span class="material-icons secondary-btn__icon">key_vertical</span>
-          {{ template "v2.component.authflow-branch.default.enter-recovery-code-instead" }}
+          {{ include "v2.component.authflow-branch.default.enter-recovery-code-instead" nil }}
         </button>
       </form>
     {{- end }}
@@ -49,69 +49,69 @@
     {{- if eq $.ActionType "create_authenticator" }}
       {{- if eq .Authentication "primary_password" }}
         <span class="material-icons secondary-btn__icon">key_vertical</span>
-        {{ template "v2.component.authflow-branch.default.setup-password-instead" }}
+        {{ include "v2.component.authflow-branch.default.setup-password-instead" nil }}
       {{- end }}
       {{- if eq .Authentication "secondary_password" }}
         <span class="material-icons secondary-btn__icon">key_vertical</span>
-        {{ template "v2.component.authflow-branch.default.setup-secondary-password-instead" }}
+        {{ include "v2.component.authflow-branch.default.setup-secondary-password-instead" nil }}
       {{- end }}
       {{- if eq .Authentication "secondary_totp" }}
         <span class="material-icons secondary-btn__icon">qr_code</span>
-        {{ template "v2.component.authflow-branch.default.setup-totp-instead" }}
+        {{ include "v2.component.authflow-branch.default.setup-totp-instead" nil }}
       {{- end }}
       {{- if eq .Authentication "primary_oob_otp_email" }}
         <span class="material-icons secondary-btn__icon">mail</span>
         {{- if .VerificationSkippable }}
-          {{ template "v2.component.authflow-branch.default.setup-oob-otp-without-verification" (dict "target" .MaskedClaimValue) }}
+          {{ include "v2.component.authflow-branch.default.setup-oob-otp-without-verification" (dict "target" .MaskedClaimValue) }}
         {{ else }}
           {{- if eq .OTPForm "code" }}
-            {{ template "v2.component.authflow-branch.default.setup-email-otp-code-instead" }}
+            {{ include "v2.component.authflow-branch.default.setup-email-otp-code-instead" nil }}
           {{- end }}
           {{- if eq .OTPForm "link" }}
-            {{ template "v2.component.authflow-branch.default.setup-email-otp-link-instead" }}
+            {{ include "v2.component.authflow-branch.default.setup-email-otp-link-instead" nil }}
           {{- end }}
         {{- end }}
       {{- end }}
       {{- if eq .Authentication "secondary_oob_otp_email" }}
         <span class="material-icons secondary-btn__icon">mail</span>
         {{- if .VerificationSkippable }}
-          {{ template "v2.component.authflow-branch.default.setup-oob-otp-without-verification" (dict "target" .MaskedClaimValue) }}
+          {{ include "v2.component.authflow-branch.default.setup-oob-otp-without-verification" (dict "target" .MaskedClaimValue) }}
         {{ else }}
           {{- if eq .OTPForm "code" }}
-            {{ template "v2.component.authflow-branch.default.setup-email-otp-code-instead" }}
+            {{ include "v2.component.authflow-branch.default.setup-email-otp-code-instead" nil }}
           {{- end }}
           {{- if eq .OTPForm "link" }}
-            {{ template "v2.component.authflow-branch.default.setup-email-otp-link-instead" }}
+            {{ include "v2.component.authflow-branch.default.setup-email-otp-link-instead" nil }}
           {{- end }}
         {{- end }}
       {{- end }}
       {{- if eq .Authentication "primary_oob_otp_sms" }}
         {{- if .VerificationSkippable }}
           <span class="material-icons secondary-btn__icon">phone_iphone</span>
-          {{ template "v2.component.authflow-branch.default.setup-oob-otp-without-verification" (dict "target" .MaskedClaimValue) }}
+          {{ include "v2.component.authflow-branch.default.setup-oob-otp-without-verification" (dict "target" .MaskedClaimValue) }}
         {{ else }}
           {{- if eq .Channel "sms" }}
             <span class="material-icons secondary-btn__icon">phone_iphone</span>
-            {{ template "v2.component.authflow-branch.default.setup-phone-otp-sms-instead" }}
+            {{ include "v2.component.authflow-branch.default.setup-phone-otp-sms-instead" nil }}
           {{- end }}
           {{- if eq .Channel "whatsapp" }}
             <span class="sso-icon whatsapp-icon secondary-btn__icon"></span>
-            {{ template "v2.component.authflow-branch.default.setup-phone-otp-whatsapp-instead" }}
+            {{ include "v2.component.authflow-branch.default.setup-phone-otp-whatsapp-instead" nil }}
           {{- end }}
         {{- end }}
       {{- end }}
       {{- if eq .Authentication "secondary_oob_otp_sms" }}
         {{- if .VerificationSkippable }}
           <span class="material-icons secondary-btn__icon">phone_iphone</span>
-          {{ template "v2.component.authflow-branch.default.setup-oob-otp-without-verification" (dict "target" .MaskedClaimValue) }}
+          {{ include "v2.component.authflow-branch.default.setup-oob-otp-without-verification" (dict "target" .MaskedClaimValue) }}
         {{ else }}
           {{- if eq .Channel "sms" }}
             <span class="material-icons secondary-btn__icon">phone_iphone</span>
-            {{ template "v2.component.authflow-branch.default.setup-phone-otp-sms-instead" }}
+            {{ include "v2.component.authflow-branch.default.setup-phone-otp-sms-instead" nil }}
           {{- end }}
           {{- if eq .Channel "whatsapp" }}
             <span class="sso-icon whatsapp-icon secondary-btn__icon"></span>
-            {{ template "v2.component.authflow-branch.default.setup-phone-otp-whatsapp-instead" }}
+            {{ include "v2.component.authflow-branch.default.setup-phone-otp-whatsapp-instead" nil }}
           {{- end }}
         {{- end }}
       {{- end }}
@@ -120,38 +120,38 @@
     {{- if eq $.ActionType "authenticate" }}
       {{- if eq .Authentication "primary_password" }}
         <span class="material-icons secondary-btn__icon">key_vertical</span>
-        {{ template "v2.component.authflow-branch.default.enter-password-instead" }}
+        {{ include "v2.component.authflow-branch.default.enter-password-instead" nil }}
       {{- end }}
       {{- if eq .Authentication "secondary_password" }}
         <span class="material-icons secondary-btn__icon">key_vertical</span>
-        {{ template "v2.component.authflow-branch.default.enter-secondary-password-instead" }}
+        {{ include "v2.component.authflow-branch.default.enter-secondary-password-instead" nil }}
       {{- end }}
       {{- if eq .Authentication "primary_passkey" }}
         <span class="material-icons secondary-btn__icon">passkey</span>
-        {{ template "v2.component.authflow-branch.default.use-passkey-instead" }}
+        {{ include "v2.component.authflow-branch.default.use-passkey-instead" nil }}
       {{- end }}
       {{- if eq .Authentication "secondary_totp" }}
         <span class="material-icons secondary-btn__icon">qr_code</span>
-        {{ template "v2.component.authflow-branch.default.enter-totp-instead" }}
+        {{ include "v2.component.authflow-branch.default.enter-totp-instead" nil }}
       {{- end }}
       {{- if ( or (eq .Authentication "primary_oob_otp_email") (eq .Authentication "secondary_oob_otp_email")) }}
         {{- if eq .OTPForm "code" }}
         <span class="material-icons secondary-btn__icon">mail</span>
-        {{ template "v2.component.authflow-branch.default.enter-email-otp-code-instead" }}
+        {{ include "v2.component.authflow-branch.default.enter-email-otp-code-instead" nil }}
         {{- end }}
         {{- if eq .OTPForm "link" }}
         <span class="material-icons secondary-btn__icon">mail</span>
-        {{ template "v2.component.authflow-branch.default.use-email-otp-link-instead" }}
+        {{ include "v2.component.authflow-branch.default.use-email-otp-link-instead" nil }}
         {{- end }}
       {{- end }}
       {{- if (or (eq .Authentication "primary_oob_otp_sms") (eq .Authentication "secondary_oob_otp_sms")) }}
         {{- if eq .Channel "sms" }}
         <span class="material-icons secondary-btn__icon">phone_iphone</span>
-        {{ template "v2.component.authflow-branch.default.enter-phone-otp-sms-instead" }}
+        {{ include "v2.component.authflow-branch.default.enter-phone-otp-sms-instead" nil }}
         {{- end }}
         {{- if eq .Channel "whatsapp" }}
         <span class="sso-icon whatsapp-icon secondary-btn__icon"></span>
-        {{ template "v2.component.authflow-branch.default.enter-phone-otp-whatsapp-instead" }}
+        {{ include "v2.component.authflow-branch.default.enter-phone-otp-whatsapp-instead" nil }}
         {{- end }}
       {{- end }}
     {{- end }}
@@ -159,11 +159,11 @@
     {{- if eq $.ActionType "verify" }}
       {{- if eq .Channel "sms" }}
         <span class="material-icons secondary-btn__icon">phone_iphone</span>
-        {{ template "v2.component.authflow-branch.default.enter-phone-otp-sms-instead" }}
+        {{ include "v2.component.authflow-branch.default.enter-phone-otp-sms-instead" nil }}
       {{- end }}
       {{- if eq .Channel "whatsapp" }}
         <span class="sso-icon whatsapp-icon secondary-btn__icon"></span>
-        {{ template "v2.component.authflow-branch.default.enter-phone-otp-whatsapp-instead" }}
+        {{ include "v2.component.authflow-branch.default.enter-phone-otp-whatsapp-instead" nil }}
       {{- end }}
     {{- end }}
 

--- a/resources/authgear/templates/en/web/authflowv2/__bot_protection_dialog.html
+++ b/resources/authgear/templates/en/web/authflowv2/__bot_protection_dialog.html
@@ -20,10 +20,10 @@ bot-protection-dialog {{ template "web/authflowv2/__bot_protection_controller.ht
   <div class="flex flex-col gap-y-8 flex-1-0-auto">
     <header class="dialog-title-description">
       <h1 class="dialog-title" id="bot-protection-title">
-        {{ template "v2.component.verify-bot-protection.default.title" }}
+        {{ include "v2.component.verify-bot-protection.default.title" nil }}
       </h1>
       <h2 class="dialog-description">
-        {{ template "v2.component.verify-bot-protection.default.description" }}
+        {{ include "v2.component.verify-bot-protection.default.description" nil }}
       </h2>
     </header>
     {{ template "web/authflowv2/__bot_protection_widget.html" . }}

--- a/resources/authgear/templates/en/web/authflowv2/__bot_protection_widget.html
+++ b/resources/authgear/templates/en/web/authflowv2/__bot_protection_widget.html
@@ -8,5 +8,5 @@
     <div class="flex justify-center h-19" data-recaptcha-v2-target="widget"></div>
 {{ end }}
 <noscript>
-  {{ template "v2.component.bot-protection-widget.default.noscript" }}
+  {{ include "v2.component.bot-protection-widget.default.noscript" nil }}
 </noscript>

--- a/resources/authgear/templates/en/web/authflowv2/__device_token_checkbox.html
+++ b/resources/authgear/templates/en/web/authflowv2/__device_token_checkbox.html
@@ -14,6 +14,6 @@
       <span class="checkbox__icon material-icons">check</span>
     </label>
   </div>
-  <label class="body-text--md" for="device-token">{{ template "v2.component.device-token-checkbox.default.label" }}</label>
+  <label class="body-text--md" for="device-token">{{ include "v2.component.device-token-checkbox.default.label" nil }}</label>
 </div>
 {{ end }}

--- a/resources/authgear/templates/en/web/authflowv2/__divider.html
+++ b/resources/authgear/templates/en/web/authflowv2/__divider.html
@@ -4,7 +4,7 @@ function like helm include function
 https://helm.sh/docs/howto/charts_tips_and_tricks/#know-your-template-functions
 */}}
 <div role="separator" class="divider {{$.Classname}}">
-  {{template "v2.component.divider.default.or-label"}}
+  {{ include "v2.component.divider.default.or-label" nil }}
 </div>
 
 {{ end }}

--- a/resources/authgear/templates/en/web/authflowv2/__error.html
+++ b/resources/authgear/templates/en/web/authflowv2/__error.html
@@ -20,17 +20,17 @@
       {{ end }}
       {{ if $general_policy_error }}
         <span>
-          {{ template "v2.error.password-policy-violated" }}
+          {{ include "v2.error.password-policy-violated" nil }}
         </span>
       {{ else if $contain_excluded_keywords_policy_error }}
         <span>
-          {{ template "v2.error.password-policy-disallowed-keywords" }}
+          {{ include "v2.error.password-policy-disallowed-keywords" nil }}
         </span>
       {{ else if $reused_error }}
         {{ range .PasswordPolicies }}
           {{ if eq .Name "PasswordReused" }}
             <span>
-              {{ template "v2.error.password-policy-reuse" (dict "size" .Info.history_size "day" .Info.history_days) }}
+              {{ include "v2.error.password-policy-reuse" (dict "size" .Info.history_size "day" .Info.history_days) }}
             </span>
           {{ end }}
         {{ end }}
@@ -47,36 +47,36 @@
           {{ end }}
           {{ if $is_missing_login_id }}
             <span>
-              {{ template "v2.error.login-id-required" (dict "variant" $.LoginIDContextualType) }}
+              {{ include "v2.error.login-id-required" (dict "variant" $.LoginIDContextualType) }}
             </span>
           {{ else if (call $.SliceContains .details.missing "x_password" ) }}
-            <span>{{ template "v2.error.password-required" }}</span>
+            <span>{{ include "v2.error.password-required" nil }}</span>
           {{ else if (call $.SliceContains .details.missing "x_oob_otp_code" ) }}
-            <span>{{ template "v2.error.oob-otp-code-required" }}</span>
+            <span>{{ include "v2.error.oob-otp-code-required" nil }}</span>
           {{ else if (call $.SliceContains .details.missing "x_totp_code" ) }}
-            <span>{{ template "v2.error.totp-code-required" }}</span>
+            <span>{{ include "v2.error.totp-code-required" nil }}</span>
           {{ else if (call $.SliceContains .details.missing "x_verification_code" ) }}
-            <span>{{ template "v2.error.verification-code-required" }}</span>
+            <span>{{ include "v2.error.verification-code-required" nil }}</span>
           {{ else if (call $.SliceContains .details.missing "x_recovery_code" ) }}
-            <span>{{ template "v2.error.recovery-code-required" }}</span>
+            <span>{{ include "v2.error.recovery-code-required" nil }}</span>
           {{ else if (call $.SliceContains .details.missing "x_old_password" ) }}
-            <span>{{ template "v2.error.old-password-required" }}</span>
+            <span>{{ include "v2.error.old-password-required" nil }}</span>
           {{ else if (call $.SliceContains .details.missing "x_new_password" ) }}
-            <span>{{ template "v2.error.new-password-required" }}</span>
+            <span>{{ include "v2.error.new-password-required" nil }}</span>
           {{ else if (call $.SliceContains .details.missing "x_confirm_password" ) }}
-            <span>{{ template "v2.error.confirm-password-required" }}</span>
+            <span>{{ include "v2.error.confirm-password-required" nil }}</span>
           {{ else if (call $.SliceContains .details.missing "x_email" ) }}
-            <span>{{ template "v2.error.email-required" }}</span>
+            <span>{{ include "v2.error.email-required" nil }}</span>
           {{ else if (call $.SliceContains .details.missing "x_e164" ) }}
-            <span>{{ template "v2.error.phone-number-required" }}</span>
+            <span>{{ include "v2.error.phone-number-required" nil }}</span>
           {{ else if (call $.SliceContains .details.missing "x_target" ) }}
             {{ if eq $.OOBAuthenticatorType "oob_otp_email" }}
-            <span>{{ template "v2.error.email-required" }}</span>
+            <span>{{ include "v2.error.email-required" nil }}</span>
             {{ else }}
-            <span>{{ template "v2.error.phone-number-required" }}</span>
+            <span>{{ include "v2.error.phone-number-required" nil }}</span>
             {{ end }}
           {{ else if (call $.SliceContains .details.missing "x_bot_protection_provider_response" ) }}
-            <span>{{ template "v2.error.bot-protection-required" }}</span>
+            <span>{{ include "v2.error.bot-protection-required" nil }}</span>
           {{ else }}
             <span>
               {{ $.Error.message }}
@@ -84,46 +84,46 @@
           {{ end }}
         {{ else if (eq .kind "format") }}
           {{ if (eq .details.format "phone") }}
-            <span>{{ template "v2.error.phone-number-format" }}</span>
+            <span>{{ include "v2.error.phone-number-format" nil }}</span>
           {{ else if (eq .details.format "email") }}
-            <span>{{ template "v2.error.invalid-email" }}</span>
+            <span>{{ include "v2.error.invalid-email" nil }}</span>
           {{ else if (eq .details.format "username") }}
-            <span>{{ template "v2.error.invalid-username" }}</span>
+            <span>{{ include "v2.error.invalid-username" nil }}</span>
           {{ else if (eq .details.format "x_totp_code") }}
-            <span>{{ template "v2.error.totp-code-format" }}</span>
+            <span>{{ include "v2.error.totp-code-format" nil }}</span>
           {{ else if (eq .details.format "x_oob_otp_code") }}
-            <span>{{ template "v2.error.oob-otp-code-format" }}</span>
+            <span>{{ include "v2.error.oob-otp-code-format" nil }}</span>
           {{ else if (eq .details.format "x_verification_code") }}
-            <span>{{ template "v2.error.verification-code-format" }}</span>
+            <span>{{ include "v2.error.verification-code-format" nil }}</span>
           {{ else if (eq .details.format "x_recovery_code") }}
-            <span>{{ template "v2.error.recovery-code-format" }}</span>
+            <span>{{ include "v2.error.recovery-code-format" nil }}</span>
           {{ else if (eq .details.format "uri") }}
-            <span>{{ template "v2.error.uri-format" }}</span>
+            <span>{{ include "v2.error.uri-format" nil }}</span>
           {{ else }}
             <span>{{ .Error.message }}</span>
           {{ end }}
         {{ else if (eq .kind "maxLength") }}
           <span>
-            {{ template "v2.error.max-length" (dict "expected" .details.expected) }}
+            {{ include "v2.error.max-length" (dict "expected" .details.expected) }}
           </span>
         {{ else if (eq .kind "blocked") }}
           {{ if (or (eq .details.reason "EmailDomainBlocklist") (eq .details.reason "EmailDomainAllowlist")) }}
-            <span>{{ template "v2.error.email-not-allowed" }}</span>
+            <span>{{ include "v2.error.email-not-allowed" nil }}</span>
           {{ else if (or (eq .details.reason "UsernameReserved") (eq .details.reason "UsernameExcludedKeywords")) }}
-            <span>{{ template "v2.error.username-not-allowed" }}</span>
+            <span>{{ include "v2.error.username-not-allowed" nil }}</span>
           {{ else if (eq .details.reason "PhoneNumberCountryCodeAllowlist") }}
-            <span>{{ template "v2.error.phone-number-not-allowed" }}</span>
+            <span>{{ include "v2.error.phone-number-not-allowed" nil }}</span>
           {{ else }}
             <span>{{ .details.reason }}</span>
           {{ end }}
         {{ else if (eq .kind "type") }}
           <span>
-            {{ template "v2.error.type" (dict "expected" (index .details.expected 0)) }}
+            {{ include "v2.error.type" (dict "expected" (index .details.expected 0)) }}
           </span>
         {{ else if (eq .kind "minimum") }}
-          <span>{{ template "v2.error.minimum" (dict "minimum" .details.minimum) }}</span>
+          <span>{{ include "v2.error.minimum" (dict "minimum" .details.minimum) }}</span>
         {{ else if (eq .kind "maximum") }}
-          <span>{{ template "v2.error.maximum" (dict "maximum" .details.maximum) }}</span>
+          <span>{{ include "v2.error.maximum" (dict "maximum" .details.maximum) }}</span>
         {{ else if (eq .kind "general") }}
           <span>{{ .details.msg }}</span>
         {{ else }}
@@ -134,72 +134,72 @@
       {{ template "authflowv2/__error_account" . }}
     {{ else if eq .Error.reason "InvalidCredentials" }}
       <span>
-        {{ template "v2.error.invalid-credentials" (dict "AuthenticationType" $info.AuthenticationType) }}
+        {{ include "v2.error.invalid-credentials" (dict "AuthenticationType" $info.AuthenticationType) }}
       </span>
     {{ else if eq .Error.reason "PasswordResetFailed" }}
       {{ if and (.Error.info) (eq .Error.info.otp_form "code") }}
-        <span>{{ template "v2.error.invalid-credentials" }}</span>
+        <span>{{ include "v2.error.invalid-credentials" nil }}</span>
       {{ else }}
-        <span>{{ template "v2.error.password-reset-failed-description" }}</span>
+        <span>{{ include "v2.error.password-reset-failed-description" nil }}</span>
       {{ end }}
     {{ else if eq .Error.reason "NewPasswordTypo" }}
-      <span>{{ template "v2.error.new-password-typo" }}</span>
+      <span>{{ include "v2.error.new-password-typo" nil }}</span>
     {{ else if eq .Error.reason "StandardAttributesEmailRequired" }}
       {{ if .Error.info.ProviderType }}
         {{ if eq .Error.info.ProviderType "github" }}
-          <span>{{ template "v2.error.email-required-github" }}</span>
+          <span>{{ include "v2.error.email-required-github" nil }}</span>
         {{ else }}
-          <span>{{ template "v2.error.developer-email-required" }}</span>
+          <span>{{ include "v2.error.developer-email-required" nil }}</span>
         {{ end }}
       {{ else }}
-        <span>{{ template "v2.error.developer-email-required" }}</span>
+        <span>{{ include "v2.error.developer-email-required" nil }}</span>
       {{ end }}
     {{ else if eq .Error.reason "InvariantViolated" }}
       {{ $cause := .Error.info.cause }}
       {{ if (eq $cause.kind "RemoveLastIdentity") }}
-        <span>{{ template "v2.error.remove-last-identity" }}</span>
+        <span>{{ include "v2.error.remove-last-identity" nil }}</span>
       {{ else if (eq $cause.kind "RemoveLastPrimaryAuthenticator") }}
-        <span>{{ template "v2.error.remove-last-primary-authenticator" }}</span>
+        <span>{{ include "v2.error.remove-last-primary-authenticator" nil }}</span>
       {{ else if (eq $cause.kind "RemoveLastSecondaryAuthenticator") }}
-        <span>{{ template "v2.error.remove-last-secondary-authenticator" }}</span>
+        <span>{{ include "v2.error.remove-last-secondary-authenticator" nil }}</span>
       {{ else if (eq $cause.kind "DuplicatedIdentity") }}
         {{ template "authflowv2/__error_account" . }}
       {{ else if (eq $cause.kind "DuplicatedAuthenticator") }}
         <span>
-          {{ template "v2.error.duplicated-authenticator" (dict "AuthenticatorType"
+          {{ include "v2.error.duplicated-authenticator" (dict "AuthenticatorType"
           $cause.AuthenticatorType) }}
         </span>
       {{ else if (eq $cause.kind "MismatchedUser") }}
-        <span>{{ template "v2.error.developer-reauthentication" }}</span>
+        <span>{{ include "v2.error.developer-reauthentication" nil }}</span>
       {{ else if (eq $cause.kind "NoAuthenticator") }}
-        <span>{{ template "v2.error.no-authenticator" }}</span>
+        <span>{{ include "v2.error.no-authenticator" nil }}</span>
       {{ else }}
         <span>{{ .Error.message }}</span>
       {{ end }}
     {{ else if eq .Error.reason "InvalidVerificationCode" }}
       <span>
-        {{ template "v2.error.verification-code-invalid" }}
+        {{ include "v2.error.verification-code-invalid" nil }}
       </span>
     {{ else if eq .Error.reason "RateLimited" }}
       {{ if eq .Error.info.bucket_name "MessagingSMSPerTarget" }}
-        <span>{{ template "v2.error.sms-send-limit-exceeded" }}</span>
+        <span>{{ include "v2.error.sms-send-limit-exceeded" nil }}</span>
       {{ else if eq .Error.info.bucket_name "MessagingSMSPerIP" }}
-        <span>{{ template "v2.error.sms-send-limit-exceeded" }}</span>
+        <span>{{ include "v2.error.sms-send-limit-exceeded" nil }}</span>
       {{ else if eq .Error.info.bucket_name "MessagingSMS" }}
-        <span>{{ template "v2.error.sms-send-limit-exceeded" }}</span>
+        <span>{{ include "v2.error.sms-send-limit-exceeded" nil }}</span>
       {{ else }}
-        <span>{{ template "v2.error.rate-limited" }}</span>
+        <span>{{ include "v2.error.rate-limited" nil }}</span>
       {{ end }}
     {{ else if eq .Error.reason "AccountLockout" }}
       <!-- We need to render a full-screen modal for this case, done in __lockout.html instead -->
     {{ else if eq .Error.reason "UsageLimitExceeded" }}
-      <span>{{ template "v2.error.usage-limit-exceeded" }}</span>
+      <span>{{ include "v2.error.usage-limit-exceeded" nil }}</span>
     {{ else if eq .Error.reason "SMSNotSupported" }}
       <span>
         {{/* TODO: replace `include` with `translateText` */}}
-        {{ if ($.Translations.HasKey "customer-support-link") }} {{ template
+        {{ if ($.Translations.HasKey "customer-support-link") }} {{ include
         "v2.error.oob-otp-sms-not-supported-with-customer-support" (dict
-        "customerSupportLink" (include "customer-support-link" nil)) }} {{ else }} {{ template "v2.error.oob-otp-sms-not-supported" }} {{ end
+        "customerSupportLink" (include "customer-support-link" nil)) }} {{ else }} {{ include "v2.error.oob-otp-sms-not-supported" nil }} {{ end
         }}
       </span>
     {{ else if eq .Error.reason "WebHookDisallowed" }}
@@ -207,39 +207,42 @@
       <span>
         {{ if $error_reason.title }} {{ $error_reason.title }} {{ else }}
         <!-- title is not provided, use default title -->
-        {{ if eq .Error.info.event_type "pre_signup" }} {{ template
-        "v2.error.webhook-pre-signup-disallowed" }} {{ else }} {{ template
-        "v2.error.webhook-disallowed" }} {{ end }} {{ end }} {{ if
-        $error_reason.reason }}
+        {{ if eq .Error.info.event_type "pre_signup" }} 
+          {{ include "v2.error.webhook-pre-signup-disallowed" nil }} 
+        {{ else }}
+          {{ include "v2.error.webhook-disallowed" nil }}
+        {{ end }} 
+    {{ end }} 
+    {{ if $error_reason.reason }}
         <br />
         {{ $error_reason.reason }} {{ end }}
       </span>
     {{ else if eq .Error.reason "WebHookInvalidResponse" }}
-      <span>{{ template "v2.error.webhook-invalid-response" }}</span>
+      <span>{{ include "v2.error.webhook-invalid-response" nil }}</span>
     {{ else if eq .Error.reason "WebHookDeliveryTimeout" }}
-      <span>{{ template "v2.error.webhook-delivery-timeout" }}</span>
+      <span>{{ include "v2.error.webhook-delivery-timeout" nil }}</span>
     {{ else if eq .Error.reason "InvalidNetwork" }}
       <span>
-        {{ template "v2.error.invalid-web3-network" (dict "chainID"
+        {{ include "v2.error.invalid-web3-network" (dict "chainID"
         $info.expected_chain_id) }}
       </span>
     {{ else if eq .Error.reason "InvalidWhatsappUser" }}
-      <span>{{ template "v2.error.invalid-whatsapp-user" }}</span>
+      <span>{{ include "v2.error.invalid-whatsapp-user" nil }}</span>
     {{ else if eq .Error.reason "NoAvailableWhatsappClient" }}
-      <span>{{ template "v2.error.no-available-whatsapp-client" }}</span>
+      <span>{{ include "v2.error.no-available-whatsapp-client" nil }}</span>
     {{ else if eq .Error.reason "ChangePasswordFailed" }}
       {{ $cause := .Error.info.cause }}
         {{ if (eq $cause.kind "PasswordReused") }}
-        <span>{{ template "v2.error.password-change-password-reused" }}</span>
+        <span>{{ include "v2.error.password-change-password-reused" nil }}</span>
         {{ else }}
         <span>{{ .Error.message }}</span>
         {{ end }}
     {{ else if eq .Error.reason "AuthenticationFlowDifferentUserID" }}
-      <span>{{ template "v2.error.unexpected-user" }}</span>
+      <span>{{ include "v2.error.unexpected-user" nil }}</span>
     {{ else if eq .Error.reason "BotProtectionVerificationFailed" }}
-      <span>{{ template "v2.error.bot-protection-verification-failed" }}</span>
+      <span>{{ include "v2.error.bot-protection-verification-failed" nil }}</span>
     {{ else }}
-      <span>{{ template "v2.error.unknown" }}{{ call $.LogUnknownError .Error }}</span>
+      <span>{{ include "v2.error.unknown" nil }}{{ call $.LogUnknownError .Error }}</span>
     {{ end }}
   {{- end -}}
 {{- end -}}
@@ -268,7 +271,7 @@
   {{ end }}
   {{/* Tell the end-user the account is not found if there is no conflict */}}
   {{ if not $is_conflict }}
-    <span>{{ template "v2.error.account-not-found" $dict }}</span>
+    <span>{{ include "v2.error.account-not-found" $dict }}</span>
   {{ end }}
   {{/* Tell the end-user these is a conflict */}}
   {{/* and give suggestion contextually */}}
@@ -281,11 +284,11 @@
       {{ $suggest_oauth = false }}
     {{ end }}
     <span>
-      {{ template "v2.error.account-conflict" $dict }}
+      {{ include "v2.error.account-conflict" $dict }}
       {{ if $suggest_oauth }}
-        {{ template "v2.error.suggestion-account-conflict-oauth" $dict }}
+        {{ include "v2.error.suggestion-account-conflict-oauth" $dict }}
       {{ else }}
-        {{ template "v2.error.suggestion-account-conflict-login-id" $dict }}
+        {{ include "v2.error.suggestion-account-conflict-login-id" $dict }}
       {{ end }}
     </span>
   {{ end }}

--- a/resources/authgear/templates/en/web/authflowv2/__error.html
+++ b/resources/authgear/templates/en/web/authflowv2/__error.html
@@ -196,10 +196,10 @@
       <span>{{ template "v2.error.usage-limit-exceeded" }}</span>
     {{ else if eq .Error.reason "SMSNotSupported" }}
       <span>
+        {{/* TODO: replace `include` with `translateText` */}}
         {{ if ($.Translations.HasKey "customer-support-link") }} {{ template
         "v2.error.oob-otp-sms-not-supported-with-customer-support" (dict
-        "customerSupportLink" ($.Translations.RenderText "customer-support-link"
-        nil)) }} {{ else }} {{ template "v2.error.oob-otp-sms-not-supported" }} {{ end
+        "customerSupportLink" (include "customer-support-link" nil)) }} {{ else }} {{ template "v2.error.oob-otp-sms-not-supported" }} {{ end
         }}
       </span>
     {{ else if eq .Error.reason "WebHookDisallowed" }}

--- a/resources/authgear/templates/en/web/authflowv2/__forgot_password_alternatives.html
+++ b/resources/authgear/templates/en/web/authflowv2/__forgot_password_alternatives.html
@@ -19,11 +19,11 @@
     <button class="secondary-btn w-full flex gap-x-2" type="submit">
       {{- if eq .Channel "sms" }}
         <span class="material-icons secondary-btn__icon">phone_iphone</span>
-        {{ template "v2.page.forgot-password-otp.default.alternatives-sms-otp" }}
+        {{ include "v2.page.forgot-password-otp.default.alternatives-sms-otp" nil }}
       {{- end }}
       {{- if eq .Channel "whatsapp" }}
         <span class="sso-icon whatsapp-icon secondary-btn__icon"></span>
-        {{ template "v2.page.forgot-password-otp.default.alternatives-whatsapp-otp" }}
+        {{ include "v2.page.forgot-password-otp.default.alternatives-whatsapp-otp" nil }}
       {{- end }}
     </button>
   </form>

--- a/resources/authgear/templates/en/web/authflowv2/__lockout.html
+++ b/resources/authgear/templates/en/web/authflowv2/__lockout.html
@@ -15,10 +15,10 @@
       <i class="material-icons screen-icon">account_circle_off</i>
       <header class="screen-title-description">
         <h1 class="screen-title" id="lockout-title">
-          {{ template "v2.component.lockout.default.title" }}
+          {{ include "v2.component.lockout.default.title" nil }}
         </h1>
         <h2 class="screen-description">
-          {{ template "v2.component.lockout.default.subtitle" }}
+          {{ include "v2.component.lockout.default.subtitle" nil }}
         </h2>
       </header>
       <div></div>
@@ -31,8 +31,8 @@
         data-controller="countdown"
         data-countdown-target="button"
         data-countdown-cooldown-until-value="{{ (rfc3339 $until) }}"
-        data-countdown-label-value="{{ template "v2.component.lockout.default.retry-button-label" . }}"
-        data-countdown-label-unit-value="{{ template "v2.component.lockout.default.retry-countdown-label-unit" . }}"
+        data-countdown-label-value="{{ include "v2.component.lockout.default.retry-button-label" . }}"
+        data-countdown-label-unit-value="{{ include "v2.component.lockout.default.retry-countdown-label-unit" . }}"
       ></button>
     </footer>
     </div>

--- a/resources/authgear/templates/en/web/authflowv2/__new_password_field.html
+++ b/resources/authgear/templates/en/web/authflowv2/__new_password_field.html
@@ -12,7 +12,7 @@
 
 <div
   data-controller="password-policy new-password-field"
-  data-new-password-field-confirm-password-error-message-value='{{ template "v2.error.new-password-typo" }}'
+  data-new-password-field-confirm-password-error-message-value='{{ include "v2.error.new-password-typo" nil }}'
   class="flex flex-col gap-y-4 {{ $.Classname }}">
   <div
     class="flex flex-col gap-y-2"

--- a/resources/authgear/templates/en/web/authflowv2/__otp_input.html
+++ b/resources/authgear/templates/en/web/authflowv2/__otp_input.html
@@ -95,7 +95,7 @@
     value="{{ or $.SubmitButtonValue "submit" }}"
     data-otp-input-target="submit"
     data-authgear-event="{{ $.SubmitEvent }}"
-  > {{ template "v2.component.button.default.label-continue" }} </button>
+  > {{ include "v2.component.button.default.label-continue" nil }} </button>
 
 </div>
 {{ end }}

--- a/resources/authgear/templates/en/web/authflowv2/__password_input.html
+++ b/resources/authgear/templates/en/web/authflowv2/__password_input.html
@@ -25,11 +25,11 @@
     autocapitalize="none"
     name="{{ .Name }}"
     {{ if eq .Type "old-password" }}
-    placeholder="{{ template "v2.component.password-input.default.placeholder-password" }}"
+    placeholder="{{ include "v2.component.password-input.default.placeholder-password" nil }}"
     {{ else if eq .Type "new-password" }}
-    placeholder="{{ template "v2.component.password-input.default.placeholder-new-password" }}"
+    placeholder="{{ include "v2.component.password-input.default.placeholder-new-password" nil }}"
     {{ else if eq .Type "confirm-password" }}
-    placeholder="{{ template "v2.component.password-input.default.placeholder-confirm-password" }}"
+    placeholder="{{ include "v2.component.password-input.default.placeholder-confirm-password" nil }}"
     {{ end }}
     data-password-visibility-toggle-target="input"
     {{ if .PasswordRules }}
@@ -41,7 +41,7 @@
     class="w-5 absolute inset-y-0 ltr:right-4 rtl:left-4 hidden"
     type="button"
     tabindex="-1"
-    title="{{ template "v2.component.password-input.default.show-password" }}"
+    title="{{ include "v2.component.password-input.default.show-password" nil }}"
     data-password-visibility-toggle-target="showButton"
     data-action="password-visibility-toggle#show">
      <span class="input__password-visibility-icon">
@@ -52,7 +52,7 @@
     class="w-5 absolute inset-y-0 ltr:right-4 rtl:left-4 hidden"
     type="button"
     tabindex="-1"
-    title="{{ template "v2.component.password-input.default.hide-password" }}"
+    title="{{ include "v2.component.password-input.default.hide-password" nil }}"
     data-password-visibility-toggle-target="hideButton"
     data-action="password-visibility-toggle#hide">
        <span class="input__password-visibility-icon">

--- a/resources/authgear/templates/en/web/authflowv2/__password_policy.html
+++ b/resources/authgear/templates/en/web/authflowv2/__password_policy.html
@@ -5,43 +5,43 @@
     {{ if eq .Name "PasswordBelowGuessableLevel" }}
     <li class="password-policy whitespace-nowrap order-first" data-password-policy-target="policy" data-password-policy-name="strength" data-min-level={{.Info.min_level}}>
       <span class="password-policy__icon material-icons material-icons--filled"></span>
-      {{ template "v2.component.new-password-field.default.password-policy-strength" }} {{ template "authflowv2/__password_strength_meter.html" (dict "Classname" "w-full")  }}
+      {{ include "v2.component.new-password-field.default.password-policy-strength" nil }} {{ template "authflowv2/__password_strength_meter.html" (dict "Classname" "w-full")  }}
     </li>
     {{ end }}
     {{ if eq .Name "PasswordTooShort" }}
     <li class="password-policy" data-min-length="{{ .Info.min_length}}" data-password-policy-target="policy" data-password-policy-name="length">
       <span class="password-policy__icon material-icons material-icons--filled"></span>
-      {{ template "v2.component.new-password-field.default.password-policy-minimum-length" (dict "length" .Info.min_length) }}
+      {{ include "v2.component.new-password-field.default.password-policy-minimum-length" (dict "length" .Info.min_length) }}
     </li>
     {{ end }}
     {{ if eq .Name "PasswordUppercaseRequired" }}
     <li class="password-policy" data-password-policy-target="policy" data-password-policy-name="uppercase">
       <span class="password-policy__icon material-icons material-icons--filled"></span>
-      {{ template "v2.component.new-password-field.default.password-policy-uppercase" }}
+      {{ include "v2.component.new-password-field.default.password-policy-uppercase" nil }}
     </li>
     {{ end }}
     {{ if eq .Name "PasswordLowercaseRequired" }}
     <li class="password-policy" data-password-policy-target="policy" data-password-policy-name="lowercase">
       <span class="password-policy__icon material-icons material-icons--filled"></span>
-      {{ template "v2.component.new-password-field.default.password-policy-lowercase" }}
+      {{ include "v2.component.new-password-field.default.password-policy-lowercase" nil }}
     </li>
     {{ end }}
     {{ if eq .Name "PasswordAlphabetRequired" }}
     <li class="password-policy" data-password-policy-target="policy" data-password-policy-name="alphabet">
       <span class="password-policy__icon material-icons material-icons--filled"></span>
-      {{ template "v2.component.new-password-field.default.password-policy-alphabet" }}
+      {{ include "v2.component.new-password-field.default.password-policy-alphabet" nil }}
     </li>
     {{ end }}
     {{ if eq .Name "PasswordDigitRequired" }}
     <li class="password-policy" data-password-policy-target="policy" data-password-policy-name="digit">
       <span class="password-policy__icon material-icons material-icons--filled"></span>
-      {{ template "v2.component.new-password-field.default.password-policy-digit" }}
+      {{ include "v2.component.new-password-field.default.password-policy-digit" nil }}
     </li>
     {{ end }}
     {{ if eq .Name "PasswordSymbolRequired" }}
     <li class="password-policy" data-password-policy-target="policy" data-password-policy-name="symbol">
       <span class="password-policy__icon material-icons material-icons--filled"></span>
-      {{ template "v2.component.new-password-field.default.password-policy-symbol" }}
+      {{ include "v2.component.new-password-field.default.password-policy-symbol" nil }}
     </li>
     {{ end }}
   {{ end }}

--- a/resources/authgear/templates/en/web/authflowv2/__password_strength_meter.html
+++ b/resources/authgear/templates/en/web/authflowv2/__password_strength_meter.html
@@ -6,14 +6,14 @@
   aria-valuemax="5"
   data-controller="password-strength-meter"
   data-password-policy-target="currentMeter"
-  data-desc-0="{{ template "v2.component.new-password-field.default.password-policy-password-strength-meter-1" }}"
-  data-desc-1="{{ template "v2.component.new-password-field.default.password-policy-password-strength-meter-1" }}"
-  data-desc-2="{{ template "v2.component.new-password-field.default.password-policy-password-strength-meter-2" }}"
-  data-desc-3="{{ template "v2.component.new-password-field.default.password-policy-password-strength-meter-3" }}"
-  data-desc-4="{{ template "v2.component.new-password-field.default.password-policy-password-strength-meter-4" }}"
-  data-desc-5="{{ template "v2.component.new-password-field.default.password-policy-password-strength-meter-5" }}"
+  data-desc-0="{{ include "v2.component.new-password-field.default.password-policy-password-strength-meter-1" nil }}"
+  data-desc-1="{{ include "v2.component.new-password-field.default.password-policy-password-strength-meter-1" nil }}"
+  data-desc-2="{{ include "v2.component.new-password-field.default.password-policy-password-strength-meter-2" nil }}"
+  data-desc-3="{{ include "v2.component.new-password-field.default.password-policy-password-strength-meter-3" nil }}"
+  data-desc-4="{{ include "v2.component.new-password-field.default.password-policy-password-strength-meter-4" nil }}"
+  data-desc-5="{{ include "v2.component.new-password-field.default.password-policy-password-strength-meter-5" nil }}"
 >
   <span class="password-strength-meter__icon material-icons"></span>
-  <span class="password-strength-meter__description" data-password-strength-meter-target="currentMeterDescription">{{ template "v2.component.new-password-field.default.password-policy-password-strength-meter-1" }}</span>
+  <span class="password-strength-meter__description" data-password-strength-meter-target="currentMeterDescription">{{ include "v2.component.new-password-field.default.password-policy-password-strength-meter-1" nil }}</span>
 </div>
 {{ end }}

--- a/resources/authgear/templates/en/web/authflowv2/__phone_input.html
+++ b/resources/authgear/templates/en/web/authflowv2/__phone_input.html
@@ -65,7 +65,7 @@
             <div class="select__search">
               <input
                 class="select__search-input"
-                placeholder="{{ template "v2.component.phone-input.default.search-label" }}"
+                placeholder="{{ include "v2.component.phone-input.default.search-label" nil }}"
                 data-controller="dismiss-keyboard-on-scroll"
                 data-custom-select-target="search"
                 data-action="input->custom-select#search"
@@ -111,7 +111,7 @@
 
         <template data-custom-select-target="emptyTemplate">
           <li class="select__empty">
-            {{ template "v2.component.phone-input.default.no-results-found" }}
+            {{ include "v2.component.phone-input.default.no-results-found" nil }}
           </li>
         </template>
       </div>

--- a/resources/authgear/templates/en/web/authflowv2/__settings_item.html
+++ b/resources/authgear/templates/en/web/authflowv2/__settings_item.html
@@ -41,7 +41,7 @@
     <p class="settings-item__description settings-description block tablet:hidden">
       {{ $item := index $.Children  0}}
       {{ if gt $length 1 }}
-        <span> {{ template "v2.page.settings.default.button-label-and-more" (dict "item" $item ) }} </span>
+        <span> {{ include "v2.page.settings.default.button-label-and-more" (dict "item" $item ) }} </span>
       {{ else }}
         {{ $item }}
       {{ end }}

--- a/resources/authgear/templates/en/web/authflowv2/__toc_pp_footer.html
+++ b/resources/authgear/templates/en/web/authflowv2/__toc_pp_footer.html
@@ -19,9 +19,10 @@
 
 {{ if $showFooter }}
 <p class="body-text--md mt-4">
+  {{/* TODO: replace `include` with `translateText` */}}
   {{ template "v2.component.toc-pp-footer.default.label" (dict "variant" $variant
-                                    "termsOfService" (.Translations.RenderText "terms-of-service-link" nil)
-                                    "privacyPolicy" (.Translations.RenderText "privacy-policy-link" nil)) }}
+                                    "termsOfService" (include "terms-of-service-link" nil)
+                                    "privacyPolicy" (include "privacy-policy-link" nil)) }}
 </p>
 {{ end }}
 {{ end }}

--- a/resources/authgear/templates/en/web/authflowv2/__toc_pp_footer.html
+++ b/resources/authgear/templates/en/web/authflowv2/__toc_pp_footer.html
@@ -20,7 +20,7 @@
 {{ if $showFooter }}
 <p class="body-text--md mt-4">
   {{/* TODO: replace `include` with `translateText` */}}
-  {{ template "v2.component.toc-pp-footer.default.label" (dict "variant" $variant
+  {{ include "v2.component.toc-pp-footer.default.label" (dict "variant" $variant
                                     "termsOfService" (include "terms-of-service-link" nil)
                                     "privacyPolicy" (include "privacy-policy-link" nil)) }}
 </p>

--- a/resources/authgear/templates/en/web/authflowv2/account_linking.html
+++ b/resources/authgear/templates/en/web/authflowv2/account_linking.html
@@ -4,10 +4,10 @@
   <div class="flex flex-col gap-y-8 flex-1-0-auto">
     <div class="screen-title-description">
       <h1 class="screen-title">
-        {{ template "v2.page.account-linking.default.title" }}
+        {{ include "v2.page.account-linking.default.title" nil }}
       </h1>
       <h2 class="screen-description">
-        {{ template "v2.page.account-linking.default.subtitle" }}
+        {{ include "v2.page.account-linking.default.subtitle" nil }}
       </h2>
       {{ template "authflowv2/__alert_message.html"
         (dict
@@ -38,7 +38,7 @@
               <div class="flex gap-2 overflow-hidden">
                 <i class="alternative-icon material-icons">mail</i>
                 <span class="flex-1 truncate">
-                  {{ template "v2.page.account-linking.default.by-email" (dict
+                  {{ include "v2.page.account-linking.default.by-email" (dict
                     "IdentityDisplayName" .MaskedDisplayName
                   ) }}
                 </span>
@@ -55,7 +55,7 @@
               <div class="flex gap-2 overflow-hidden">
                 <i class="alternative-icon material-icons">smartphone</i>
                 <span class="flex-1 truncate">
-                  {{ template "v2.page.account-linking.default.by-phone" (dict
+                  {{ include "v2.page.account-linking.default.by-phone" (dict
                     "IdentityDisplayName" .MaskedDisplayName
                   ) }}
                 </span>
@@ -72,7 +72,7 @@
               <div class="flex gap-2 overflow-hidden">
                 <i class="alternative-icon material-icons">person</i>
                 <span class="flex-1 truncate">
-                  {{ template "v2.page.account-linking.default.by-username" (dict
+                  {{ include "v2.page.account-linking.default.by-username" (dict
                     "IdentityDisplayName" .MaskedDisplayName
                   ) }}
                 </span>

--- a/resources/authgear/templates/en/web/authflowv2/account_status.html
+++ b/resources/authgear/templates/en/web/authflowv2/account_status.html
@@ -5,30 +5,30 @@
     <i class="material-icons screen-icon">account_circle_off</i>
     <header class="screen-title-description">
       <h1 class="screen-title">
-        {{ template "v2.error.disabled-user-title" }}
+        {{ include "v2.error.disabled-user-title" nil }}
       </h1>
       {{- if $.Error }}
         <h2 class="screen-description">
           {{- if eq .Error.reason "DisabledUser" }}
             {{- if $.Error.info.reason }}
-              {{ template "v2.error.disabled-user-subtitle" }}
+              {{ include "v2.error.disabled-user-subtitle" nil }}
               <br>
-              {{ template "v2.error.disabled-user-reason" (dict "reason" $.Error.info.reason) }}
+              {{ include "v2.error.disabled-user-reason" (dict "reason" $.Error.info.reason) }}
             {{- else }}
-              {{ template "v2.error.disabled-user-subtitle" }}
+              {{ include "v2.error.disabled-user-subtitle" nil }}
             {{- end }}
           {{- end }}
 
           {{- if eq $.Error.reason "DeactivatedUser" }}
-            {{ template "v2.error.deactivated-user" }}
+            {{ include "v2.error.deactivated-user" nil }}
           {{- end }}
 
           {{- if eq $.Error.reason "ScheduledDeletionByAdmin" }}
-            {{ template "v2.error.scheduled-deletion-by-admin" (dict "date" (ensureTime $.Error.info.delete_at) "rfc3339" (rfc3339 (ensureTime $.Error.info.delete_at))) }}
+            {{ include "v2.error.scheduled-deletion-by-admin" (dict "date" (ensureTime $.Error.info.delete_at) "rfc3339" (rfc3339 (ensureTime $.Error.info.delete_at))) }}
           {{- end }}
 
           {{- if eq $.Error.reason "ScheduledDeletionByEndUser" }}
-            {{ template "v2.error.scheduled-deletion-by-end-user" (dict "date" (ensureTime $.Error.info.delete_at) "rfc3339" (rfc3339 (ensureTime $.Error.info.delete_at))) }}
+            {{ include "v2.error.scheduled-deletion-by-end-user" (dict "date" (ensureTime $.Error.info.delete_at) "rfc3339" (rfc3339 (ensureTime $.Error.info.delete_at))) }}
           {{- end }}
         </h2>
       {{- end }}
@@ -37,7 +37,7 @@
 
   <footer>
     <a class="primary-btn w-full" href="/login" data-turbo="false">
-      {{ template "v2.page.account-status.default.return-button-label" }}
+      {{ include "v2.page.account-status.default.return-button-label" nil }}
     </a>
   </footer>
   </div>

--- a/resources/authgear/templates/en/web/authflowv2/change_password.html
+++ b/resources/authgear/templates/en/web/authflowv2/change_password.html
@@ -8,16 +8,16 @@
 <div class="flex-1-0-auto">
   <h1 class="screen-title">
     {{ if (eq .Reason "expiry") }}
-      {{ template "v2.page.change-password.expiry.title" }}
+      {{ include "v2.page.change-password.expiry.title" nil }}
     {{ else }}
-      {{ template "v2.page.change-password.default.title" }}
+      {{ include "v2.page.change-password.default.title" nil }}
     {{ end }}
   </h1>
   <h2 class="screen-description mt-4">
     {{ if (eq .Reason "expiry") }}
-      {{ template "v2.page.change-password.expiry.subtitle" }}
+      {{ include "v2.page.change-password.expiry.subtitle" nil }}
     {{ else }}
-      {{ template "v2.page.change-password.default.subtitle" }}
+      {{ include "v2.page.change-password.default.subtitle" nil }}
     {{ end }}
   </h2>
   {{ template "authflowv2/__alert_message.html"
@@ -58,7 +58,7 @@
     value=""
     data-authgear-event="authgear.button.change_password"
   >
-  {{ template "v2.page.change-password.default.update-button-label" }}
+  {{ include "v2.page.change-password.default.update-button-label" nil }}
   </button>
 
   </form>

--- a/resources/authgear/templates/en/web/authflowv2/change_password_success.html
+++ b/resources/authgear/templates/en/web/authflowv2/change_password_success.html
@@ -11,9 +11,9 @@
   <i class="material-icons screen-icon">check_circle</i>
   <header class="screen-title-description">
     <h1 class="screen-title">
-      {{ template "v2.page.change-password-success.default.title" }}
+      {{ include "v2.page.change-password-success.default.title" nil }}
     </h1>
-    <p class="screen-description">{{ template "v2.page.change-password-success.default.description" }}</p>
+    <p class="screen-description">{{ include "v2.page.change-password-success.default.description" nil }}</p>
     {{ template "authflowv2/__alert_message.html"
       (dict
         "Type" "error"
@@ -30,7 +30,7 @@
         name="x_action"
         value=""
       >
-        {{ template "v2.component.button.default.label-continue" }}
+        {{ include "v2.component.button.default.label-continue" nil }}
       </button>
     </footer>
 </form>

--- a/resources/authgear/templates/en/web/authflowv2/create_password.html
+++ b/resources/authgear/templates/en/web/authflowv2/create_password.html
@@ -6,7 +6,7 @@
 {{ end }}
 <div class="flex flex-col gap-y-8 flex-1-0-auto">
   <h1 class="screen-title">
-    {{ template "v2.page.create-password.default.title" }}
+    {{ include "v2.page.create-password.default.title" nil }}
   </h1>
   {{ template "authflowv2/__alert_message.html"
     (dict
@@ -50,7 +50,7 @@
       value=""
       data-authgear-event="authgear.button.create_password"
     >
-      {{ template "v2.component.button.default.label-continue" }}
+      {{ include "v2.component.button.default.label-continue" nil }}
     </button>
   </form>
 

--- a/resources/authgear/templates/en/web/authflowv2/csrf_error_instruction.html
+++ b/resources/authgear/templates/en/web/authflowv2/csrf_error_instruction.html
@@ -8,53 +8,53 @@
 
 <div class="mx-1 mt-10 tablet:mt-20">
   <h1 class="screen-title text-[18px]">
-    {{ template "v2.page.csrf-error-instruction.default.instruction-header" }}
+    {{ include "v2.page.csrf-error-instruction.default.instruction-header" nil }}
   </h1>
 
   {{ if eq $.Device "iOS" }}
   <ul class="list-decimal ml-6 mt-6 space-y-2 dark:text-white">
-    <li>{{ template "v2.page.csrf-error-instruction.ios.step-1" }}</li>
-    <li>{{ template "v2.page.csrf-error-instruction.ios.step-2" }}</li>
-    <li>{{ template "v2.page.csrf-error-instruction.ios.step-3" }}</li>
+    <li>{{ include "v2.page.csrf-error-instruction.ios.step-1" nil }}</li>
+    <li>{{ include "v2.page.csrf-error-instruction.ios.step-2" nil }}</li>
+    <li>{{ include "v2.page.csrf-error-instruction.ios.step-3" nil }}</li>
   </ul>
   <div class="mt-6 mx-6 object-contain">
     <img src="{{ $instruction_image_src_ios }}" alt="" />
   </div>
   {{ else if eq $.Device "Chrome" }}
   <ul class="list-decimal ml-6 mt-6 space-y-2 dark:text-white">
-    <li>{{ template "v2.page.csrf-error-instruction.chrome-desktop.step-1" }}</li>
-    <li>{{ template "v2.page.csrf-error-instruction.chrome-desktop.step-2" }}</li>
-    <li>{{ template "v2.page.csrf-error-instruction.chrome-desktop.step-3" }}</li>
-    <li>{{ template "v2.page.csrf-error-instruction.chrome-desktop.step-4" }}</li>
+    <li>{{ include "v2.page.csrf-error-instruction.chrome-desktop.step-1" nil }}</li>
+    <li>{{ include "v2.page.csrf-error-instruction.chrome-desktop.step-2" nil }}</li>
+    <li>{{ include "v2.page.csrf-error-instruction.chrome-desktop.step-3" nil }}</li>
+    <li>{{ include "v2.page.csrf-error-instruction.chrome-desktop.step-4" nil }}</li>
   </ul>
   <img src="{{ $instruction_image_src_chrome }}" alt="" class="mt-6"/>
   {{ else if eq $.Device "ChromeAndroid" }}
   <ul class="list-decimal ml-6 mt-6 space-y-2 dark:text-white">
-    <li>{{ template "v2.page.csrf-error-instruction.android.step-1" }}</li>
-    <li>{{ template "v2.page.csrf-error-instruction.android.step-2" }}</li>
-    <li>{{ template "v2.page.csrf-error-instruction.android.step-3" }}</li>
-    <li>{{ template "v2.page.csrf-error-instruction.android.step-4" }}</li>
+    <li>{{ include "v2.page.csrf-error-instruction.android.step-1" nil }}</li>
+    <li>{{ include "v2.page.csrf-error-instruction.android.step-2" nil }}</li>
+    <li>{{ include "v2.page.csrf-error-instruction.android.step-3" nil }}</li>
+    <li>{{ include "v2.page.csrf-error-instruction.android.step-4" nil }}</li>
   </ul>
   <div class="mt-6 mx-6 object-contain">
     <img src="{{ $instruction_image_src_android }}" alt="" />
   </div>
   {{ else if eq $.Device "Samsung" }}
   <ul class="list-decimal ml-6 mt-8 space-y-2 dark:text-white">
-    <li>{{ template "v2.page.csrf-error-instruction.samsung.step-1" }}</li>
-    <li>{{ template "v2.page.csrf-error-instruction.samsung.step-2" }}</li>
-    <li>{{ template "v2.page.csrf-error-instruction.samsung.step-3" }}</li>
-    <li>{{ template "v2.page.csrf-error-instruction.samsung.step-4" }}</li>
-    <li>{{ template "v2.page.csrf-error-instruction.samsung.step-5" }}</li>
-    <li>{{ template "v2.page.csrf-error-instruction.samsung.step-6" }}</li>
+    <li>{{ include "v2.page.csrf-error-instruction.samsung.step-1" nil }}</li>
+    <li>{{ include "v2.page.csrf-error-instruction.samsung.step-2" nil }}</li>
+    <li>{{ include "v2.page.csrf-error-instruction.samsung.step-3" nil }}</li>
+    <li>{{ include "v2.page.csrf-error-instruction.samsung.step-4" nil }}</li>
+    <li>{{ include "v2.page.csrf-error-instruction.samsung.step-5" nil }}</li>
+    <li>{{ include "v2.page.csrf-error-instruction.samsung.step-6" nil }}</li>
   </ul>
   <div class="mt-6 mx-6 object-contain">
     <img src="{{ $instruction_image_src_samsung }}" alt="" />
   </div>
   {{ else }}
   <ul class="list-decimal ml-6 mt-6 space-y-2 dark:text-white">
-    <li>{{ template "v2.page.csrf-error-instruction.default.step-1" }}</li>
-    <li>{{ template "v2.page.csrf-error-instruction.default.step-2" }}</li>
-    <li>{{ template "v2.page.csrf-error-instruction.default.step-3" }}</li>
+    <li>{{ include "v2.page.csrf-error-instruction.default.step-1" nil }}</li>
+    <li>{{ include "v2.page.csrf-error-instruction.default.step-2" nil }}</li>
+    <li>{{ include "v2.page.csrf-error-instruction.default.step-3" nil }}</li>
   </ul>
   {{ end }}
 

--- a/resources/authgear/templates/en/web/authflowv2/csrf_error_page.html
+++ b/resources/authgear/templates/en/web/authflowv2/csrf_error_page.html
@@ -5,12 +5,12 @@
   {{ template "authflowv2/__header.html" . }}
   <div class="text-center">
     <h1 class="mb-5 screen-title text-2xl">
-      {{ template "v2.page.csrf-error.default.title" }}
+      {{ include "v2.page.csrf-error.default.title" nil }}
     </h1>
 
     <p class="body-text--md max-w-85 mx-auto">
-      {{ template "v2.page.csrf-error.default.message" }}
-      <a href="{{ call $.MakeURL "/errors/cookie_instruction" }}"> {{ template "v2.page.csrf-error.default.see-instructions" }}</a>
+      {{ include "v2.page.csrf-error.default.message" nil }}
+      <a href="{{ call $.MakeURL "/errors/cookie_instruction" }}"> {{ include "v2.page.csrf-error.default.see-instructions" nil }}</a>
     </p> 
   </div>
 </div>

--- a/resources/authgear/templates/en/web/authflowv2/enter_oob_otp.html
+++ b/resources/authgear/templates/en/web/authflowv2/enter_oob_otp.html
@@ -14,20 +14,20 @@
   <div class="flex flex-col gap-y-8 flex-1-0-auto">
     <div class="screen-title-description">
       <h1 class="screen-title">
-        {{ template "v2.page.enter-oob-otp.default.title" }}
+        {{ include "v2.page.enter-oob-otp.default.title" nil }}
       </h1>
       <h2 class="screen-description">
         {{ if eq $.Channel "whatsapp" }}
           {{ if eq $.FlowType "reauth" }}
-            {{ template "v2.page.enter-oob-otp.auth-email-or-sms.subtitle-reauth--whatsapp" . }}
+            {{ include "v2.page.enter-oob-otp.auth-email-or-sms.subtitle-reauth--whatsapp" . }}
           {{ else }}
-            {{ template "v2.page.enter-oob-otp.auth-whatsapp.subtitle" . }}
+            {{ include "v2.page.enter-oob-otp.auth-whatsapp.subtitle" . }}
           {{ end }}
         {{ else }}
           {{ if eq $.FlowType "reauth" }}
-            {{ template "v2.page.enter-oob-otp.auth-email-or-sms.subtitle-reauth" . }}
+            {{ include "v2.page.enter-oob-otp.auth-email-or-sms.subtitle-reauth" . }}
           {{ else }}
-            {{ template "v2.page.enter-oob-otp.auth-email-or-sms.subtitle" . }}
+            {{ include "v2.page.enter-oob-otp.auth-email-or-sms.subtitle" . }}
           {{ end }}
         {{ end }}
       </h2>

--- a/resources/authgear/templates/en/web/authflowv2/enter_password.html
+++ b/resources/authgear/templates/en/web/authflowv2/enter_password.html
@@ -14,9 +14,9 @@
   <header class="screen-title-description">
     <h1 class="screen-title">
       {{ if eq $.AuthenticationStage "secondary" }}
-        {{ template "v2.page.enter-password.auth-secondary.title" }}
+        {{ include "v2.page.enter-password.auth-secondary.title" nil }}
       {{ else }}
-        {{ template "v2.page.enter-password.auth-primary.title" }}
+        {{ include "v2.page.enter-password.auth-primary.title" nil }}
       {{ end }}
     </h1>
     {{ if eq $.FlowType "reauth" }}
@@ -73,12 +73,12 @@
       data-authgear-event="authgear.button.enter_password"
       data-action-button
     >
-      {{ template "v2.component.button.default.label-continue" }}
+      {{ include "v2.component.button.default.label-continue" nil }}
     </button>
     <!-- This page for entering password. So if the user reaches this page normally, forgot password link should be provided -->
     {{ if eq $.AuthenticationStage "primary" }}
       <p class="body-text--md">
-        <a href="{{ call $.MakeURL "/authflow/v2/forgot_password" "q_login_id_input_type" $.ForgotPasswordInputType "q_login_id" $.ForgotPasswordLoginID "x_step" "" }}">{{ template "v2.page.enter-password.default.forgot-password-button-label" }}</a>
+        <a href="{{ call $.MakeURL "/authflow/v2/forgot_password" "q_login_id_input_type" $.ForgotPasswordInputType "q_login_id" $.ForgotPasswordLoginID "x_step" "" }}">{{ include "v2.page.enter-password.default.forgot-password-button-label" nil }}</a>
       </p>
     {{ end }}
   </form>

--- a/resources/authgear/templates/en/web/authflowv2/enter_recovery_code.html
+++ b/resources/authgear/templates/en/web/authflowv2/enter_recovery_code.html
@@ -11,14 +11,14 @@
   <div class="flex flex-col gap-y-8 flex-1-0-auto">
     <div class="screen-title-description">
       <h1 class="screen-title">
-        {{ template "v2.page.enter-recovery-code.default.title" }}
+        {{ include "v2.page.enter-recovery-code.default.title" nil }}
       </h1>
 
       <h2 class="screen-description">
         {{ if eq $.FlowType "reauth" }}
-          {{ template "v2.page.enter-recovery-code.reauth.description" }}
+          {{ include "v2.page.enter-recovery-code.reauth.description" nil }}
         {{ else }}
-          {{ template "v2.page.enter-recovery-code.default.description" }}
+          {{ include "v2.page.enter-recovery-code.default.description" nil }}
         {{ end }}
       </h2>
 
@@ -55,7 +55,7 @@
         autocomplete="one-time-code"
         autocapitalize="characters"
         name="x_recovery_code"
-        placeholder="{{ template "v2.page.enter-recovery-code.default.enter-recovery-code-placeholder" }}"
+        placeholder="{{ include "v2.page.enter-recovery-code.default.enter-recovery-code-placeholder" nil }}"
       >
 
       {{ if $display_input_error }}
@@ -75,7 +75,7 @@
         value=""
         data-authgear-event="authgear.button.enter_recovery_code"
       >
-        {{ template "v2.component.button.default.label-continue" }}
+        {{ include "v2.component.button.default.label-continue" nil }}
       </button>
     </form>
 

--- a/resources/authgear/templates/en/web/authflowv2/enter_totp.html
+++ b/resources/authgear/templates/en/web/authflowv2/enter_totp.html
@@ -11,13 +11,13 @@
   <div class="flex flex-col gap-y-8 flex-1-0-auto">
     <div class="screen-title-description">
       <h1 class="screen-title">
-        {{ template "v2.page.enter-totp.default.title" }}
+        {{ include "v2.page.enter-totp.default.title" nil }}
       </h1>
       <h2 class="screen-description">
         {{ if eq $.FlowType "reauth" }}
-          {{ template "v2.page.enter-totp.reauth.description" . }}
+          {{ include "v2.page.enter-totp.reauth.description" . }}
         {{ else }}
-          {{ template "v2.page.enter-totp.default.description" . }}
+          {{ include "v2.page.enter-totp.default.description" . }}
         {{ end }}
       </h2>
 

--- a/resources/authgear/templates/en/web/authflowv2/forgot_password.html
+++ b/resources/authgear/templates/en/web/authflowv2/forgot_password.html
@@ -29,12 +29,12 @@
   {{ if $.RequiresLoginIDInput }}
     <div class="flex flex-col gap-8 flex-1-0-auto">
       <header class="screen-title-description">
-        <h1 class="screen-title">{{ template "v2.page.forgot-password.default.title" }}</h1>
+        <h1 class="screen-title">{{ include "v2.page.forgot-password.default.title" nil }}</h1>
         <p class="screen-description">
           {{ if $show_phone_input }}
-            {{ template "v2.page.forgot-password.default.phone-input-description" }}
+            {{ include "v2.page.forgot-password.default.phone-input-description" nil }}
           {{ else }}
-            {{ template "v2.page.forgot-password.default.email-input-description" }}
+            {{ include "v2.page.forgot-password.default.email-input-description" nil }}
           {{ end }}
         </p>
         {{ template "authflowv2/__alert_message.html"
@@ -67,7 +67,7 @@
                 autocomplete="username"
                 autocapitalize="none"
                 name="x_login_id"
-                placeholder="{{ template "v2.component.input.default.placeholder-email" }}"
+                placeholder="{{ include "v2.component.input.default.placeholder-email" nil }}"
               />
             {{ end }}
 
@@ -100,7 +100,7 @@
               name="x_action"
               value=""
               data-authgear-event="authgear.button.send_reset_password_code">
-              {{ template "v2.component.button.default.label-send" }}
+              {{ include "v2.component.button.default.label-send" nil }}
             </button>
             {{ if gt (len $.Alternatives) 0 }}
               {{ template "authflowv2/__divider.html"  }}
@@ -119,13 +119,13 @@
       <i class="screen-icon material-icons">forward_to_inbox</i>
       <header class="screen-title-description">
         <h1 class="screen-title">
-          {{ template "v2.page.forgot-password.default.title" }}
+          {{ include "v2.page.forgot-password.default.title" nil }}
         </h1>
         <p class="screen-description">
           {{ if eq $.LoginIDInputType "phone" }}
-            {{ template "v2.page.forgot-password.default.send-phone-description" (dict "LoginID" $.LoginID) }}
+            {{ include "v2.page.forgot-password.default.send-phone-description" (dict "LoginID" $.LoginID) }}
           {{ else }}
-            {{ template "v2.page.forgot-password.default.send-email-description" (dict "LoginID" $.LoginID) }}
+            {{ include "v2.page.forgot-password.default.send-email-description" (dict "LoginID" $.LoginID) }}
           {{ end }}
         </p>
       </header>
@@ -155,7 +155,7 @@
             name="x_action"
             value=""
             data-authgear-event="authgear.button.send_reset_password_code">
-            {{ template "v2.component.button.default.label-send" }}
+            {{ include "v2.component.button.default.label-send" nil }}
           </button>
         </form>
         {{ if gt (len $.Alternatives) 0 }}
@@ -178,7 +178,7 @@
       data-turbo-action="replace"
       href="{{ .Href }}">
       <i class="alternative-icon material-icons">smartphone</i>
-      {{ template "v2.page.forgot-password.email.send-via-phone" }}
+      {{ include "v2.page.forgot-password.email.send-via-phone" nil }}
     </a>
   {{ else if eq .AlternativeType "email" }}
     <a
@@ -186,7 +186,7 @@
       data-turbo-action="replace"
       href="{{ .Href }}">
       <i class="alternative-icon material-icons">mail</i>
-      {{ template "v2.page.forgot-password.phone.send-via-email" }}
+      {{ include "v2.page.forgot-password.phone.send-via-email" nil }}
     </a>
   {{ end }}
 {{ end }}

--- a/resources/authgear/templates/en/web/authflowv2/forgot_password_link_sent.html
+++ b/resources/authgear/templates/en/web/authflowv2/forgot_password_link_sent.html
@@ -11,10 +11,10 @@
 
     <header class="screen-title-description">
       <h1 class="screen-title">
-        {{ template "v2.page.forgot-password-link-sent.default.title" }}
+        {{ include "v2.page.forgot-password-link-sent.default.title" nil }}
       </h1>
       <p class="screen-description">
-        {{ template "v2.page.forgot-password-link-sent.default.description" (dict "MaskedLoginID" $.MaskedDisplayName) }}
+        {{ include "v2.page.forgot-password-link-sent.default.description" (dict "MaskedLoginID" $.MaskedDisplayName) }}
       </p>
       {{ template "authflowv2/__alert_message.html"
         (dict
@@ -37,10 +37,10 @@
         data-controller="countdown"
         data-countdown-target="button"
         data-countdown-cooldown-value="{{ $.ResendCooldown }}"
-        data-countdown-label-value='{{ template "v2.page.forgot-password-link-sent.default.resend" }}'
+        data-countdown-label-value='{{ include "v2.page.forgot-password-link-sent.default.resend" nil }}'
         data-countdown-label-unit-value='{{ include "v2.page.forgot-password-link-sent.default.resent-countdown-label-unit" nil }}'
         data-authgear-event="authgear.button.resend_reset_password_link">
-        {{ template "v2.page.forgot-password-link-sent.default.resend" }}
+        {{ include "v2.page.forgot-password-link-sent.default.resend" nil }}
       </button>
     </footer>
   </form>

--- a/resources/authgear/templates/en/web/authflowv2/forgot_password_otp.html
+++ b/resources/authgear/templates/en/web/authflowv2/forgot_password_otp.html
@@ -11,13 +11,13 @@
   <div class="flex flex-col gap-y-8 flex-1-0-auto">
     <div class="screen-title-description">
       <h1 class="screen-title">
-        {{ template "v2.page.forgot-password-otp.default.title"}}
+        {{ include "v2.page.forgot-password-otp.default.title" nil}}
       </h1>
       <h2 class="screen-description">
         {{ if eq $.Channel "whatsapp" }}
-          {{ template "v2.page.forgot-password-otp.default.whatsapp-description" . }}
+          {{ include "v2.page.forgot-password-otp.default.whatsapp-description" . }}
         {{ else }}
-          {{ template "v2.page.forgot-password-otp.default.description" . }}
+          {{ include "v2.page.forgot-password-otp.default.description" . }}
         {{ end }}
       </h2>
 

--- a/resources/authgear/templates/en/web/authflowv2/ldap_login.html
+++ b/resources/authgear/templates/en/web/authflowv2/ldap_login.html
@@ -12,7 +12,7 @@
       {{ if ($.Translations.HasKey (printf "v2.component.ldap-branding.default.label-%s" $.LDAPServerName)) }}
         {{ include (printf "v2.component.ldap-branding.default.label-%s" $.LDAPServerName) nil }}
       {{ else }}
-        {{ template "v2.component.ldap-branding.default.label" }}
+        {{ include "v2.component.ldap-branding.default.label" nil }}
       {{ end }}
     </h1>
     {{ template "authflowv2/__alert_message.html"
@@ -48,7 +48,7 @@
         value="{{ $.Username }}"
 
         data-text-field-target="input"
-        placeholder="{{ template "v2.component.input.default.placeholder-login-id" (dict "variant" "username") }}"
+        placeholder="{{ include "v2.component.input.default.placeholder-login-id" (dict "variant" "username") }}"
         required
       >
       {{ if $.LDAPUsernameInputError.HasErrorMessage }}
@@ -76,7 +76,7 @@
       data-authgear-event="authgear.button.login_with_ldap"
       data-action-button
     >
-      {{ template "v2.component.button.default.label-continue" }}
+      {{ include "v2.component.button.default.label-continue" nil }}
     </button>
   </form>
 

--- a/resources/authgear/templates/en/web/authflowv2/login.html
+++ b/resources/authgear/templates/en/web/authflowv2/login.html
@@ -67,13 +67,13 @@
       {{ template "authflowv2/__header.html" . }}
       <div class="screen-title-description">
         <h1 class="screen-title">
-          {{ template "v2.page.login.default.title" (dict
+          {{ include "v2.page.login.default.title" (dict
             "AppName" $appName
             "ClientName" $clientName)
           }}
         </h1>
         <h2 class="screen-description">
-          {{ template "v2.page.login.default.subtitle" (dict
+          {{ include "v2.page.login.default.subtitle" (dict
             "AppName" $appName
             "ClientName" $clientName)
           }}
@@ -153,7 +153,7 @@
               autocomplete="username webauthn"
               autocapitalize="none"
               name="x_login_id"
-              placeholder="{{ template "v2.component.input.default.placeholder-login-id" (dict "variant" $.NonPhoneLoginIDType) }}"
+              placeholder="{{ include "v2.component.input.default.placeholder-login-id" (dict "variant" $.NonPhoneLoginIDType) }}"
               data-controller="retain-form-input"
               data-action="input->retain-form-input#input retain-form-input:input->retain-form-form#input"
               data-retain-form-form-target="input"
@@ -185,14 +185,14 @@
           {{/* Therefore, in this page, we opt-out for Turbo form submission. */}}
           {{/* Then the next page can use modal mediation normally. */}}
           data-authgear-event="authgear.button.sign_in"
-        >{{ template "v2.component.button.default.label-login" }}</button>
+        >{{ include "v2.component.button.default.label-login" nil }}</button>
       {{ end }}
     </form>
 
     {{ if (not $is_login_only) }}
       <p class="body-text--md mt-4">
         {{ $signupHref := call $.MakeURL "/signup" "q_login_id_input_type" $.LoginIDInputType "x_step" "" }}
-        {{ template "v2.page.login.default.switch-to-signup" (dict "href" $signupHref )}}
+        {{ include "v2.page.login.default.switch-to-signup" (dict "href" $signupHref )}}
       </p>
     {{ end }}
 
@@ -212,7 +212,7 @@
                   mail
                 {{- end -}}
               </i>
-              {{ template "v2.component.button.default.label-continue-with-text-login-id" (dict "variant" $.NonPhoneLoginIDType) }}
+              {{ include "v2.component.button.default.label-continue-with-text-login-id" (dict "variant" $.NonPhoneLoginIDType) }}
             </div>
           </a>
         {{ end }}
@@ -223,7 +223,7 @@
             href="{{ call $.MakeURL "" "q_login_id_input_type" "phone" }}">
             <div class="flex gap-2">
               <i class="alternative-icon material-icons">smartphone</i>
-              {{ template "v2.component.button.default.label-continue-with-phone" }}
+              {{ include "v2.component.button.default.label-continue-with-phone" nil }}
             </div>
           </a>
         {{ end }}
@@ -277,7 +277,7 @@
                     {{ if ($.Translations.HasKey (printf "v2.component.ldap-branding.default.label-%s" .server_name)) }}
                       {{ include (printf "v2.component.ldap-branding.default.label-%s" .server_name) nil }}
                     {{ else }}
-                      {{ template "v2.component.ldap-branding.default.label" }}
+                      {{ include "v2.component.ldap-branding.default.label" nil }}
                     {{ end }}
                   </span>
                 </div>
@@ -302,7 +302,7 @@
                   passkey
                 </i>
                 <span>
-                  {{ template "v2.component.button.default.label-continue-with-passkey" }}
+                  {{ include "v2.component.button.default.label-continue-with-passkey" nil }}
                 </span>
               </div>
               </span>

--- a/resources/authgear/templates/en/web/authflowv2/oob_otp_link.html
+++ b/resources/authgear/templates/en/web/authflowv2/oob_otp_link.html
@@ -12,11 +12,11 @@
     <i class="screen-icon material-icons">check_circle</i>
     <header class="screen-title-description">
       <h1 class="screen-title">
-        {{ template "v2.page.oob-otp-link.approved.title" }}
+        {{ include "v2.page.oob-otp-link.approved.title" nil }}
       </h1>
 
       <p class="screen-description">
-        {{ template "v2.page.oob-otp-link.approved.description" }}
+        {{ include "v2.page.oob-otp-link.approved.description" nil }}
       </p>
       {{ template "authflowv2/__alert_message.html"
         (dict
@@ -40,7 +40,7 @@
         value="check"
         data-authgear-event="authgear.button.redirect_login_link_result"
       >
-        {{ template "v2.component.button.default.label-continue" }}
+        {{ include "v2.component.button.default.label-continue" nil }}
       </button>
     </footer>
   </form>
@@ -52,14 +52,14 @@
 <i class="screen-icon material-icons">forward_to_inbox</i>
 <header class="screen-title-description">
   <h1 class="screen-title">
-    {{ template "v2.page.oob-otp-link.default.title" }}
+    {{ include "v2.page.oob-otp-link.default.title" nil }}
   </h1>
 
   <p class="screen-description">
     {{- if eq $.FlowType "reauth" }}
-      {{ template "v2.page.oob-otp-link.initial-reauth.description" (dict "target" $.MaskedClaimValue) }}
+      {{ include "v2.page.oob-otp-link.initial-reauth.description" (dict "target" $.MaskedClaimValue) }}
     {{- else }}
-      {{ template "v2.page.oob-otp-link.initial.description" (dict "target" $.MaskedClaimValue) }}
+      {{ include "v2.page.oob-otp-link.initial.description" (dict "target" $.MaskedClaimValue) }}
     {{- end }}
   </p>
 
@@ -91,11 +91,11 @@
       data-controller="countdown"
       data-countdown-target="button"
       data-countdown-cooldown-value="{{ $.ResendCooldown }}"
-      data-countdown-label-value='{{ template "v2.page.oob-otp-link.default.resend-button-label" }}'
-      data-countdown-label-unit-value='{{ template "v2.page.oob-otp-link.default.resend-countdown-label-unit" }}'
+      data-countdown-label-value='{{ include "v2.page.oob-otp-link.default.resend-button-label" nil }}'
+      data-countdown-label-unit-value='{{ include "v2.page.oob-otp-link.default.resend-countdown-label-unit" nil }}'
       data-authgear-event="authgear.button.resend_login_link_otp"
     >
-      {{ template "v2.page.oob-otp-link.default.resend-button-label" }}
+      {{ include "v2.page.oob-otp-link.default.resend-button-label" nil }}
     </button>
   </form>
   {{ template "authflowv2/__authflow_branch.html" . }}

--- a/resources/authgear/templates/en/web/authflowv2/prompt_create_passkey.html
+++ b/resources/authgear/templates/en/web/authflowv2/prompt_create_passkey.html
@@ -7,10 +7,10 @@
     <i class="material-icons screen-icon">encrypted</i>
     <header class="screen-title-description">
       <h1 class="screen-title">
-        {{ template "v2.page.prompt-create-passkey.default.title" }}
+        {{ include "v2.page.prompt-create-passkey.default.title" nil }}
       </h1>
       <p class="screen-description">
-        {{ template "v2.page.prompt-create-passkey.default.description" }}
+        {{ include "v2.page.prompt-create-passkey.default.description" nil }}
       </p>
       {{ template "authflowv2/__alert_message.html"
         (dict
@@ -30,7 +30,7 @@
         data-authgear-event="authgear.button.create_passkey"
         disabled
         >
-        {{ template "v2.component.button.default.label-continue" }}
+        {{ include "v2.component.button.default.label-continue" nil }}
       </button>
       <form
         method="post"
@@ -45,7 +45,7 @@
           name="x_action"
           value="skip"
           >
-          {{ template "v2.page.prompt-create-passkey.default.skip" }}
+          {{ include "v2.page.prompt-create-passkey.default.skip" nil }}
         </button>
       </form>
     </footer>

--- a/resources/authgear/templates/en/web/authflowv2/reset_password.html
+++ b/resources/authgear/templates/en/web/authflowv2/reset_password.html
@@ -23,10 +23,10 @@
 {{ else }}
 <div class="flex-1-0-auto">
   <h1 class="screen-title">
-    {{ template "v2.page.reset-password.default.title" }}
+    {{ include "v2.page.reset-password.default.title" nil }}
   </h1>
   <h2 class="screen-description mt-4">
-  {{ template "v2.page.reset-password.default.subtitle" }}
+  {{ include "v2.page.reset-password.default.subtitle" nil }}
   </h2>
   {{ template "authflowv2/__alert_message.html"
     (dict
@@ -66,7 +66,7 @@
     value=""
     data-authgear-event="authgear.button.reset_password"
   >
-  {{ template "v2.page.reset-password.default.title" }}
+  {{ include "v2.page.reset-password.default.title" nil }}
   </button>
 
   </form>

--- a/resources/authgear/templates/en/web/authflowv2/reset_password_success.html
+++ b/resources/authgear/templates/en/web/authflowv2/reset_password_success.html
@@ -3,9 +3,9 @@
   <i class="material-icons screen-icon">check_circle</i>
   <header class="screen-title-description">
     <h1 class="screen-title">
-      {{ template "v2.page.reset-password-success.default.title" }}
+      {{ include "v2.page.reset-password-success.default.title" nil }}
     </h1>
-    <p class="screen-description">{{ template "v2.page.reset-password-success.default.description" }}</p>
+    <p class="screen-description">{{ include "v2.page.reset-password-success.default.description" nil }}</p>
     {{ template "authflowv2/__alert_message.html"
       (dict
         "Type" "error"
@@ -18,7 +18,7 @@
     <div></div>
     <footer>
       <a class="primary-btn w-full" href="{{ call $.MakeURL "/login" "x_step" "" "x_can_back_to_login" "" }}" data-turbo="false">
-        {{ template "v2.component.button.default.label-continue" }}
+        {{ include "v2.component.button.default.label-continue" nil }}
       </a>
     </footer>
   {{ end }}

--- a/resources/authgear/templates/en/web/authflowv2/select_account.html
+++ b/resources/authgear/templates/en/web/authflowv2/select_account.html
@@ -8,14 +8,14 @@
   <header class="screen-title-description">
     <h1 class="screen-title">
       {{ if $.ClientName }}
-        {{ template "v2.page.select-account.default.title" (dict "AppOrClientName" $.ClientName) }}
+        {{ include "v2.page.select-account.default.title" (dict "AppOrClientName" $.ClientName) }}
       {{ else }}
         {{ $appName := (translate "app.name" nil) }}
-        {{ template "v2.page.select-account.default.title" (dict "AppOrClientName" $appName) }}
+        {{ include "v2.page.select-account.default.title" (dict "AppOrClientName" $appName) }}
       {{ end }}
     </h1>
     <p class="screen-description">
-      {{ template "v2.page.select-account.default.description" (merge (dict) $.UserProfile (dict "IdentityDisplayName" $.IdentityDisplayName)) }}
+      {{ include "v2.page.select-account.default.description" (merge (dict) $.UserProfile (dict "IdentityDisplayName" $.IdentityDisplayName)) }}
     </p>
     {{ template "authflowv2/__alert_message.html"
       (dict
@@ -34,7 +34,7 @@
       value="continue"
       data-authgear-event="authgear.button.continue_with_current_account"
       >
-      {{ template "v2.component.button.default.label-continue" }}
+      {{ include "v2.component.button.default.label-continue" nil }}
     </button>
     <button
       class="label-btn w-full"
@@ -43,7 +43,7 @@
       value="login"
       data-authgear-event="authgear.button.use_another_account"
       >
-      {{ template "v2.page.select-account.default.use-another-account" }}
+      {{ include "v2.page.select-account.default.use-another-account" nil }}
     </button>
   </footer>
 </form>

--- a/resources/authgear/templates/en/web/authflowv2/settings.html
+++ b/resources/authgear/templates/en/web/authflowv2/settings.html
@@ -21,7 +21,7 @@
       <p class="body-text--lg">
         {{ $editProfileHref := call $.MakeURL "/settings/profile"}}
         <a href="{{ $editProfileHref }}" >
-          {{ template "v2.page.settings.default.link-label-edit-profile" . }}
+          {{ include "v2.page.settings.default.link-label-edit-profile" . }}
         </a>
       </p>
 
@@ -32,10 +32,10 @@
   <div class="flex flex-col gap-2">
     <div class="flex flex-col gap-1">
       <h2 class="settings-title text-start">
-        {{ template "v2.page.settings.default.title-my-account" . }}
+        {{ include "v2.page.settings.default.title-my-account" . }}
       </h2>
       <div class="settings-description text-start">
-        {{ template "v2.page.settings.default.description-my-account" . }}
+        {{ include "v2.page.settings.default.description-my-account" . }}
       </div>
     </div>
 
@@ -93,10 +93,10 @@
   <div class="flex flex-col gap-2">
     <div class="flex flex-col gap-1">
       <h2 class="settings-title text-start">
-        {{ template "v2.page.settings.default.title-security" . }}
+        {{ include "v2.page.settings.default.title-security" . }}
       </h2>
       <div class="settings-description text-start">
-        {{ template "v2.page.settings.default.description-security" . }}
+        {{ include "v2.page.settings.default.description-security" . }}
       </div>
     </div>
 
@@ -177,7 +177,7 @@
         <i class="alternative-icon material-icons">
           home
         </i>
-        {{ template "v2.page.settings.default.button-label-back-to-app" . }}
+        {{ include "v2.page.settings.default.button-label-back-to-app" . }}
       </div>
     </a>
   </div>

--- a/resources/authgear/templates/en/web/authflowv2/settings_picture_edit.html
+++ b/resources/authgear/templates/en/web/authflowv2/settings_picture_edit.html
@@ -63,9 +63,9 @@
       data-action="click->image-picker#onClickFile"
     >
       {{ if $.Picture }}
-        {{ template "v2.page.settings-profile.default.button-label-upload-new-picture" . }}
+        {{ include "v2.page.settings-profile.default.button-label-upload-new-picture" . }}
       {{ else }}
-        {{ template "v2.page.settings-profile.default.button-label-add-picture" . }}
+        {{ include "v2.page.settings-profile.default.button-label-add-picture" . }}
       {{ end }}
     </button>
 
@@ -80,7 +80,7 @@
         value="save"
         data-image-picker-target="buttonRemove"
       >
-        {{ template "v2.page.settings-profile.default.button-label-remove-picture" . }}
+        {{ include "v2.page.settings-profile.default.button-label-remove-picture" . }}
       </button>
     </form>
 
@@ -92,7 +92,7 @@
       data-image-picker-target="buttonSave"
       data-action="click->image-picker#onClickSave"
     >
-      {{ template "v2.component.button.default.label-save" }}
+      {{ include "v2.component.button.default.label-save" nil }}
     </button>
   </div>
 </div>

--- a/resources/authgear/templates/en/web/authflowv2/settings_profile_edit_gender.html
+++ b/resources/authgear/templates/en/web/authflowv2/settings_profile_edit_gender.html
@@ -68,7 +68,7 @@
     value="save"
     data-authgear-event="authgear.button.update_profile"
   >
-    {{ template "v2.component.button.default.label-save" }}
+    {{ include "v2.component.button.default.label-save" nil }}
   </button>
 </form>
 

--- a/resources/authgear/templates/en/web/authflowv2/setup_oob_otp.html
+++ b/resources/authgear/templates/en/web/authflowv2/setup_oob_otp.html
@@ -16,18 +16,18 @@
   <div class="flex flex-col gap-y-8 flex-1-0-auto">
     <div class="space-y-4">
       <h1 class="screen-title">
-        {{ template "v2.page.setup-oob-otp.default.title" }}
+        {{ include "v2.page.setup-oob-otp.default.title" nil }}
       </h1>
       <h2 class="screen-description">
         {{- if eq $.OOBAuthenticatorType "oob_otp_sms" }}
           {{- if eq .Channel "whatsapp" }}
-            {{ template "v2.page.setup-oob-otp.whatsapp.subtitle" }}
+            {{ include "v2.page.setup-oob-otp.whatsapp.subtitle" nil }}
           {{ else }}
-            {{ template "v2.page.setup-oob-otp.sms.subtitle" }}
+            {{ include "v2.page.setup-oob-otp.sms.subtitle" nil }}
           {{- end }}
         {{- end }}
         {{- if eq $.OOBAuthenticatorType "oob_otp_email" }}
-          {{ template "v2.page.setup-oob-otp.email.subtitle" }}
+          {{ include "v2.page.setup-oob-otp.email.subtitle" nil }}
         {{ end }}
       </h2>
 
@@ -77,7 +77,7 @@
         name="x_target"
         autocomplete="email"
         autocapitalize="none"
-        placeholder="{{ template "v2.component.input.default.placeholder-email" }}"
+        placeholder="{{ include "v2.component.input.default.placeholder-email" nil }}"
       >
       {{- end }}
 
@@ -93,7 +93,7 @@
         name="x_action"
         value=""
         data-authgear-event="authgear.button.setup_oob_otp"
-      >{{ template "v2.component.button.default.label-continue" }}</button>
+      >{{ include "v2.component.button.default.label-continue" nil }}</button>
     </form>
 
     {{ template "authflowv2/__authflow_branch.html" $ }}

--- a/resources/authgear/templates/en/web/authflowv2/setup_totp.html
+++ b/resources/authgear/templates/en/web/authflowv2/setup_totp.html
@@ -3,9 +3,9 @@
 
 <div class="flex flex-col gap-y-8 flex-1-0-auto">
   <div class="space-y-4">
-    <h1 class="screen-title">{{ template "v2.page.setup-totp.default.title" }}</h1>
+    <h1 class="screen-title">{{ include "v2.page.setup-totp.default.title" nil }}</h1>
 
-    <h2 class="screen-description">{{ template "v2.page.setup-totp.default.description" }}</h2>
+    <h2 class="screen-description">{{ include "v2.page.setup-totp.default.description" nil }}</h2>
     {{ template "authflowv2/__alert_message.html"
       (dict
         "Type" "error"
@@ -22,7 +22,7 @@
       <p
         id="copy-button-source"
         class="code-block__text"
-      >{{ template "v2.page.setup-totp.default.raw-secret" (dict "secret" $.Secret) }}</p>
+      >{{ include "v2.page.setup-totp.default.raw-secret" (dict "secret" $.Secret) }}</p>
 
       <button
         class="tertiary-btn"
@@ -31,7 +31,7 @@
         data-copy-button-source-value="#copy-button-source"
         data-action="copy-button#copy"
       >
-        {{ template "v2.component.button.default.copy" }}
+        {{ include "v2.component.button.default.copy" nil }}
       </button>
     </div>
 
@@ -39,7 +39,7 @@
       class="primary-btn w-full mt-10"
       href="{{ call $.MakeURL "setup_totp" "q_setup_totp_step" "verify"}}"
     >
-      {{ template "v2.component.button.default.label-continue" }}
+      {{ include "v2.component.button.default.label-continue" nil }}
     </a>
   </div>
 

--- a/resources/authgear/templates/en/web/authflowv2/setup_totp_verify.html
+++ b/resources/authgear/templates/en/web/authflowv2/setup_totp_verify.html
@@ -11,10 +11,10 @@
   <div class="flex flex-col gap-y-8 flex-1-0-auto">
     <div class="screen-title-description">
       <h1 class="screen-title">
-        {{ template "v2.page.setup-totp-verify.default.title" }}
+        {{ include "v2.page.setup-totp-verify.default.title" nil }}
       </h1>
       <h2 class="screen-description">
-        {{ template "v2.page.setup-totp-verify.default.description" . }}
+        {{ include "v2.page.setup-totp-verify.default.description" . }}
       </h2>
 
       {{ template "authflowv2/__alert_message.html"
@@ -61,7 +61,7 @@
         class="mt-4 inline-block link-btn"
         href="{{ call $.MakeURL "setup_totp" "q_setup_totp_step" "" }}"
       >
-        {{ template "v2.page.setup-totp-verify.default.rescan-button-label" }}
+        {{ include "v2.page.setup-totp-verify.default.rescan-button-label" nil }}
       </a>
     </div>
 

--- a/resources/authgear/templates/en/web/authflowv2/signup.html
+++ b/resources/authgear/templates/en/web/authflowv2/signup.html
@@ -46,12 +46,12 @@
       <div class="screen-title-description">
         <h1 class="screen-title">
           {{ if eq $.UIVariant "signup_login" }}
-            {{ template "v2.page.signup.signup-login.title" (dict
+            {{ include "v2.page.signup.signup-login.title" (dict
               "AppName" $appName
               "ClientName" $clientName)
             }}
           {{ else }}
-            {{ template "v2.page.signup.default.title" (dict
+            {{ include "v2.page.signup.default.title" (dict
               "AppName" $appName
               "ClientName" $clientName)
             }}
@@ -59,12 +59,12 @@
         </h1>
         <h2 class="screen-description">
           {{ if eq $.UIVariant "signup_login" }}
-            {{ template "v2.page.signup.signup-login.subtitle" (dict
+            {{ include "v2.page.signup.signup-login.subtitle" (dict
               "AppName" $appName
               "ClientName" $clientName)
             }}
           {{ else }}
-            {{ template "v2.page.signup.default.subtitle" (dict
+            {{ include "v2.page.signup.default.subtitle" (dict
               "AppName" $appName
               "ClientName" $clientName)
             }}
@@ -138,7 +138,7 @@
             name="q_login_id"
             autocomplete="username"
             autocapitalize="none"
-            placeholder="{{ template "v2.component.input.default.placeholder-login-id" (dict "variant" $.LoginIDKey) }}"
+            placeholder="{{ include "v2.component.input.default.placeholder-login-id" (dict "variant" $.LoginIDKey) }}"
             data-controller="retain-form-input"
             data-action="input->retain-form-input#input retain-form-input:input->retain-form-form#input"
             data-retain-form-form-target="input"
@@ -169,14 +169,14 @@
         name="x_action"
         value="login_id"
         data-authgear-event="authgear.button.sign_up"
-      >{{ template "v2.component.button.default.label-continue" }}</button>
+      >{{ include "v2.component.button.default.label-continue" nil }}</button>
     {{ end }}
   </form>
 
   {{ if $.CanSwitchToLogin }}
     <p class="body-text--md mt-4">
       {{ $loginHref := call $.MakeURL "/login" "q_login_id_input_type" $.LoginIDInputType "x_step" "" }}
-      {{ template "v2.page.signup.default.switch-to-login" (dict "href" $loginHref )}}
+      {{ include "v2.page.signup.default.switch-to-login" (dict "href" $loginHref )}}
     </p>
   {{ end }}
 
@@ -190,7 +190,7 @@
               href="{{ call $.MakeURL "" "q_login_id_key" .login_id_key "q_login_id_input_type" .login_id_input_type }}">
               <div class="flex gap-2">
                 <i class="alternative-icon material-icons">mail</i>
-                {{ template "v2.page.signup.default.signup-with-email" }}
+                {{ include "v2.page.signup.default.signup-with-email" nil }}
               </div>
             </a>
           {{ end }}
@@ -199,7 +199,7 @@
               href="{{ call $.MakeURL "" "q_login_id_key" .login_id_key "q_login_id_input_type" .login_id_input_type }}">
               <div class="flex gap-2">
                 <i class="alternative-icon material-icons">person</i>
-                {{ template "v2.page.signup.default.signup-with-username" }}
+                {{ include "v2.page.signup.default.signup-with-username" nil }}
               </div>
             </a>
           {{ end }}
@@ -208,7 +208,7 @@
               href="{{ call $.MakeURL "" "q_login_id_key" .login_id_key "q_login_id_input_type" .login_id_input_type }}">
               <div class="flex gap-2">
                 <i class="alternative-icon material-icons">smartphone</i>
-                {{ template "v2.page.signup.default.signup-with-photo" }}
+                {{ include "v2.page.signup.default.signup-with-photo" nil }}
               </div>
             </a>
           {{ end }}
@@ -262,7 +262,7 @@
                   {{ if ($.Translations.HasKey (printf "v2.component.ldap-branding.default.label-%s" .server_name)) }}
                     {{ include (printf "v2.component.ldap-branding.default.label-%s" .server_name) nil }}
                   {{ else }}
-                    {{ template "v2.component.ldap-branding.default.label" }}
+                    {{ include "v2.component.ldap-branding.default.label" nil }}
                   {{ end }}
                 </span>
               </div>
@@ -288,7 +288,7 @@
                 passkey
               </i>
               <span>
-                {{ template "v2.component.button.default.label-continue-with-passkey" }}
+                {{ include "v2.component.button.default.label-continue-with-passkey" nil }}
               </span>
             </div>
             </span>

--- a/resources/authgear/templates/en/web/authflowv2/terminate_other_sessions.html
+++ b/resources/authgear/templates/en/web/authflowv2/terminate_other_sessions.html
@@ -11,8 +11,8 @@
     {{ $.CSRFField }}
     <i class="material-icons screen-icon">phone_iphone</i>
     <header class="screen-title-description">
-      <h1 class="screen-title">{{ template "v2.page.terminate-other-sessions.default.title" }}</h1>
-      <p class="screen-description">{{ template "v2.page.terminate-other-sessions.default.description" }}</p>
+      <h1 class="screen-title">{{ include "v2.page.terminate-other-sessions.default.title" nil }}</h1>
+      <p class="screen-description">{{ include "v2.page.terminate-other-sessions.default.description" nil }}</p>
       {{ template "authflowv2/__alert_message.html"
         (dict
           "Type" "error"
@@ -31,7 +31,7 @@
         value="confirm"
         data-authgear-event="authgear.button.confirm_terminate_other_sessions"
       >
-        {{ template "v2.component.button.default.label-continue" }}
+        {{ include "v2.component.button.default.label-continue" nil }}
       </button>
       <button
         class="label-btn w-full"
@@ -40,7 +40,7 @@
         value="cancel"
         data-authgear-event="authgear.button.cancel_terminate_other_sessions"
       >
-        {{ template "v2.page.terminate-other-sessions.default.cancel-button-label" }}
+        {{ include "v2.page.terminate-other-sessions.default.cancel-button-label" nil }}
       </button>
     </footer>
   </form>

--- a/resources/authgear/templates/en/web/authflowv2/use_passkey.html
+++ b/resources/authgear/templates/en/web/authflowv2/use_passkey.html
@@ -5,13 +5,13 @@
     <i class="screen-icon material-icons">passkey</i>
     <header class="screen-title-description">
       <h1 class="screen-title">
-        {{ template "v2.page.use-passkey.default.title" }}
+        {{ include "v2.page.use-passkey.default.title" nil }}
       </h1>
       <p class="screen-description">
         {{ if eq $.FlowType "reauth" }}
-          {{ template "v2.page.use-passkey.reauth.description" }}
+          {{ include "v2.page.use-passkey.reauth.description" nil }}
         {{ else }}
-          {{ template "v2.page.use-passkey.default.description" }}
+          {{ include "v2.page.use-passkey.default.description" nil }}
         {{ end }}
       </p>
       {{ template "authflowv2/__alert_message.html"
@@ -38,7 +38,7 @@
         data-authflow-passkey-request-target="button"
         disabled
       >
-        {{ template "v2.page.use-passkey.default.button-action-label" }}
+        {{ include "v2.page.use-passkey.default.button-action-label" nil }}
       </button>
       <form
         class="hidden"

--- a/resources/authgear/templates/en/web/authflowv2/verify_bot_protection.html
+++ b/resources/authgear/templates/en/web/authflowv2/verify_bot_protection.html
@@ -13,7 +13,7 @@
 >
   <header class="screen-title-description">
     <h1 class="screen-title">
-      {{ template "v2.component.verify-bot-protection.default.title" }}
+      {{ include "v2.component.verify-bot-protection.default.title" nil }}
     </h1>
     {{ template "authflowv2/__alert_message.html"
       (dict
@@ -22,7 +22,7 @@
       )
     }}
     <p class="screen-description">
-      {{ template "v2.component.verify-bot-protection.default.description" }}
+      {{ include "v2.component.verify-bot-protection.default.description" nil }}
     </p>
   </header>
   <form method="POST" novalidate class="flex flex-col gap-y-4 items-center">
@@ -40,7 +40,7 @@
       data-authgear-event="authgear.button.verify_bot_protection"
       data-action-button
     >
-      {{ template "v2.component.button.default.label-continue" }}
+      {{ include "v2.component.button.default.label-continue" nil }}
     </button>
   </form>
 </div>

--- a/resources/authgear/templates/en/web/authflowv2/verify_login_link.html
+++ b/resources/authgear/templates/en/web/authflowv2/verify_login_link.html
@@ -14,10 +14,10 @@
     <div class="screen-icon-layout flex-1-0-auto">
       <i class="screen-icon material-icons">check_circle</i>
       <h1 class="screen-title">
-        {{ template "v2.page.verify-login-link.approved.title" }}
+        {{ include "v2.page.verify-login-link.approved.title" nil }}
       </h1>
       <p class="screen-description">
-        {{ template "v2.page.verify-login-link.approved.description" (dict "AppOrClientName" $appName) }}
+        {{ include "v2.page.verify-login-link.approved.description" (dict "AppOrClientName" $appName) }}
       </p>
       {{ template "authflowv2/__alert_message.html"
         (dict
@@ -38,8 +38,8 @@
     >
       {{ $.CSRFField }}
       <input type="hidden" name="x_oob_otp_code" value="{{ .Code }}">
-      <h1 class="screen-title">{{ template "v2.page.verify-login-link.default.title" }}</h1>
-      <p class="screen-description">{{ template "v2.page.verify-login-link.default.description" (dict "AppOrClientName" $appName) }}</p>
+      <h1 class="screen-title">{{ include "v2.page.verify-login-link.default.title" nil }}</h1>
+      <p class="screen-description">{{ include "v2.page.verify-login-link.default.description" (dict "AppOrClientName" $appName) }}</p>
       {{ template "authflowv2/__alert_message.html"
         (dict
           "Type" "error"
@@ -54,7 +54,7 @@
         name="x_action"
         value=""
         data-authgear-event="authgear.button.verify_login_link">
-        {{ template "v2.page.verify-login-link.default.approve-button-label" }}
+        {{ include "v2.page.verify-login-link.default.approve-button-label" nil }}
       </button>
     </form>
   {{ end }}

--- a/resources/authgear/templates/en/web/authflowv2/view_recovery_code.html
+++ b/resources/authgear/templates/en/web/authflowv2/view_recovery_code.html
@@ -4,10 +4,10 @@
 <div class="flex-1-0-auto">
   <div class="space-y-4">
     <h1 class="screen-title">
-      {{ template "v2.page.view-recovery-code.default.title" }}
+      {{ include "v2.page.view-recovery-code.default.title" nil }}
     </h1>
     <h2 class="screen-description">
-      {{ template "v2.page.view-recovery-code.default.storage-description" }}
+      {{ include "v2.page.view-recovery-code.default.storage-description" nil }}
     </h2>
     {{ template "authflowv2/__alert_message.html"
       (dict
@@ -41,7 +41,7 @@
           name="x_action"
           value="download"
         >
-          {{ template "v2.component.button.default.download" }}
+          {{ include "v2.component.button.default.download" nil }}
         </button>
       </form>
       {{ end }}
@@ -52,7 +52,7 @@
         data-copy-button-source-value="#copy-button-source"
         data-action="copy-button#copy"
       >
-        {{ template "v2.component.button.default.copy" }}
+        {{ include "v2.component.button.default.copy" nil }}
       </button>
     </div>
   </div>
@@ -65,7 +65,7 @@
   >
     {{ $.CSRFField }}
     <button class="btn primary-btn w-full" type="submit" name="x_action" value="proceed">
-    {{ template "v2.component.button.default.label-continue" }}
+    {{ include "v2.component.button.default.label-continue" nil }}
     </button>
   </form>
 </div>

--- a/resources/authgear/templates/en/web/authflowv2/wechat.html
+++ b/resources/authgear/templates/en/web/authflowv2/wechat.html
@@ -12,10 +12,10 @@
 <div class="screen-action-layout flex-1-0-auto">
   <header class="screen-title-description">
     <h1 class="screen-title">
-      {{ template "v2.page.wechat-auth.default.title" }}
+      {{ include "v2.page.wechat-auth.default.title" nil }}
     </h1>
     <h2 class="screen-description">
-      {{ template "v2.page.wechat-auth.default.app-description" }}
+      {{ include "v2.page.wechat-auth.default.app-description" nil }}
     </h2>
     {{ template "authflowv2/__alert_message.html"
       (dict
@@ -43,7 +43,7 @@
     data-click-to-switch-target="clickToHide"
     data-action="click-to-switch#click"
   >
-    {{ template "v2.page.wechat-auth.default.open-app" }}
+    {{ include "v2.page.wechat-auth.default.open-app" nil }}
   </a>
 
   <button
@@ -54,7 +54,7 @@
     data-is-refresh-link="true"
     data-click-to-switch-target="clickToShow"
   >
-    {{ template "v2.page.wechat-auth.default.proceed" }}
+    {{ include "v2.page.wechat-auth.default.proceed" nil }}
   </button>
 
   </form>
@@ -66,10 +66,10 @@
 <div class="screen-action-layout flex-1-0-auto">
   <header class="screen-title-description">
     <h1 class="screen-title">
-      {{ template "v2.page.wechat-auth.default.title" }}
+      {{ include "v2.page.wechat-auth.default.title" nil }}
     </h1>
     <h2 class="screen-description">
-      {{ template "v2.page.wechat-auth.default.qr-code-description" }}
+      {{ include "v2.page.wechat-auth.default.qr-code-description" nil }}
     </h2>
   </header>
 


### PR DESCRIPTION
ref DEV-2057

## What's in this PR?
1. Forbid `.Translations.Rendertext`
2. Change `.Translations.Rendertext` to `include`
3. Forbid `template "v2.___"`
4. Change `template "v2.___"` to `include "v2.___"`

## TODO
We planned to change as `translate` originally, but decided to switch to include first due to [this](https://linear.app/authgear/issue/DEV-1945/[translation-key-linter]-allow-translate-only#comment-ca3a59c7)

## Preview
Pending. Checked some screens ok, hvnt screenshot yet