### PR TITLE
Build ONCE docker image - Part 4

### DIFF
--- a/.github/actions/build-custom-image/action.yaml
+++ b/.github/actions/build-custom-image/action.yaml
@@ -1,6 +1,6 @@
 name: Build custom image
 inputs:
-  target:
+  dockerfile:
     required: true
   image_name:
     required: true
@@ -26,7 +26,7 @@ runs:
       gcloud auth configure-docker "$REPO"
   - name: Build and Push
     env:
-      TARGET: ${{ inputs.target }}
+      DOCKERFILE: ${{ inputs.dockerfile }}
       IMAGE_NAME: ${{ inputs.image_name }}
       REPO: ${{ inputs.docker_repo }}
       BUILD_ARCH: amd64

--- a/.github/actions/build-custom-image/action.yaml
+++ b/.github/actions/build-custom-image/action.yaml
@@ -29,20 +29,17 @@ runs:
       TARGET: ${{ inputs.target }}
       IMAGE_NAME: ${{ inputs.image_name }}
       REPO: ${{ inputs.docker_repo }}
+      BUILD_ARCH: amd64
+      EXTRA_BUILD_OPTS: '--ssh=default'
+      OUTPUT: ${{ format('type=image,name={0},push-by-digest=true,name-canonical=true,push=true', inputs.image_name) }}
     shell: bash
     run: |
-      METADATA_FILE="$(mktemp).json"
+      export METADATA_FILE="$(mktemp).json"
       echo "METADATA_FILE=$METADATA_FILE"
-      make -C custombuild build-image \
-        TARGET=$TARGET \
-        BUILD_ARCH=amd64 \
-        OUTPUT="type=image,name=$IMAGE_NAME,push-by-digest=true,name-canonical=true,push=true" \
-        IMAGE_NAME=$IMAGE_NAME \
-        METADATA_FILE="$METADATA_FILE" \
-        EXTRA_BUILD_OPTS="--ssh=default"
+      make -C custombuild build-image
       (set -x && cat "$METADATA_FILE")
-      DIGEST="$(jq < "$METADATA_FILE" '.["containerimage.digest"]' -r)"
-      make -C custombuild tag-image SOURCE_DIGESTS="$DIGEST" IMAGE_NAME=$IMAGE_NAME
+      export SOURCE_DIGESTS="$(jq < "$METADATA_FILE" '.["containerimage.digest"]' -r)"
+      make -C custombuild tag-image
   - name: docker logout
     if: ${{ always() }}
     env:

--- a/.github/actions/build-custom-image/action.yaml
+++ b/.github/actions/build-custom-image/action.yaml
@@ -28,7 +28,6 @@ runs:
     env:
       DOCKERFILE: ${{ inputs.dockerfile }}
       IMAGE_NAME: ${{ inputs.image_name }}
-      REPO: ${{ inputs.docker_repo }}
       BUILD_ARCH: amd64
       EXTRA_BUILD_OPTS: '--ssh=default'
       OUTPUT: ${{ format('type=image,name={0},push-by-digest=true,name-canonical=true,push=true', inputs.image_name) }}

--- a/.github/actions/build-image/action.yaml
+++ b/.github/actions/build-image/action.yaml
@@ -1,6 +1,6 @@
 name: Build image
 inputs:
-  target:
+  dockerfile:
     required: true
   image_name:
     required: true
@@ -43,7 +43,7 @@ runs:
       echo "image_digest=$DIGEST" >> "$GITHUB_OUTPUT"
     shell: bash
     env:
-      TARGET: ${{ inputs.target }}
+      DOCKERFILE: ${{ inputs.dockerfile }}
       IMAGE_NAME: ${{ inputs.image_name }}
       OUTPUT: ${{ (inputs.push_image == 'true') && format('type=image,name={0},push-by-digest=true,name-canonical=true,push=true', inputs.image_name) || '' }}
       BUILD_ARCH: ${{ inputs.build_arch }}

--- a/.github/actions/build-image/action.yaml
+++ b/.github/actions/build-image/action.yaml
@@ -35,14 +35,9 @@ runs:
       printf "$DOCKER_PASSWORD" | docker login --password-stdin --username "$DOCKER_USERNAME" $DOCKER_REGISTRY
   - id: build_image
     run: |
-      METADATA_FILE="$(mktemp).json"
+      export METADATA_FILE="$(mktemp).json"
       echo "METADATA_FILE=$METADATA_FILE"
