### PR TITLE
Use substring match to filter posthog type error

### DIFF
--- a/portal/src/ReactApp.tsx
+++ b/portal/src/ReactApp.tsx
@@ -83,10 +83,7 @@ async function loadSystemConfig(): Promise<SystemConfig> {
 }
 
 function isPosthogResetGroupsException(ex: SentryException) {
-  return (
-    ex.type === "TypeError" &&
-    ex.value === "posthog.resetGroups is not a function"
-  );
+  return ex.type === "TypeError" && ex.value?.includes("posthog.resetGroups");
 }
 function isPosthogResetGroupsEvent(event: SentryEvent) {
   return event.exception?.values?.some(isPosthogResetGroupsException) ?? false;


### PR DESCRIPTION
ref DEV-1767

## Notes
Actually not sure how to reproduce [this](https://authgear.sentry.io/issues/5897586517/?alert_rule_id=15285121&alert_timestamp=1727150257207&alert_type=email&environment=production&notification_uuid=904c3b4b-2df3-4f8d-912c-49c1e67af8d3&project=4507492100014080&referrer=alert_email)

Decided to use a substring match to also catch error like this.

Question - maybe I should just filter all errors with `posthog` in it? 🤔 Since we plan to handle it properly in [this issue](https://linear.app/authgear/issue/DEV-2131/integrate-gtm-posthog-osano-properly) anyway.

cc @tung2744 
