### PR TITLE
Rename store_grant_mock.go to store_grant_mock_test.go

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,7 +45,6 @@ ensure-important-modules-up-to-date:
 generate:
 	go generate ./pkg/... ./cmd/...
 	cd ./e2e && go generate ./...
-	$(MAKE) fmt
 
 .PHONY: test
 test:

--- a/pkg/lib/oauth/handler/handler_token_test.go
+++ b/pkg/lib/oauth/handler/handler_token_test.go
@@ -34,7 +34,7 @@ func TestTokenHandler(t *testing.T) {
 		idTokenIssuer := NewMockIDTokenIssuer(ctrl)
 		idTokenIssuer.EXPECT().Iss().Return(origin).AnyTimes()
 
-		offlineGrants := oauth.NewMockOfflineGrantStore(ctrl)
+		offlineGrants := NewMockTokenHandlerOfflineGrantStore(ctrl)
 
 		authorizations := NewMockAuthorizationService(ctrl)
 

--- a/pkg/lib/oauth/store_grant.go
+++ b/pkg/lib/oauth/store_grant.go
@@ -7,7 +7,7 @@ import (
 	"github.com/authgear/authgear-server/pkg/lib/session/idpsession"
 )
 
-//go:generate mockgen -source=store_grant.go -destination=store_grant_mock.go -package oauth
+//go:generate mockgen -source=store_grant.go -destination=store_grant_mock_test.go -package oauth
 
 type CodeGrantStore interface {
 	GetCodeGrant(codeHash string) (*CodeGrant, error)

--- a/pkg/lib/oauth/store_grant_mock_test.go
+++ b/pkg/lib/oauth/store_grant_mock_test.go
@@ -8,10 +8,9 @@ import (
 	reflect "reflect"
 	time "time"
 
-	gomock "github.com/golang/mock/gomock"
-
 	access "github.com/authgear/authgear-server/pkg/lib/session/access"
 	idpsession "github.com/authgear/authgear-server/pkg/lib/session/idpsession"
+	gomock "github.com/golang/mock/gomock"
 )
 
 // MockCodeGrantStore is a mock of CodeGrantStore interface.


### PR DESCRIPTION
`make fmt` is programmed to ignore `_mock_test.go`. So this generated file should be named `store_grant_mock_test.go`.