-      make build-image \
-        BUILD_ARCH=$BUILD_ARCH \
-        OUTPUT=$OUTPUT \
-        TARGET=$TARGET \
-        IMAGE_NAME=$IMAGE_NAME \
-        METADATA_FILE="$METADATA_FILE"
+      make build-image
       (set -x && cat "$METADATA_FILE")
       DIGEST="$(jq < "$METADATA_FILE" '.["containerimage.digest"]' -r)"
       echo "image_digest=$DIGEST" >> "$GITHUB_OUTPUT"
@@ -50,7 +45,7 @@ runs:
     env:
       TARGET: ${{ inputs.target }}
       IMAGE_NAME: ${{ inputs.image_name }}
-      OUTPUT: ${{ (inputs.push_image == 'true') && 'type=image,name=$$IMAGE_NAME,push-by-digest=true,name-canonical=true,push=true' || ''}}
+      OUTPUT: ${{ (inputs.push_image == 'true') && format('type=image,name={0},push-by-digest=true,name-canonical=true,push=true', inputs.image_name) || '' }}
       BUILD_ARCH: ${{ inputs.build_arch }}
   - name: docker logout
     if: ${{ always() }}

--- a/.github/actions/build-image/action.yaml
+++ b/.github/actions/build-image/action.yaml
@@ -34,6 +34,12 @@ runs:
     run: |
       printf "$DOCKER_PASSWORD" | docker login --password-stdin --username "$DOCKER_USERNAME" $DOCKER_REGISTRY
   - id: build_image
+    env:
+      DOCKERFILE: ${{ inputs.dockerfile }}
+      IMAGE_NAME: ${{ inputs.image_name }}
+      OUTPUT: ${{ (inputs.push_image == 'true') && format('type=image,name={0},push-by-digest=true,name-canonical=true,push=true', inputs.image_name) || '' }}
+      BUILD_ARCH: ${{ inputs.build_arch }}
+    shell: bash
     run: |
       export METADATA_FILE="$(mktemp).json"
       echo "METADATA_FILE=$METADATA_FILE"
@@ -41,12 +47,6 @@ runs:
       (set -x && cat "$METADATA_FILE")
       DIGEST="$(jq < "$METADATA_FILE" '.["containerimage.digest"]' -r)"
       echo "image_digest=$DIGEST" >> "$GITHUB_OUTPUT"
-    shell: bash
-    env:
-      DOCKERFILE: ${{ inputs.dockerfile }}
-      IMAGE_NAME: ${{ inputs.image_name }}
-      OUTPUT: ${{ (inputs.push_image == 'true') && format('type=image,name={0},push-by-digest=true,name-canonical=true,push=true', inputs.image_name) || '' }}
-      BUILD_ARCH: ${{ inputs.build_arch }}
   - name: docker logout
     if: ${{ always() }}
     env:

--- a/.github/workflows/custom-build.yaml
+++ b/.github/workflows/custom-build.yaml
@@ -66,7 +66,7 @@ jobs:
     - name: Build and push to HK
       uses: ./.github/actions/build-custom-image
       with:
-        target: authgearx
+        dockerfile: ./cmd/authgearx/Dockerfile
         image_name: "${{ secrets.AUTHGEAR_CUSTOM_BUILD_REPO_PREFIX_HK }}/authgear-server"
         gcp_project_id: ${{ secrets.AUTHGEAR_CUSTOM_BUILD_GOOGLE_PROJECT_ID_HK }}
         gcp_workload_identity_provider: ${{ secrets.AUTHGEAR_CUSTOM_BUILD_GOOGLE_WORKLOAD_IDENTITY_PROVIDER_HK }}
@@ -75,7 +75,7 @@ jobs:
     - name: Build and push to US
       uses: ./.github/actions/build-custom-image
       with:
-        target: authgearx
+        dockerfile: ./cmd/authgearx/Dockerfile
         image_name: "${{ secrets.AUTHGEAR_CUSTOM_BUILD_REPO_PREFIX_US }}/authgear-server"
         gcp_project_id: ${{ secrets.AUTHGEAR_CUSTOM_BUILD_GOOGLE_PROJECT_ID_US }}
         gcp_workload_identity_provider: ${{ secrets.AUTHGEAR_CUSTOM_BUILD_GOOGLE_WORKLOAD_IDENTITY_PROVIDER_US }}
@@ -117,7 +117,7 @@ jobs:
     - name: Build and push to HK
       uses: ./.github/actions/build-custom-image
       with:
