### PR TITLE
Trim whitespaces in email and username checker

### DIFF
--- a/pkg/admin/facade/identity.go
+++ b/pkg/admin/facade/identity.go
@@ -10,6 +10,7 @@ import (
 	"github.com/authgear/authgear-server/pkg/lib/authn/identity"
 	"github.com/authgear/authgear-server/pkg/lib/config"
 	interactionintents "github.com/authgear/authgear-server/pkg/lib/interaction/intents"
+	"github.com/authgear/authgear-server/pkg/util/stringutil"
 )
 
 type IdentityService interface {
@@ -69,7 +70,7 @@ func (f *IdentityFacade) Create(ctx context.Context, userID string, identityDef 
 		LoginID: &identity.LoginIDSpec{
 			Key:   loginIDInput.Key,
 			Type:  loginIDKeyCofig.Type,
-			Value: loginIDInput.Value,
+			Value: stringutil.NewUserInputString(loginIDInput.Value),
 		},
 	}
 

--- a/pkg/admin/facade/user.go
+++ b/pkg/admin/facade/user.go
@@ -16,6 +16,7 @@ import (
 	interactionintents "github.com/authgear/authgear-server/pkg/lib/interaction/intents"
 	"github.com/authgear/authgear-server/pkg/util/clock"
 	"github.com/authgear/authgear-server/pkg/util/graphqlutil"
+	"github.com/authgear/authgear-server/pkg/util/stringutil"
 )
 
 type UserService interface {
@@ -94,7 +95,7 @@ func (f *UserFacade) Create(ctx context.Context, identityDef model.IdentityDef, 
 		LoginID: &identity.LoginIDSpec{
 			Key:   loginIDInput.Key,
 			Type:  loginIDKeyCofig.Type,
-			Value: loginIDInput.Value,
+			Value: stringutil.NewUserInputString(loginIDInput.Value),
 		},
 	}
 

--- a/pkg/latte/intent_authenticate.go
+++ b/pkg/latte/intent_authenticate.go
@@ -6,6 +6,7 @@ import (
 	"github.com/authgear/authgear-server/pkg/api/model"
 	"github.com/authgear/authgear-server/pkg/lib/authn/identity"
 	"github.com/authgear/authgear-server/pkg/lib/workflow"
+	"github.com/authgear/authgear-server/pkg/util/stringutil"
 	"github.com/authgear/authgear-server/pkg/util/validation"
 )
 
@@ -51,7 +52,7 @@ func (i *IntentAuthenticate) ReactTo(ctx context.Context, deps *workflow.Depende
 		spec := &identity.Spec{
 			Type: model.IdentityTypeLoginID,
 			LoginID: &identity.LoginIDSpec{
-				Value: loginID,
+				Value: stringutil.NewUserInputString(loginID),
 			},
 		}
 

--- a/pkg/latte/intent_change_email.go
+++ b/pkg/latte/intent_change_email.go
@@ -10,6 +10,7 @@ import (
 	"github.com/authgear/authgear-server/pkg/lib/authn/identity"
 	"github.com/authgear/authgear-server/pkg/lib/session"
 	"github.com/authgear/authgear-server/pkg/lib/workflow"
+	"github.com/authgear/authgear-server/pkg/util/stringutil"
 	"github.com/authgear/authgear-server/pkg/util/validation"
 )
 
@@ -66,7 +67,7 @@ func (i *IntentChangeEmail) ReactTo(ctx context.Context, deps *workflow.Dependen
 				LoginID: &identity.LoginIDSpec{
 					Type:  model.LoginIDKeyTypeEmail,
 					Key:   string(model.LoginIDKeyTypeEmail),
-					Value: loginID,
+					Value: stringutil.NewUserInputString(loginID),
 				},
 			}
 			exactMatch, _, err := deps.Identities.SearchBySpec(ctx, spec)

--- a/pkg/latte/intent_create_login_id.go
+++ b/pkg/latte/intent_create_login_id.go
@@ -10,6 +10,7 @@ import (
 	"github.com/authgear/authgear-server/pkg/lib/authn/identity"
 	"github.com/authgear/authgear-server/pkg/lib/workflow"
 	"github.com/authgear/authgear-server/pkg/util/errorutil"
+	"github.com/authgear/authgear-server/pkg/util/stringutil"
 	"github.com/authgear/authgear-server/pkg/util/validation"
 )
 
@@ -66,7 +67,7 @@ func (i *IntentCreateLoginID) ReactTo(ctx context.Context, deps *workflow.Depend
 				LoginID: &identity.LoginIDSpec{
 					Type:  i.LoginIDType,
 					Key:   i.LoginIDKey,
-					Value: loginID,
+					Value: stringutil.NewUserInputString(loginID),
 				},
 			}
 

--- a/pkg/latte/intent_forgot_password_v2.go
+++ b/pkg/latte/intent_forgot_password_v2.go
@@ -7,6 +7,7 @@ import (
 	"github.com/authgear/authgear-server/pkg/api/model"
 	"github.com/authgear/authgear-server/pkg/lib/authn/identity"
 	"github.com/authgear/authgear-server/pkg/lib/workflow"
+	"github.com/authgear/authgear-server/pkg/util/stringutil"
 	"github.com/authgear/authgear-server/pkg/util/validation"
 )
 
@@ -56,7 +57,7 @@ func (i *IntentForgotPasswordV2) ReactTo(ctx context.Context, deps *workflow.Dep
 			spec := &identity.Spec{
 				Type: model.IdentityTypeLoginID,
 				LoginID: &identity.LoginIDSpec{
-					Value: loginID,
+					Value: stringutil.NewUserInputString(loginID),
 				},
 			}
 

--- a/pkg/latte/node_change_email.go
+++ b/pkg/latte/node_change_email.go
@@ -6,6 +6,7 @@ import (
 	"github.com/authgear/authgear-server/pkg/api/model"
 	"github.com/authgear/authgear-server/pkg/lib/authn/identity"
 	"github.com/authgear/authgear-server/pkg/lib/workflow"
+	"github.com/authgear/authgear-server/pkg/util/stringutil"
 )
 
 func init() {
@@ -42,7 +43,7 @@ func (n *NodeChangeEmail) ReactTo(ctx context.Context, deps *workflow.Dependenci
 			LoginID: &identity.LoginIDSpec{
 				Type:  model.LoginIDKeyTypeEmail,
 				Key:   string(model.LoginIDKeyTypeEmail),
-				Value: loginID,
+				Value: stringutil.NewUserInputString(loginID),
 			},
 		}
 

--- a/pkg/lib/accountmanagement/service_identity.go
+++ b/pkg/lib/accountmanagement/service_identity.go
@@ -14,6 +14,7 @@ import (
 	"github.com/authgear/authgear-server/pkg/lib/authn/authenticator"
 	"github.com/authgear/authgear-server/pkg/lib/authn/identity"
 	"github.com/authgear/authgear-server/pkg/lib/session"
+	"github.com/authgear/authgear-server/pkg/util/stringutil"
 	"github.com/authgear/authgear-server/pkg/util/uuid"
 )
 
@@ -1089,7 +1090,7 @@ func (i *Service) makeLoginIDSpec(loginIDKey string, loginID string) (*identity.
 		LoginID: &identity.LoginIDSpec{
 			Key:   loginIDKey,
 			Type:  typ,
-			Value: loginID,
+			Value: stringutil.NewUserInputString(loginID),
 		},
 	}
 	return identitySpec, nil

--- a/pkg/lib/authenticationflow/declarative/intent_account_recovery_flow_step_select_destination.go
+++ b/pkg/lib/authenticationflow/declarative/intent_account_recovery_flow_step_select_destination.go
@@ -201,11 +201,11 @@ func deriveAllowedAccountRecoveryDestinationOptions(
 		return []*AccountRecoveryDestinationOptionInternal{
 			{
 				AccountRecoveryDestinationOption: AccountRecoveryDestinationOption{
-					MaskedDisplayName: mail.MaskAddress(iden.IdentitySpec.LoginID.Value),
+					MaskedDisplayName: mail.MaskAddress(iden.IdentitySpec.LoginID.Value.TrimSpace()),
 					Channel:           AccountRecoveryChannelEmail,
 					OTPForm:           AccountRecoveryOTPForm(allowedChannel.OTPForm),
 				},
-				TargetLoginID: iden.IdentitySpec.LoginID.Value,
+				TargetLoginID: iden.IdentitySpec.LoginID.Value.TrimSpace(),
 			},
 		}
 	case config.AccountRecoveryCodeChannelSMS:
@@ -215,11 +215,11 @@ func deriveAllowedAccountRecoveryDestinationOptions(
 		return []*AccountRecoveryDestinationOptionInternal{
 			{
 				AccountRecoveryDestinationOption: AccountRecoveryDestinationOption{
-					MaskedDisplayName: phone.Mask(iden.IdentitySpec.LoginID.Value),
+					MaskedDisplayName: phone.Mask(iden.IdentitySpec.LoginID.Value.TrimSpace()),
 					Channel:           AccountRecoveryChannelSMS,
 					OTPForm:           AccountRecoveryOTPForm(allowedChannel.OTPForm),
 				},
-				TargetLoginID: iden.IdentitySpec.LoginID.Value,
+				TargetLoginID: iden.IdentitySpec.LoginID.Value.TrimSpace(),
 			},
 		}
 	case config.AccountRecoveryCodeChannelWhatsapp:
@@ -229,11 +229,11 @@ func deriveAllowedAccountRecoveryDestinationOptions(
 		return []*AccountRecoveryDestinationOptionInternal{
 			{
 				AccountRecoveryDestinationOption: AccountRecoveryDestinationOption{
-					MaskedDisplayName: phone.Mask(iden.IdentitySpec.LoginID.Value),
+					MaskedDisplayName: phone.Mask(iden.IdentitySpec.LoginID.Value.TrimSpace()),
 					Channel:           AccountRecoveryChannelWhatsapp,
 					OTPForm:           AccountRecoveryOTPForm(allowedChannel.OTPForm),
 				},
-				TargetLoginID: iden.IdentitySpec.LoginID.Value,
+				TargetLoginID: iden.IdentitySpec.LoginID.Value.TrimSpace(),
 			},
 		}
 	}

--- a/pkg/lib/authenticationflow/declarative/intent_create_identity_login_id.go
+++ b/pkg/lib/authenticationflow/declarative/intent_create_identity_login_id.go
@@ -10,6 +10,7 @@ import (
 	authflow "github.com/authgear/authgear-server/pkg/lib/authenticationflow"
 	"github.com/authgear/authgear-server/pkg/lib/authn/identity"
 	"github.com/authgear/authgear-server/pkg/lib/config"
+	"github.com/authgear/authgear-server/pkg/util/stringutil"
 )
 
 func init() {
@@ -99,7 +100,7 @@ func (n *IntentCreateIdentityLoginID) makeLoginIDSpec(loginID string) *identity.
 	spec := &identity.Spec{
 		Type: model.IdentityTypeLoginID,
 		LoginID: &identity.LoginIDSpec{
-			Value: loginID,
+			Value: stringutil.NewUserInputString(loginID),
 		},
 	}
 	switch n.Identification {

--- a/pkg/lib/authenticationflow/declarative/intent_lookup_identity_login_id.go
+++ b/pkg/lib/authenticationflow/declarative/intent_lookup_identity_login_id.go
@@ -13,6 +13,7 @@ import (
 	authflow "github.com/authgear/authgear-server/pkg/lib/authenticationflow"
 	"github.com/authgear/authgear-server/pkg/lib/authn/identity"
 	"github.com/authgear/authgear-server/pkg/lib/config"
+	"github.com/authgear/authgear-server/pkg/util/stringutil"
 )
 
 func init() {
@@ -82,7 +83,7 @@ func (n *IntentLookupIdentityLoginID) ReactTo(ctx context.Context, deps *authflo
 		spec := &identity.Spec{
 			Type: model.IdentityTypeLoginID,
 			LoginID: &identity.LoginIDSpec{
-				Value: loginID,
+				Value: stringutil.NewUserInputString(loginID),
 			},
 		}
 

--- a/pkg/lib/authenticationflow/declarative/intent_promote_identity_login_id.go
+++ b/pkg/lib/authenticationflow/declarative/intent_promote_identity_login_id.go
@@ -13,6 +13,7 @@ import (
 	"github.com/authgear/authgear-server/pkg/lib/authn/identity"
 	"github.com/authgear/authgear-server/pkg/lib/config"
 	"github.com/authgear/authgear-server/pkg/util/slice"
+	"github.com/authgear/authgear-server/pkg/util/stringutil"
 )
 
 func init() {
@@ -78,7 +79,7 @@ func (n *IntentPromoteIdentityLoginID) ReactTo(ctx context.Context, deps *authfl
 		specForLookup := &identity.Spec{
 			Type: model.IdentityTypeLoginID,
 			LoginID: &identity.LoginIDSpec{
-				Value: loginID,
+				Value: stringutil.NewUserInputString(loginID),
 			},
 		}
 
@@ -139,7 +140,7 @@ func (n *IntentPromoteIdentityLoginID) makeLoginIDSpec(loginID string) *identity
 	spec := &identity.Spec{
 		Type: model.IdentityTypeLoginID,
 		LoginID: &identity.LoginIDSpec{
-			Value: loginID,
+			Value: stringutil.NewUserInputString(loginID),
 		},
 	}
 	switch n.Identification {

--- a/pkg/lib/authenticationflow/declarative/intent_use_account_recovery_identity.go
+++ b/pkg/lib/authenticationflow/declarative/intent_use_account_recovery_identity.go
@@ -9,6 +9,7 @@ import (
 	authflow "github.com/authgear/authgear-server/pkg/lib/authenticationflow"
 	"github.com/authgear/authgear-server/pkg/lib/authn/identity"
 	"github.com/authgear/authgear-server/pkg/lib/config"
+	"github.com/authgear/authgear-server/pkg/util/stringutil"
 )
 
 func init() {
@@ -68,7 +69,7 @@ func (n *IntentUseAccountRecoveryIdentity) ReactTo(ctx context.Context, deps *au
 		spec := &identity.Spec{
 			Type: model.IdentityTypeLoginID,
 			LoginID: &identity.LoginIDSpec{
-				Value: loginID,
+				Value: stringutil.NewUserInputString(loginID),
 			},
 		}
 

--- a/pkg/lib/authenticationflow/declarative/intent_use_identity_login_id.go
+++ b/pkg/lib/authenticationflow/declarative/intent_use_identity_login_id.go
@@ -9,6 +9,7 @@ import (
 	authflow "github.com/authgear/authgear-server/pkg/lib/authenticationflow"
 	"github.com/authgear/authgear-server/pkg/lib/authn/identity"
 	"github.com/authgear/authgear-server/pkg/lib/config"
+	"github.com/authgear/authgear-server/pkg/util/stringutil"
 )
 
 func init() {
@@ -73,7 +74,7 @@ func (n *IntentUseIdentityLoginID) ReactTo(ctx context.Context, deps *authflow.D
 		spec := &identity.Spec{
 			Type: model.IdentityTypeLoginID,
 			LoginID: &identity.LoginIDSpec{
-				Value: loginID,
+				Value: stringutil.NewUserInputString(loginID),
 			},
 		}
 

--- a/pkg/lib/authn/identity/info.go
+++ b/pkg/lib/authn/identity/info.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/authgear/authgear-server/pkg/api/model"
 	"github.com/authgear/authgear-server/pkg/lib/config"
+	"github.com/authgear/authgear-server/pkg/util/stringutil"
 )
 
 type Info struct {
@@ -32,7 +33,7 @@ func (i *Info) ToSpec() Spec {
 			LoginID: &LoginIDSpec{
 				Key:   i.LoginID.LoginIDKey,
 				Type:  i.LoginID.LoginIDType,
-				Value: i.LoginID.LoginID,
+				Value: stringutil.NewUserInputString(i.LoginID.LoginID),
 			},
 		}
 	case model.IdentityTypeOAuth:

--- a/pkg/lib/authn/identity/loginid/checker.go
+++ b/pkg/lib/authn/identity/loginid/checker.go
@@ -28,10 +28,10 @@ func (c *Checker) validateOne(ctx *validation.Context, loginID identity.LoginIDS
 	allowed := false
 	for _, keyConfig := range c.Config.Keys {
 		if keyConfig.Key == loginID.Key {
-			if len(loginID.Value) > *keyConfig.MaxLength {
+			if len(loginID.Value.TrimSpace()) > *keyConfig.MaxLength {
 				ctx.EmitError("maxLength", map[string]interface{}{
 					"expected": *keyConfig.MaxLength,
-					"actual":   len(loginID.Value),
+					"actual":   len(loginID.Value.TrimSpace()),
 				})
 				return
 			}
@@ -44,10 +44,10 @@ func (c *Checker) validateOne(ctx *validation.Context, loginID identity.LoginIDS
 		return
 	}
 
-	if loginID.Value == "" {
+	if loginID.Value.TrimSpace() == "" {
 		ctx.EmitError("required", nil)
 		return
 	}
 
-	c.TypeCheckerFactory.NewChecker(loginID.Type, options).Validate(originCtx, loginID.Value)
+	c.TypeCheckerFactory.NewChecker(loginID.Type, options).Validate(originCtx, loginID.Value.TrimSpace())
 }

--- a/pkg/lib/authn/identity/loginid/checker_test.go
+++ b/pkg/lib/authn/identity/loginid/checker_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/authgear/authgear-server/pkg/lib/authn/identity"
 	"github.com/authgear/authgear-server/pkg/lib/config"
 	"github.com/authgear/authgear-server/pkg/util/resource"
+	"github.com/authgear/authgear-server/pkg/util/stringutil"
 )
 
 func newLoginIDKeyConfig(key string, t model.LoginIDKeyType, maxLength int) config.LoginIDKeyConfig {
@@ -70,22 +71,22 @@ func TestLoginIDChecker(t *testing.T) {
 			}
 			var loginID identity.LoginIDSpec
 
-			loginID = identity.LoginIDSpec{Key: "username", Type: model.LoginIDKeyTypeUsername, Value: "johndoe"}
+			loginID = identity.LoginIDSpec{Key: "username", Type: model.LoginIDKeyTypeUsername, Value: stringutil.NewUserInputString("johndoe")}
 
 			So(checker.ValidateOne(loginID, options), ShouldBeNil)
-			loginID = identity.LoginIDSpec{Key: "email", Type: model.LoginIDKeyTypeEmail, Value: "johndoe@example.com"}
+			loginID = identity.LoginIDSpec{Key: "email", Type: model.LoginIDKeyTypeEmail, Value: stringutil.NewUserInputString("johndoe@example.com")}
 			So(checker.ValidateOne(loginID, options), ShouldBeNil)
 
-			loginID = identity.LoginIDSpec{Key: "nickname", Type: "", Value: "johndoe"}
+			loginID = identity.LoginIDSpec{Key: "nickname", Type: "", Value: stringutil.NewUserInputString("johndoe")}
 			So(checker.ValidateOne(loginID, options), ShouldBeError, "invalid login ID:\n/login_id: login ID key is not allowed")
 
-			loginID = identity.LoginIDSpec{Key: "username", Type: model.LoginIDKeyTypeUsername, Value: "foobarexample"}
+			loginID = identity.LoginIDSpec{Key: "username", Type: model.LoginIDKeyTypeUsername, Value: stringutil.NewUserInputString("foobarexample")}
 			So(checker.ValidateOne(loginID, options), ShouldBeError, "invalid login ID:\n/login_id: maxLength\n  map[actual:13 expected:10]")
 
-			loginID = identity.LoginIDSpec{Key: "email", Type: model.LoginIDKeyTypeEmail, Value: ""}
+			loginID = identity.LoginIDSpec{Key: "email", Type: model.LoginIDKeyTypeEmail, Value: stringutil.NewUserInputString("")}
 			So(checker.ValidateOne(loginID, options), ShouldBeError, "invalid login ID:\n/login_id: required")
 
-			loginID = identity.LoginIDSpec{Key: "phone", Type: model.LoginIDKeyTypePhone, Value: "51234567"}
+			loginID = identity.LoginIDSpec{Key: "phone", Type: model.LoginIDKeyTypePhone, Value: stringutil.NewUserInputString("51234567")}
 			So(checker.ValidateOne(loginID, options), ShouldBeError, "invalid login ID:\n/login_id: format\n  map[format:phone]")
 		})
 	})

--- a/pkg/lib/authn/identity/loginid/provider.go
+++ b/pkg/lib/authn/identity/loginid/provider.go
@@ -50,11 +50,12 @@ func (p *Provider) GetByValue(ctx context.Context, value string) ([]*identity.Lo
 	im := map[string]*identity.LoginID{}
 	for _, config := range p.Config.Keys {
 		// Normalize expects loginID is in correct type so we have to validate it first.
-		invalid := p.Checker.ValidateOne(identity.LoginIDSpec{
+		spec := identity.LoginIDSpec{
 			Key:   config.Key,
 			Type:  config.Type,
 			Value: stringutil.NewUserInputString(value),
-		}, CheckerOptions{
+		}
+		invalid := p.Checker.ValidateOne(spec, CheckerOptions{
 			// Admin can create email login id which bypass domains blocklist allowlist
 			// it should not affect getting identity
 			// skip the checking when getting identity
@@ -65,7 +66,7 @@ func (p *Provider) GetByValue(ctx context.Context, value string) ([]*identity.Lo
 		}
 
 		normalizer := p.NormalizerFactory.NormalizerWithLoginIDType(config.Type)
-		normalizedloginID, err := normalizer.Normalize(value)
+		normalizedloginID, err := normalizer.Normalize(spec.Value.TrimSpace())
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/lib/authn/identity/loginid/provider.go
+++ b/pkg/lib/authn/identity/loginid/provider.go
@@ -70,8 +70,12 @@ func (p *Provider) GetByValue(ctx context.Context, value string) ([]*identity.Lo
 		if err != nil {
 			return nil, err
 		}
+		uniqueKey, err := normalizer.ComputeUniqueKey(normalizedloginID)
+		if err != nil {
+			return nil, err
+		}
 
-		i, err := p.Store.GetByLoginID(ctx, config.Key, normalizedloginID)
+		i, err := p.Store.GetByUniqueKey(ctx, uniqueKey)
 		if errors.Is(err, api.ErrIdentityNotFound) {
 			continue
 		} else if err != nil {
@@ -100,8 +104,12 @@ func (p *Provider) GetByKeyAndValue(ctx context.Context, key string, value strin
 	if err != nil {
 		return nil, api.ErrGetUsersInvalidArgument.New("invalid Login ID value")
 	}
+	uniqueKey, err := normalizer.ComputeUniqueKey(normalizedloginID)
+	if err != nil {
+		return nil, err
+	}
 
-	i, err := p.Store.GetByLoginID(ctx, key, normalizedloginID)
+	i, err := p.Store.GetByUniqueKey(ctx, uniqueKey)
 
 	if err != nil {
 		return nil, err

--- a/pkg/lib/authn/identity/loginid/store.go
+++ b/pkg/lib/authn/identity/loginid/store.go
@@ -142,16 +142,6 @@ func (s *Store) Get(ctx context.Context, userID, id string) (*identity.LoginID, 
 	return s.scan(rows)
 }
 
-func (s *Store) GetByLoginID(ctx context.Context, loginIDKey string, loginID string) (*identity.LoginID, error) {
-	q := s.selectQuery().Where(`l.login_id = ? AND l.login_id_key = ?`, loginID, loginIDKey)
-	rows, err := s.SQLExecutor.QueryRowWith(ctx, q)
-	if err != nil {
-		return nil, err
-	}
-
-	return s.scan(rows)
-}
-
 func (s *Store) GetByUniqueKey(ctx context.Context, uniqueKey string) (*identity.LoginID, error) {
 	q := s.selectQuery().Where(`l.unique_key = ?`, uniqueKey)
 	rows, err := s.SQLExecutor.QueryRowWith(ctx, q)

--- a/pkg/lib/authn/identity/loginid_spec.go
+++ b/pkg/lib/authn/identity/loginid_spec.go
@@ -2,10 +2,11 @@ package identity
 
 import (
 	"github.com/authgear/authgear-server/pkg/api/model"
+	"github.com/authgear/authgear-server/pkg/util/stringutil"
 )
 
 type LoginIDSpec struct {
-	Key   string               `json:"key"`
-	Type  model.LoginIDKeyType `json:"type"`
-	Value string               `json:"value"`
+	Key   string                     `json:"key"`
+	Type  model.LoginIDKeyType       `json:"type"`
+	Value stringutil.UserInputString `json:"value"`
 }

--- a/pkg/lib/authn/identity/migrate_spec.go
+++ b/pkg/lib/authn/identity/migrate_spec.go
@@ -2,6 +2,7 @@ package identity
 
 import (
 	"github.com/authgear/authgear-server/pkg/api/model"
+	"github.com/authgear/authgear-server/pkg/util/stringutil"
 )
 
 type MigrateSpec struct {
@@ -16,7 +17,7 @@ func (s *MigrateSpec) GetSpec() *Spec {
 		LoginID: &LoginIDSpec{
 			Type:  s.LoginID.Type,
 			Key:   s.LoginID.Key,
-			Value: s.LoginID.Value,
+			Value: stringutil.NewUserInputString(s.LoginID.Value),
 		},
 	}
 }

--- a/pkg/lib/authn/identity/service/service.go
+++ b/pkg/lib/authn/identity/service/service.go
@@ -278,7 +278,7 @@ func (s *Service) GetMany(ctx context.Context, ids []string) ([]*identity.Info, 
 func (s *Service) getBySpec(ctx context.Context, spec *identity.Spec) (*identity.Info, error) {
 	switch spec.Type {
 	case model.IdentityTypeLoginID:
-		loginID := spec.LoginID.Value
+		loginID := spec.LoginID.Value.TrimSpace()
 		l, err := s.LoginID.GetByValue(ctx, loginID)
 		if err != nil {
 			return nil, err
@@ -823,7 +823,7 @@ func (s *Service) Create(ctx context.Context, info *identity.Info) error {
 func (s *Service) UpdateWithSpec(ctx context.Context, info *identity.Info, spec *identity.Spec, options identity.NewIdentityOptions) (*identity.Info, error) {
 	switch info.Type {
 	case model.IdentityTypeLoginID:
-		i, err := s.LoginID.WithValue(info.LoginID, spec.LoginID.Value, loginid.CheckerOptions{
+		i, err := s.LoginID.WithValue(info.LoginID, spec.LoginID.Value.TrimSpace(), loginid.CheckerOptions{
 			EmailByPassBlocklistAllowlist: options.LoginIDEmailByPassBlocklistAllowlist,
 		})
 		if err != nil {

--- a/pkg/lib/interaction/nodes/select_identity_end.go
+++ b/pkg/lib/interaction/nodes/select_identity_end.go
@@ -70,7 +70,7 @@ func (e *EdgeSelectIdentityEnd) Instantiate(goCtx context.Context, ctx *interact
 			case model.IdentityTypeLoginID:
 				loginIDValue := e.IdentitySpec.LoginID.Value
 				err = ctx.Events.DispatchEventOnCommit(goCtx, &nonblocking.AuthenticationFailedLoginIDEventPayload{
-					LoginID: loginIDValue,
+					LoginID: loginIDValue.TrimSpace(),
 				})
 				if err != nil {
 					return nil, err

--- a/pkg/lib/interaction/nodes/use_identity_login_id.go
+++ b/pkg/lib/interaction/nodes/use_identity_login_id.go
@@ -9,6 +9,7 @@ import (
 	"github.com/authgear/authgear-server/pkg/lib/authn/identity"
 	"github.com/authgear/authgear-server/pkg/lib/config"
 	"github.com/authgear/authgear-server/pkg/lib/interaction"
+	"github.com/authgear/authgear-server/pkg/util/stringutil"
 )
 
 func init() {
@@ -78,7 +79,7 @@ func (e *EdgeUseIdentityLoginID) Instantiate(goCtx context.Context, ctx *interac
 		LoginID: &identity.LoginIDSpec{
 			Key:   loginIDKey,
 			Type:  typ,
-			Value: loginID,
+			Value: stringutil.NewUserInputString(loginID),
 		},
 	}
 

--- a/pkg/lib/userimport/service.go
+++ b/pkg/lib/userimport/service.go
@@ -19,6 +19,7 @@ import (
 	"github.com/authgear/authgear-server/pkg/lib/rolesgroups"
 	"github.com/authgear/authgear-server/pkg/util/accesscontrol"
 	"github.com/authgear/authgear-server/pkg/util/log"
+	"github.com/authgear/authgear-server/pkg/util/stringutil"
 	"github.com/authgear/authgear-server/pkg/util/uuid"
 )
 
@@ -364,7 +365,7 @@ func (s *UserImportService) insertIdentitiesInTxn(ctx context.Context, detail *D
 					LoginID: &identity.LoginIDSpec{
 						Type:  model.LoginIDKeyTypeEmail,
 						Key:   key,
-						Value: *emailPtr,
+						Value: stringutil.NewUserInputString(*emailPtr),
 					},
 				})
 			}
@@ -389,7 +390,7 @@ func (s *UserImportService) insertIdentitiesInTxn(ctx context.Context, detail *D
 					LoginID: &identity.LoginIDSpec{
 						Type:  model.LoginIDKeyTypePhone,
 						Key:   key,
-						Value: *phoneNumberPtr,
+						Value: stringutil.NewUserInputString(*phoneNumberPtr),
 					},
 				})
 			}
@@ -415,7 +416,7 @@ func (s *UserImportService) insertIdentitiesInTxn(ctx context.Context, detail *D
 					LoginID: &identity.LoginIDSpec{
 						Type:  model.LoginIDKeyTypeUsername,
 						Key:   key,
-						Value: *preferredUsernamePtr,
+						Value: stringutil.NewUserInputString(*preferredUsernamePtr),
 					},
 				})
 			}
@@ -858,7 +859,7 @@ func (s *UserImportService) upsertIdentitiesInTxnHelper(ctx context.Context, det
 			LoginID: &identity.LoginIDSpec{
 				Type:  typ,
 				Key:   string(typ),
-				Value: *ptr,
+				Value: stringutil.NewUserInputString(*ptr),
 			},
 		}
 		err := s.upsertIdentityInTxn(ctx, detail, userID, infos, spec)

--- a/pkg/util/stringutil/userinputstring.go
+++ b/pkg/util/stringutil/userinputstring.go
@@ -1,0 +1,32 @@
+package stringutil
+
+import (
+	"encoding"
+	"strings"
+)
+
+type UserInputString struct {
+	UnsafeString string
+}
+
+func (s UserInputString) TrimSpace() string {
+	return strings.TrimSpace(s.UnsafeString)
+}
+
+var _ encoding.TextMarshaler = UserInputString{}
+var _ encoding.TextUnmarshaler = &UserInputString{}
+
+func (s *UserInputString) UnmarshalText(text []byte) error {
+	*s = UserInputString{
+		UnsafeString: string(text),
+	}
+	return nil
+}
+
+func (s UserInputString) MarshalText() ([]byte, error) {
+	return []byte(s.UnsafeString), nil
+}
+
+func NewUserInputString(unsafeString string) UserInputString {
+	return UserInputString{UnsafeString: unsafeString}
+}

--- a/pkg/util/stringutil/userinputstring_test.go
+++ b/pkg/util/stringutil/userinputstring_test.go
@@ -1,0 +1,48 @@
+package stringutil
+
+import (
+	"encoding/json"
+	"testing"
+
+	. "github.com/smartystreets/goconvey/convey"
+)
+
+func TestUserInputString(t *testing.T) {
+	Convey("TrimSpace", t, func() {
+		s := UserInputString{
+			UnsafeString: "\t  hi \n",
+		}
+		So(s.TrimSpace(), ShouldResemble, "hi")
+	})
+
+	Convey("UnmarshalText", t, func() {
+		jsonStr := "{ \"teststr\": \" userinputstr \\n \" }"
+
+		type testStruct struct {
+			TestStr UserInputString `json:"teststr"`
+		}
+
+		var s testStruct
+
+		err := json.Unmarshal([]byte(jsonStr), &s)
+
+		So(err, ShouldBeNil)
+		So(s.TestStr.UnsafeString, ShouldEqual, " userinputstr \n ")
+		So(s.TestStr.TrimSpace(), ShouldEqual, "userinputstr")
+	})
+
+	Convey("MarshalText", t, func() {
+		type testStruct struct {
+			TestStr UserInputString `json:"teststr"`
+		}
+
+		result, err := json.Marshal(testStruct{
+			TestStr: UserInputString{
+				UnsafeString: " userinputstr \n ",
+			},
+		})
+
+		So(err, ShouldBeNil)
+		So(string(result), ShouldEqual, "{\"teststr\":\" userinputstr \\n \"}")
+	})
+}


### PR DESCRIPTION
ref DEV-2253

- We did validate emails, but mail.ParseAddress is success when the email containing a space.