### PR TITLE
Use another port for vite hmr

### DIFF
--- a/authui/vite.config.ts
+++ b/authui/vite.config.ts
@@ -430,5 +430,8 @@ export default defineConfig(() => ({
   server: {
     host: "0.0.0.0",
     port: 5173,
+    hmr: {
+      port: 51733,
+    },
   },
 }));

--- a/portal/vite.config.ts
+++ b/portal/vite.config.ts
@@ -35,6 +35,9 @@ export default defineConfig(() => ({
   server: {
     host: "0.0.0.0",
     port: 1234,
+    hmr: {
+      port: 51234,
+    },
   },
   build: {
     outDir: "../dist",


### PR DESCRIPTION
When using vite development server, there are always some http requests load indefinitely. It seems that the default port of hmr of vite development server is `3100` which collides with the port we used for authgear server.