### PR TITLE
Fix key input validation pattern and test

### DIFF
--- a/docs/specs/roles-groups.md
+++ b/docs/specs/roles-groups.md
@@ -8,7 +8,7 @@
 - [Changes in User Info](#changes-in-user-info)
 - [Changes in the headers of resolver](#changes-in-the-headers-of-resolver)
 - [Changes in blocking event hooks](#changes-in-blocking-event-hooks)
-- [Changes in search](#changes-in-search)
+- [Changes in user listing](#changes-in-user-listing)
 - [Changes in account deletion and account anonymization](#changes-in-account-deletion-and-account-anonymization)
 
 # Roles and Groups
@@ -23,7 +23,7 @@
 
 - The key must be nonempty.
 - The key must be between 1 and 40 characters long.
-- The key must satisfy this regex `[a-zA-Z_][a-zA-Z0-9:_]*`. That is, the valid characters of the key are alphanumeric, a colon, or an underscore. The first character must be an alphabet or an underscore.
+- The key must satisfy this regex `^[a-zA-Z_][a-zA-Z0-9:_]*$`. That is, the valid characters of the key are alphanumeric, a colon, or an underscore. The first character must be an alphabet or an underscore.
 - The prefix `authgear:` is reserved for future use.
 
 Here are some example of valid keys:

--- a/pkg/lib/rolesgroups/key.go
+++ b/pkg/lib/rolesgroups/key.go
@@ -9,7 +9,7 @@ var KeySchema = validation.NewSimpleSchema(`
 		"type": "string",
 		"minLength": 1,
 		"maxLength": 40,
-		"pattern": "[a-zA-Z_][a-zA-Z0-9:_]*",
+		"pattern": "^[a-zA-Z_][a-zA-Z0-9:_]*$",
 		"format": "x_role_group_key"
 	}
 `)

--- a/pkg/lib/rolesgroups/key_test.go
+++ b/pkg/lib/rolesgroups/key_test.go
@@ -12,7 +12,7 @@ func TestValidateKey(t *testing.T) {
 <root>: minLength
   map[actual:0 expected:1]
 <root>: pattern
-  map[actual: expected:[a-zA-Z_][a-zA-Z0-9:_]*]`)
+  map[actual: expected:^[a-zA-Z_][a-zA-Z0-9:_]*$]`)
 
 		So(ValidateKey("a0123456789012345678901234567890123456789"), ShouldBeError, `invalid value:
 <root>: maxLength
@@ -20,12 +20,29 @@ func TestValidateKey(t *testing.T) {
 
 		So(ValidateKey("1"), ShouldBeError, `invalid value:
 <root>: pattern
-  map[actual:1 expected:[a-zA-Z_][a-zA-Z0-9:_]*]`)
+  map[actual:1 expected:^[a-zA-Z_][a-zA-Z0-9:_]*$]`)
+
+		So(ValidateKey("#$%^&*AND*&&^%$#"), ShouldBeError, `invalid value:
+<root>: pattern
+  map[actual:#$%^&*AND*&&^%$# expected:^[a-zA-Z_][a-zA-Z0-9:_]*$]`)
+
+		So(ValidateKey("user#123ok"), ShouldBeError, `invalid value:
+<root>: pattern
+  map[actual:user#123ok expected:^[a-zA-Z_][a-zA-Z0-9:_]*$]`)
+
+		So(ValidateKey("GOOD key"), ShouldBeError, `invalid value:
+<root>: pattern
+  map[actual:GOOD key expected:^[a-zA-Z_][a-zA-Z0-9:_]*$]`)
+
+		So(ValidateKey("0admin"), ShouldBeError, `invalid value:
+<root>: pattern
+  map[actual:0admin expected:^[a-zA-Z_][a-zA-Z0-9:_]*$]`)
 
 		So(ValidateKey("authgear:user"), ShouldBeError, `invalid value:
 <root>: format
   map[error:key cannot start with the preserved prefix: `+"`"+`authgear:`+"`"+` format:x_role_group_key]`)
 
+		So(ValidateKey("manager:SUPER_ADMIN1"), ShouldBeNil)
 		So(ValidateKey("manager"), ShouldBeNil)
 	})
 }


### PR DESCRIPTION
@louischan-oursky fixed validation pattern and added few more tests to it🙏

Preview:

```
=== RUN   TestValidateKey
.........
10 total assertions

--- PASS: TestValidateKey (0.00s)
PASS
ok      github.com/authgear/authgear-server/pkg/lib/rolesgroups (cached)
```