### PR TITLE
Use 303 / 200 to perform OAuth redirect

### DIFF
--- a/.vettedpositions
+++ b/.vettedpositions
@@ -296,8 +296,8 @@
 /pkg/lib/dpop/middleware.go:45:35: requestcontext
 /pkg/lib/healthz/healthz.go:27:23: requestcontext
 /pkg/lib/infra/middleware/sentry.go:21:47: requestcontext
-/pkg/lib/oauth/response_mode.go:105:40: requestcontext
-/pkg/lib/oauth/response_mode.go:117:40: requestcontext
+/pkg/lib/oauth/response_mode.go:109:40: requestcontext
+/pkg/lib/oauth/response_mode.go:121:40: requestcontext
 /pkg/lib/oauth/scope.go:116:34: requestcontext
 /pkg/lib/oauthrelyingparty/oauthrelyingpartyutil/contextbackground.go:11:52: contextbackground
 /pkg/lib/otelauthgear/nethttp.go:30:10: requestcontext

--- a/.vettedpositions
+++ b/.vettedpositions
@@ -296,8 +296,9 @@
 /pkg/lib/dpop/middleware.go:45:35: requestcontext
 /pkg/lib/healthz/healthz.go:27:23: requestcontext
 /pkg/lib/infra/middleware/sentry.go:21:47: requestcontext
-/pkg/lib/oauth/response_mode.go:109:40: requestcontext
-/pkg/lib/oauth/response_mode.go:121:40: requestcontext
+/pkg/lib/oauth/response_mode.go:122:40: requestcontext
+/pkg/lib/oauth/response_mode.go:149:40: requestcontext
+/pkg/lib/oauth/response_mode.go:161:40: requestcontext
 /pkg/lib/oauth/scope.go:116:34: requestcontext
 /pkg/lib/oauthrelyingparty/oauthrelyingpartyutil/contextbackground.go:11:52: contextbackground
 /pkg/lib/otelauthgear/nethttp.go:30:10: requestcontext

--- a/experiments/DEV-2544/main.go
+++ b/experiments/DEV-2544/main.go
@@ -1,0 +1,78 @@
+package main
+
+import (
+	"net/http"
+	"time"
+)
+
+var indexHTML = `
+<!DOCTYPE html>
+<html>
+	<head>
+		<meta name="viewport" content="width=device-width, initial-scale=1" />
+		<title>index</title>
+	</head>
+	<body style="background-color: green;">
+		<p>
+			This page has a green background.
+		</p>
+
+		<button id="use-iframe" type="button">Use iframe to redirect</button>
+		<p>
+			It is expected that when you use iframe to redirect,
+			this page stays unchanged until the iframe has fully loaded.
+			By that moment, the iframe will trigger top navigation and redirect.
+		</p>
+
+		<form action="/redirect" method="POST">
+			<button id="use-form-post" type="submit">POST URL and then be redirected</button>
+		</form>
+		<p>
+			However, as of 2025-03-06 with Chrome Desktop 133, using form post
+			will have a similar effect. The browser will still display the current page while
+			the form post request is loading.
+		</p>
+		<script>
+			document.getElementById("use-iframe").addEventListener("click", (e) => {
+				const newIframe = document.createElement("iframe");
+				newIframe.setAttribute("src", "/redirect");
+				newIframe.setAttribute("sandbox", "allow-scripts allow-top-navigation");
+				newIframe.setAttribute("width", "0");
+				newIframe.setAttribute("height", "0");
+				newIframe.setAttribute("style", "visibility: hidden;");
+				document.body.appendChild(newIframe);
+			});
+		</script>
+	</body>
+</html>
+`
+
+var redirectHTML = `
+<!DOCTYPE html>
+<html>
+	<head>
+		<meta name="viewport" content="width=device-width, initial-scale=1" />
+		<title>redirect</title>
+	</head>
+	<body style="background-color: red;">
+		<script>
+			window.location.href = "customuri://host/path";
+		</script>
+	</body>
+</html>
+`
+
+func main() {
+	http.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/html")
+		w.Write([]byte(indexHTML))
+	})
+	http.HandleFunc("/redirect", func(w http.ResponseWriter, r *http.Request) {
+		time.Sleep(5 * time.Second)
+		w.Header().Set("Content-Type", "text/html")
+		w.Header().Set("Location", "customuri://host/path")
+		w.WriteHeader(http.StatusSeeOther)
+		w.Write([]byte(redirectHTML))
+	})
+	http.ListenAndServe(":3000", nil)
+}