-        target: portalx
+        dockerfile: ./cmd/portalx/Dockerfile
         image_name: "${{ secrets.AUTHGEAR_CUSTOM_BUILD_REPO_PREFIX_HK }}/authgear-portal"
         gcp_project_id: ${{ secrets.AUTHGEAR_CUSTOM_BUILD_GOOGLE_PROJECT_ID_HK }}
         gcp_workload_identity_provider: ${{ secrets.AUTHGEAR_CUSTOM_BUILD_GOOGLE_WORKLOAD_IDENTITY_PROVIDER_HK }}
@@ -126,7 +126,7 @@ jobs:
     - name: Build and push to US
       uses: ./.github/actions/build-custom-image
       with:
-        target: portalx
+        dockerfile: ./cmd/portalx/Dockerfile
         image_name: "${{ secrets.AUTHGEAR_CUSTOM_BUILD_REPO_PREFIX_US }}/authgear-portal"
         gcp_project_id: ${{ secrets.AUTHGEAR_CUSTOM_BUILD_GOOGLE_PROJECT_ID_US }}
         gcp_workload_identity_provider: ${{ secrets.AUTHGEAR_CUSTOM_BUILD_GOOGLE_WORKLOAD_IDENTITY_PROVIDER_US }}

--- a/.github/workflows/oursky.yaml
+++ b/.github/workflows/oursky.yaml
@@ -34,7 +34,7 @@ jobs:
     - uses: ./.github/actions/docker-buildx-create
     - name: Build and Push
       env:
-        TARGET: authgearx
+        DOCKERFILE: ./cmd/authgearx/Dockerfile
         BUILD_ARCH: amd64
         IMAGE_NAME: ${{ format('{0}/authgear-server', secrets.AUTHGEAR_CUSTOM_BUILD_REPO_PREFIX) }}
         OUTPUT: ${{ format('type=image,name={0}/authgear-server,push-by-digest=true,name-canonical=true,push=true', secrets.AUTHGEAR_CUSTOM_BUILD_REPO_PREFIX) }}
@@ -77,7 +77,7 @@ jobs:
     - uses: ./.github/actions/docker-buildx-create
     - name: Build and Push
       env:
-        TARGET: portalx
+        DOCKERFILE: ./cmd/portalx/Dockerfile
         BUILD_ARCH: amd64
         IMAGE_NAME: ${{ format('{0}/authgear-portal', secrets.AUTHGEAR_CUSTOM_BUILD_REPO_PREFIX) }}
         OUTPUT: ${{ format('type=image,name={0}/authgear-portal,push-by-digest=true,name-canonical=true,push=true', secrets.AUTHGEAR_CUSTOM_BUILD_REPO_PREFIX) }}

--- a/.github/workflows/oursky.yaml
+++ b/.github/workflows/oursky.yaml
@@ -34,21 +34,18 @@ jobs:
     - uses: ./.github/actions/docker-buildx-create
     - name: Build and Push
       env:
-        REPO_PREFIX: ${{ secrets.AUTHGEAR_CUSTOM_BUILD_REPO_PREFIX }}
+        TARGET: authgearx
+        BUILD_ARCH: amd64
+        IMAGE_NAME: ${{ format('{0}/authgear-server', secrets.AUTHGEAR_CUSTOM_BUILD_REPO_PREFIX) }}
+        OUTPUT: ${{ format('type=image,name={0}/authgear-server,push-by-digest=true,name-canonical=true,push=true', secrets.AUTHGEAR_CUSTOM_BUILD_REPO_PREFIX) }}
+        EXTRA_BUILD_OPTS: '--ssh=default'
       run: |
-        METADATA_FILE="$(mktemp).json"
+        export METADATA_FILE="$(mktemp).json"
         echo "METADATA_FILE=$METADATA_FILE"
-        IMAGE_NAME="$REPO_PREFIX/authgear-server"
-        make -C custombuild build-image \
-          TARGET=authgearx \
-          BUILD_ARCH=amd64 \
-          OUTPUT="type=image,name=$IMAGE_NAME,push-by-digest=true,name-canonical=true,push=true" \
-          IMAGE_NAME=$IMAGE_NAME \
-          METADATA_FILE="$METADATA_FILE" \
-          EXTRA_BUILD_OPTS="--ssh=default"
+        make -C custombuild build-image
         (set -x && cat "$METADATA_FILE")
