### PR TITLE
Specify browserslistrc more accurately

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -58,6 +58,9 @@ jobs:
     - run: npm run ensure-reproducible-build
       working-directory: ./authui
       if: ${{ !cancelled() }}
+    - run: npm run browserslist-coverage-lint
+      working-directory: ./authui
+      if: ${{ !cancelled() }}
 
   portal-test:
     if: ${{ github.repository != 'oursky/authgear-server' }}
@@ -106,6 +109,9 @@ jobs:
       working-directory: ./portal
       if: ${{ !cancelled() }}
     - run: npm run ensure-reproducible-build
+      working-directory: ./portal
+      if: ${{ !cancelled() }}
+    - run: npm run browserslist-coverage-lint
       working-directory: ./portal
       if: ${{ !cancelled() }}
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -212,8 +212,6 @@ As the first project `accounts` is created by the script instead of by user, we 
 
 cert-manager@v1.7.3 has transitive dependency problem.
 
-siwe has to be 1.1.6. siwe@2.x has runtime error on page load. siwe@1.1.6 requires ethers@5.5.1.
-
 When intl-tel-input is >= 21, it switched to use CSS variables. https://github.com/jackocnr/intl-tel-input/releases/tag/v21.0.0
 The problem is that it uses `--custom-var: url("../some-path");`, which is rejected by Parcel https://github.com/parcel-bundler/parcel/blob/v2.10.2/packages/transformers/css/src/CSSTransformer.js#L135
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -212,6 +212,8 @@ As the first project `accounts` is created by the script instead of by user, we 
 
 cert-manager@v1.7.3 has transitive dependency problem.
 