--- a/k6/authflow.js
+++ b/k6/authflow.js
@@ -84,7 +84,10 @@ export function redirect(result) {
   if (!checkResult) {
     fail(`unexpected action: ${result}`);
   }
-  return http.get(result.action.data.finish_redirect_uri);
+  return http.get(result.action.data.finish_redirect_uri, {
+    // Do not follow redirect so that the body can be captured.
+    redirects: 0,
+  });
 }
 
 function authflowIdentify({ username, phone, email, result }) {

--- a/pkg/auth/handler/oauth/redirect.go
+++ b/pkg/auth/handler/oauth/redirect.go
@@ -14,7 +14,7 @@ func ConfigureProxyRedirectRoute(route httproute.Route) httproute.Route {
 }
 
 type ProtocolProxyRedirectHandler interface {
-	Validate(redirectURIWithQuery string) error
+	Validate(redirectURIWithQuery string) (*oauth.WriteResponseOptions, error)
 }
 
 type ProxyRedirectHandler struct {
@@ -23,10 +23,10 @@ type ProxyRedirectHandler struct {
 
 func (h *ProxyRedirectHandler) ServeHTTP(rw http.ResponseWriter, r *http.Request) {
 	redirectURI := r.URL.Query().Get("redirect_uri")
-	err := h.ProxyRedirectHandler.Validate(redirectURI)
+	options, err := h.ProxyRedirectHandler.Validate(redirectURI)
 
 	if err == nil {
-		oauth.HTMLRedirect(rw, r, redirectURI)
+		oauth.WriteResponse(rw, r, *options)
 	} else {
 		http.Error(rw, err.Error(), 400)
 	}

--- a/pkg/lib/config/oauth.go
+++ b/pkg/lib/config/oauth.go
@@ -204,6 +204,10 @@ type OAuthClientConfig struct {
 	PreAuthenticatedURLAllowedOrigins      []string                     `json:"x_pre_authenticated_url_allowed_origins,omitempty"`
 }
 
+func (c *OAuthClientConfig) UseHTTP200() bool {
+	return c.CustomUIURI != ""
+}
+
 var _ = Schema.Add("AuthenticationFlowAllowlist", `
 {
 	"type": "object",

--- a/pkg/lib/oauth/handler/handler_authz.go
+++ b/pkg/lib/oauth/handler/handler_authz.go
@@ -514,7 +514,7 @@ func (h *AuthorizationHandler) doHandle(
 	sessionType := resolvedSession.SessionType()
 	sessionID := resolvedSession.SessionID()
 
-	result, err := h.finishAuthorization(ctx, redirectURI, r, sessionType, sessionID, authenticationInfo, idTokenHintSID, nil, autoGrantAuthz)
+	result, err := h.finishAuthorization(ctx, client, redirectURI, r, sessionType, sessionID, authenticationInfo, idTokenHintSID, nil, autoGrantAuthz)
 	if err != nil {
 		if errors.Is(err, oauth.ErrAuthorizationNotFound) {
 			return nil, protocol.NewError("access_denied", "authorization required")
@@ -582,6 +582,7 @@ func (h *AuthorizationHandler) doHandlePreAuthenticatedURL(
 	return authorizationResultCode{
 		RedirectURI:  redirectURI,
 		ResponseMode: r.ResponseMode(),
+		UseHTTP200:   client.UseHTTP200(),
 		Response:     resp,
 		Cookies:      []*http.Cookie{cookie},
 	}, nil
@@ -625,6 +626,7 @@ func (h *AuthorizationHandler) handleSettingsAction(
 
 func (h *AuthorizationHandler) finishSettingsAction(
 	ctx context.Context,
+	client *config.OAuthClientConfig,
 	redirectURI *url.URL,
 	r protocol.AuthorizationRequest,
 	cookies []*http.Cookie,
@@ -649,6 +651,7 @@ func (h *AuthorizationHandler) finishSettingsAction(
 	return authorizationResultCode{
 		RedirectURI:  redirectURI,
 		ResponseMode: r.ResponseMode(),
+		UseHTTP200:   client.UseHTTP200(),
 		Response:     resp,
 		Cookies:      cookies,
 	}, nil
@@ -656,6 +659,7 @@ func (h *AuthorizationHandler) finishSettingsAction(
 
 func (h *AuthorizationHandler) finishAuthorization(
 	ctx context.Context,
+	client *config.OAuthClientConfig,
 	redirectURI *url.URL,
 	r protocol.AuthorizationRequest,
 	sessionType session.Type,
@@ -710,6 +714,7 @@ func (h *AuthorizationHandler) finishAuthorization(
 	return authorizationResultCode{
 		RedirectURI:  redirectURI,
 		ResponseMode: r.ResponseMode(),
+		UseHTTP200:   client.UseHTTP200(),
 		Response:     resp,
 		Cookies:      cookies,
 	}, nil
@@ -736,7 +741,7 @@ func (h *AuthorizationHandler) doHandleConsentRequest(
 	responseType := r.ResponseType()
 	switch {
 	case responseType.Equal(SettingsActonResponseType):
-		return h.finishSettingsAction(ctx, redirectURI, r, []*http.Cookie{})
+		return h.finishSettingsAction(ctx, client, redirectURI, r, []*http.Cookie{})
 	default:
 		_, uiInfoByProduct, err := h.UIInfoResolver.ResolveForAuthorizationEndpoint(ctx, client, r)
 		if err != nil {
@@ -752,7 +757,7 @@ func (h *AuthorizationHandler) doHandleConsentRequest(
 			sessionType = session.Type(authenticationInfo.AuthenticatedBySessionType)
 		}
 
-		return h.finishAuthorization(ctx, redirectURI, r, sessionType, sessionID, authenticationInfo, idTokenHintSID, []*http.Cookie{}, grantAuthz)
+		return h.finishAuthorization(ctx, client, redirectURI, r, sessionType, sessionID, authenticationInfo, idTokenHintSID, []*http.Cookie{}, grantAuthz)
 	}
 }
 

--- a/pkg/lib/oauth/handler/handler_authz_test.go
+++ b/pkg/lib/oauth/handler/handler_authz_test.go
@@ -136,7 +136,6 @@ func TestAuthorizationHandler(t *testing.T) {
 					"client_id":    "client-id",
 					"redirect_uri": "http://accounts.example.com/settings",
 				})
-				So(resp.Result().StatusCode, ShouldEqual, 200)
 				So(resp.Body.String(), ShouldEqual, redirectHTML(
 					"http://accounts.example.com/settings?error=unauthorized_client&error_description=response+type+is+not+allowed+for+this+client",
 				))
@@ -154,7 +153,6 @@ func TestAuthorizationHandler(t *testing.T) {
 				"client_id":     "client-id",
 				"response_type": "code",
 			})
-			So(resp.Result().StatusCode, ShouldEqual, 200)
 			So(resp.Body.String(), ShouldEqual, redirectHTML(
 				"https://example.com/cb?error=invalid_request&error_description=scope+is+required&from=sso",
 			))
@@ -174,7 +172,6 @@ func TestAuthorizationHandler(t *testing.T) {
 						"client_id":     "client-id",
 						"response_type": "code",
 					})
-					So(resp.Result().StatusCode, ShouldEqual, 200)
 					So(resp.Body.String(), ShouldEqual, redirectHTML(
 						"https://example.com/?error=invalid_request&error_description=scope+is+required",
 					))
@@ -186,7 +183,6 @@ func TestAuthorizationHandler(t *testing.T) {
 						"response_type": "code",
 						"scope":         "openid",
 					})
-					So(resp.Result().StatusCode, ShouldEqual, 200)
 					So(resp.Body.String(), ShouldEqual, redirectHTML(
 						"https://example.com/?error=invalid_request&error_description=PKCE+code+challenge+is+required+for+public+clients",
 					))
@@ -200,7 +196,6 @@ func TestAuthorizationHandler(t *testing.T) {
 						"code_challenge_method": "plain",
 						"code_challenge":        "code-verifier",
 					})
-					So(resp.Result().StatusCode, ShouldEqual, 200)
 					So(resp.Body.String(), ShouldEqual, redirectHTML(
 						"https://example.com/?error=invalid_request&error_description=only+%27S256%27+PKCE+transform+is+supported",
 					))
@@ -215,7 +210,6 @@ func TestAuthorizationHandler(t *testing.T) {
 					"code_challenge_method": "S256",
 					"code_challenge":        "E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM",
 				})
-				So(resp.Result().StatusCode, ShouldEqual, 200)
 				So(resp.Body.String(), ShouldEqual, redirectHTML(
 					"https://example.com/?error=invalid_scope&error_description=must+request+%27openid%27+scope",
 				))
@@ -285,7 +279,6 @@ func TestAuthorizationHandler(t *testing.T) {
 					).Times(1).Return(authorization, nil)
 
 					resp := handle(ctx, req)
-					So(resp.Result().StatusCode, ShouldEqual, 200)
 					So(resp.Body.String(), ShouldEqual, redirectHTML(
 						"https://example.com/?code=authz-code&state=my-state",
 					))
@@ -340,7 +333,6 @@ func TestAuthorizationHandler(t *testing.T) {
 					}, &oidc.UIInfoByProduct{}, nil)
 
 					resp := handle(ctx, req)
-					So(resp.Result().StatusCode, ShouldEqual, 200)
 					So(resp.Body.String(), ShouldEqual, redirectHTML(
 						"https://example.com/?code=authz-code",
 					))
@@ -378,7 +370,6 @@ func TestAuthorizationHandler(t *testing.T) {
 					"response_type": "none",
 					"scope":         "email",
 				})
-				So(resp.Result().StatusCode, ShouldEqual, 200)
 				So(resp.Body.String(), ShouldEqual, redirectHTML(
 					"https://example.com/?error=invalid_scope&error_description=must+request+%27openid%27+scope",
 				))
@@ -442,7 +433,6 @@ func TestAuthorizationHandler(t *testing.T) {
 					}, &oidc.UIInfoByProduct{}, nil)
 
 					resp := handle(ctx, req)
-					So(resp.Result().StatusCode, ShouldEqual, 200)
 					So(resp.Body.String(), ShouldEqual, redirectHTML(
 						"https://example.com/?state=my-state",
 					))
@@ -502,7 +492,6 @@ func TestAuthorizationHandler(t *testing.T) {
 
 				ctx := context.Background()
 				resp := handle(ctx, req)
-				So(resp.Result().StatusCode, ShouldEqual, 200)
 				So(resp.Body.String(), ShouldEqual, redirectHTML(
 					"https://example.com/?state=my-state",
 				))

--- a/pkg/lib/oauth/handler/handler_proxy_redirect_test.go
+++ b/pkg/lib/oauth/handler/handler_proxy_redirect_test.go
@@ -1,16 +1,17 @@
 package handler_test
 
 import (
+	"net/url"
 	"testing"
 
 	. "github.com/smartystreets/goconvey/convey"
 
 	"github.com/authgear/authgear-server/pkg/lib/config"
+	"github.com/authgear/authgear-server/pkg/lib/oauth"
 	"github.com/authgear/authgear-server/pkg/lib/oauth/handler"
 )
 
 func TestProxyRedirectHandler(t *testing.T) {
-
 	h := handler.ProxyRedirectHandler{
 		OAuthConfig: &config.OAuthConfig{
 			Clients: []config.OAuthClientConfig{
@@ -26,35 +27,86 @@ func TestProxyRedirectHandler(t *testing.T) {
 		HTTPOrigin: "http://auth.example.com",
 	}
 
+	testError := func(input string, error string) {
+		_, err := h.Validate(input)
+		So(err, ShouldNotBeNil)
+		So(err, ShouldBeError, error)
+	}
+
+	testOK := func(input string, expected *oauth.WriteResponseOptions) {
+		actual, err := h.Validate(input)
+		So(err, ShouldBeNil)
+		So(actual, ShouldEqual, expected)
+	}
+
 	Convey("ProxyRedirectHandler", t, func() {
 		Convey("should allow allowlisted", func() {
-			var err error
+			testOK("http://app.example.com/auth?query=test#abc", &oauth.WriteResponseOptions{
+				RedirectURI: &url.URL{
+					Scheme:   "http",
+					Host:     "app.example.com",
+					Path:     "/auth",
+					RawQuery: "query=test",
+					Fragment: "abc",
+				},
+				ResponseMode: "query",
+				UseHTTP200:   true,
+				Response:     make(map[string]string),
+			})
 
-			err = h.Validate("http://app.example.com/auth?query=test#abc")
-			So(err, ShouldBeNil)
+			testOK("com.example.myapp://host/path?code=code", &oauth.WriteResponseOptions{
+				RedirectURI: &url.URL{
+					Scheme:   "com.example.myapp",
+					Host:     "host",
+					Path:     "/path",
+					RawQuery: "code=code",
+				},
+				ResponseMode: "query",
+				UseHTTP200:   false,
+				Response:     make(map[string]string),
+			})
 
-			err = h.Validate("com.example.myapp://host/path?code=code")
-			So(err, ShouldBeNil)
-
-			err = h.Validate("com.example.myapp://host/path?error=cancel")
-			So(err, ShouldBeNil)
+			testOK("com.example.myapp://host/path?error=cancel", &oauth.WriteResponseOptions{
+				RedirectURI: &url.URL{
+					Scheme:   "com.example.myapp",
+					Host:     "host",
+					Path:     "/path",
+					RawQuery: "error=cancel",
+				},
+				ResponseMode: "query",
+				UseHTTP200:   false,
+				Response:     make(map[string]string),
+			})
 		})
 
 		Convey("should allow all path under custom ui", func() {
-			var err error
+			testOK("http://authui.example.com/auth/complete?state=state", &oauth.WriteResponseOptions{
+				RedirectURI: &url.URL{
+					Scheme:   "http",
+					Host:     "authui.example.com",
+					Path:     "/auth/complete",
+					RawQuery: "state=state",
+				},
+				ResponseMode: "query",
+				UseHTTP200:   true,
+				Response:     make(map[string]string),
+			})
 
-			err = h.Validate("http://authui.example.com/auth/complete?state=state")
-			So(err, ShouldBeNil)
-
-			err = h.Validate("http://authui.example.com/error?error=")
-			So(err, ShouldBeNil)
+			testOK("http://authui.example.com/error?error=", &oauth.WriteResponseOptions{
+				RedirectURI: &url.URL{
+					Scheme:   "http",
+					Host:     "authui.example.com",
+					Path:     "/error",
+					RawQuery: "error=",
+				},
+				ResponseMode: "query",
+				UseHTTP200:   true,
+				Response:     make(map[string]string),
+			})
 		})
 
 		Convey("should reject uri that not on the list", func() {
-			var err error
-
-			err = h.Validate("http://app2.example.com/auth/complete?state=state")
-			So(err, ShouldBeError, "redirect URI is not allowed")
+			testError("http://app2.example.com/auth/complete?state=state", "redirect URI is not allowed")
 		})
 	})
 

--- a/pkg/lib/oauth/oidc/handler/handler_end_session.go
+++ b/pkg/lib/oauth/oidc/handler/handler_end_session.go
@@ -81,7 +81,18 @@ func (h *EndSessionHandler) Handle(ctx context.Context, s session.ResolvedSessio
 		redirectURI = urlutil.WithQueryParamsAdded(uri, map[string]string{"state": state}).String()
 	}
 
-	oauth.HTMLRedirect(rw, r, redirectURI)
+	redirectURIURL, err := url.Parse(redirectURI)
+	if err != nil {
+		panic(err)
+	}
+
+	writeResponseOptions := oauth.WriteResponseOptions{
+		RedirectURI:  redirectURIURL,
+		ResponseMode: "query",
+		UseHTTP200:   client.UseHTTP200(),
+		Response:     make(map[string]string),
+	}
+	oauth.WriteResponse(rw, r, writeResponseOptions)
 	return nil
 }
 

--- a/pkg/lib/oauth/response_mode.go
+++ b/pkg/lib/oauth/response_mode.go
@@ -68,26 +68,66 @@ func init() {
 	}
 }
 
-func WriteResponse(w http.ResponseWriter, r *http.Request, redirectURI *url.URL, responseMode string, response map[string]string) {
+type WriteResponseOptions struct {
+	RedirectURI  *url.URL
+	ResponseMode string
+	UseHTTP200   bool
+	Response     map[string]string
+}
+
+func WriteResponse(w http.ResponseWriter, r *http.Request, options WriteResponseOptions) {
+	responseMode := options.ResponseMode
 	if responseMode == "" {
 		responseMode = "query"
 	}
 
+	useHTTP200 := options.UseHTTP200
+
 	switch responseMode {
 	case "query":
-		HTMLRedirect(w, r, urlutil.WithQueryParamsAdded(redirectURI, response).String())
+		switch useHTTP200 {
+		case true:
+			HTTP200HTMLRedirect(w, r, urlutil.WithQueryParamsAdded(options.RedirectURI, options.Response).String())
+		default:
+			HTTP303HTMLRedirect(w, r, urlutil.WithQueryParamsAdded(options.RedirectURI, options.Response).String())
+		}
 	case "fragment":
-		HTMLRedirect(w, r, urlutil.WithQueryParamsSetToFragment(redirectURI, response).String())
+		switch useHTTP200 {
+		case true:
+			HTTP200HTMLRedirect(w, r, urlutil.WithQueryParamsSetToFragment(options.RedirectURI, options.Response).String())
+		default:
+			HTTP303HTMLRedirect(w, r, urlutil.WithQueryParamsSetToFragment(options.RedirectURI, options.Response).String())
+		}
 	case "cookie":
-		HTMLRedirect(w, r, urlutil.WithQueryParamsAdded(redirectURI, response).String())
+		switch useHTTP200 {
+		case true:
+			HTTP200HTMLRedirect(w, r, urlutil.WithQueryParamsAdded(options.RedirectURI, options.Response).String())
+		default:
+			HTTP303HTMLRedirect(w, r, urlutil.WithQueryParamsAdded(options.RedirectURI, options.Response).String())
+		}
 	case "form_post":
-		FormPost(w, r, redirectURI, response)
+		FormPost(w, r, options.RedirectURI, options.Response)
 	default:
 		http.Error(w, fmt.Sprintf("oauth: invalid response_mode %s", responseMode), http.StatusBadRequest)
 	}
 }
 
-func HTMLRedirect(rw http.ResponseWriter, r *http.Request, redirectURI string) {
+func HTTP200HTMLRedirect(rw http.ResponseWriter, r *http.Request, redirectURI string) {
+	// This redirect approach is kept for backward compatibility with custom UI is in use.
+	// See https://linear.app/authgear/issue/DEV-2544/revisit-oauth-redirect-approach
+	rw.Header().Set("Content-Type", "text/html; charset=utf-8")
+	rw.WriteHeader(http.StatusOK)
+
+	err := htmlRedirectTemplate.Execute(rw, map[string]string{
+		"CSPNonce":     httputil.GetCSPNonce(r.Context()),
+		"redirect_uri": redirectURI,
+	})
+	if err != nil {
+		panic(fmt.Errorf("oauth: failed to execute html_redirect template: %w", err))
+	}
+}
+
+func HTTP303HTMLRedirect(rw http.ResponseWriter, r *http.Request, redirectURI string) {
 	// About this redirect approach.
 	// We use a combination of redirects in this approach.
 	//


### PR DESCRIPTION
ref DEV-2544

Tested with the following
1. iOS ASWebAuthenticationSession
2. iOS WebView
3. Chrome CustomTabs on Pixel (Emulator)
4. Chrome WebView on Pixel (Emulator)
5. Xiaomi CustomTabs on Redmi (Device)
6. A custom UI that uses iframe to load the redirect URI.