### PR TITLE
Handle admin_api reset password in authflow v2

### DIFF
--- a/pkg/admin/graphql/user_mutation.go
+++ b/pkg/admin/graphql/user_mutation.go
@@ -12,6 +12,7 @@ import (
 	"github.com/authgear/authgear-server/pkg/api/event/nonblocking"
 	apimodel "github.com/authgear/authgear-server/pkg/api/model"
 	"github.com/authgear/authgear-server/pkg/lib/authn/otp"
+	"github.com/authgear/authgear-server/pkg/lib/feature/forgotpassword"
 	"github.com/authgear/authgear-server/pkg/util/accesscontrol"
 	"github.com/authgear/authgear-server/pkg/util/graphqlutil"
 	"github.com/authgear/authgear-server/pkg/util/phone"
@@ -388,7 +389,9 @@ var _ = registerMutationField(
 
 			gqlCtx := GQLContext(p.Context)
 
-			err := gqlCtx.ForgotPassword.SendCode(loginID, nil)
+			err := gqlCtx.ForgotPassword.SendCode(loginID, &forgotpassword.CodeOptions{
+				IsAdminAPIResetPassword: true,
+			})
 			if err != nil {
 				return nil, err
 			}

--- a/pkg/auth/deps.go
+++ b/pkg/auth/deps.go
@@ -202,6 +202,7 @@ var DependencySet = wire.NewSet(
 	wire.Bind(new(handlerwebapp.SettingsSessionListingService), new(*sessionlisting.SessionListingService)),
 	wire.Bind(new(handlerwebapp.EnterLoginIDService), new(*identityservice.Service)),
 	wire.Bind(new(handlerwebapp.PasswordPolicy), new(*password.Checker)),
+	wire.Bind(new(handlerwebappauthflowv2.ResetPasswordHandlerPasswordPolicy), new(*password.Checker)),
 	wire.Bind(new(handlerwebapp.ResetPasswordService), new(*forgotpassword.Service)),
 	wire.Bind(new(handlerwebapp.LogoutSessionManager), new(*session.Manager)),
 	wire.Bind(new(handlerwebapp.PageService), new(*webapp.Service2)),

--- a/pkg/auth/deps.go
+++ b/pkg/auth/deps.go
@@ -35,6 +35,7 @@ import (
 	featuresiwe "github.com/authgear/authgear-server/pkg/lib/feature/siwe"
 	featurestdattrs "github.com/authgear/authgear-server/pkg/lib/feature/stdattrs"
 	"github.com/authgear/authgear-server/pkg/lib/feature/verification"
+	"github.com/authgear/authgear-server/pkg/lib/infra/db/appdb"
 	"github.com/authgear/authgear-server/pkg/lib/infra/middleware"
 	"github.com/authgear/authgear-server/pkg/lib/interaction"
 	"github.com/authgear/authgear-server/pkg/lib/meter"
@@ -123,6 +124,8 @@ var DependencySet = wire.NewSet(
 	wire.Bind(new(handlerwebapp.AuthflowSignupEndpointsProvider), new(*endpoints.Endpoints)),
 	wire.Bind(new(handlerwebapp.AuthflowPromoteEndpointsProvider), new(*endpoints.Endpoints)),
 	wire.Bind(new(oidchandler.WebAppURLsProvider), new(*endpoints.Endpoints)),
+
+	wire.Bind(new(handlerwebappauthflowv2.ResetPasswordHandlerDatabase), new(*appdb.Handle)),
 
 	webapp.DependencySet,
 	wire.Bind(new(handlerwebapp.AnonymousUserPromotionService), new(*webapp.AnonymousUserPromotionService)),

--- a/pkg/auth/handler/webapp/authflowv2/reset_password.go
+++ b/pkg/auth/handler/webapp/authflowv2/reset_password.go
@@ -168,6 +168,9 @@ func (h *AuthflowV2ResetPasswordHandler) serveHTTPNonAuthflow(w http.ResponseWri
 		if err != nil {
 			return err
 		}
+		// reset success
+		result := webapp.Result{RedirectURI: AuthflowV2RouteResetPasswordSuccess}
+		result.WriteResponse(w, r)
 		return nil
 	})
 

--- a/pkg/auth/handler/webapp/authflowv2/reset_password.go
+++ b/pkg/auth/handler/webapp/authflowv2/reset_password.go
@@ -9,6 +9,7 @@ import (
 	"github.com/authgear/authgear-server/pkg/auth/webapp"
 	"github.com/authgear/authgear-server/pkg/lib/authenticationflow/declarative"
 	"github.com/authgear/authgear-server/pkg/lib/authn/authenticator/password"
+	"github.com/authgear/authgear-server/pkg/lib/authn/otp"
 	"github.com/authgear/authgear-server/pkg/lib/feature/forgotpassword"
 	"github.com/authgear/authgear-server/pkg/util/httproute"
 	pwd "github.com/authgear/authgear-server/pkg/util/password"
@@ -224,8 +225,6 @@ func (h *AuthflowV2ResetPasswordHandler) serveHTTPAuthflow(w http.ResponseWriter
 	}
 }
 
-var fromAdminAPIQueryKey = "x_from_admin_api"
-
 func isURLFromAdminAPI(r *http.Request) bool {
-	return r.URL.Query().Get(fromAdminAPIQueryKey) == "true"
+	return r.URL.Query().Get(otp.FromAdminAPIQueryKey) == "true"
 }

--- a/pkg/auth/handler/webapp/authflowv2/reset_password.go
+++ b/pkg/auth/handler/webapp/authflowv2/reset_password.go
@@ -130,8 +130,8 @@ func (h *AuthflowV2ResetPasswordHandler) serveHTTPNonAuthflow(w http.ResponseWri
 			}
 			if err != nil {
 				if apierrors.IsAPIError(err) {
-					// TODO: render error
-					// renderError(w, r, err)
+					// Still uses AuthflowController to render error because of same logic
+					h.Controller.ErrorRenderer.RenderError(w, r, err)
 				} else {
 					panic(err)
 				}

--- a/pkg/auth/handler/webapp/authflowv2/reset_password.go
+++ b/pkg/auth/handler/webapp/authflowv2/reset_password.go
@@ -123,8 +123,7 @@ func (h *AuthflowV2ResetPasswordHandler) serveHTTPNonAuthflow(w http.ResponseWri
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			var err error
 			if code == "" {
-				// TODO: make this an api error
-				err = fmt.Errorf("code is required in admin api reset password page")
+				err = newCodeRequiredErr()
 			} else {
 				err = handler(w, r)
 			}
@@ -248,4 +247,10 @@ var fromAdminAPIQueryKey = "x_from_admin_api"
 
 func isURLFromAdminAPI(r *http.Request) bool {
 	return r.URL.Query().Get(fromAdminAPIQueryKey) == "true"
+}
+
+func newCodeRequiredErr() *apierrors.APIError {
+	apiErr := apierrors.AsAPIError(fmt.Errorf("code required in admin_api reset password page"))
+	apiErr.Reason = "CodeRequiredInAdminAPIResetPasswordPage"
+	return apiErr
 }

--- a/pkg/lib/authn/otp/sender.go
+++ b/pkg/lib/authn/otp/sender.go
@@ -18,8 +18,9 @@ type AdditionalContext struct {
 }
 
 type SendOptions struct {
-	OTP               string
-	AdditionalContext *AdditionalContext
+	OTP                     string
+	AdditionalContext       *AdditionalContext
+	IsAdminAPIResetPassword bool
 }
 
 type EndpointsProvider interface {
@@ -105,6 +106,9 @@ func (s *MessageSender) setupTemplateContext(msg *PreparedMessage, opts SendOpti
 			linkURL = s.Endpoints.ResetPasswordEndpointURL()
 			query := linkURL.Query()
 			query.Set("code", opts.OTP)
+			if opts.IsAdminAPIResetPassword {
+				query.Set("x_from_admin_api", "true")
+			}
 			linkURL.RawQuery = query.Encode()
 
 		default:

--- a/pkg/lib/authn/otp/sender.go
+++ b/pkg/lib/authn/otp/sender.go
@@ -76,6 +76,8 @@ type MessageSender struct {
 	WhatsappService WhatsappService
 }
 
+var FromAdminAPIQueryKey = "x_from_admin_api"
+
 func (s *MessageSender) setupTemplateContext(msg *PreparedMessage, opts SendOptions) (*translation.PartialTemplateVariables, error) {
 	email := ""
 	if msg.email != nil {
@@ -107,7 +109,7 @@ func (s *MessageSender) setupTemplateContext(msg *PreparedMessage, opts SendOpti
 			query := linkURL.Query()
 			query.Set("code", opts.OTP)
 			if opts.IsAdminAPIResetPassword {
-				query.Set("x_from_admin_api", "true")
+				query.Set(FromAdminAPIQueryKey, "true")
 			}
 			linkURL.RawQuery = query.Encode()
 

--- a/pkg/lib/deps/deps_common.go
+++ b/pkg/lib/deps/deps_common.go
@@ -381,6 +381,7 @@ var CommonDependencySet = wire.NewSet(
 		wire.Bind(new(authenticationflow.ForgotPasswordService), new(*forgotpassword.Service)),
 		wire.Bind(new(workflow.ResetPasswordService), new(*forgotpassword.Service)),
 		wire.Bind(new(authenticationflow.ResetPasswordService), new(*forgotpassword.Service)),
+		wire.Bind(new(handlerwebappauthflowv2.ResetPasswordHandlerResetPasswordService), new(*forgotpassword.Service)),
 		wire.Bind(new(facade.SendPasswordService), new(*forgotpassword.Sender)),
 	),
 

--- a/pkg/lib/feature/forgotpassword/service.go
+++ b/pkg/lib/feature/forgotpassword/service.go
@@ -89,6 +89,7 @@ type CodeOptions struct {
 	AuthenticationFlowJSONPointer jsonpointer.T
 	Kind                          CodeKind
 	Channel                       CodeChannel
+	IsAdminAPIResetPassword       bool
 }
 
 // SendCode uses loginID to look up Email Login IDs and Phone Number Login IDs.
@@ -221,8 +222,9 @@ func (s *Service) sendEmail(email string, userID string, options *CodeOptions) e
 	}
 
 	err = s.OTPSender.Send(msg, otp.SendOptions{
-		OTP:               code,
-		AdditionalContext: &ctx,
+		OTP:                     code,
+		AdditionalContext:       &ctx,
+		IsAdminAPIResetPassword: options.IsAdminAPIResetPassword,
 	})
 	if err != nil {
 		return err


### PR DESCRIPTION
ref DEV-2048

## What's in this PR?
This PR
- generates `admin_reset_password` flow as an account_recovery flow by default
- uses said flow when the account_recovery_code has `FlowReference.Name == "admin_reset_password"`

## Preview

https://github.com/user-attachments/assets/c50df1e8-1456-4506-a3cb-0180aae3f569