-        DIGEST="$(jq < "$METADATA_FILE" '.["containerimage.digest"]' -r)"
-        make -C custombuild tag-image SOURCE_DIGESTS="$DIGEST" IMAGE_NAME=$IMAGE_NAME
+        export SOURCE_DIGESTS="$(jq < "$METADATA_FILE" '.["containerimage.digest"]' -r)"
+        make -C custombuild tag-image
     - name: Clean up SSH key
       if: ${{ always() }}
       run: |
@@ -80,21 +77,18 @@ jobs:
     - uses: ./.github/actions/docker-buildx-create
     - name: Build and Push
       env:
-        REPO_PREFIX: ${{ secrets.AUTHGEAR_CUSTOM_BUILD_REPO_PREFIX }}
+        TARGET: portalx
+        BUILD_ARCH: amd64
+        IMAGE_NAME: ${{ format('{0}/authgear-portal', secrets.AUTHGEAR_CUSTOM_BUILD_REPO_PREFIX) }}
+        OUTPUT: ${{ format('type=image,name={0}/authgear-portal,push-by-digest=true,name-canonical=true,push=true', secrets.AUTHGEAR_CUSTOM_BUILD_REPO_PREFIX) }}
+        EXTRA_BUILD_OPTS: '--ssh=default'
       run: |
-        METADATA_FILE="$(mktemp).json"
+        export METADATA_FILE="$(mktemp).json"
         echo "METADATA_FILE=$METADATA_FILE"
-        IMAGE_NAME="$REPO_PREFIX/authgear-portal"
-        make -C custombuild build-image \
-          TARGET=portalx \
-          BUILD_ARCH=amd64 \
-          OUTPUT="type=image,name=$IMAGE_NAME,push-by-digest=true,name-canonical=true,push=true" \
-          IMAGE_NAME=$IMAGE_NAME \
-          METADATA_FILE="$METADATA_FILE" \
-          EXTRA_BUILD_OPTS="--ssh=default"
+        make -C custombuild build-image
         (set -x && cat "$METADATA_FILE")
-        DIGEST="$(jq < "$METADATA_FILE" '.["containerimage.digest"]' -r)"
-        make -C custombuild tag-image SOURCE_DIGESTS="$DIGEST" IMAGE_NAME=$IMAGE_NAME
+        export SOURCE_DIGESTS="$(jq < "$METADATA_FILE" '.["containerimage.digest"]' -r)"
+        make -C custombuild tag-image
     - name: Clean up SSH key
       if: ${{ always() }}
       run: |

--- a/.github/workflows/run-builds.yaml
+++ b/.github/workflows/run-builds.yaml
@@ -142,3 +142,68 @@ jobs:
       if: ${{ always() }}
       run: |
         docker logout quay.io
+
+  once-image-amd64:
+    if: ${{ github.repository != 'oursky/authgear-server' }}
+    runs-on: ubuntu-24.04
+    outputs:
+      image_digest: ${{ steps.build_image.outputs.image_digest }}
+    env:
+      PUSH_IMAGE: "${{ (github.repository == 'authgear/authgear-server' && github.event_name == 'push') && 'true' || 'false' }}"
+    steps:
+    - uses: actions/checkout@v4
+    - id: build_image
+      uses: ./.github/actions/build-image
+      with:
+        dockerfile: ./once/Dockerfile
+        image_name: quay.io/theauthgear/authgear-once
+        push_image: "${{ env.PUSH_IMAGE }}"
+        build_arch: amd64
+        docker_registry: quay.io
+        docker_username: "${{ env.PUSH_IMAGE == 'true' && secrets.QUAY_USERNAME || '' }}"
+        docker_password: "${{ env.PUSH_IMAGE == 'true' && secrets.QUAY_ROBOT_TOKEN || '' }}"
+  once-image-arm64:
+    if: ${{ (github.repository == 'authgear/authgear-server' && github.event_name == 'push' && !inputs.amd64-build-only) }}
+    runs-on: ubuntu-24.04-arm
+    outputs:
+      image_digest: ${{ steps.build_image.outputs.image_digest }}
+    env:
+      PUSH_IMAGE: "${{ (github.repository == 'authgear/authgear-server' && github.event_name == 'push') && 'true' || 'false' }}"
+    steps:
+    - uses: actions/checkout@v4
+    - id: build_image
+      uses: ./.github/actions/build-image
+      with:
+        dockerfile: ./once/Dockerfile
+        image_name: quay.io/theauthgear/authgear-once
+        push_image: "${{ env.PUSH_IMAGE }}"
+        build_arch: arm64
+        docker_registry: quay.io
+        docker_username: "${{ env.PUSH_IMAGE == 'true' && secrets.QUAY_USERNAME || '' }}"
+        docker_password: "${{ env.PUSH_IMAGE == 'true' && secrets.QUAY_ROBOT_TOKEN || '' }}"
+  once-image:
+    if: ${{ (github.repository == 'authgear/authgear-server' && github.event_name == 'push' && !inputs.amd64-build-only) }}
+    runs-on: ubuntu-24.04
+    needs: ["once-image-amd64", "once-image-arm64"]
+    env:
+      IMAGE_NAME: quay.io/theauthgear/authgear-once
+      PUSH_IMAGE: "${{ (github.repository == 'authgear/authgear-server' && github.event_name == 'push') && 'true' || 'false' }}"
+      SOURCE_DIGESTS: ${{ format('{0} {1}', needs.once-image-amd64.outputs.image_digest, needs.once-image-arm64.outputs.image_digest) }}
+    steps:
+    - uses: actions/checkout@v4
+    - uses: ./.github/actions/set-git-tag-name
+      with:
+        github_ref_type: ${{ github.ref_type }}
+        github_ref_name: ${{ github.ref_name }}
+    - name: docker login
+      if: ${{ github.repository == 'authgear/authgear-server' && github.event_name == 'push' }}
+      env:
+        DOCKER_USERNAME: ${{ secrets.QUAY_USERNAME }}
+        DOCKER_PASSWORD: ${{ secrets.QUAY_ROBOT_TOKEN }}
+      run: |
+        printf "$DOCKER_PASSWORD" | docker login --password-stdin --username "$DOCKER_USERNAME" quay.io
+    - run: make tag-image
+    - name: docker logout
+      if: ${{ always() }}
+      run: |
+        docker logout quay.io

