### PR TITLE
Fix infinite loop in authflow

### DIFF
--- a/pkg/lib/authenticationflow/accept.go
+++ b/pkg/lib/authenticationflow/accept.go
@@ -23,6 +23,10 @@ func NewAcceptResult() *AcceptResult {
 	}
 }
 
+const (
+	MAX_LOOP = 100
+)
+
 // Accept executes the flow to the deepest using input.
 // In addition to the errors caused by intents and nodes,
 // ErrEOF and ErrNoChange can be returned.
@@ -58,7 +62,12 @@ func accept(ctx context.Context, deps *Dependencies, flows Flows, result *Accept
 		}
 	}()
 
+	loopCount := 0
 	for {
+		loopCount += 1
+		if loopCount > MAX_LOOP {
+			panic(fmt.Errorf("number of loops reached limit"))
+		}
 		var findInputReactorResult *FindInputReactorResult
 		findInputReactorResult, err = FindInputReactor(ctx, deps, flows)
 		if err != nil {

--- a/pkg/lib/authenticationflow/declarative/intent_login_flow_step_create_authenticator.go
+++ b/pkg/lib/authenticationflow/declarative/intent_login_flow_step_create_authenticator.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/iawaknahc/jsonschema/pkg/jsonpointer"
 
+	"github.com/authgear/authgear-server/pkg/api"
 	"github.com/authgear/authgear-server/pkg/api/model"
 	authflow "github.com/authgear/authgear-server/pkg/lib/authenticationflow"
 	"github.com/authgear/authgear-server/pkg/lib/authn/authenticator"
@@ -105,8 +106,8 @@ func (i *IntentLoginFlowStepCreateAuthenticator) CanReactTo(ctx context.Context,
 		return nil, err
 	}
 	if len(flows.Nearest.Nodes) == 0 && len(internalOptions) == 0 {
-		// Nothing can be selected, skip this step.
-		return nil, authflow.ErrEOF
+		// Nothing can be selected, throw error because this step cannot be skipped in login flow
+		return nil, api.ErrNoAuthenticator
 	}
 
 	// Let the input to select which authentication method to use.


### PR DESCRIPTION
ref DEV-2610

The infinite loop occurs when:
1. Your authflow requires you to create a new authenticator (Possibly due to 2fa grace period)
2. Your config do not have a creatable authenticator

`IntentLoginFlowStepCreateAuthenticator` returns `authflow.ErrEOF` in `CanReactTo`, which cause the parent intent to handle the input. The parent intent is `IntentLoginFlowStepAuthenticate`, which then react to the input with a new `IntentLoginFlowStepCreateAuthenticator` subflow, causing infinite loop.