+caniuse-lite is not up-to-latest, which makes `last x versions` in `.browserslistrc` outdated. However, updating to `caniuse-lite 1.0.30001655` will lead to breaking changes in `doiuse 6.0.2` and `stylelint-no-unsupported-browser-features 8.0.2`. Thus, we need to override `caniuse-lite 1.0.30001653` until doiuse patch [this fix](https://github.com/anandthakker/doiuse/pull/191).
+
 When intl-tel-input is >= 21, it switched to use CSS variables. https://github.com/jackocnr/intl-tel-input/releases/tag/v21.0.0
 The problem is that it uses `--custom-var: url("../some-path");`, which is rejected by Parcel https://github.com/parcel-bundler/parcel/blob/v2.10.2/packages/transformers/css/src/CSSTransformer.js#L135
 

--- a/authui/.browserslistrc
+++ b/authui/.browserslistrc
@@ -3,3 +3,4 @@ Android >= 5.0
 last 2 Chrome versions
 last 2 Edge versions
 last 2 Firefox versions
+not dead # no browsers without security updates

--- a/authui/.browserslistrc
+++ b/authui/.browserslistrc
@@ -1,6 +1,8 @@
 iOS >= 14
+Safari >= 14
 Android >= 5.0
-last 2 Chrome versions
-last 2 Edge versions
-last 2 Firefox versions
-not dead # no browsers without security updates
+last 5 Chrome versions
+last 5 ChromeAndroid versions
+last 5 Edge versions
+last 5 Firefox versions
+>=0.4% and not dead

--- a/authui/package-lock.json
+++ b/authui/package-lock.json
@@ -37,7 +37,6 @@
         "@types/zxcvbn": "4.4.4",
         "browserslist": "4.23.3",
         "buffer": "6.0.3",
-        "caniuse-lite": "1.0.30001653",
         "eslint": "8.45.0",
         "eslint-plugin-compat": "4.2.0",
         "jest": "29.7.0",

--- a/authui/package-lock.json
+++ b/authui/package-lock.json
@@ -35,6 +35,7 @@
         "@types/grecaptcha": "3.0.9",
         "@types/luxon": "3.3.4",
         "@types/zxcvbn": "4.4.4",
+        "browserslist": "4.23.3",
         "buffer": "6.0.3",
         "caniuse-lite": "1.0.30001653",
         "eslint": "8.45.0",

--- a/authui/package.json
+++ b/authui/package.json
@@ -36,6 +36,7 @@
     "@types/grecaptcha": "3.0.9",
     "@types/luxon": "3.3.4",
     "@types/zxcvbn": "4.4.4",
+    "browserslist": "4.23.3",
     "buffer": "6.0.3",
     "caniuse-lite": "1.0.30001653",
     "eslint": "8.45.0",

--- a/authui/package.json
+++ b/authui/package.json
@@ -24,6 +24,7 @@
     "process": false
   },
   "overrides": {
+    "caniuse-lite": "1.0.30001653",
     "ethers": {
       "ws": "^7.5.10"
     }
@@ -38,7 +39,6 @@
     "@types/zxcvbn": "4.4.4",
     "browserslist": "4.23.3",
     "buffer": "6.0.3",
-    "caniuse-lite": "1.0.30001653",
     "eslint": "8.45.0",
     "eslint-plugin-compat": "4.2.0",
     "jest": "29.7.0",

--- a/authui/package.json
+++ b/authui/package.json
@@ -18,7 +18,8 @@
     "build": "vite build --outDir '../resources/authgear/generated'",
     "watch": "vite build --watch --outDir '../resources/authgear/generated'",
     "test": "jest",
-    "ensure-reproducible-build": "../scripts/sh/ensure-reproducible-build.sh -n 5 -p '../resources/authgear/generated/manifest.json'"
+    "ensure-reproducible-build": "../scripts/sh/ensure-reproducible-build.sh -n 5 -p '../resources/authgear/generated/manifest.json'",
+    "browserslist-coverage-lint": "../scripts/sh/ensure-browserslist-coverage.sh"
   },
   "alias": {
     "process": false

--- a/portal/.browserslistrc
+++ b/portal/.browserslistrc
@@ -8,3 +8,4 @@ last 2 Edge versions
 last 2 Chrome versions
 last 2 Firefox versions
 Safari >= 11
+not dead # no browsers without security updates

--- a/portal/.browserslistrc
+++ b/portal/.browserslistrc
@@ -4,8 +4,11 @@
 # As of 2020-08-27, the latest version of Edge is 84.
 # And Edge has adopted a release schedule similar to Chrome and Firefox.
 # Therefore we can write this.
-last 2 Edge versions
-last 2 Chrome versions
-last 2 Firefox versions
-Safari >= 11
-not dead # no browsers without security updates
+iOS >= 14
+Safari >= 14
+Android >= 5.0
+last 5 Chrome versions
+last 5 ChromeAndroid versions
+last 5 Edge versions
+last 5 Firefox versions
+>=0.4% and not dead

--- a/portal/package.json
+++ b/portal/package.json
@@ -15,7 +15,8 @@
     "eslint": "eslint --cache './src/**/*.{js,ts,jsx,tsx}'",
     "stylelint": "stylelint --cache './src/**/*.{css,scss}'",
     "gentype": "graphql-codegen --config ./graphql.portal.codegen.yaml && graphql-codegen --config ./graphql.adminapi.codegen.yaml",
-    "ensure-reproducible-build": "../scripts/sh/ensure-reproducible-build.sh -n 5 -p './dist/.vite/manifest.json'"
+    "ensure-reproducible-build": "../scripts/sh/ensure-reproducible-build.sh -n 5 -p './dist/.vite/manifest.json'",
+    "browserslist-coverage-lint": "../scripts/sh/ensure-browserslist-coverage.sh"
   },
   "overrides": {
     "word-wrap": "@aashutoshrathi/word-wrap"

--- a/scripts/sh/ensure-browserslist-coverage.sh
+++ b/scripts/sh/ensure-browserslist-coverage.sh
@@ -1,13 +1,22 @@
 #!/bin/sh
-# This script is used to test whether the ./.browerslistrc has enough coverage
 
-coverage=$(npx browserslist --json --coverage | python3 -c 'import json,sys;print(json.load(sys.stdin)["coverage"]["global"])')
-TARGET=90
-expr="$coverage > $TARGET"
-result=$(echo "$expr" | bc)
+# This script is used to test whether .browerslistrc has enough coverage
 
-echo 1>&2 "$expr: $result"
+echo 1>&2 "[INFO] Script executed from ${PWD}"
 
-if [ $result = 0 ]; then
-  exit 1
-fi
+main() {
+  TARGET=90
+  coverage=$(npx browserslist --json --coverage | python3 -c 'import json,sys;print(json.load(sys.stdin)["coverage"]["global"])')
+  expr="$coverage > $TARGET"
+  result=$(echo "$expr" | bc)
+  echo 1>&2 "[INFO] $expr is $result"
+  if [ $result = 0 ]; then
+
+    echo 1>&2 "[ERROR] Coverage $coverage is below $TARGET"
+    exit 1
+  fi
+}
+
+echo 1>&2 "[INFO] Start of script"
+main
+echo 1>&2 "[INFO] End of script"

--- a/scripts/sh/ensure-browserslist-coverage.sh
+++ b/scripts/sh/ensure-browserslist-coverage.sh
@@ -1,0 +1,13 @@
+#!/bin/sh
+# This script is used to test whether the ./.browerslistrc has enough coverage
+
+coverage=$(npx browserslist --json --coverage | python3 -c 'import json,sys;print(json.load(sys.stdin)["coverage"]["global"])')
+TARGET=90
+expr="$coverage > $TARGET"
+result=$(echo "$expr" | bc)
+
+echo 1>&2 "$expr: $result"
+
+if [ $result = 0 ]; then
+  exit 1
+fi


### PR DESCRIPTION
ref DEV-2108


[New authUI coverage: 85.6%](https://browsersl.ist/#q=iOS+%3E%3D+14%0Alast+5+Chrome+versions%0Alast+5+ChromeAndroid+versions%0Alast+5+Edge+versions%0Alast+5+Safari+versions+%23+non-iOS+Safari%0Alast+5+Firefox+versions%0Alast+5+FirefoxAndroid+versions%0Alast+2+Samsung+versions+%23+Samsung+default+browser+-+Samsung+Internet%0Anot+dead+%23+no+browsers+without+security+updates%0A)

Fixed

- `Android` referred to Android webview instead of all browsers on Android (ref https://github.com/browserslist/browserslist/blob/ee095bd1934a43f6a591acff7e8a3e05be86cf61/README.md?plain=1#L333)
- included more versions, some browsers like Chrome 127 is still the most popular (current 129, that makes Chrome 127 not included in `last 2 Chrome versions`