### PR TITLE
Make custom attribute save button bottom bar sticky

### DIFF
--- a/portal/src/graphql/portal/CustomAttributesConfigurationScreen.tsx
+++ b/portal/src/graphql/portal/CustomAttributesConfigurationScreen.tsx
@@ -178,7 +178,11 @@ const CustomAttributesConfigurationScreen: React.VFC =
     }
 
     return (
-      <FormContainer form={form} showDiscardButton={true}>
+      <FormContainer
+        form={form}
+        showDiscardButton={true}
+        stickyFooterComponent={true}
+      >
         <CustomAttributesConfigurationScreenContent form={form} />
       </FormContainer>
     );

--- a/portal/src/graphql/portal/CustomAttributesConfigurationScreen.tsx
+++ b/portal/src/graphql/portal/CustomAttributesConfigurationScreen.tsx
@@ -129,7 +129,7 @@ const CustomAttributesConfigurationScreenContent: React.VFC<CustomAttributesConf
 
     return (
       <>
-        <ScreenContent>
+        <ScreenContent layout="list">
           <div className={styles.widget}>
             <div className="flex gap-x-1">
               <NavBreadcrumb

--- a/portal/src/graphql/portal/StandardAttributesConfigurationScreen.tsx
+++ b/portal/src/graphql/portal/StandardAttributesConfigurationScreen.tsx
@@ -137,7 +137,7 @@ const StandardAttributesConfigurationScreenContent: React.VFC<StandardAttributes
     );
     return (
       <>
-        <ScreenContent>
+        <ScreenContent layout="list">
           <ScreenTitle className={styles.widget}>
             <FormattedMessage id="StandardAttributesConfigurationScreen.title" />
           </ScreenTitle>


### PR DESCRIPTION
ref DEV-2086

Also quickly skimmed through all screens, seems all other non-sticky-footer save buttons are intentional. IOW, only this screen need changes

EDIT: just observed another problem, the table width did not grow. Lemme fix fix
EDIT2: fixed in [12ed2e8](https://github.com/authgear/authgear-server/pull/4758/commits/12ed2e8c322a343d96bd0509c8fec356a373f857)


## Problematic Preview - table width not grow

<img width="1919" alt="image" src="https://github.com/user-attachments/assets/12a01408-9755-4cd4-a780-b31634fa80f2">

## Preview

| standard | custom |
| ------  | ----- |
| <img width="1640" alt="image" src="https://github.com/user-attachments/assets/65bd464f-50d9-43bb-a475-b6a8edfcc038">        | <img width="1621" alt="image" src="https://github.com/user-attachments/assets/e9b3c5e9-db0d-479c-aeed-9a623500093a">    |	
