### PR TITLE
Add a sso callback route for any project

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -192,4 +192,4 @@ OTEL_METRIC_EXPORT_INTERVAL=5000
 # Use OTEL_SERVICE_NAME to specify service.name
 OTEL_SERVICE_NAME=authgear
 
-OAUTH_DEMO_CREDENTIAL_REDIRECT_URI=http://localhost:3100/noproject/sso/oauth2/callback
+SHARED_AUTHGEAR_ENDPOINT=http://localhost:3100

--- a/.env.example
+++ b/.env.example
@@ -191,3 +191,5 @@ OTEL_METRIC_EXPORT_INTERVAL=5000
 
 # Use OTEL_SERVICE_NAME to specify service.name
 OTEL_SERVICE_NAME=authgear
+
+OAUTH_DEMO_CREDENTIAL_REDIRECT_URI=http://localhost:3100/noproject/sso/oauth2/callback

--- a/.vettedpositions
+++ b/.vettedpositions
@@ -42,10 +42,10 @@
 /pkg/auth/handler/webapp/auth_entry_point_middleware.go:31:31: requestcontext
 /pkg/auth/handler/webapp/auth_entry_point_middleware.go:32:35: requestcontext
 /pkg/auth/handler/webapp/authflow_change_password.go:96:26: requestcontext
-/pkg/auth/handler/webapp/authflow_controller.go:1008:30: requestcontext
-/pkg/auth/handler/webapp/authflow_controller.go:1013:24: requestcontext
-/pkg/auth/handler/webapp/authflow_controller.go:1021:19: requestcontext
-/pkg/auth/handler/webapp/authflow_controller.go:1029:18: requestcontext
+/pkg/auth/handler/webapp/authflow_controller.go:1014:30: requestcontext
+/pkg/auth/handler/webapp/authflow_controller.go:1019:24: requestcontext
+/pkg/auth/handler/webapp/authflow_controller.go:1027:19: requestcontext
+/pkg/auth/handler/webapp/authflow_controller.go:1035:18: requestcontext
 /pkg/auth/handler/webapp/authflow_create_password.go:132:26: requestcontext
 /pkg/auth/handler/webapp/authflow_enter_oob_otp.go:156:26: requestcontext
 /pkg/auth/handler/webapp/authflow_enter_password.go:139:26: requestcontext
@@ -55,7 +55,8 @@
 /pkg/auth/handler/webapp/authflow_forgot_password.go:227:33: requestcontext
 /pkg/auth/handler/webapp/authflow_forgot_password_otp.go:213:26: requestcontext
 /pkg/auth/handler/webapp/authflow_forgot_password_success.go:52:26: requestcontext
-/pkg/auth/handler/webapp/authflow_login.go:197:33: requestcontext
+/pkg/auth/handler/webapp/authflow_login.go:196:33: requestcontext
+/pkg/auth/handler/webapp/authflow_wechat.go:171:26: requestcontext
 /pkg/auth/handler/webapp/authflow_oob_otp_link.go:136:26: requestcontext
 /pkg/auth/handler/webapp/authflow_promote.go:128:33: requestcontext
 /pkg/auth/handler/webapp/authflow_prompt_create_passkey.go:102:26: requestcontext
@@ -69,9 +70,9 @@
 /pkg/auth/handler/webapp/authflow_terminate_other_sessions.go:73:26: requestcontext
 /pkg/auth/handler/webapp/authflow_use_passkey.go:108:26: requestcontext
 /pkg/auth/handler/webapp/authflow_view_recovery_code.go:85:26: requestcontext
-/pkg/auth/handler/webapp/authflow_wechat.go:168:26: requestcontext
+/pkg/auth/handler/webapp/authflow_wechat.go:171:26: requestcontext
 /pkg/auth/handler/webapp/authflow_whatsapp_otp.go:147:26: requestcontext
-/pkg/auth/handler/webapp/authflowv2/account_linking.go:151:26: requestcontext
+/pkg/auth/handler/webapp/authflowv2/account_linking.go:154:26: requestcontext
 /pkg/auth/handler/webapp/authflowv2/change_password.go:115:26: requestcontext
 /pkg/auth/handler/webapp/authflowv2/change_password_success.go:65:35: requestcontext
 /pkg/auth/handler/webapp/authflowv2/create_password.go:179:26: requestcontext
@@ -84,11 +85,11 @@
 /pkg/auth/handler/webapp/authflowv2/forgot_password.go:286:33: requestcontext
 /pkg/auth/handler/webapp/authflowv2/forgot_password_link_sent.go:86:26: requestcontext
 /pkg/auth/handler/webapp/authflowv2/forgot_password_otp.go:204:26: requestcontext
-/pkg/auth/handler/webapp/authflowv2/internal_signup_login.go:234:33: requestcontext
+/pkg/auth/handler/webapp/authflowv2/internal_signup_login.go:236:33: requestcontext
 /pkg/auth/handler/webapp/authflowv2/ldap_login.go:109:26: requestcontext
-/pkg/auth/handler/webapp/authflowv2/login.go:247:33: requestcontext
+/pkg/auth/handler/webapp/authflowv2/login.go:221:33: requestcontext
 /pkg/auth/handler/webapp/authflowv2/oob_otp_link.go:170:26: requestcontext
-/pkg/auth/handler/webapp/authflowv2/promote.go:139:33: requestcontext
+/pkg/auth/handler/webapp/authflowv2/promote.go:141:33: requestcontext
 /pkg/auth/handler/webapp/authflowv2/prompt_create_passkey.go:126:26: requestcontext
 /pkg/auth/handler/webapp/authflowv2/reauth.go:42:33: requestcontext
 /pkg/auth/handler/webapp/authflowv2/reset_password.go:129:30: requestcontext
@@ -112,7 +113,7 @@
 /pkg/auth/handler/webapp/authflowv2/settings_identity_edit_phone.go:134:30: requestcontext
 /pkg/auth/handler/webapp/authflowv2/settings_identity_edit_username.go:121:30: requestcontext
 /pkg/auth/handler/webapp/authflowv2/settings_identity_list_email.go:153:30: requestcontext
-/pkg/auth/handler/webapp/authflowv2/settings_identity_list_oauth.go:138:30: requestcontext
+/pkg/auth/handler/webapp/authflowv2/settings_identity_list_oauth.go:140:30: requestcontext
 /pkg/auth/handler/webapp/authflowv2/settings_identity_list_phone.go:153:30: requestcontext
 /pkg/auth/handler/webapp/authflowv2/settings_identity_list_username.go:88:30: requestcontext
 /pkg/auth/handler/webapp/authflowv2/settings_identity_new_username.go:74:30: requestcontext
@@ -144,7 +145,7 @@
 /pkg/auth/handler/webapp/authflowv2/verify_bot_protection.go:85:26: requestcontext
 /pkg/auth/handler/webapp/authflowv2/verify_login_link.go:113:30: requestcontext
 /pkg/auth/handler/webapp/authflowv2/view_recovery_code.go:86:26: requestcontext
-/pkg/auth/handler/webapp/authflowv2/wechat.go:169:26: requestcontext
+/pkg/auth/handler/webapp/authflowv2/wechat.go:172:26: requestcontext
 /pkg/auth/handler/webapp/change_password.go:72:27: requestcontext
 /pkg/auth/handler/webapp/change_secondary_password.go:71:27: requestcontext
 /pkg/auth/handler/webapp/confirm_terminate_other_sessions.go:66:27: requestcontext
@@ -295,6 +296,7 @@
 /pkg/lib/deps/middleware_request.go:46:39: requestcontext
 /pkg/lib/deps/middleware_request.go:50:24: requestcontext
 /pkg/lib/deps/providers.go:168:25: requestcontext
+/pkg/lib/deps/providers.go:175:36: requestcontext
 /pkg/lib/dpop/middleware.go:45:35: requestcontext
 /pkg/lib/healthz/healthz.go:30:23: requestcontext
 /pkg/lib/infra/middleware/sentry.go:21:47: requestcontext
@@ -338,3 +340,4 @@
 /pkg/util/pubsub/http_handler.go:51:40: requestcontext
 /pkg/util/sentry/request.go:25:9: requestcontext
 /pkg/util/template/engine.go:344:9: requestcontext
+/pkg/auth/handler/webapp/noproject_sso_callback.go:38:9: requestcontext

--- a/.vettedpositions
+++ b/.vettedpositions
@@ -56,7 +56,6 @@
 /pkg/auth/handler/webapp/authflow_forgot_password_otp.go:213:26: requestcontext
 /pkg/auth/handler/webapp/authflow_forgot_password_success.go:52:26: requestcontext
 /pkg/auth/handler/webapp/authflow_login.go:196:33: requestcontext
-/pkg/auth/handler/webapp/authflow_wechat.go:171:26: requestcontext
 /pkg/auth/handler/webapp/authflow_oob_otp_link.go:136:26: requestcontext
 /pkg/auth/handler/webapp/authflow_promote.go:128:33: requestcontext
 /pkg/auth/handler/webapp/authflow_prompt_create_passkey.go:102:26: requestcontext
@@ -70,6 +69,7 @@
 /pkg/auth/handler/webapp/authflow_terminate_other_sessions.go:73:26: requestcontext
 /pkg/auth/handler/webapp/authflow_use_passkey.go:108:26: requestcontext
 /pkg/auth/handler/webapp/authflow_view_recovery_code.go:85:26: requestcontext
+/pkg/auth/handler/webapp/authflow_wechat.go:171:26: requestcontext
 /pkg/auth/handler/webapp/authflow_wechat.go:171:26: requestcontext
 /pkg/auth/handler/webapp/authflow_whatsapp_otp.go:147:26: requestcontext
 /pkg/auth/handler/webapp/authflowv2/account_linking.go:154:26: requestcontext
@@ -172,6 +172,7 @@
 /pkg/auth/handler/webapp/login.go:115:28: requestcontext
 /pkg/auth/handler/webapp/login_link_otp.go:121:27: requestcontext
 /pkg/auth/handler/webapp/logout.go:71:27: requestcontext
+/pkg/auth/handler/webapp/noproject_sso_callback.go:38:9: requestcontext
 /pkg/auth/handler/webapp/panic_middleware.go:68:61: requestcontext
 /pkg/auth/handler/webapp/passkey_creation_options.go:43:28: requestcontext
 /pkg/auth/handler/webapp/passkey_request_options.go:52:28: requestcontext
@@ -340,4 +341,3 @@
 /pkg/util/pubsub/http_handler.go:51:40: requestcontext
 /pkg/util/sentry/request.go:25:9: requestcontext
 /pkg/util/template/engine.go:344:9: requestcontext
-/pkg/auth/handler/webapp/noproject_sso_callback.go:38:9: requestcontext

--- a/cmd/authgear/background/wire_gen.go
+++ b/cmd/authgear/background/wire_gen.go
@@ -877,11 +877,11 @@ func newUserService(p *deps.BackgroundProvider, appID string, appContext *config
 		Clock:           clockClock,
 		Random:          rand,
 	}
