### PR TITLE
Add deviceInfo param to createSession mutation

### DIFF
--- a/pkg/admin/facade/oauth.go
+++ b/pkg/admin/facade/oauth.go
@@ -49,7 +49,7 @@ type OAuthFacade struct {
 	OAuthClientResolver OAuthClientResolver
 }
 
-func (f *OAuthFacade) CreateSession(ctx context.Context, clientID string, userID string) (session.ListableSession, protocol.TokenResponse, error) {
+func (f *OAuthFacade) CreateSession(ctx context.Context, clientID string, userID string, deviceInfo map[string]interface{}) (session.ListableSession, protocol.TokenResponse, error) {
 	scopes := []string{
 		"openid",
 		oauth.OfflineAccess,
@@ -59,7 +59,6 @@ func (f *OAuthFacade) CreateSession(ctx context.Context, clientID string, userID
 		UserID:          userID,
 		AuthenticatedAt: f.Clock.NowUTC(),
 	}
-	deviceInfo := make(map[string]interface{})
 
 	client := f.OAuthClientResolver.ResolveClient(clientID)
 	if client == nil {

--- a/pkg/admin/graphql/context.go
+++ b/pkg/admin/graphql/context.go
@@ -169,7 +169,7 @@ type AuthorizationFacade interface {
 }
 
 type OAuthFacade interface {
-	CreateSession(ctx context.Context, clientID string, userID string) (session.ListableSession, protocol.TokenResponse, error)
+	CreateSession(ctx context.Context, clientID string, userID string, deviceInfo map[string]interface{}) (session.ListableSession, protocol.TokenResponse, error)
 }
 
 type SessionListingService interface {

--- a/portal/src/graphql/adminapi/globalTypes.generated.ts
+++ b/portal/src/graphql/adminapi/globalTypes.generated.ts
@@ -432,6 +432,8 @@ export type CreateRolePayload = {
 export type CreateSessionInput = {
   /** Target client ID. */
   clientID: Scalars['String']['input'];
+  /** Base64-encoded Device information. */
+  deviceInfo?: InputMaybe<Scalars['String']['input']>;
   /** Target user ID. */
   userID: Scalars['ID']['input'];
 };

--- a/portal/src/graphql/adminapi/schema.graphql
+++ b/portal/src/graphql/adminapi/schema.graphql
@@ -724,6 +724,9 @@ input CreateSessionInput {
   """Target client ID."""
   clientID: String!
 
+  """Base64-encoded Device information."""
+  deviceInfo: String
+
   """Target user ID."""
   userID: ID!
 }


### PR DESCRIPTION
ref DEV-2490

Accepts URL-safe base64-encoded deviceInfo in `createSession` mutation, similar to OAuth's `x_device_info`