--- a/.github/workflows/run-builds.yaml
+++ b/.github/workflows/run-builds.yaml
@@ -21,7 +21,7 @@ jobs:
     - id: build_image
       uses: ./.github/actions/build-image
       with:
-        target: authgear
+        dockerfile: ./cmd/authgear/Dockerfile
         image_name: quay.io/theauthgear/authgear-server
         push_image: "${{ env.PUSH_IMAGE }}"
         build_arch: amd64
@@ -40,7 +40,7 @@ jobs:
     - id: build_image
       uses: ./.github/actions/build-image
       with:
-        target: authgear
+        dockerfile: ./cmd/authgear/Dockerfile
         image_name: quay.io/theauthgear/authgear-server
         push_image: "${{ env.PUSH_IMAGE }}"
         build_arch: arm64
@@ -53,11 +53,9 @@ jobs:
     runs-on: ubuntu-24.04
     needs: ["authgear-image-amd64", "authgear-image-arm64"]
     env:
-      TARGET: authgear
       IMAGE_NAME: quay.io/theauthgear/authgear-server
       PUSH_IMAGE: "${{ (github.repository == 'authgear/authgear-server' && github.event_name == 'push') && 'true' || 'false' }}"
-      AMD64_DIGEST: "${{needs.authgear-image-amd64.outputs.image_digest}}"
-      ARM64_DIGEST: "${{needs.authgear-image-arm64.outputs.image_digest}}"
+      SOURCE_DIGESTS: ${{ format('{0} {1}', needs.authgear-image-amd64.outputs.image_digest, needs.authgear-image-arm64.outputs.image_digest) }}
     steps:
     - uses: actions/checkout@v4
     - uses: ./.github/actions/set-git-tag-name
@@ -71,7 +69,7 @@ jobs:
         DOCKER_PASSWORD: ${{ secrets.QUAY_ROBOT_TOKEN }}
       run: |
         printf "$DOCKER_PASSWORD" | docker login --password-stdin --username "$DOCKER_USERNAME" quay.io
-    - run: make tag-image SOURCE_DIGESTS="$AMD64_DIGEST $ARM64_DIGEST" IMAGE_NAME=$IMAGE_NAME
+    - run: make tag-image
     - name: docker logout
       if: ${{ always() }}
       run: |
@@ -90,7 +88,7 @@ jobs:
     - id: build_image
       uses: ./.github/actions/build-image
       with:
-        target: portal
+        dockerfile: ./cmd/portal/Dockerfile
         image_name: quay.io/theauthgear/authgear-portal
         push_image: "${{ env.PUSH_IMAGE }}"
         build_arch: amd64
@@ -110,7 +108,7 @@ jobs:
     - id: build_image
       uses: ./.github/actions/build-image
       with:
