### PR TITLE
Add yaml-language-server to contribution docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -98,6 +98,7 @@ This project uses asdf, and there is a .tool-versions file at the project root.
    `authgear.yaml` must contain the following contents for the portal to work.
 
    ```yaml
+   # yaml-language-server: $schema=../tmp/app-config.schema.json # get this by running `make export-schemas`
    id: accounts # Make sure the ID matches AUTHGEAR_APP_ID environment variable.
    http:
       # Make sure this matches the host used to access main Authgear server.


### PR DESCRIPTION
## Notes
Or should we actually host these schemas through this repo?

## Preview
<img width="1088" alt="image" src="https://github.com/user-attachments/assets/cac8731e-349d-4f21-be66-b14effec04d2">

## What's in this PR?

Allow local editing of `authgear.yaml` and `authgear.secrets.yaml` have said features

> 
    YAML validation:
        Detects whether the entire file is valid yaml
    Validation:
        Detects errors such as:
            Node is not found
            Node has an invalid key node type
            Node has an invalid type
            Node is not a valid child node
        Detects warnings such as:
            Node is an additional property of parent
    Auto completion:
        Auto completes on all commands
        Scalar nodes autocomplete to schema's defaults if they exist
    Hover support:
        Hovering over a node shows description if available
    Document outlining:
        Shows a complete document outline of all nodes in the document


ref https://github.com/redhat-developer/yaml-language-server?tab=readme-ov-file#features