### PR TITLE
[WIP] Build ONCE docker image - Part 4

### DIFF
--- a/pkg/portal/model/system_config.go
+++ b/pkg/portal/model/system_config.go
@@ -5,6 +5,7 @@ import (
 )
 
 type SystemConfig struct {
+	AuthgearAppID             string         `json:"authgearAppID"`
 	AuthgearClientID          string         `json:"authgearClientID"`
 	AuthgearEndpoint          string         `json:"authgearEndpoint"`
 	AuthgearWebSDKSessionType string         `json:"authgearWebSDKSessionType"`

--- a/pkg/portal/model/system_config.go
+++ b/pkg/portal/model/system_config.go
@@ -9,6 +9,7 @@ type SystemConfig struct {
 	AuthgearClientID          string         `json:"authgearClientID"`
 	AuthgearEndpoint          string         `json:"authgearEndpoint"`
 	AuthgearWebSDKSessionType string         `json:"authgearWebSDKSessionType"`
+	IsAuthgearOnce            bool           `json:"isAuthgearOnce"`
 	SentryDSN                 string         `json:"sentryDSN,omitempty"`
 	AppHostSuffix             string         `json:"appHostSuffix"`
 	AvailableLanguages        []string       `json:"availableLanguages"`

--- a/pkg/portal/service/system_config.go
+++ b/pkg/portal/service/system_config.go
@@ -51,6 +51,7 @@ func (p *SystemConfigProvider) SystemConfig(ctx context.Context) (*model.SystemC
 	}
 
 	return &model.SystemConfig{
+		AuthgearAppID:             p.AuthgearConfig.AppID,
 		AuthgearClientID:          p.AuthgearConfig.ClientID,
 		AuthgearEndpoint:          p.AuthgearConfig.Endpoint,
 		AuthgearWebSDKSessionType: p.AuthgearConfig.WebSDKSessionType,

--- a/pkg/portal/service/system_config.go
+++ b/pkg/portal/service/system_config.go
@@ -55,6 +55,7 @@ func (p *SystemConfigProvider) SystemConfig(ctx context.Context) (*model.SystemC
 		AuthgearClientID:          p.AuthgearConfig.ClientID,
 		AuthgearEndpoint:          p.AuthgearConfig.Endpoint,
 		AuthgearWebSDKSessionType: p.AuthgearConfig.WebSDKSessionType,
+		IsAuthgearOnce:            AUTHGEARONCE,
 		SentryDSN:                 p.FrontendSentryConfig.DSN,
 		AppHostSuffix:             p.AppConfig.HostSuffix,
 		AvailableLanguages:        intl.AvailableLanguages,

--- a/portal/src/system-config.ts
+++ b/portal/src/system-config.ts
@@ -7,6 +7,7 @@ export interface SystemConfig {
   authgearClientID: string;
   authgearEndpoint: string;
   authgearWebSDKSessionType: "cookie" | "refresh_token";
+  isAuthgearOnce: boolean;
   sentryDSN: string;
   appHostSuffix: string;
   availableLanguages: string[];
@@ -251,6 +252,7 @@ export function instantiateSystemConfig(
     authgearClientID: config.authgearClientID ?? "",
     authgearEndpoint: config.authgearEndpoint ?? "",
     authgearWebSDKSessionType: config.authgearWebSDKSessionType ?? "cookie",
+    isAuthgearOnce: config.isAuthgearOnce ?? false,
     sentryDSN: config.sentryDSN ?? "",
     appHostSuffix: config.appHostSuffix ?? "",
     availableLanguages: config.availableLanguages ?? [DEFAULT_TEMPLATE_LOCALE],

--- a/portal/src/system-config.ts
+++ b/portal/src/system-config.ts
@@ -3,6 +3,7 @@ import MESSAGES from "./locale-data/en.json";
 import { DEFAULT_TEMPLATE_LOCALE } from "./resources";
 
 export interface SystemConfig {
+  authgearAppID: string;
   authgearClientID: string;
   authgearEndpoint: string;
   authgearWebSDKSessionType: "cookie" | "refresh_token";
@@ -246,6 +247,7 @@ export function instantiateSystemConfig(
   config: PartialSystemConfig
 ): SystemConfig {
   return {
+    authgearAppID: config.authgearAppID ?? "",
     authgearClientID: config.authgearClientID ?? "",
     authgearEndpoint: config.authgearEndpoint ?? "",
     authgearWebSDKSessionType: config.authgearWebSDKSessionType ?? "cookie",


### PR DESCRIPTION
ref DEV-2412

<img width="1508" alt="SCR-20250314-qlml" src="https://github.com/user-attachments/assets/d45859ea-c688-4f88-a432-cc8ec6871818" />

(Note that the accounts project is hidden and the create project button is hidden)

It can be tested with `./once/docker-compose.yaml`

```
services:
  once:
    build:
      context: ../
      dockerfile: ./once/Dockerfile
    volumes:
    - postgres_data:/var/lib/postgresql/data
    - redis_data:/var/lib/redis/data
    - certbot_data:/etc/letsencrypt
    - minio_data:/var/lib/minio/data
    environment:
      POSTGRES_PASSWORD: "1234"
      REDIS_PASSWORD: "1234"
      MINIO_ROOT_PASSWORD: "12345678"
      # Edit your /etc/hosts to include those hosts.
      AUTHGEAR_HTTP_ORIGIN_PORTAL: "http://portal.localhost"
      AUTHGEAR_HTTP_ORIGIN_ACCOUNTS: "http://accounts.localhost"
      AUTHGEAR_HTTP_ORIGIN_PROJECT: "http://project.localhost"
      AUTHGEAR_CERTBOT_RUN_INTERVAL: "86400"
      AUTHGEAR_ONCE_ADMIN_USER_EMAIL: "louischan@oursky.com"
      AUTHGEAR_ONCE_ADMIN_USER_PASSWORD: "12345678"
      #AUTHGEAR_CERTBOT_ENVIRONMENT: "production"
    ports:
    - "80:80"
    - "443:443"
    - "5432:5432"
    - "9001:9001"
    - "8090:8090"

volumes:
  postgres_data:
    driver: local
  redis_data:
    driver: local
  certbot_data:
    driver: local
  minio_data:
    driver: local
```

```
cd once
# To remove any previous data
docker compose down -v
docker compose build
docker compose up
# Visit http://portal.localhost
```