-        target: portal
+        dockerfile: ./cmd/portal/Dockerfile
         image_name: quay.io/theauthgear/authgear-portal
         push_image: "${{ env.PUSH_IMAGE }}"
         build_arch: arm64
@@ -123,11 +121,9 @@ jobs:
     runs-on: ubuntu-24.04
     needs: ["portal-image-amd64", "portal-image-arm64"]
     env:
-      TARGET: authgear
       IMAGE_NAME: quay.io/theauthgear/authgear-portal
       PUSH_IMAGE: "${{ (github.repository == 'authgear/authgear-server' && github.event_name == 'push') && 'true' || 'false' }}"
-      AMD64_DIGEST: "${{needs.portal-image-amd64.outputs.image_digest}}"
-      ARM64_DIGEST: "${{needs.portal-image-arm64.outputs.image_digest}}"
+      SOURCE_DIGESTS: ${{ format('{0} {1}', needs.portal-image-amd64.outputs.image_digest, needs.portal-image-arm64.outputs.image_digest) }}
     steps:
     - uses: actions/checkout@v4
     - uses: ./.github/actions/set-git-tag-name
@@ -141,7 +137,7 @@ jobs:
         DOCKER_PASSWORD: ${{ secrets.QUAY_ROBOT_TOKEN }}
       run: |
         printf "$DOCKER_PASSWORD" | docker login --password-stdin --username "$DOCKER_USERNAME" quay.io
-    - run: make tag-image SOURCE_DIGESTS="$AMD64_DIGEST $ARM64_DIGEST" IMAGE_NAME=$IMAGE_NAME
+    - run: make tag-image
     - name: docker logout
       if: ${{ always() }}
       run: |

--- a/makefiles/common.mk
+++ b/makefiles/common.mk
@@ -59,6 +59,7 @@ build:
 
 .PHONY: build-image
 build-image:
+DOCKERFILE ?= ./Dockerfile
 IMAGE_TAG_BASE ::= $(IMAGE_NAME):$(GIT_HASH)
 BUILD_OPTS ::=
 ifeq ($(BUILD_ARCH),amd64)
@@ -82,7 +83,7 @@ build-image:
 	@# See https://github.com/authgear/authgear-server/pull/4943#discussion_r1891263998
 	docker build --pull \
 		--provenance=false \
-		--file ./cmd/$(TARGET)/Dockerfile \
+		--file "$(DOCKERFILE)" \
 		$(BUILD_OPTS) \
 		--build-arg GIT_HASH=$(GIT_HASH) ${BUILD_CTX}
 

--- a/makefiles/common.mk
+++ b/makefiles/common.mk
@@ -1,19 +1,3 @@
-# The use of variables
-#
-# We use simply expanded variables in this Makefile.
-#
-# This means
-# 1. You use ::= instead of = because = defines a recursively expanded variable.
-#    See https://www.gnu.org/software/make/manual/html_node/Simple-Assignment.html
-# 2. You use ::= instead of := because ::= is a POSIX standard.
-#    See https://www.gnu.org/software/make/manual/html_node/Simple-Assignment.html
-# 3. You do not use ?= because it is shorthand to define a recursively expanded variable.
-#    See https://www.gnu.org/software/make/manual/html_node/Conditional-Assignment.html
-#    You should use the long form documented in the above link instead.
-# 4. When you override a variable in the command line, as documented in https://www.gnu.org/software/make/manual/html_node/Overriding.html
-#    you specify the variable with ::= instead of = or :=
-#    If you fail to do so, the variable becomes recursively expanded variable accidentally.
-#
 ifeq ($(origin GIT_HASH), undefined)
 GIT_HASH ::= git-$(shell git rev-parse --short=12 HEAD)
 endif

--- a/makefiles/common.mk
+++ b/makefiles/common.mk
@@ -15,10 +15,10 @@
 #    If you fail to do so, the variable becomes recursively expanded variable accidentally.
 #
 ifeq ($(origin GIT_HASH), undefined)
-	GIT_HASH ::= git-$(shell git rev-parse --short=12 HEAD)
+GIT_HASH ::= git-$(shell git rev-parse --short=12 HEAD)
 endif
 ifeq ($(origin LDFLAGS), undefined)
-	LDFLAGS ::= "-X github.com/authgear/authgear-server/pkg/version.Version=${GIT_HASH}"
+LDFLAGS ::= "-X github.com/authgear/authgear-server/pkg/version.Version=${GIT_HASH}"
 endif
 
 
