### PR TITLE
Use max-height for brand-logo customisation

### DIFF
--- a/authui/src/authflowv2/components/brand-logo.css
+++ b/authui/src/authflowv2/components/brand-logo.css
@@ -29,10 +29,16 @@
   }
 
   .brand-logo--default {
-    /* use max-height as variable to ensure the object-contain width won't outgrow max-width */
+    /* In preflight.css, image has been given max-width: 100% and height: auto */
+    /* See https://tailwindcss.com/docs/preflight#images-are-constrained-to-the-parent-width */
+
+    /* In here, we try to be more explicit */
+    /* 1. Tell the browser to set the image dimension according to its aspect ratio. */
+    @apply w-auto h-auto;
+    /* 2. But the max-width cannot be larger than the parent */
+    @apply max-w-full;
+    /* 3. Apply the variable to max-height so that the used height is clipped when width == max-width (100%) */
     max-height: var(--brand-logo__height);
-    max-width: 100%;
-    height: 100%;
   }
 
   /* Below data-src selector is a workaround until css :has() is widely-supported */

--- a/authui/src/authflowv2/components/brand-logo.css
+++ b/authui/src/authflowv2/components/brand-logo.css
@@ -29,7 +29,10 @@
   }
 
   .brand-logo--default {
-    height: var(--brand-logo__height);
+    /* use max-height as variable to ensure the object-contain width won't outgrow max-width */
+    max-height: var(--brand-logo__height);
+    max-width: 100%;
+    height: 100%;
   }
 
   /* Below data-src selector is a workaround until css :has() is widely-supported */


### PR DESCRIPTION
To prevent object-contain-ed width out grow max-width

## Preview

https://github.com/user-attachments/assets/a97e1d95-a6d3-4006-ac5f-0fc6011aafac