-	oAuthDemoCredentialRedirectURI := environmentConfig.OAuthDemoCredentialRedirectURI
+	sharedAuthgearEndpoint := environmentConfig.SharedAuthgearEndpoint
 	oAuthEndpoints := &endpoints.OAuthEndpoints{
-		HTTPHost:                       httpHost,
-		HTTPProto:                      httpProto,
-		OAuthDemoCredentialRedirectURI: oAuthDemoCredentialRedirectURI,
+		HTTPHost:               httpHost,
+		HTTPProto:              httpProto,
+		SharedAuthgearEndpoint: sharedAuthgearEndpoint,
 	}
 	globalUIImplementation := environmentConfig.UIImplementation
 	globalUISettingsImplementation := environmentConfig.UISettingsImplementation

--- a/cmd/authgear/background/wire_gen.go
+++ b/cmd/authgear/background/wire_gen.go
@@ -877,6 +877,12 @@ func newUserService(p *deps.BackgroundProvider, appID string, appContext *config
 		Clock:           clockClock,
 		Random:          rand,
 	}
+	oAuthDemoCredentialRedirectURI := environmentConfig.OAuthDemoCredentialRedirectURI
+	oAuthEndpoints := &endpoints.OAuthEndpoints{
+		HTTPHost:                       httpHost,
+		HTTPProto:                      httpProto,
+		OAuthDemoCredentialRedirectURI: oAuthDemoCredentialRedirectURI,
+	}
 	globalUIImplementation := environmentConfig.UIImplementation
 	globalUISettingsImplementation := environmentConfig.UISettingsImplementation
 	uiImplementationService := &web.UIImplementationService{
@@ -885,8 +891,7 @@ func newUserService(p *deps.BackgroundProvider, appID string, appContext *config
 		GlobalUISettingsImplementation: globalUISettingsImplementation,
 	}
 	endpointsEndpoints := &endpoints.Endpoints{
-		HTTPHost:                httpHost,
-		HTTPProto:               httpProto,
+		OAuthEndpoints:          oAuthEndpoints,
 		UIImplementationService: uiImplementationService,
 	}
 	oauthclientResolver := &oauthclient.Resolver{

--- a/e2e/cmd/e2e/pkg/wire_gen.go
+++ b/e2e/cmd/e2e/pkg/wire_gen.go
@@ -832,6 +832,12 @@ func newUserImport(p *deps.AppProvider) *userimport.UserImportService {
 		Clock:           clockClock,
 		Random:          rand,
 	}
+	oAuthDemoCredentialRedirectURI := environmentConfig.OAuthDemoCredentialRedirectURI
+	oAuthEndpoints := &endpoints.OAuthEndpoints{
+		HTTPHost:                       httpHost,
+		HTTPProto:                      httpProto,
+		OAuthDemoCredentialRedirectURI: oAuthDemoCredentialRedirectURI,
+	}
 	globalUIImplementation := environmentConfig.UIImplementation
 	globalUISettingsImplementation := environmentConfig.UISettingsImplementation
 	uiImplementationService := &web.UIImplementationService{
@@ -840,8 +846,7 @@ func newUserImport(p *deps.AppProvider) *userimport.UserImportService {
 		GlobalUISettingsImplementation: globalUISettingsImplementation,
 	}
 	endpointsEndpoints := &endpoints.Endpoints{
-		HTTPHost:                httpHost,
-		HTTPProto:               httpProto,
+		OAuthEndpoints:          oAuthEndpoints,
 		UIImplementationService: uiImplementationService,
 	}
 	oauthclientResolver := &oauthclient.Resolver{

--- a/e2e/cmd/e2e/pkg/wire_gen.go
+++ b/e2e/cmd/e2e/pkg/wire_gen.go
@@ -832,11 +832,11 @@ func newUserImport(p *deps.AppProvider) *userimport.UserImportService {
 		Clock:           clockClock,
 		Random:          rand,
 	}
-	oAuthDemoCredentialRedirectURI := environmentConfig.OAuthDemoCredentialRedirectURI
+	sharedAuthgearEndpoint := environmentConfig.SharedAuthgearEndpoint
 	oAuthEndpoints := &endpoints.OAuthEndpoints{
-		HTTPHost:                       httpHost,
-		HTTPProto:                      httpProto,
-		OAuthDemoCredentialRedirectURI: oAuthDemoCredentialRedirectURI,
+		HTTPHost:               httpHost,
+		HTTPProto:              httpProto,
+		SharedAuthgearEndpoint: sharedAuthgearEndpoint,
 	}
 	globalUIImplementation := environmentConfig.UIImplementation
 	globalUISettingsImplementation := environmentConfig.UISettingsImplementation

--- a/pkg/admin/wire_gen.go
+++ b/pkg/admin/wire_gen.go
@@ -1027,8 +1027,12 @@ func newGraphQLHandler(p *deps.RequestProvider) http.Handler {
 		HTTPClient:                   oAuthHTTPClient,
 		SimpleStoreRedisFactory:      simpleStoreRedisFactory,
 	}
+	pool := rootProvider.RedisPool
+	redisEnvironmentConfig := &environmentConfig.RedisConfig
+	globalRedisCredentialsEnvironmentConfig := &environmentConfig.GlobalRedis
+	globalredisHandle := globalredis.NewHandle(pool, redisEnvironmentConfig, globalRedisCredentialsEnvironmentConfig, factory)
 	webappoauthStore := &webappoauth.Store{
-		Redis: appredisHandle,
+		Redis: globalredisHandle,
 		AppID: appID,
 	}
 	mfaFacade := &facade.MFAFacade{

--- a/pkg/admin/wire_gen.go
+++ b/pkg/admin/wire_gen.go
@@ -929,11 +929,11 @@ func newGraphQLHandler(p *deps.RequestProvider) http.Handler {
 		Clock:           clockClock,
 		Random:          rand,
 	}
-	oAuthDemoCredentialRedirectURI := environmentConfig.OAuthDemoCredentialRedirectURI
+	sharedAuthgearEndpoint := environmentConfig.SharedAuthgearEndpoint
 	oAuthEndpoints := &endpoints.OAuthEndpoints{
-		HTTPHost:                       httpHost,
-		HTTPProto:                      httpProto,
-		OAuthDemoCredentialRedirectURI: oAuthDemoCredentialRedirectURI,
+		HTTPHost:               httpHost,
+		HTTPProto:              httpProto,
+		SharedAuthgearEndpoint: sharedAuthgearEndpoint,
 	}
 	globalUIImplementation := environmentConfig.UIImplementation
 	globalUISettingsImplementation := environmentConfig.UISettingsImplementation

--- a/pkg/admin/wire_gen.go
+++ b/pkg/admin/wire_gen.go
@@ -929,6 +929,12 @@ func newGraphQLHandler(p *deps.RequestProvider) http.Handler {
 		Clock:           clockClock,
 		Random:          rand,
 	}
+	oAuthDemoCredentialRedirectURI := environmentConfig.OAuthDemoCredentialRedirectURI
+	oAuthEndpoints := &endpoints.OAuthEndpoints{
+		HTTPHost:                       httpHost,
+		HTTPProto:                      httpProto,
+		OAuthDemoCredentialRedirectURI: oAuthDemoCredentialRedirectURI,
+	}
 	globalUIImplementation := environmentConfig.UIImplementation
 	globalUISettingsImplementation := environmentConfig.UISettingsImplementation
 	uiImplementationService := &web.UIImplementationService{
@@ -937,8 +943,7 @@ func newGraphQLHandler(p *deps.RequestProvider) http.Handler {
 		GlobalUISettingsImplementation: globalUISettingsImplementation,
 	}
 	endpointsEndpoints := &endpoints.Endpoints{
-		HTTPHost:                httpHost,
-		HTTPProto:               httpProto,
+		OAuthEndpoints:          oAuthEndpoints,
 		UIImplementationService: uiImplementationService,
 	}
 	oauthclientResolver := &oauthclient.Resolver{
@@ -1033,7 +1038,6 @@ func newGraphQLHandler(p *deps.RequestProvider) http.Handler {
 	globalredisHandle := globalredis.NewHandle(pool, redisEnvironmentConfig, globalRedisCredentialsEnvironmentConfig, factory)
 	webappoauthStore := &webappoauth.Store{
 		Redis: globalredisHandle,
-		AppID: appID,
 	}
 	mfaFacade := &facade.MFAFacade{
 		Coordinator: coordinator,

--- a/pkg/auth/deps.go
+++ b/pkg/auth/deps.go
@@ -121,12 +121,11 @@ var DependencySet = wire.NewSet(
 	wire.Bind(new(handlerwebapp.PanicMiddlewareEndpointsProvider), new(*endpoints.Endpoints)),
 	wire.Bind(new(webapp.AuthflowNavigatorEndpointsProvider), new(*endpoints.Endpoints)),
 	wire.Bind(new(webapp.SuccessPageMiddlewareEndpointsProvider), new(*endpoints.Endpoints)),
-	wire.Bind(new(handlerwebappauthflowv2.AuthflowLoginEndpointsProvider), new(*endpoints.Endpoints)),
 	wire.Bind(new(handlerwebappauthflowv2.AuthflowV2NavigatorEndpointsProvider), new(*endpoints.Endpoints)),
-	wire.Bind(new(handlerwebappauthflowv2.AuthflowV2PromoteEndpointsProvider), new(*endpoints.Endpoints)),
 	wire.Bind(new(handlerwebapp.AuthflowSignupEndpointsProvider), new(*endpoints.Endpoints)),
 	wire.Bind(new(handlerwebapp.AuthflowPromoteEndpointsProvider), new(*endpoints.Endpoints)),
 	wire.Bind(new(oidchandler.WebAppURLsProvider), new(*endpoints.Endpoints)),
+	wire.Bind(new(handlerwebapp.AuthflowEndpoints), new(*endpoints.Endpoints)),
 
 	wire.Bind(new(handlerwebappauthflowv2.ResetPasswordHandlerDatabase), new(*appdb.Handle)),
 

--- a/pkg/auth/deps.go
+++ b/pkg/auth/deps.go
@@ -421,6 +421,9 @@ var NoProjectDependencySet = wire.NewSet(
 	deps.ProvideHTTPHost,
 	deps.ProvideHTTPProto,
 
+	webappoauth.DependencySet,
+	wire.Bind(new(handlerwebappauthflowv2.NoProjectSSOCallbackHandlerOAuthStateStore), new(*webappoauth.Store)),
+
 	wire.Struct(new(web.StaticAssetResolver), "*"),
 	wire.Bind(new(viewmodelswebapp.StaticAssetResolver), new(*web.StaticAssetResolver)),
 	wire.Bind(new(translation.StaticAssetResolver), new(*web.StaticAssetResolver)),

--- a/pkg/auth/deps.go
+++ b/pkg/auth/deps.go
@@ -422,7 +422,7 @@ var NoProjectDependencySet = wire.NewSet(
 	deps.ProvideHTTPProto,
 
 	webappoauth.DependencySet,
-	wire.Bind(new(handlerwebappauthflowv2.NoProjectSSOCallbackHandlerOAuthStateStore), new(*webappoauth.Store)),
+	wire.Bind(new(handlerwebapp.NoProjectSSOCallbackHandlerOAuthStateStore), new(*webappoauth.Store)),
 
 	wire.Struct(new(web.StaticAssetResolver), "*"),
 	wire.Bind(new(viewmodelswebapp.StaticAssetResolver), new(*web.StaticAssetResolver)),

--- a/pkg/auth/handler/webapp/authflow_controller_mock_test.go
+++ b/pkg/auth/handler/webapp/authflow_controller_mock_test.go
@@ -8,6 +8,7 @@ import (
 	context "context"
 	json "encoding/json"
 	http "net/http"
+	url "net/url"
 	reflect "reflect"
 
 	webapp "github.com/authgear/authgear-server/pkg/auth/webapp"
@@ -457,4 +458,41 @@ func (m *MockAuthflowNavigator) NavigateVerifyBotProtection(result *webapp.Resul
 func (mr *MockAuthflowNavigatorMockRecorder) NavigateVerifyBotProtection(result interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NavigateVerifyBotProtection", reflect.TypeOf((*MockAuthflowNavigator)(nil).NavigateVerifyBotProtection), result)
+}
+
+// MockAuthflowEndpoints is a mock of AuthflowEndpoints interface.
+type MockAuthflowEndpoints struct {
+	ctrl     *gomock.Controller
+	recorder *MockAuthflowEndpointsMockRecorder
+}
+
+// MockAuthflowEndpointsMockRecorder is the mock recorder for MockAuthflowEndpoints.
+type MockAuthflowEndpointsMockRecorder struct {
+	mock *MockAuthflowEndpoints
+}
+
+// NewMockAuthflowEndpoints creates a new mock instance.
+func NewMockAuthflowEndpoints(ctrl *gomock.Controller) *MockAuthflowEndpoints {
+	mock := &MockAuthflowEndpoints{ctrl: ctrl}
+	mock.recorder = &MockAuthflowEndpointsMockRecorder{mock}
+	return mock
+}
+
+// EXPECT returns an object that allows the caller to indicate expected use.
+func (m *MockAuthflowEndpoints) EXPECT() *MockAuthflowEndpointsMockRecorder {
+	return m.recorder
+}
+
+// SSOCallbackURL mocks base method.
+func (m *MockAuthflowEndpoints) SSOCallbackURL(alias string, isDemo bool) *url.URL {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "SSOCallbackURL", alias, isDemo)
+	ret0, _ := ret[0].(*url.URL)
+	return ret0
+}
+
+// SSOCallbackURL indicates an expected call of SSOCallbackURL.
+func (mr *MockAuthflowEndpointsMockRecorder) SSOCallbackURL(alias, isDemo interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SSOCallbackURL", reflect.TypeOf((*MockAuthflowEndpoints)(nil).SSOCallbackURL), alias, isDemo)
 }

--- a/pkg/auth/handler/webapp/authflow_login.go
+++ b/pkg/auth/handler/webapp/authflow_login.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
-
 	"net/url"
 
 	"github.com/authgear/oauthrelyingparty/pkg/api/oauthrelyingparty"
@@ -43,7 +42,7 @@ func ConfigureAuthflowLoginRoute(route httproute.Route) httproute.Route {
 }
 
 type AuthflowLoginEndpointsProvider interface {
-	SSOCallbackURL(alias string) *url.URL
+	SSOCallbackURL(alias string, isDemo bool) *url.URL
 }
 
 type AuthflowLoginViewModel struct {
@@ -92,7 +91,7 @@ func (h *AuthflowLoginHandler) ServeHTTP(w http.ResponseWriter, r *http.Request)
 	}
 
 	oauthPostAction := func(ctx context.Context, s *webapp.Session, providerAlias string) error {
-		callbackURL := h.Endpoints.SSOCallbackURL(providerAlias).String()
+		callbackURL := h.Endpoints.SSOCallbackURL(providerAlias, false).String()
 		input := map[string]interface{}{
 			"identification": "oauth",
 			"alias":          providerAlias,

--- a/pkg/auth/handler/webapp/authflow_promote.go
+++ b/pkg/auth/handler/webapp/authflow_promote.go
@@ -39,7 +39,7 @@ func ConfigureAuthflowPromoteRoute(route httproute.Route) httproute.Route {
 }
 
 type AuthflowPromoteEndpointsProvider interface {
-	SSOCallbackURL(alias string) *url.URL
+	SSOCallbackURL(alias string, isDemo bool) *url.URL
 }
 
 type AuthflowPromoteHandler struct {
@@ -85,7 +85,7 @@ func (h *AuthflowPromoteHandler) ServeHTTP(w http.ResponseWriter, r *http.Reques
 
 	handlers.PostAction("oauth", func(ctx context.Context, s *webapp.Session, screen *webapp.AuthflowScreenWithFlowResponse) error {
 		providerAlias := r.Form.Get("x_provider_alias")
-		callbackURL := h.Endpoints.SSOCallbackURL(providerAlias).String()
+		callbackURL := h.Endpoints.SSOCallbackURL(providerAlias, false).String()
 		input := map[string]interface{}{
 			"identification": "oauth",
 			"alias":          providerAlias,

--- a/pkg/auth/handler/webapp/authflow_signup.go
+++ b/pkg/auth/handler/webapp/authflow_signup.go
@@ -42,7 +42,7 @@ func ConfigureAuthflowSignupRoute(route httproute.Route) httproute.Route {
 }
 
 type AuthflowSignupEndpointsProvider interface {
-	SSOCallbackURL(alias string) *url.URL
+	SSOCallbackURL(alias string, isDemo bool) *url.URL
 }
 
 type AuthflowSignupHandler struct {
@@ -100,7 +100,7 @@ func (h *AuthflowSignupHandler) ServeHTTP(w http.ResponseWriter, r *http.Request
 
 	handlers.PostAction("oauth", func(ctx context.Context, s *webapp.Session, screen *webapp.AuthflowScreenWithFlowResponse) error {
 		providerAlias := r.Form.Get("x_provider_alias")
-		callbackURL := h.Endpoints.SSOCallbackURL(providerAlias).String()
+		callbackURL := h.Endpoints.SSOCallbackURL(providerAlias, false).String()
 		input := map[string]interface{}{
 			"identification": "oauth",
 			"alias":          providerAlias,

--- a/pkg/auth/handler/webapp/authflow_wechat.go
+++ b/pkg/auth/handler/webapp/authflow_wechat.go
@@ -43,6 +43,7 @@ type AuthflowWechatHandlerOAuthStateStore interface {
 }
 
 type AuthflowWechatHandler struct {
+	AppID           config.AppID
 	Controller      *AuthflowController
 	BaseViewModel   *viewmodels.BaseViewModeler
 	Renderer        Renderer
@@ -57,6 +58,7 @@ func (h *AuthflowWechatHandler) GetData(ctx context.Context, w http.ResponseWrit
 
 	screenData := screen.StateTokenFlowResponse.Action.Data.(declarative.OAuthData)
 	state := &webappoauth.WebappOAuthState{
+		AppID:            string(h.AppID),
 		WebSessionID:     s.ID,
 		UIImplementation: config.Deprecated_UIImplementationAuthflow,
 		XStep:            screen.Screen.StateToken.XStep,

--- a/pkg/auth/handler/webapp/authflow_wechat.go
+++ b/pkg/auth/handler/webapp/authflow_wechat.go
@@ -66,6 +66,7 @@ func (h *AuthflowWechatHandler) GetData(ctx context.Context, w http.ResponseWrit
 			Path:     r.URL.Path,
 			RawQuery: r.URL.Query().Encode(),
 		}).String(),
+		ProviderAlias: screenData.Alias,
 	}
 	stateToken, err := h.OAuthStateStore.GenerateState(ctx, state)
 	if err != nil {

--- a/pkg/auth/handler/webapp/authflowv2/account_linking.go
+++ b/pkg/auth/handler/webapp/authflowv2/account_linking.go
@@ -53,7 +53,6 @@ type AuthflowV2AccountLinkingHandler struct {
 	Controller    *handlerwebapp.AuthflowController
 	BaseViewModel *viewmodels.BaseViewModeler
 	Renderer      handlerwebapp.Renderer
-	Endpoints     handlerwebapp.AuthflowSignupEndpointsProvider
 }
 
 func NewAuthflowV2AccountLinkingViewModel(s *webapp.Session, screen *webapp.AuthflowScreenWithFlowResponse) AuthflowV2AccountLinkingViewModel {
@@ -128,10 +127,13 @@ func (h *AuthflowV2AccountLinkingHandler) ServeHTTP(w http.ResponseWriter, r *ht
 			}
 		case config.AuthenticationFlowIdentificationOAuth:
 			providerAlias := option.Alias
+			redirectURI, err := h.Controller.GetSSOCallbackURL(providerAlias)
+			if err != nil {
+				return err
+			}
 			input = map[string]interface{}{
-				"index": index,
-				// TODO: Support demo credentials
-				"redirect_uri": h.Endpoints.SSOCallbackURL(providerAlias, false).String(),
+				"index":        index,
+				"redirect_uri": redirectURI,
 			}
 		case config.AuthenticationFlowIdentificationLDAP:
 			// TODO(DEV-1672): Support Account Linking for LDAP

--- a/pkg/auth/handler/webapp/authflowv2/account_linking.go
+++ b/pkg/auth/handler/webapp/authflowv2/account_linking.go
@@ -129,8 +129,9 @@ func (h *AuthflowV2AccountLinkingHandler) ServeHTTP(w http.ResponseWriter, r *ht
 		case config.AuthenticationFlowIdentificationOAuth:
 			providerAlias := option.Alias
 			input = map[string]interface{}{
-				"index":        index,
-				"redirect_uri": h.Endpoints.SSOCallbackURL(providerAlias).String(),
+				"index": index,
+				// TODO: Support demo credentials
+				"redirect_uri": h.Endpoints.SSOCallbackURL(providerAlias, false).String(),
 			}
 		case config.AuthenticationFlowIdentificationLDAP:
 			// TODO(DEV-1672): Support Account Linking for LDAP

--- a/pkg/auth/handler/webapp/authflowv2/deps.go
+++ b/pkg/auth/handler/webapp/authflowv2/deps.go
@@ -81,4 +81,5 @@ var DependencySet = wire.NewSet(
 	wire.Struct(new(AuthflowV2SettingsIdentityEditUsernameHandler), "*"),
 	wire.Struct(new(AuthflowV2SettingsIdentityListOAuthHandler), "*"),
 	wire.Struct(new(PreviewWidgetHandler), "*"),
+	wire.Struct(new(SSOCallbackHandler), "*"),
 )

--- a/pkg/auth/handler/webapp/authflowv2/deps.go
+++ b/pkg/auth/handler/webapp/authflowv2/deps.go
@@ -81,5 +81,4 @@ var DependencySet = wire.NewSet(
 	wire.Struct(new(AuthflowV2SettingsIdentityEditUsernameHandler), "*"),
 	wire.Struct(new(AuthflowV2SettingsIdentityListOAuthHandler), "*"),
 	wire.Struct(new(PreviewWidgetHandler), "*"),
-	wire.Struct(new(SSOCallbackHandler), "*"),
 )

--- a/pkg/auth/handler/webapp/authflowv2/internal_signup_login.go
+++ b/pkg/auth/handler/webapp/authflowv2/internal_signup_login.go
@@ -134,7 +134,8 @@ func (h *InternalAuthflowV2SignupLoginHandler) ServeHTTP(w http.ResponseWriter, 
 
 	handlers.PostAction("oauth", func(ctx context.Context, s *webapp.Session, screen *webapp.AuthflowScreenWithFlowResponse) error {
 		providerAlias := r.Form.Get("x_provider_alias")
-		callbackURL := h.Endpoints.SSOCallbackURL(providerAlias).String()
+		// TODO: Support demo credentials
+		callbackURL := h.Endpoints.SSOCallbackURL(providerAlias, false).String()
 		input := map[string]interface{}{
 			"identification": "oauth",
 			"alias":          providerAlias,

--- a/pkg/auth/handler/webapp/authflowv2/login.go
+++ b/pkg/auth/handler/webapp/authflowv2/login.go
@@ -39,7 +39,7 @@ var AuthflowLoginLoginIDSchema = validation.NewSimpleSchema(`
 `)
 
 type AuthflowLoginEndpointsProvider interface {
-	SSOCallbackURL(alias string) *url.URL
+	SSOCallbackURL(alias string, isDemo bool) *url.URL
 }
 
 type AuthflowLoginViewModel struct {
@@ -107,7 +107,8 @@ func (h *AuthflowV2LoginHandler) ServeHTTP(w http.ResponseWriter, r *http.Reques
 	}
 
 	oauthPostAction := func(ctx context.Context, s *webapp.Session, screen *webapp.AuthflowScreenWithFlowResponse, providerAlias string) error {
-		callbackURL := h.Endpoints.SSOCallbackURL(providerAlias).String()
+		// TODO: Support demo credentials
+		callbackURL := h.Endpoints.SSOCallbackURL(providerAlias, false).String()
 		input := map[string]interface{}{
 			"identification": "oauth",
 			"alias":          providerAlias,

--- a/pkg/auth/handler/webapp/authflowv2/login.go
+++ b/pkg/auth/handler/webapp/authflowv2/login.go
@@ -101,31 +101,7 @@ func (h *AuthflowV2LoginHandler) ServeHTTP(w http.ResponseWriter, r *http.Reques
 		RedirectURI: h.Controller.RedirectURI(r),
 	}
 
-	oauthPostAction := func(ctx context.Context, s *webapp.Session, screen *webapp.AuthflowScreenWithFlowResponse, providerAlias string) error {
-		callbackURL, err := h.Controller.GetSSOCallbackURL(providerAlias)
-		if err != nil {
-			return err
-		}
-		input := map[string]interface{}{
-			"identification": "oauth",
-			"alias":          providerAlias,
-			"redirect_uri":   callbackURL,
-			"response_mode":  oauthrelyingparty.ResponseModeFormPost,
-		}
-
-		err = handlerwebapp.HandleIdentificationBotProtection(ctx, config.AuthenticationFlowIdentificationOAuth, screen.StateTokenFlowResponse, r.Form, input)
-		if err != nil {
-			return err
-		}
-
-		result, err := h.Controller.ReplaceScreen(ctx, r, s, authflow.FlowTypeSignupLogin, input)
-		if err != nil {
-			return err
-		}
-
-		result.WriteResponse(w, r)
-		return nil
-	}
+	oauthPostAction := h.makeOauthPostAction(w, r)
 
 	var handlers handlerwebapp.AuthflowControllerHandlers
 	handlers.Get(func(ctx context.Context, s *webapp.Session, screen *webapp.AuthflowScreenWithFlowResponse) error {
@@ -243,4 +219,32 @@ func (h *AuthflowV2LoginHandler) ServeHTTP(w http.ResponseWriter, r *http.Reques
 	})
 
 	h.Controller.HandleStartOfFlow(r.Context(), w, r, opts, authflow.FlowTypeLogin, &handlers, nil)
+}
+
+func (h *AuthflowV2LoginHandler) makeOauthPostAction(w http.ResponseWriter, r *http.Request) func(ctx context.Context, s *webapp.Session, screen *webapp.AuthflowScreenWithFlowResponse, providerAlias string) error {
+	return func(ctx context.Context, s *webapp.Session, screen *webapp.AuthflowScreenWithFlowResponse, providerAlias string) error {
+		callbackURL, err := h.Controller.GetSSOCallbackURL(providerAlias)
+		if err != nil {
+			return err
+		}
+		input := map[string]interface{}{
+			"identification": "oauth",
+			"alias":          providerAlias,
+			"redirect_uri":   callbackURL,
+			"response_mode":  oauthrelyingparty.ResponseModeFormPost,
+		}
+
+		err = handlerwebapp.HandleIdentificationBotProtection(ctx, config.AuthenticationFlowIdentificationOAuth, screen.StateTokenFlowResponse, r.Form, input)
+		if err != nil {
+			return err
+		}
+
+		result, err := h.Controller.ReplaceScreen(ctx, r, s, authflow.FlowTypeSignupLogin, input)
+		if err != nil {
+			return err
+		}
+
+		result.WriteResponse(w, r)
+		return nil
+	}
 }

--- a/pkg/auth/handler/webapp/authflowv2/noproject_sso_callback.go
+++ b/pkg/auth/handler/webapp/authflowv2/noproject_sso_callback.go
@@ -1,9 +1,11 @@
 package authflowv2
 
 import (
+	"context"
 	"net/http"
 
 	handlerwebapp "github.com/authgear/authgear-server/pkg/auth/handler/webapp"
+	"github.com/authgear/authgear-server/pkg/lib/webappoauth"
 	"github.com/authgear/authgear-server/pkg/util/httproute"
 	"github.com/authgear/authgear-server/pkg/util/template"
 )
@@ -11,7 +13,7 @@ import (
 func ConfigureNoProjectSSOCallbackRoute(route httproute.Route) httproute.Route {
 	return route.
 		WithMethods("GET").
-		WithPathPattern("/noproject/sso/callback")
+		WithPathPattern("/noproject/sso/oauth2/callback")
 }
 
 var TemplateWebAuthflowSSOCallbackHTML = template.RegisterHTML(
@@ -19,8 +21,25 @@ var TemplateWebAuthflowSSOCallbackHTML = template.RegisterHTML(
 	handlerwebapp.Components...,
 )
 
+type NoProjectSSOCallbackHandlerOAuthStateStore interface {
+	RecoverState(ctx context.Context, stateToken string) (state *webappoauth.WebappOAuthState, err error)
+}
+
 type SSOCallbackHandler struct {
+	OAuthStateStore NoProjectSSOCallbackHandlerOAuthStateStore
 }
 
 func (h *SSOCallbackHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	if err := r.ParseForm(); err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	stateToken := r.FormValue("state")
+	_, err := h.OAuthStateStore.RecoverState(r.Context(), stateToken)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+	// TODO
 }

--- a/pkg/auth/handler/webapp/authflowv2/noproject_sso_callback.go
+++ b/pkg/auth/handler/webapp/authflowv2/noproject_sso_callback.go
@@ -1,0 +1,26 @@
+package authflowv2
+
+import (
+	"net/http"
+
+	handlerwebapp "github.com/authgear/authgear-server/pkg/auth/handler/webapp"
+	"github.com/authgear/authgear-server/pkg/util/httproute"
+	"github.com/authgear/authgear-server/pkg/util/template"
+)
+
+func ConfigureNoProjectSSOCallbackRoute(route httproute.Route) httproute.Route {
+	return route.
+		WithMethods("GET").
+		WithPathPattern("/noproject/sso/callback")
+}
+
+var TemplateWebAuthflowSSOCallbackHTML = template.RegisterHTML(
+	"web/authflowv2/sso_callback.html",
+	handlerwebapp.Components...,
+)
+
+type SSOCallbackHandler struct {
+}
+
+func (h *SSOCallbackHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+}

--- a/pkg/auth/handler/webapp/authflowv2/promote.go
+++ b/pkg/auth/handler/webapp/authflowv2/promote.go
@@ -35,7 +35,7 @@ func ConfigureAuthflowV2PromoteRoute(route httproute.Route) httproute.Route {
 }
 
 type AuthflowV2PromoteEndpointsProvider interface {
-	SSOCallbackURL(alias string) *url.URL
+	SSOCallbackURL(alias string, isDemo bool) *url.URL
 }
 
 type AuthflowV2PromoteHandler struct {
@@ -86,7 +86,8 @@ func (h *AuthflowV2PromoteHandler) ServeHTTP(w http.ResponseWriter, r *http.Requ
 
 	handlers.PostAction("oauth", func(ctx context.Context, s *webapp.Session, screen *webapp.AuthflowScreenWithFlowResponse) error {
 		providerAlias := r.Form.Get("x_provider_alias")
-		callbackURL := h.Endpoints.SSOCallbackURL(providerAlias).String()
+		// TODO: Support demo credentials
+		callbackURL := h.Endpoints.SSOCallbackURL(providerAlias, false).String()
 		input := map[string]interface{}{
 			"identification": "oauth",
 			"alias":          providerAlias,

--- a/pkg/auth/handler/webapp/authflowv2/promote.go
+++ b/pkg/auth/handler/webapp/authflowv2/promote.go
@@ -43,7 +43,6 @@ type AuthflowV2PromoteHandler struct {
 	BaseViewModel     *viewmodels.BaseViewModeler
 	AuthflowViewModel *viewmodels.AuthflowViewModeler
 	Renderer          handlerwebapp.Renderer
-	Endpoints         AuthflowV2PromoteEndpointsProvider
 }
 
 func (h *AuthflowV2PromoteHandler) GetData(
@@ -86,8 +85,10 @@ func (h *AuthflowV2PromoteHandler) ServeHTTP(w http.ResponseWriter, r *http.Requ
 
 	handlers.PostAction("oauth", func(ctx context.Context, s *webapp.Session, screen *webapp.AuthflowScreenWithFlowResponse) error {
 		providerAlias := r.Form.Get("x_provider_alias")
-		// TODO: Support demo credentials
-		callbackURL := h.Endpoints.SSOCallbackURL(providerAlias, false).String()
+		callbackURL, err := h.Controller.GetSSOCallbackURL(providerAlias)
+		if err != nil {
+			return err
+		}
 		input := map[string]interface{}{
 			"identification": "oauth",
 			"alias":          providerAlias,
@@ -95,7 +96,7 @@ func (h *AuthflowV2PromoteHandler) ServeHTTP(w http.ResponseWriter, r *http.Requ
 			"response_mode":  oauthrelyingparty.ResponseModeFormPost,
 		}
 
-		err := handlerwebapp.HandleIdentificationBotProtection(ctx, config.AuthenticationFlowIdentificationOAuth, screen.StateTokenFlowResponse, r.Form, input)
+		err = handlerwebapp.HandleIdentificationBotProtection(ctx, config.AuthenticationFlowIdentificationOAuth, screen.StateTokenFlowResponse, r.Form, input)
 		if err != nil {
 			return err
 		}

--- a/pkg/auth/handler/webapp/authflowv2/routes.go
+++ b/pkg/auth/handler/webapp/authflowv2/routes.go
@@ -361,6 +361,7 @@ func (n *AuthflowV2Navigator) navigateStepIdentify(ctx context.Context, s *webap
 				UIImplementation: config.UIImplementationAuthflowV2,
 				XStep:            s.Screen.StateToken.XStep,
 				ErrorRedirectURI: errorRedirectURI.String(),
+				ProviderAlias:    data.Alias,
 			}
 			stateToken, err := n.OAuthStateStore.GenerateState(ctx, state)
 			if err != nil {

--- a/pkg/auth/handler/webapp/authflowv2/routes.go
+++ b/pkg/auth/handler/webapp/authflowv2/routes.go
@@ -132,6 +132,7 @@ type AuthflowV2NavigatorOAuthStateStore interface {
 }
 
 type AuthflowV2Navigator struct {
+	AppID           config.AppID
 	Endpoints       AuthflowV2NavigatorEndpointsProvider
 	OAuthStateStore AuthflowV2NavigatorOAuthStateStore
 }
@@ -355,6 +356,7 @@ func (n *AuthflowV2Navigator) navigateStepIdentify(ctx context.Context, s *webap
 			errorRedirectURI := url.URL{Path: r.URL.Path, RawQuery: r.URL.Query().Encode()}
 
 			state := &webappoauth.WebappOAuthState{
+				AppID:            string(n.AppID),
 				WebSessionID:     webSessionID,
 				UIImplementation: config.UIImplementationAuthflowV2,
 				XStep:            s.Screen.StateToken.XStep,

--- a/pkg/auth/handler/webapp/authflowv2/settings_identity_list_oauth.go
+++ b/pkg/auth/handler/webapp/authflowv2/settings_identity_list_oauth.go
@@ -14,6 +14,7 @@ import (
 	"github.com/authgear/authgear-server/pkg/lib/accountmanagement"
 	"github.com/authgear/authgear-server/pkg/lib/authn/identity"
 	identityservice "github.com/authgear/authgear-server/pkg/lib/authn/identity/service"
+	"github.com/authgear/authgear-server/pkg/lib/config"
 	"github.com/authgear/authgear-server/pkg/lib/feature/verification"
 	"github.com/authgear/authgear-server/pkg/lib/infra/db/appdb"
 	"github.com/authgear/authgear-server/pkg/lib/session"
@@ -43,6 +44,7 @@ type AuthflowV2SettingsIdentityListOAuthViewModel struct {
 }
 
 type AuthflowV2SettingsIdentityListOAuthHandler struct {
+	AppID             config.AppID
 	Database          *appdb.Handle
 	ControllerFactory handlerwebapp.ControllerFactory
 	BaseViewModel     *viewmodels.BaseViewModeler
@@ -166,6 +168,7 @@ func (h *AuthflowV2SettingsIdentityListOAuthHandler) ServeHTTP(w http.ResponseWr
 		}
 
 		state := &webappoauth.WebappOAuthState{
+			AppID:                  string(h.AppID),
 			AccountManagementToken: output.Token,
 		}
 		stateToken, err := h.OAuthStateStore.GenerateState(ctx, state)

--- a/pkg/auth/handler/webapp/authflowv2/settings_identity_list_oauth.go
+++ b/pkg/auth/handler/webapp/authflowv2/settings_identity_list_oauth.go
@@ -170,6 +170,7 @@ func (h *AuthflowV2SettingsIdentityListOAuthHandler) ServeHTTP(w http.ResponseWr
 		state := &webappoauth.WebappOAuthState{
 			AppID:                  string(h.AppID),
 			AccountManagementToken: output.Token,
+			ProviderAlias:          alias,
 		}
 		stateToken, err := h.OAuthStateStore.GenerateState(ctx, state)
 		if err != nil {

--- a/pkg/auth/handler/webapp/authflowv2/settings_identity_list_oauth.go
+++ b/pkg/auth/handler/webapp/authflowv2/settings_identity_list_oauth.go
@@ -157,7 +157,8 @@ func (h *AuthflowV2SettingsIdentityListOAuthHandler) ServeHTTP(w http.ResponseWr
 		s := session.GetSession(ctx)
 
 		alias := r.Form.Get("x_provider_alias")
-		redirectURI := h.Endpoints.SSOCallbackURL(alias).String()
+		// TODO: Support demo credentials
+		redirectURI := h.Endpoints.SSOCallbackURL(alias, false).String()
 
 		output, err := h.AccountManagement.StartAddIdentityOAuth(ctx, s, &accountmanagement.StartAddIdentityOAuthInput{
 			Alias:       alias,

--- a/pkg/auth/handler/webapp/authflowv2/wechat.go
+++ b/pkg/auth/handler/webapp/authflowv2/wechat.go
@@ -67,6 +67,7 @@ func (h *AuthflowV2WechatHandler) GetData(ctx context.Context, w http.ResponseWr
 			Path:     r.URL.Path,
 			RawQuery: r.URL.Query().Encode(),
 		}).String(),
+		ProviderAlias: screenData.Alias,
 	}
 	stateToken, err := h.OAuthStateStore.GenerateState(ctx, state)
 	if err != nil {

--- a/pkg/auth/handler/webapp/authflowv2/wechat.go
+++ b/pkg/auth/handler/webapp/authflowv2/wechat.go
@@ -44,6 +44,7 @@ type AuthflowV2WechatHandlerOAuthStateStore interface {
 }
 
 type AuthflowV2WechatHandler struct {
+	AppID           config.AppID
 	Controller      *handlerwebapp.AuthflowController
 	BaseViewModel   *viewmodels.BaseViewModeler
 	Renderer        handlerwebapp.Renderer
@@ -58,6 +59,7 @@ func (h *AuthflowV2WechatHandler) GetData(ctx context.Context, w http.ResponseWr
 
 	screenData := screen.StateTokenFlowResponse.Action.Data.(declarative.OAuthData)
 	state := &webappoauth.WebappOAuthState{
+		AppID:            string(h.AppID),
 		WebSessionID:     s.ID,
 		UIImplementation: config.UIImplementationAuthflowV2,
 		XStep:            screen.Screen.StateToken.XStep,

--- a/pkg/auth/handler/webapp/deps.go
+++ b/pkg/auth/handler/webapp/deps.go
@@ -125,4 +125,6 @@ var DependencySet = wire.NewSet(
 	wire.Struct(new(AuthflowFinishFlowHandler), "*"),
 
 	wire.Struct(new(ResponseWriter), "*"),
+
+	wire.Struct(new(NoProjectSSOCallbackHandler), "*"),
 )

--- a/pkg/auth/handler/webapp/noproject_sso_callback.go
+++ b/pkg/auth/handler/webapp/noproject_sso_callback.go
@@ -1,10 +1,9 @@
-package authflowv2
+package webapp
 
 import (
 	"context"
 	"net/http"
 
-	handlerwebapp "github.com/authgear/authgear-server/pkg/auth/handler/webapp"
 	"github.com/authgear/authgear-server/pkg/lib/webappoauth"
 	"github.com/authgear/authgear-server/pkg/util/httproute"
 	"github.com/authgear/authgear-server/pkg/util/template"
@@ -18,18 +17,18 @@ func ConfigureNoProjectSSOCallbackRoute(route httproute.Route) httproute.Route {
 
 var TemplateWebAuthflowSSOCallbackHTML = template.RegisterHTML(
 	"web/authflowv2/sso_callback.html",
-	handlerwebapp.Components...,
+	Components...,
 )
 
 type NoProjectSSOCallbackHandlerOAuthStateStore interface {
 	RecoverState(ctx context.Context, stateToken string) (state *webappoauth.WebappOAuthState, err error)
 }
 
-type SSOCallbackHandler struct {
+type NoProjectSSOCallbackHandler struct {
 	OAuthStateStore NoProjectSSOCallbackHandlerOAuthStateStore
 }
 
-func (h *SSOCallbackHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+func (h *NoProjectSSOCallbackHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	if err := r.ParseForm(); err != nil {
 		http.Error(w, err.Error(), http.StatusBadRequest)
 		return

--- a/pkg/auth/handler/webapp/noproject_sso_callback.go
+++ b/pkg/auth/handler/webapp/noproject_sso_callback.go
@@ -54,8 +54,7 @@ func (h *NoProjectSSOCallbackHandler) ServeHTTP(w http.ResponseWriter, r *http.R
 		return nil
 	})
 	if err != nil {
-		http.Error(w, fmt.Sprintf("failed to resolve public origin of app id: %s", state.AppID), http.StatusInternalServerError)
-		return
+		panic(fmt.Errorf("failed to resolve public origin of app id: %s %w", state.AppID, err))
 	}
 
 	publicOriginURL, err := url.Parse(publicOrigin)

--- a/pkg/auth/handler/webapp/noproject_sso_callback.go
+++ b/pkg/auth/handler/webapp/noproject_sso_callback.go
@@ -16,7 +16,7 @@ import (
 
 func ConfigureNoProjectSSOCallbackRoute(route httproute.Route) httproute.Route {
 	return route.
-		WithMethods("GET").
+		WithMethods("OPTIONS", "POST", "GET").
 		WithPathPattern("/noproject/sso/oauth2/callback")
 }
 

--- a/pkg/auth/handler/webapp/noproject_sso_callback.go
+++ b/pkg/auth/handler/webapp/noproject_sso_callback.go
@@ -63,9 +63,9 @@ func (h *NoProjectSSOCallbackHandler) ServeHTTP(w http.ResponseWriter, r *http.R
 		panic(fmt.Errorf("unexpected: public origin of app %s is not a valid url. %w", state.AppID, err))
 	}
 	oauthEndpoints := endpoints.NewOAuthEndpoints(publicOriginURL)
-	redirectURL := oauthEndpoints.SSOCallbackURL(state.ProviderAlias)
+	redirectURL := oauthEndpoints.SSOCallbackURL(state.ProviderAlias, false)
 	redirectURL.RawQuery = r.URL.RawQuery
 
 	// Use 307 so that method and body is kept
-	http.Redirect(w, r, oauthEndpoints.SSOCallbackURL(state.ProviderAlias).String(), http.StatusTemporaryRedirect)
+	http.Redirect(w, r, redirectURL.String(), http.StatusTemporaryRedirect)
 }

--- a/pkg/auth/handler/webapp/settings.go
+++ b/pkg/auth/handler/webapp/settings.go
@@ -41,7 +41,7 @@ func ConfigureSettingsRoute(route httproute.Route) httproute.Route {
 }
 
 type SettingsEndpointsProvider interface {
-	SSOCallbackURL(provider string) *url.URL
+	SSOCallbackURL(alias string, isDemo bool) *url.URL
 }
 
 type SettingsOAuthStateStore interface {

--- a/pkg/auth/routes.go
+++ b/pkg/auth/routes.go
@@ -583,7 +583,7 @@ func NewRouter(p *deps.RootProvider, configSource *configsource.ConfigSource) ht
 
 	// Routes without project context
 	router.Add(webapphandlerauthflowv2.ConfigureNoProjectPreviewWidgetRoute(noProjectRoute), p.RootHandler(newPreviewWidgetHandler))
-	router.Add(webapphandlerauthflowv2.ConfigureNoProjectSSOCallbackRoute(noProjectRoute), p.RootHandler(newNoProjectSSOCallbackHandler))
+	router.Add(webapphandler.ConfigureNoProjectSSOCallbackRoute(noProjectRoute), p.RootHandler(newNoProjectSSOCallbackHandler))
 
 	router.NotFound(webappNotFoundRoute, &webapphandler.ImplementationSwitcherHandler{
 		Interaction: p.Handler(newWebAppNotFoundHandler),

--- a/pkg/auth/routes.go
+++ b/pkg/auth/routes.go
@@ -583,6 +583,7 @@ func NewRouter(p *deps.RootProvider, configSource *configsource.ConfigSource) ht
 
 	// Routes without project context
 	router.Add(webapphandlerauthflowv2.ConfigureNoProjectPreviewWidgetRoute(noProjectRoute), p.RootHandler(newPreviewWidgetHandler))
+	router.Add(webapphandlerauthflowv2.ConfigureNoProjectSSOCallbackRoute(noProjectRoute), p.RootHandler(newNoProjectSSOCallbackHandler))
 
 	router.NotFound(webappNotFoundRoute, &webapphandler.ImplementationSwitcherHandler{
 		Interaction: p.Handler(newWebAppNotFoundHandler),

--- a/pkg/auth/routes.go
+++ b/pkg/auth/routes.go
@@ -583,7 +583,7 @@ func NewRouter(p *deps.RootProvider, configSource *configsource.ConfigSource) ht
 
 	// Routes without project context
 	router.Add(webapphandlerauthflowv2.ConfigureNoProjectPreviewWidgetRoute(noProjectRoute), p.RootHandler(newPreviewWidgetHandler))
-	router.Add(webapphandler.ConfigureNoProjectSSOCallbackRoute(noProjectRoute), p.RootHandler(newNoProjectSSOCallbackHandler))
+	router.Add(webapphandler.ConfigureNoProjectSSOCallbackRoute(noProjectRoute), p.RootHandlerWithConfigSource(configSource, newNoProjectSSOCallbackHandler))
 
 	router.NotFound(webappNotFoundRoute, &webapphandler.ImplementationSwitcherHandler{
 		Interaction: p.Handler(newWebAppNotFoundHandler),

--- a/pkg/auth/webapp/authflow_routes.go
+++ b/pkg/auth/webapp/authflow_routes.go
@@ -76,6 +76,7 @@ type AuthflowNavigatorOAuthStateStore interface {
 }
 
 type AuthflowNavigator struct {
+	AppID           config.AppID
 	Endpoints       AuthflowNavigatorEndpointsProvider
 	OAuthStateStore AuthflowNavigatorOAuthStateStore
 }
@@ -275,6 +276,7 @@ func (n *AuthflowNavigator) navigateStepIdentify(ctx context.Context, s *Authflo
 			q := authorizationURL.Query()
 
 			state := &webappoauth.WebappOAuthState{
+				AppID:            string(n.AppID),
 				WebSessionID:     webSessionID,
 				UIImplementation: config.Deprecated_UIImplementationAuthflow,
 				XStep:            s.Screen.StateToken.XStep,

--- a/pkg/auth/webapp/authflow_routes.go
+++ b/pkg/auth/webapp/authflow_routes.go
@@ -281,6 +281,7 @@ func (n *AuthflowNavigator) navigateStepIdentify(ctx context.Context, s *Authflo
 				UIImplementation: config.Deprecated_UIImplementationAuthflow,
 				XStep:            s.Screen.StateToken.XStep,
 				ErrorRedirectURI: expectedPath,
+				ProviderAlias:    data.Alias,
 			}
 
 			stateToken, err := n.OAuthStateStore.GenerateState(ctx, state)

--- a/pkg/auth/wire_handler.go
+++ b/pkg/auth/wire_handler.go
@@ -44,6 +44,13 @@ func newPreviewWidgetHandler(p *deps.RootProvider, w http.ResponseWriter, r *htt
 	))
 }
 
+func newNoProjectSSOCallbackHandler(p *deps.RootProvider, w http.ResponseWriter, r *http.Request, ctx context.Context) http.Handler {
+	panic(wire.Build(
+		wire.Struct(new(handlerwebappauthflowv2.SSOCallbackHandler), "*"),
+		wire.Bind(new(http.Handler), new(*handlerwebappauthflowv2.SSOCallbackHandler)),
+	))
+}
+
 func newOAuthAuthorizeHandler(p *deps.RequestProvider) http.Handler {
 	panic(wire.Build(
 		DependencySet,

--- a/pkg/auth/wire_handler.go
+++ b/pkg/auth/wire_handler.go
@@ -46,6 +46,7 @@ func newPreviewWidgetHandler(p *deps.RootProvider, w http.ResponseWriter, r *htt
 
 func newNoProjectSSOCallbackHandler(p *deps.RootProvider, w http.ResponseWriter, r *http.Request, ctx context.Context) http.Handler {
 	panic(wire.Build(
+		NoProjectDependencySet,
 		wire.Struct(new(handlerwebappauthflowv2.SSOCallbackHandler), "*"),
 		wire.Bind(new(http.Handler), new(*handlerwebappauthflowv2.SSOCallbackHandler)),
 	))

--- a/pkg/auth/wire_handler.go
+++ b/pkg/auth/wire_handler.go
@@ -14,6 +14,7 @@ import (
 	handlersaml "github.com/authgear/authgear-server/pkg/auth/handler/saml"
 	handlerwebapp "github.com/authgear/authgear-server/pkg/auth/handler/webapp"
 	handlerwebappauthflowv2 "github.com/authgear/authgear-server/pkg/auth/handler/webapp/authflowv2"
+	"github.com/authgear/authgear-server/pkg/lib/config/configsource"
 	"github.com/authgear/authgear-server/pkg/lib/deps"
 	"github.com/authgear/authgear-server/pkg/lib/healthz"
 	"github.com/authgear/authgear-server/pkg/lib/web"
@@ -44,7 +45,7 @@ func newPreviewWidgetHandler(p *deps.RootProvider, w http.ResponseWriter, r *htt
 	))
 }
 
-func newNoProjectSSOCallbackHandler(p *deps.RootProvider, w http.ResponseWriter, r *http.Request, ctx context.Context) http.Handler {
+func newNoProjectSSOCallbackHandler(configSource *configsource.ConfigSource, p *deps.RootProvider, w http.ResponseWriter, r *http.Request, ctx context.Context) http.Handler {
 	panic(wire.Build(
 		NoProjectDependencySet,
 		wire.Struct(new(handlerwebapp.NoProjectSSOCallbackHandler), "*"),

--- a/pkg/auth/wire_handler.go
+++ b/pkg/auth/wire_handler.go
@@ -47,8 +47,8 @@ func newPreviewWidgetHandler(p *deps.RootProvider, w http.ResponseWriter, r *htt
 func newNoProjectSSOCallbackHandler(p *deps.RootProvider, w http.ResponseWriter, r *http.Request, ctx context.Context) http.Handler {
 	panic(wire.Build(
 		NoProjectDependencySet,
-		wire.Struct(new(handlerwebappauthflowv2.SSOCallbackHandler), "*"),
-		wire.Bind(new(http.Handler), new(*handlerwebappauthflowv2.SSOCallbackHandler)),
+		wire.Struct(new(handlerwebapp.NoProjectSSOCallbackHandler), "*"),
+		wire.Bind(new(http.Handler), new(*handlerwebapp.NoProjectSSOCallbackHandler)),
 	))
 }
 

--- a/pkg/lib/config/environment.go
+++ b/pkg/lib/config/environment.go
@@ -32,6 +32,8 @@ type ProjectWizardImplementaion string
 
 type GlobalWhatsappAPIType WhatsappAPIType
 
+type OAuthDemoCredentialRedirectURI string
+
 func (s AppHostSuffixes) CheckIsDefaultDomain(host string) bool {
 	for _, suffix := range s {
 		if before, found := strings.CutSuffix(host, suffix); found {
@@ -117,6 +119,8 @@ type EnvironmentConfig struct {
 	UserExportObjectStore *UserExportObjectStoreConfig `envconfig:"USEREXPORT_OBJECT_STORE"`
 
 	SMSGatewayConfig SMSGatewayEnvironmentConfig `envconfig:"SMS_GATEWAY"`
+
+	OAuthDemoCredentialRedirectURI OAuthDemoCredentialRedirectURI `envconfig:"OAUTH_DEMO_CREDENTIAL_REDIRECT_URI"`
 }
 
 const (

--- a/pkg/lib/config/environment.go
+++ b/pkg/lib/config/environment.go
@@ -32,7 +32,7 @@ type ProjectWizardImplementaion string
 
 type GlobalWhatsappAPIType WhatsappAPIType
 
-type OAuthDemoCredentialRedirectURI string
+type SharedAuthgearEndpoint string
 
 func (s AppHostSuffixes) CheckIsDefaultDomain(host string) bool {
 	for _, suffix := range s {
@@ -120,7 +120,7 @@ type EnvironmentConfig struct {
 
 	SMSGatewayConfig SMSGatewayEnvironmentConfig `envconfig:"SMS_GATEWAY"`
 
-	OAuthDemoCredentialRedirectURI OAuthDemoCredentialRedirectURI `envconfig:"OAUTH_DEMO_CREDENTIAL_REDIRECT_URI"`
+	SharedAuthgearEndpoint SharedAuthgearEndpoint `envconfig:"SHARED_AUTHGEAR_ENDPOINT"`
 }
 
 const (

--- a/pkg/lib/deps/deps_provider.go
+++ b/pkg/lib/deps/deps_provider.go
@@ -47,6 +47,7 @@ var EnvConfigDeps = wire.NewSet(
 		"WhatsappAPIType",
 		"UserExportObjectStore",
 		"SMSGatewayConfig",
+		"OAuthDemoCredentialRedirectURI",
 	),
 	wire.FieldsOf(new(*config.SMSGatewayEnvironmentConfig),
 		"Default",

--- a/pkg/lib/deps/deps_provider.go
+++ b/pkg/lib/deps/deps_provider.go
@@ -47,7 +47,7 @@ var EnvConfigDeps = wire.NewSet(
 		"WhatsappAPIType",
 		"UserExportObjectStore",
 		"SMSGatewayConfig",
-		"OAuthDemoCredentialRedirectURI",
+		"SharedAuthgearEndpoint",
 	),
 	wire.FieldsOf(new(*config.SMSGatewayEnvironmentConfig),
 		"Default",

--- a/pkg/lib/deps/providers.go
+++ b/pkg/lib/deps/providers.go
@@ -6,7 +6,7 @@ import (
 
 	getsentry "github.com/getsentry/sentry-go"
 
-	"github.com/authgear/authgear-server"
+	runtimeresource "github.com/authgear/authgear-server"
 	"github.com/authgear/authgear-server/pkg/lib/config"
 	"github.com/authgear/authgear-server/pkg/lib/config/configsource"
 	"github.com/authgear/authgear-server/pkg/lib/infra/db"
@@ -166,6 +166,13 @@ func (p *RootProvider) NewAppProvider(ctx context.Context, appCtx *config.AppCon
 func (p *RootProvider) RootHandler(factory func(*RootProvider, http.ResponseWriter, *http.Request, context.Context) http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		h := factory(p, w, r, r.Context())
+		h.ServeHTTP(w, r)
+	})
+}
+
+func (p *RootProvider) RootHandlerWithConfigSource(cfgSource *configsource.ConfigSource, factory func(*configsource.ConfigSource, *RootProvider, http.ResponseWriter, *http.Request, context.Context) http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		h := factory(cfgSource, p, w, r, r.Context())
 		h.ServeHTTP(w, r)
 	})
 }

--- a/pkg/lib/endpoints/deps.go
+++ b/pkg/lib/endpoints/deps.go
@@ -1,9 +1,19 @@
 package endpoints
 
 import (
+	"net/url"
+
+	"github.com/authgear/authgear-server/pkg/util/httputil"
 	"github.com/google/wire"
 )
 
 var DependencySet = wire.NewSet(
 	wire.Struct(new(Endpoints), "*"),
 )
+
+func NewOAuthEndpoints(origin *url.URL) *OAuthEndpoints {
+	return &OAuthEndpoints{
+		HTTPHost:  httputil.HTTPHost(origin.Host),
+		HTTPProto: httputil.HTTPProto(origin.Scheme),
+	}
+}

--- a/pkg/lib/endpoints/deps.go
+++ b/pkg/lib/endpoints/deps.go
@@ -3,8 +3,9 @@ package endpoints
 import (
 	"net/url"
 
-	"github.com/authgear/authgear-server/pkg/util/httputil"
 	"github.com/google/wire"
+
+	"github.com/authgear/authgear-server/pkg/util/httputil"
 )
 
 var DependencySet = wire.NewSet(

--- a/pkg/lib/endpoints/deps.go
+++ b/pkg/lib/endpoints/deps.go
@@ -8,6 +8,7 @@ import (
 )
 
 var DependencySet = wire.NewSet(
+	wire.Struct(new(OAuthEndpoints), "*"),
 	wire.Struct(new(Endpoints), "*"),
 )
 

--- a/pkg/lib/endpoints/endpoints.go
+++ b/pkg/lib/endpoints/endpoints.go
@@ -10,24 +10,28 @@ import (
 	"github.com/authgear/authgear-server/pkg/util/urlutil"
 )
 
+type OAuthEndpoints struct {
+	HTTPHost  httputil.HTTPHost
+	HTTPProto httputil.HTTPProto
+}
+
 type EndpointsUIImplementationService interface {
 	GetUIImplementation() config.UIImplementation
 }
 
 type Endpoints struct {
-	HTTPHost                httputil.HTTPHost
-	HTTPProto               httputil.HTTPProto
+	*OAuthEndpoints
 	UIImplementationService EndpointsUIImplementationService
 }
 
-func (e *Endpoints) Origin() *url.URL {
+func (e *OAuthEndpoints) Origin() *url.URL {
 	return &url.URL{
 		Host:   string(e.HTTPHost),
 		Scheme: string(e.HTTPProto),
 	}
 }
 
-func (e *Endpoints) urlOf(relPath string) *url.URL {
+func (e *OAuthEndpoints) urlOf(relPath string) *url.URL {
 	// If we do not set Path = "/", then in urlOf,
 	// Path will have no leading /.
 	// It is problematic when Path is used in comparison.
@@ -41,6 +45,13 @@ func (e *Endpoints) urlOf(relPath string) *url.URL {
 	// Because String() will add leading / to make the URL legal.
 	u := e.Origin()
 	u.Path = path.Join("/", relPath)
+	return u
+}
+
+func (e *OAuthEndpoints) SSOCallbackEndpointURL() *url.URL { return e.urlOf("sso/oauth2/callback") }
+func (e *OAuthEndpoints) SSOCallbackURL(alias string) *url.URL {
+	u := e.SSOCallbackEndpointURL()
+	u.Path = path.Join(u.Path, url.PathEscape(alias))
 	return u
 }
 
@@ -101,7 +112,6 @@ func (e *Endpoints) VerifyBotProtectionEndpointURL() *url.URL {
 		panic(fmt.Errorf("unexpected ui implementation %s", uiImpl))
 	}
 }
-func (e *Endpoints) SSOCallbackEndpointURL() *url.URL { return e.urlOf("sso/oauth2/callback") }
 
 func (e *Endpoints) WeChatAuthorizeEndpointURL() *url.URL { return e.urlOf("sso/wechat/auth") }
 func (e *Endpoints) WeChatCallbackEndpointURL() *url.URL {
@@ -183,12 +193,6 @@ func (e *Endpoints) SettingsEditLoginIDUsername(loginIDKey string) *url.URL {
 	q := u.Query()
 	q.Set("q_login_id_key", loginIDKey)
 	u.RawQuery = q.Encode()
-	return u
-}
-
-func (e *Endpoints) SSOCallbackURL(alias string) *url.URL {
-	u := e.SSOCallbackEndpointURL()
-	u.Path = path.Join(u.Path, url.PathEscape(alias))
 	return u
 }
 

--- a/pkg/lib/endpoints/endpoints.go
+++ b/pkg/lib/endpoints/endpoints.go
@@ -11,9 +11,9 @@ import (
 )
 
 type OAuthEndpoints struct {
-	HTTPHost                       httputil.HTTPHost
-	HTTPProto                      httputil.HTTPProto
-	OAuthDemoCredentialRedirectURI config.OAuthDemoCredentialRedirectURI
+	HTTPHost               httputil.HTTPHost
+	HTTPProto              httputil.HTTPProto
+	SharedAuthgearEndpoint config.SharedAuthgearEndpoint
 }
 
 type EndpointsUIImplementationService interface {
@@ -52,10 +52,11 @@ func (e *OAuthEndpoints) urlOf(relPath string) *url.URL {
 func (e *OAuthEndpoints) SSOCallbackEndpointURL() *url.URL { return e.urlOf("sso/oauth2/callback") }
 func (e *OAuthEndpoints) SSOCallbackURL(alias string, isDemo bool) *url.URL {
 	if isDemo {
-		u, err := url.Parse(string(e.OAuthDemoCredentialRedirectURI))
+		u, err := url.Parse(string(e.SharedAuthgearEndpoint))
 		if err != nil {
-			panic(fmt.Errorf("demo credential redirect uri is not a valid uri: %w", err))
+			panic(fmt.Errorf("SHARED_AUTHGEAR_ENDPOINT is not a valid uri: %w", err))
 		}
+		u.Path = path.Join(u.Path, "/noproject/sso/oauth2/callback")
 		return u
 	}
 	u := e.SSOCallbackEndpointURL()

--- a/pkg/lib/endpoints/endpoints.go
+++ b/pkg/lib/endpoints/endpoints.go
@@ -11,8 +11,9 @@ import (
 )
 
 type OAuthEndpoints struct {
-	HTTPHost  httputil.HTTPHost
-	HTTPProto httputil.HTTPProto
+	HTTPHost                       httputil.HTTPHost
+	HTTPProto                      httputil.HTTPProto
+	OAuthDemoCredentialRedirectURI config.OAuthDemoCredentialRedirectURI
 }
 
 type EndpointsUIImplementationService interface {
@@ -49,7 +50,14 @@ func (e *OAuthEndpoints) urlOf(relPath string) *url.URL {
 }
 
 func (e *OAuthEndpoints) SSOCallbackEndpointURL() *url.URL { return e.urlOf("sso/oauth2/callback") }
-func (e *OAuthEndpoints) SSOCallbackURL(alias string) *url.URL {
+func (e *OAuthEndpoints) SSOCallbackURL(alias string, isDemo bool) *url.URL {
+	if isDemo {
+		u, err := url.Parse(string(e.OAuthDemoCredentialRedirectURI))
+		if err != nil {
+			panic(fmt.Errorf("demo credential redirect uri is not a valid uri: %w", err))
+		}
+		return u
+	}
 	u := e.SSOCallbackEndpointURL()
 	u.Path = path.Join(u.Path, url.PathEscape(alias))
 	return u

--- a/pkg/lib/endpoints/endpoints_test.go
+++ b/pkg/lib/endpoints/endpoints_test.go
@@ -11,9 +11,9 @@ func TestEndpoints(t *testing.T) {
 	Convey("Endpoints", t, func() {
 		endpoints := Endpoints{
 			OAuthEndpoints: &OAuthEndpoints{
-				HTTPProto:                      "https",
-				HTTPHost:                       "example.com",
-				OAuthDemoCredentialRedirectURI: "https://example.com/demo",
+				HTTPProto:              "https",
+				HTTPHost:               "example.com",
+				SharedAuthgearEndpoint: "https://shared.example.com",
 			},
 		}
 
@@ -37,6 +37,6 @@ func TestEndpoints(t *testing.T) {
 		So(endpoints.SettingsEndpointURL().String(), ShouldEqual, "https://example.com/settings")
 		So(endpoints.SSOCallbackEndpointURL().String(), ShouldEqual, "https://example.com/sso/oauth2/callback")
 		So(endpoints.SSOCallbackURL("google", false).String(), ShouldEqual, "https://example.com/sso/oauth2/callback/google")
-		So(endpoints.SSOCallbackURL("google", true).String(), ShouldEqual, "https://example.com/demo")
+		So(endpoints.SSOCallbackURL("google", true).String(), ShouldEqual, "https://shared.example.com/noproject/sso/oauth2/callback")
 	})
 }

--- a/pkg/lib/endpoints/endpoints_test.go
+++ b/pkg/lib/endpoints/endpoints_test.go
@@ -11,8 +11,9 @@ func TestEndpoints(t *testing.T) {
 	Convey("Endpoints", t, func() {
 		endpoints := Endpoints{
 			OAuthEndpoints: &OAuthEndpoints{
-				HTTPProto: "https",
-				HTTPHost:  "example.com",
+				HTTPProto:                      "https",
+				HTTPHost:                       "example.com",
+				OAuthDemoCredentialRedirectURI: "https://example.com/demo",
 			},
 		}
 
@@ -35,6 +36,7 @@ func TestEndpoints(t *testing.T) {
 		So(endpoints.LogoutEndpointURL().String(), ShouldEqual, "https://example.com/logout")
 		So(endpoints.SettingsEndpointURL().String(), ShouldEqual, "https://example.com/settings")
 		So(endpoints.SSOCallbackEndpointURL().String(), ShouldEqual, "https://example.com/sso/oauth2/callback")
-		So(endpoints.SSOCallbackURL("google").String(), ShouldEqual, "https://example.com/sso/oauth2/callback/google")
+		So(endpoints.SSOCallbackURL("google", false).String(), ShouldEqual, "https://example.com/sso/oauth2/callback/google")
+		So(endpoints.SSOCallbackURL("google", true).String(), ShouldEqual, "https://example.com/demo")
 	})
 }

--- a/pkg/lib/endpoints/endpoints_test.go
+++ b/pkg/lib/endpoints/endpoints_test.go
@@ -10,8 +10,10 @@ import (
 func TestEndpoints(t *testing.T) {
 	Convey("Endpoints", t, func() {
 		endpoints := Endpoints{
-			HTTPProto: "https",
-			HTTPHost:  "example.com",
+			OAuthEndpoints: &OAuthEndpoints{
+				HTTPProto: "https",
+				HTTPHost:  "example.com",
+			},
 		}
 
 		So(endpoints.Origin(), ShouldResemble, &url.URL{

--- a/pkg/lib/interaction/context.go
+++ b/pkg/lib/interaction/context.go
@@ -154,7 +154,7 @@ type OAuthProviderFactory interface {
 }
 
 type OAuthRedirectURIBuilder interface {
-	SSOCallbackURL(alias string) *url.URL
+	SSOCallbackURL(alias string, isDemo bool) *url.URL
 	WeChatAuthorizeURL(alias string) *url.URL
 	WeChatCallbackEndpointURL() *url.URL
 }

--- a/pkg/lib/interaction/nodes/use_identity_oauth_provider.go
+++ b/pkg/lib/interaction/nodes/use_identity_oauth_provider.go
@@ -84,6 +84,7 @@ func (e *EdgeUseIdentityOAuthProvider) Instantiate(goCtx context.Context, ctx *i
 	}
 
 	state := &webappoauth.WebappOAuthState{
+		AppID:            string(ctx.Config.ID),
 		UIImplementation: config.UIImplementationInteraction,
 		WebSessionID:     ctx.WebSessionID,
 	}

--- a/pkg/lib/interaction/nodes/use_identity_oauth_provider.go
+++ b/pkg/lib/interaction/nodes/use_identity_oauth_provider.go
@@ -77,7 +77,7 @@ func (e *EdgeUseIdentityOAuthProvider) Instantiate(goCtx context.Context, ctx *i
 
 	nonce := crypto.SHA256String(nonceSource)
 
-	redirectURIForOAuthProvider := ctx.OAuthRedirectURIBuilder.SSOCallbackURL(alias).String()
+	redirectURIForOAuthProvider := ctx.OAuthRedirectURIBuilder.SSOCallbackURL(alias, false).String()
 	// Special case: wechat needs to use a special callback endpoint.
 	if providerConfig.Type() == wechat.Type {
 		redirectURIForOAuthProvider = ctx.OAuthRedirectURIBuilder.WeChatCallbackEndpointURL().String()

--- a/pkg/lib/interaction/nodes/use_identity_oauth_provider.go
+++ b/pkg/lib/interaction/nodes/use_identity_oauth_provider.go
@@ -87,6 +87,7 @@ func (e *EdgeUseIdentityOAuthProvider) Instantiate(goCtx context.Context, ctx *i
 		AppID:            string(ctx.Config.ID),
 		UIImplementation: config.UIImplementationInteraction,
 		WebSessionID:     ctx.WebSessionID,
+		ProviderAlias:    alias,
 	}
 	stateToken, err := ctx.OAuthStateStore.GenerateState(goCtx, state)
 	if err != nil {

--- a/pkg/lib/interaction/nodes/use_identity_oauth_user_info.go
+++ b/pkg/lib/interaction/nodes/use_identity_oauth_user_info.go
@@ -56,7 +56,7 @@ func (e *EdgeUseIdentityOAuthUserInfo) Instantiate(goCtx context.Context, ctx *i
 		return nil, fmt.Errorf("invalid nonce")
 	}
 
-	redirectURI := ctx.OAuthRedirectURIBuilder.SSOCallbackURL(alias)
+	redirectURI := ctx.OAuthRedirectURIBuilder.SSOCallbackURL(alias, false)
 
 	providerConfig, err := ctx.OAuthProviderFactory.GetProviderConfig(alias)
 	if err != nil {

--- a/pkg/lib/oauth/oidc/id_token_test.go
+++ b/pkg/lib/oauth/oidc/id_token_test.go
@@ -82,8 +82,10 @@ func TestIDTokenIssuer(t *testing.T) {
 		issuer := &IDTokenIssuer{
 			Secrets: secrets,
 			BaseURL: &endpoints.Endpoints{
-				HTTPHost:  "test.authgear.com",
-				HTTPProto: "http",
+				OAuthEndpoints: &endpoints.OAuthEndpoints{
+					HTTPHost:  "test.authgear.com",
+					HTTPProto: "http",
+				},
 			},
 			UserInfoService: mockUserInfoService,
 			Clock:           clock.NewMockClockAtTime(now),

--- a/pkg/lib/oauth/token_encoding_test.go
+++ b/pkg/lib/oauth/token_encoding_test.go
@@ -72,8 +72,10 @@ func TestAccessToken(t *testing.T) {
 			Clock:         clock.NewMockClockAtTime(now),
 			IDTokenIssuer: mockIDTokenIssuer,
 			BaseURL: &endpoints.Endpoints{
-				HTTPHost:  "test1.authgear.com",
-				HTTPProto: "http",
+				OAuthEndpoints: &endpoints.OAuthEndpoints{
+					HTTPHost:  "test1.authgear.com",
+					HTTPProto: "http",
+				},
 			},
 			Events:     mockEventService,
 			Identities: mockIdentityService,

--- a/pkg/lib/webappoauth/state.go
+++ b/pkg/lib/webappoauth/state.go
@@ -8,6 +8,7 @@ type WebappOAuthState struct {
 	AppID            string                  `json:"app_id"`
 	UIImplementation config.UIImplementation `json:"ui_implementation"`
 	WebSessionID     string                  `json:"web_session_id"`
+	ProviderAlias    string                  `json:"provider_alias"`
 
 	// authflow, authflowv2 specific fields
 	XStep            string `json:"x_step"`

--- a/pkg/lib/webappoauth/state.go
+++ b/pkg/lib/webappoauth/state.go
@@ -5,6 +5,7 @@ import (
 )
 
 type WebappOAuthState struct {
+	AppID            string                  `json:"app_id"`
 	UIImplementation config.UIImplementation `json:"ui_implementation"`
 	WebSessionID     string                  `json:"web_session_id"`
 

--- a/pkg/redisqueue/wire_gen.go
+++ b/pkg/redisqueue/wire_gen.go
@@ -789,11 +789,11 @@ func newUserImportService(ctx context.Context, p *deps.AppProvider) *userimport.
 		Clock:           clock,
 		Random:          rand,
 	}
-	oAuthDemoCredentialRedirectURI := environmentConfig.OAuthDemoCredentialRedirectURI
+	sharedAuthgearEndpoint := environmentConfig.SharedAuthgearEndpoint
 	oAuthEndpoints := &endpoints.OAuthEndpoints{
-		HTTPHost:                       httpHost,
-		HTTPProto:                      httpProto,
-		OAuthDemoCredentialRedirectURI: oAuthDemoCredentialRedirectURI,
+		HTTPHost:               httpHost,
+		HTTPProto:              httpProto,
+		SharedAuthgearEndpoint: sharedAuthgearEndpoint,
 	}
 	globalUIImplementation := environmentConfig.UIImplementation
 	globalUISettingsImplementation := environmentConfig.UISettingsImplementation

--- a/pkg/redisqueue/wire_gen.go
+++ b/pkg/redisqueue/wire_gen.go
@@ -789,6 +789,12 @@ func newUserImportService(ctx context.Context, p *deps.AppProvider) *userimport.
 		Clock:           clock,
 		Random:          rand,
 	}
+	oAuthDemoCredentialRedirectURI := environmentConfig.OAuthDemoCredentialRedirectURI
+	oAuthEndpoints := &endpoints.OAuthEndpoints{
+		HTTPHost:                       httpHost,
+		HTTPProto:                      httpProto,
+		OAuthDemoCredentialRedirectURI: oAuthDemoCredentialRedirectURI,
+	}
 	globalUIImplementation := environmentConfig.UIImplementation
 	globalUISettingsImplementation := environmentConfig.UISettingsImplementation
 	uiImplementationService := &web.UIImplementationService{
@@ -797,8 +803,7 @@ func newUserImportService(ctx context.Context, p *deps.AppProvider) *userimport.
 		GlobalUISettingsImplementation: globalUISettingsImplementation,
 	}
 	endpointsEndpoints := &endpoints.Endpoints{
-		HTTPHost:                httpHost,
-		HTTPProto:               httpProto,
+		OAuthEndpoints:          oAuthEndpoints,
 		UIImplementationService: uiImplementationService,
 	}
 	oauthclientResolver := &oauthclient.Resolver{

--- a/pkg/resolver/wire_gen.go
+++ b/pkg/resolver/wire_gen.go
@@ -225,11 +225,11 @@ func newSessionMiddleware(p *deps.RequestProvider) httproute.Middleware {
 	oAuthKeyMaterials := deps.ProvideOAuthKeyMaterials(secretConfig)
 	httpHost := deps.ProvideHTTPHost(request, trustProxy)
 	httpProto := deps.ProvideHTTPProto(request, trustProxy)
-	oAuthDemoCredentialRedirectURI := environmentConfig.OAuthDemoCredentialRedirectURI
+	sharedAuthgearEndpoint := environmentConfig.SharedAuthgearEndpoint
 	oAuthEndpoints := &endpoints.OAuthEndpoints{
-		HTTPHost:                       httpHost,
-		HTTPProto:                      httpProto,
-		OAuthDemoCredentialRedirectURI: oAuthDemoCredentialRedirectURI,
+		HTTPHost:               httpHost,
+		HTTPProto:              httpProto,
+		SharedAuthgearEndpoint: sharedAuthgearEndpoint,
 	}
 	uiConfig := appConfig.UI
 	globalUIImplementation := environmentConfig.UIImplementation

--- a/pkg/resolver/wire_gen.go
+++ b/pkg/resolver/wire_gen.go
@@ -225,6 +225,12 @@ func newSessionMiddleware(p *deps.RequestProvider) httproute.Middleware {
 	oAuthKeyMaterials := deps.ProvideOAuthKeyMaterials(secretConfig)
 	httpHost := deps.ProvideHTTPHost(request, trustProxy)
 	httpProto := deps.ProvideHTTPProto(request, trustProxy)
+	oAuthDemoCredentialRedirectURI := environmentConfig.OAuthDemoCredentialRedirectURI
+	oAuthEndpoints := &endpoints.OAuthEndpoints{
+		HTTPHost:                       httpHost,
+		HTTPProto:                      httpProto,
+		OAuthDemoCredentialRedirectURI: oAuthDemoCredentialRedirectURI,
+	}
 	uiConfig := appConfig.UI
 	globalUIImplementation := environmentConfig.UIImplementation
 	globalUISettingsImplementation := environmentConfig.UISettingsImplementation
@@ -234,8 +240,7 @@ func newSessionMiddleware(p *deps.RequestProvider) httproute.Middleware {
 		GlobalUISettingsImplementation: globalUISettingsImplementation,
 	}
 	endpointsEndpoints := &endpoints.Endpoints{
-		HTTPHost:                httpHost,
-		HTTPProto:               httpProto,
+		OAuthEndpoints:          oAuthEndpoints,
 		UIImplementationService: uiImplementationService,
 	}
 	userStore := &user.Store{


### PR DESCRIPTION
ref DEV-2716

This pr is not testable at the moment, but you can test the endpoint with the following steps:

1. Update `.env`, set `SHARED_AUTHGEAR_ENDPOINT`
2. Have a valid item in `oauth.providers`. The provider should whitelist `http://localhost:3100/noproject/sso/oauth2/callback` as a redirect url.
3. Modify `GetSSOCallbackURL` in `AuthflowController`.

```diff
diff --git a/pkg/auth/handler/webapp/authflow_controller.go b/pkg/auth/handler/webapp/authflow_controller.go
index 8e4b27506..fd2030851 100644
--- a/pkg/auth/handler/webapp/authflow_controller.go
+++ b/pkg/auth/handler/webapp/authflow_controller.go
@@ -1180,10 +1180,11 @@ func (c *AuthflowController) finishSession(
 }
 
 func (c *AuthflowController) GetSSOCallbackURL(alias string) (string, error) {
-       oauthProviderConfig, ok := c.OAuthSSOConfig.GetProviderConfig(alias)
-       if !ok {
-               return "", fmt.Errorf("unknown alias %s", alias)
-       }
-       callbackURL := c.Endpoints.SSOCallbackURL(alias, config.OAuthSSOProviderConfig(oauthProviderConfig).IsMissingCredentialAllowed()).String()
+       // oauthProviderConfig, ok := c.OAuthSSOConfig.GetProviderConfig(alias)
+       // if !ok {
+       //      return "", fmt.Errorf("unknown alias %s", alias)
+       // }
+       // callbackURL := c.Endpoints.SSOCallbackURL(alias, config.OAuthSSOProviderConfig(oauthProviderConfig).IsMissingCredentialAllowed()).String()
+       callbackURL := c.Endpoints.SSOCallbackURL(alias, true).String()
        return callbackURL, nil
 }
```