@@ -32,10 +32,10 @@ GO_BUILD_TAGS ::= osusergo netgo static_build timetzdata
 # we use a simpler mechanism to append to GO_BUILD_TAGS.
 # We define AUTHGEARLITE and AUTHGEARONCE, and if they are 1, then the corresponding build tag is appended.
 ifeq ($(AUTHGEARLITE), 1)
-	GO_BUILD_TAGS += authgearlite
+GO_BUILD_TAGS += authgearlite
 endif
 ifeq ($(AUTHGEARONCE), 1)
-	GO_BUILD_TAGS += authgearonce
+GO_BUILD_TAGS += authgearonce
 endif
 # authgeardev: This build tag represents the build is for local development purpose.
 #              Currently, it affects whether the builtin resource FS uses OS FS or embed.FS.

--- a/makefiles/guideline.mk
+++ b/makefiles/guideline.mk
@@ -1,0 +1,38 @@
+# Guideline on authoring makefiles.
+#
+# 1. We use simply expanded variables.
+# This means
+# - You use ::= instead of = because = defines a recursively expanded variable.
+#   See https://www.gnu.org/software/make/manual/html_node/Simple-Assignment.html
+# - You use ::= instead of := because ::= is a POSIX standard.
+#   See https://www.gnu.org/software/make/manual/html_node/Simple-Assignment.html
+# - You do not use ?= because it is shorthand to define a recursively expanded variable.
+#   See https://www.gnu.org/software/make/manual/html_node/Conditional-Assignment.html
+#   You should use the long form documented in the above link instead.
+# - When you override a variable in the command line, as documented in https://www.gnu.org/software/make/manual/html_node/Overriding.html
+#   you specify the variable with ::= instead of = or :=
+#   If you fail to do so, the variable becomes recursively expanded variable accidentally.
+#
+# 2. Global variables SHOULD BE declared at the beginning of the makefile.
+#    Global variables are available to all makefile targets.
+#
+# 3. Target-specific variables SHOULD BE used if the variables are applicable to 1 target only.
+#    See https://www.gnu.org/software/make/manual/html_node/Target_002dspecific.html
+#
+# 4. Makefile conditionals controls what makefile "sees".
+#    Therefore, the body usually does not have leading tab characters.
+#    See https://www.gnu.org/software/make/manual/html_node/Conditionals.html
+#
+# 5. Environment variables seen by make become a a make variable automatically.
+#    See https://www.gnu.org/software/make/manual/html_node/Environment.html
+#    Therefore, you DO NOT write `make something A="$A" B="$B"`.
+#    Instead, you should make the environment variable visible to make.
+#    For example,
+#
+#      export A=A
+#      export B=B
+#      make something
+#
+#    or
+#
+#      A=A B=B make something

