### PR TITLE
Change missing template into include in translation linter

### DIFF
--- a/devtools/gotemplatelinter/transation_key_rule_check_template.go
+++ b/devtools/gotemplatelinter/transation_key_rule_check_template.go
@@ -17,10 +17,6 @@ func CheckTemplate(templateNode *parse.TemplateNode) (err error) {
 	}
 
 	key := templateNode.Name
-	if IsSpecialCase(key) {
-		return
-	}
-
 	return fmt.Errorf("template translation is forbidden: `%s`", key)
 }
 

--- a/resources/authgear/templates/en/web/authflowv2/__html_head.html
+++ b/resources/authgear/templates/en/web/authflowv2/__html_head.html
@@ -1,7 +1,7 @@
 {{ define "authflowv2/__html_head.html" }}
 <head>
 <meta charset="UTF-8">
-<title>{{ template "app.name" }}</title>
+<title>{{ include "app.name" nil }}</title>
 <link rel="shortcut icon" href="{{ call $.StaticAssetURL "favicon" }}">
 <meta name="x-authgear-page-loaded-at" content="{{ .PageLoadedAt }}">
 <meta name="x-phone-input-only-countries" content="{{ $.AllowedPhoneCountryCodeJSON }}">


### PR DESCRIPTION
cont'd PR #4733

Just realized not even special cases should be allowed in template, so removed it. 🙏 

(Ran `make lint-translation-keys`, expected no change)