### PR TITLE
Support AUTHGEARDEBUG_DATABASE_CONNECTION_WAIT_TIME_TIMEOUT_MILLISECONDS

### DIFF
--- a/.vettedpositions
+++ b/.vettedpositions
@@ -334,7 +334,7 @@
 /pkg/util/jwkutil/contextbackground.go:11:52: contextbackground
 /pkg/util/otelutil/nethttp.go:120:46: requestcontext
 /pkg/util/otelutil/nethttp.go:130:49: requestcontext
-/pkg/util/otelutil/oteldatabasesql/instrumentation.go:270:13: contextbackground
+/pkg/util/otelutil/oteldatabasesql/instrumentation.go:295:13: contextbackground
 /pkg/util/pubsub/http_handler.go:51:40: requestcontext
 /pkg/util/sentry/request.go:25:9: requestcontext
 /pkg/util/template/engine.go:344:9: requestcontext

--- a/pkg/util/otelutil/oteldatabasesql/instrumentation_test.go
+++ b/pkg/util/otelutil/oteldatabasesql/instrumentation_test.go
@@ -1,0 +1,55 @@
+package oteldatabasesql
+
+import (
+	"os"
+	"testing"
+	"time"
+
+	. "github.com/smartystreets/goconvey/convey"
+)
+
+func TestGetAUTHGEARDEBUG_DATABASE_CONNECTION_WAIT_TIME_TIMEOUT_MILLISECONDS(t *testing.T) {
+	Convey("Test get_AUTHGEARDEBUG_DATABASE_CONNECTION_WAIT_TIME_TIMEOUT_MILLISECONDS function", t, func() {
+		Convey("When env var is not set", func() {
+			os.Unsetenv("AUTHGEARDEBUG_DATABASE_CONNECTION_WAIT_TIME_TIMEOUT_MILLISECONDS")
+
+			timeout := get_AUTHGEARDEBUG_DATABASE_CONNECTION_WAIT_TIME_TIMEOUT_MILLISECONDS()
+			So(timeout, ShouldEqual, time.Duration(0))
+		})
+
+		Convey("When env var is empty", func() {
+			os.Setenv("AUTHGEARDEBUG_DATABASE_CONNECTION_WAIT_TIME_TIMEOUT_MILLISECONDS", "")
+
+			timeout := get_AUTHGEARDEBUG_DATABASE_CONNECTION_WAIT_TIME_TIMEOUT_MILLISECONDS()
+			So(timeout, ShouldEqual, time.Duration(0))
+		})
+
+		Convey("When env var is not a valid integer", func() {
+			os.Setenv("AUTHGEARDEBUG_DATABASE_CONNECTION_WAIT_TIME_TIMEOUT_MILLISECONDS", "not-an-integer")
+
+			timeout := get_AUTHGEARDEBUG_DATABASE_CONNECTION_WAIT_TIME_TIMEOUT_MILLISECONDS()
+			So(timeout, ShouldEqual, time.Duration(0))
+		})
+
+		Convey("When env var is zero", func() {
+			os.Setenv("AUTHGEARDEBUG_DATABASE_CONNECTION_WAIT_TIME_TIMEOUT_MILLISECONDS", "0")
+
+			timeout := get_AUTHGEARDEBUG_DATABASE_CONNECTION_WAIT_TIME_TIMEOUT_MILLISECONDS()
+			So(timeout, ShouldEqual, time.Duration(0))
+		})
+
+		Convey("When env var is negative", func() {
+			os.Setenv("AUTHGEARDEBUG_DATABASE_CONNECTION_WAIT_TIME_TIMEOUT_MILLISECONDS", "-100")
+
+			timeout := get_AUTHGEARDEBUG_DATABASE_CONNECTION_WAIT_TIME_TIMEOUT_MILLISECONDS()
+			So(timeout, ShouldEqual, time.Duration(0))
+		})
+
+		Convey("When env var is positive", func() {
+			os.Setenv("AUTHGEARDEBUG_DATABASE_CONNECTION_WAIT_TIME_TIMEOUT_MILLISECONDS", "1000")
+
+			timeout := get_AUTHGEARDEBUG_DATABASE_CONNECTION_WAIT_TIME_TIMEOUT_MILLISECONDS()
+			So(timeout, ShouldEqual, time.Duration(1000)*time.Millisecond)
+		})
+	})
+}


### PR DESCRIPTION
ref DEV-2729

To use it, set this to sensible value, like 3000.