--- a/pkg/portal/model/system_config.go
+++ b/pkg/portal/model/system_config.go
@@ -5,6 +5,7 @@ import (
 )
 
 type SystemConfig struct {
+	AuthgearAppID             string         `json:"authgearAppID"`
 	AuthgearClientID          string         `json:"authgearClientID"`
 	AuthgearEndpoint          string         `json:"authgearEndpoint"`
 	AuthgearWebSDKSessionType string         `json:"authgearWebSDKSessionType"`

--- a/pkg/portal/model/system_config.go
+++ b/pkg/portal/model/system_config.go
@@ -9,6 +9,7 @@ type SystemConfig struct {
 	AuthgearClientID          string         `json:"authgearClientID"`
 	AuthgearEndpoint          string         `json:"authgearEndpoint"`
 	AuthgearWebSDKSessionType string         `json:"authgearWebSDKSessionType"`
+	IsAuthgearOnce            bool           `json:"isAuthgearOnce"`
 	SentryDSN                 string         `json:"sentryDSN,omitempty"`
 	AppHostSuffix             string         `json:"appHostSuffix"`
 	AvailableLanguages        []string       `json:"availableLanguages"`

--- a/pkg/portal/service/system_config.go
+++ b/pkg/portal/service/system_config.go
@@ -51,6 +51,7 @@ func (p *SystemConfigProvider) SystemConfig(ctx context.Context) (*model.SystemC
 	}
 
 	return &model.SystemConfig{
+		AuthgearAppID:             p.AuthgearConfig.AppID,
 		AuthgearClientID:          p.AuthgearConfig.ClientID,
 		AuthgearEndpoint:          p.AuthgearConfig.Endpoint,
 		AuthgearWebSDKSessionType: p.AuthgearConfig.WebSDKSessionType,

--- a/pkg/portal/service/system_config.go
+++ b/pkg/portal/service/system_config.go
@@ -55,6 +55,7 @@ func (p *SystemConfigProvider) SystemConfig(ctx context.Context) (*model.SystemC
 		AuthgearClientID:          p.AuthgearConfig.ClientID,
 		AuthgearEndpoint:          p.AuthgearConfig.Endpoint,
 		AuthgearWebSDKSessionType: p.AuthgearConfig.WebSDKSessionType,
+		IsAuthgearOnce:            AUTHGEARONCE,
 		SentryDSN:                 p.FrontendSentryConfig.DSN,
 		AppHostSuffix:             p.AppConfig.HostSuffix,
 		AvailableLanguages:        intl.AvailableLanguages,

--- a/portal/src/system-config.ts
+++ b/portal/src/system-config.ts
@@ -7,6 +7,7 @@ export interface SystemConfig {
   authgearClientID: string;
   authgearEndpoint: string;
   authgearWebSDKSessionType: "cookie" | "refresh_token";
+  isAuthgearOnce: boolean;
   sentryDSN: string;
   appHostSuffix: string;
   availableLanguages: string[];
@@ -251,6 +252,7 @@ export function instantiateSystemConfig(
     authgearClientID: config.authgearClientID ?? "",
     authgearEndpoint: config.authgearEndpoint ?? "",
     authgearWebSDKSessionType: config.authgearWebSDKSessionType ?? "cookie",
+    isAuthgearOnce: config.isAuthgearOnce ?? false,
     sentryDSN: config.sentryDSN ?? "",
     appHostSuffix: config.appHostSuffix ?? "",
     availableLanguages: config.availableLanguages ?? [DEFAULT_TEMPLATE_LOCALE],

--- a/portal/src/system-config.ts
+++ b/portal/src/system-config.ts
@@ -3,6 +3,7 @@ import MESSAGES from "./locale-data/en.json";
 import { DEFAULT_TEMPLATE_LOCALE } from "./resources";
 
 export interface SystemConfig {
+  authgearAppID: string;
   authgearClientID: string;
   authgearEndpoint: string;
   authgearWebSDKSessionType: "cookie" | "refresh_token";
@@ -246,6 +247,7 @@ export function instantiateSystemConfig(
   config: PartialSystemConfig
 ): SystemConfig {
   return {
+    authgearAppID: config.authgearAppID ?? "",
     authgearClientID: config.authgearClientID ?? "",
     authgearEndpoint: config.authgearEndpoint ?? "",
     authgearWebSDKSessionType: config.authgearWebSDKSessionType ?? "cookie",


### PR DESCRIPTION
ref DEV-2412

<img width="1508" alt="SCR-20250314-qlml" src="https://github.com/user-attachments/assets/d45859ea-c688-4f88-a432-cc8ec6871818" />

(Note that the accounts project is hidden and the create project button is hidden)

It can be tested with `./once/docker-compose.yaml`

```
services:
  once:
    build:
      context: ../
      dockerfile: ./once/Dockerfile
    volumes:
    - postgres_data:/var/lib/postgresql/data
    - redis_data:/var/lib/redis/data
    - certbot_data:/etc/letsencrypt
    - minio_data:/var/lib/minio/data
    environment:
      POSTGRES_PASSWORD: "1234"
      REDIS_PASSWORD: "1234"
      MINIO_ROOT_PASSWORD: "12345678"
      # Edit your /etc/hosts to include those hosts.
      AUTHGEAR_HTTP_ORIGIN_PORTAL: "http://portal.localhost"
      AUTHGEAR_HTTP_ORIGIN_ACCOUNTS: "http://accounts.localhost"
      AUTHGEAR_HTTP_ORIGIN_PROJECT: "http://project.localhost"
      AUTHGEAR_CERTBOT_RUN_INTERVAL: "86400"
      AUTHGEAR_ONCE_ADMIN_USER_EMAIL: "louischan@oursky.com"
      AUTHGEAR_ONCE_ADMIN_USER_PASSWORD: "12345678"
      #AUTHGEAR_CERTBOT_ENVIRONMENT: "production"
    ports:
    - "80:80"
    - "443:443"
    - "5432:5432"
    - "9001:9001"
    - "8090:8090"

volumes:
  postgres_data:
    driver: local
  redis_data:
    driver: local
  certbot_data:
    driver: local
  minio_data:
    driver: local
```

```
cd once
# To remove any previous data
docker compose down -v
docker compose build
docker compose up
# Visit http://portal.localhost
```
