### PR TITLE
Support oauth demo credentials in authflow

### DIFF
--- a/cmd/portal/internal/check.go
+++ b/cmd/portal/internal/check.go
@@ -74,7 +74,7 @@ func checkConfigSource(ctx context.Context, cs *ConfigSource) error {
 		},
 	}
 
-	if err := baseSecrets.Overlay(secretsConfig).Validate(appConfig); err != nil {
+	if err := baseSecrets.Overlay(secretsConfig).Validate(ctx, appConfig); err != nil {
 		return fmt.Errorf("invalid secrets config: %w", err)
 	}
 

--- a/e2e/tests/oauth/demo_credential_provider.test.yaml
+++ b/e2e/tests/oauth/demo_credential_provider.test.yaml
@@ -1,0 +1,60 @@
+name: Demo Credential OAuth Provider
+authgear.yaml:
+  override: |
+    authentication:
+      identities:
+        - oauth
+      primary_authenticators:
+        - password
+
+    identity:
+      oauth:
+        providers:
+          - alias: facebook
+            type: facebook
+            missing_credential_allowed: true
+    authentication_flow:
+      login_flows:
+        - name: default
+          steps:
+          - type: identify
+            one_of:
+            - identification: oauth
+
+steps:
+  - action: "create"
+    input: |
+      {
+        "type": "login",
+        "name": "default"
+      }
+    output:
+      result: |
+        {
+          "action": {
+            "type": "identify"
+          }
+        }
+
+  - action: input
+    input: |
+      {
+        "identification": "oauth",
+        "alias": "facebook",
+        "redirect_uri": "http://mock"
+      }
+    output:
+      result: |
+        {
+          "action": {
+            "type": "identify",
+            "identification": "oauth",
+            "data": {
+              "type": "oauth_data",
+              "alias": "facebook",
+              "oauth_provider_type": "facebook",
+              "oauth_authorization_url": "[[string]]",
+              "provider_status": "using_demo_credentials"
+            }
+          }
+        } 

--- a/e2e/var/authgear.secrets.yaml
+++ b/e2e/var/authgear.secrets.yaml
@@ -152,3 +152,11 @@ secrets:
   data:
     - service_provider_id: e2e
       certificates: []
+
+- key: sso.oauth.demo_credentials
+  data:
+    items:
+      - provider_config:
+          client_id: facebooke2e
+          type: facebook
+        client_secret: "testsecret"

--- a/pkg/admin/wire_gen.go
+++ b/pkg/admin/wire_gen.go
@@ -1019,6 +1019,7 @@ func newGraphQLHandler(p *deps.RequestProvider) http.Handler {
 		Sender:      messagingSender,
 	}
 	oAuthSSOProviderCredentials := deps.ProvideOAuthSSOProviderCredentials(secretConfig)
+	ssooAuthDemoCredentials := deps.ProvideSSOOAuthDemoCredentials(secretConfig)
 	oAuthHTTPClient := sso.ProvideOAuthHTTPClient(environmentConfig)
 	simpleStoreRedisFactory := &sso.SimpleStoreRedisFactory{
 		AppID: appID,
@@ -1027,6 +1028,7 @@ func newGraphQLHandler(p *deps.RequestProvider) http.Handler {
 	oAuthProviderFactory := &sso.OAuthProviderFactory{
 		IdentityConfig:               identityConfig,
 		Credentials:                  oAuthSSOProviderCredentials,
+		SSOOAuthDemoCredentials:      ssooAuthDemoCredentials,
 		Clock:                        clockClock,
 		StandardAttributesNormalizer: normalizer,
 		HTTPClient:                   oAuthHTTPClient,

--- a/pkg/lib/authenticationflow/declarative/data_identification.go
+++ b/pkg/lib/authenticationflow/declarative/data_identification.go
@@ -56,15 +56,11 @@ func NewIdentificationOptionLoginID(i config.AuthenticationFlowIdentification, a
 	}
 }
 
-func NewIdentificationOptionsOAuth(oauthConfig *config.OAuthSSOConfig, oauthFeatureConfig *config.OAuthSSOProvidersFeatureConfig, authflowCfg *config.AuthenticationFlowBotProtection, appCfg *config.BotProtectionConfig) []IdentificationOption {
+func NewIdentificationOptionsOAuth(oauthConfig *config.OAuthSSOConfig, oauthFeatureConfig *config.OAuthSSOProvidersFeatureConfig, authflowCfg *config.AuthenticationFlowBotProtection, appCfg *config.BotProtectionConfig, demoCredentials *config.SSOOAuthDemoCredentials) []IdentificationOption {
 	output := []IdentificationOption{}
 	for _, p := range oauthConfig.Providers {
 		if !identity.IsOAuthSSOProviderTypeDisabled(p.AsProviderConfig(), oauthFeatureConfig) {
-			status := OAuthProviderStatusActive
-			if p.IsMissingCredentialAllowed() {
-				status = OAuthProviderStatusMissingCredentials
-				// TODO(tung): Add demo status
-			}
+			status := p.ComputeProviderStatus(demoCredentials)
 
 			output = append(output, IdentificationOption{
 				Identification: config.AuthenticationFlowIdentificationOAuth,

--- a/pkg/lib/authenticationflow/declarative/data_oauth.go
+++ b/pkg/lib/authenticationflow/declarative/data_oauth.go
@@ -2,16 +2,11 @@ package declarative
 
 import (
 	authflow "github.com/authgear/authgear-server/pkg/lib/authenticationflow"
+	"github.com/authgear/authgear-server/pkg/lib/config"
 	"github.com/authgear/authgear-server/pkg/lib/oauthrelyingparty/wechat"
 )
 
-type OAuthProviderStatus string
-
-const (
-	OAuthProviderStatusActive               OAuthProviderStatus = "active"
-	OAuthProviderStatusMissingCredentials   OAuthProviderStatus = "missing_credentials"
-	OAuthProviderStatusUsingDemoCredentials OAuthProviderStatus = "using_demo_credentials" // nolint: gosec
-)
+type OAuthProviderStatus = config.OAuthProviderStatus
 
 type OAuthData struct {
 	TypedData

--- a/pkg/lib/authenticationflow/declarative/intent_login_flow_step_identify.go
+++ b/pkg/lib/authenticationflow/declarative/intent_login_flow_step_identify.go
@@ -88,6 +88,7 @@ func NewIntentLoginFlowStepIdentify(ctx context.Context, deps *authflow.Dependen
 			oauthOptions := NewIdentificationOptionsOAuth(
 				deps.Config.Identity.OAuth,
 				deps.FeatureConfig.Identity.OAuth.Providers, b.BotProtection, deps.Config.BotProtection,
+				deps.SSOOAuthDemoCredentials,
 			)
 			options = append(options, oauthOptions...)
 		case config.AuthenticationFlowIdentificationPasskey:

--- a/pkg/lib/authenticationflow/declarative/intent_lookup_identity_oauth.go
+++ b/pkg/lib/authenticationflow/declarative/intent_lookup_identity_oauth.go
@@ -47,7 +47,13 @@ func (i *IntentLookupIdentityOAuth) CanReactTo(ctx context.Context, deps *authfl
 			authflowCfg = currentBranch.GetBotProtectionConfig()
 		}
 
-		oauthOptions := NewIdentificationOptionsOAuth(deps.Config.Identity.OAuth, deps.FeatureConfig.Identity.OAuth.Providers, authflowCfg, deps.Config.BotProtection)
+		oauthOptions := NewIdentificationOptionsOAuth(
+			deps.Config.Identity.OAuth,
+			deps.FeatureConfig.Identity.OAuth.Providers,
+			authflowCfg,
+			deps.Config.BotProtection,
+			deps.SSOOAuthDemoCredentials,
+		)
 		isBotProtectionRequired, err := IsBotProtectionRequired(ctx, deps, flows, i.JSONPointer)
 		if err != nil {
 			return nil, err

--- a/pkg/lib/authenticationflow/declarative/intent_oauth.go
+++ b/pkg/lib/authenticationflow/declarative/intent_oauth.go
@@ -64,7 +64,13 @@ func (i *IntentOAuth) CanReactTo(ctx context.Context, deps *authflow.Dependencie
 			authflowCfg = currentBranch.GetBotProtectionConfig()
 		}
 
-		oauthOptions := NewIdentificationOptionsOAuth(deps.Config.Identity.OAuth, deps.FeatureConfig.Identity.OAuth.Providers, authflowCfg, deps.Config.BotProtection)
+		oauthOptions := NewIdentificationOptionsOAuth(
+			deps.Config.Identity.OAuth,
+			deps.FeatureConfig.Identity.OAuth.Providers,
+			authflowCfg,
+			deps.Config.BotProtection,
+			deps.SSOOAuthDemoCredentials,
+		)
 
 		isBotProtectionRequired, err := IsBotProtectionRequired(ctx, deps, flows, i.JSONPointer)
 		if err != nil {

--- a/pkg/lib/authenticationflow/declarative/intent_promote_flow_step_identify.go
+++ b/pkg/lib/authenticationflow/declarative/intent_promote_flow_step_identify.go
@@ -106,6 +106,7 @@ func NewIntentPromoteFlowStepIdentify(ctx context.Context, deps *authflow.Depend
 				deps.FeatureConfig.Identity.OAuth.Providers,
 				b.BotProtection,
 				deps.Config.BotProtection,
+				deps.SSOOAuthDemoCredentials,
 			)
 			options = append(options, oauthOptions...)
 		case config.AuthenticationFlowIdentificationPasskey:

--- a/pkg/lib/authenticationflow/declarative/intent_promote_identity_oauth.go
+++ b/pkg/lib/authenticationflow/declarative/intent_promote_identity_oauth.go
@@ -51,7 +51,13 @@ func (i *IntentPromoteIdentityOAuth) CanReactTo(ctx context.Context, deps *authf
 		if currentBranch, ok := current.(config.AuthenticationFlowObjectBotProtectionConfigProvider); ok {
 			authflowCfg = currentBranch.GetBotProtectionConfig()
 		}
-		oauthOptions := NewIdentificationOptionsOAuth(deps.Config.Identity.OAuth, deps.FeatureConfig.Identity.OAuth.Providers, authflowCfg, deps.Config.BotProtection)
+		oauthOptions := NewIdentificationOptionsOAuth(
+			deps.Config.Identity.OAuth,
+			deps.FeatureConfig.Identity.OAuth.Providers,
+			authflowCfg,
+			deps.Config.BotProtection,
+			deps.SSOOAuthDemoCredentials,
+		)
 
 		isBotProtectionRequired, err := IsBotProtectionRequired(ctx, deps, flows, i.JSONPointer)
 		if err != nil {

--- a/pkg/lib/authenticationflow/declarative/intent_signup_flow_step_identify.go
+++ b/pkg/lib/authenticationflow/declarative/intent_signup_flow_step_identify.go
@@ -156,6 +156,7 @@ func NewIntentSignupFlowStepIdentify(ctx context.Context, deps *authflow.Depende
 				deps.FeatureConfig.Identity.OAuth.Providers,
 				b.BotProtection,
 				deps.Config.BotProtection,
+				deps.SSOOAuthDemoCredentials,
 			)
 			options = append(options, oauthOptions...)
 		case config.AuthenticationFlowIdentificationPasskey:

--- a/pkg/lib/authenticationflow/declarative/intent_signup_login_flow_step_identify.go
+++ b/pkg/lib/authenticationflow/declarative/intent_signup_login_flow_step_identify.go
@@ -56,6 +56,7 @@ func NewIntentSignupLoginFlowStepIdentify(ctx context.Context, deps *authflow.De
 				deps.FeatureConfig.Identity.OAuth.Providers,
 				b.BotProtection,
 				deps.Config.BotProtection,
+				deps.SSOOAuthDemoCredentials,
 			)
 			options = append(options, oauthOptions...)
 		case config.AuthenticationFlowIdentificationPasskey:

--- a/pkg/lib/authenticationflow/declarative/utils_common.go
+++ b/pkg/lib/authenticationflow/declarative/utils_common.go
@@ -747,11 +747,7 @@ func getOAuthData(ctx context.Context, deps *authflow.Dependencies, opts GetOAut
 		return
 	}
 
-	status := OAuthProviderStatusActive
-	if config.OAuthSSOProviderConfig(providerConfig).IsMissingCredentialAllowed() {
-		status = OAuthProviderStatusMissingCredentials
-		// TODO(tung): Add demo status
-	}
+	status := config.OAuthSSOProviderConfig(providerConfig).ComputeProviderStatus(deps.SSOOAuthDemoCredentials)
 
 	data = NewOAuthData(OAuthData{
 		Alias:                 opts.Alias,

--- a/pkg/lib/authenticationflow/dependencies.go
+++ b/pkg/lib/authenticationflow/dependencies.go
@@ -239,8 +239,9 @@ type UserFacade interface {
 }
 
 type Dependencies struct {
-	Config        *config.AppConfig
-	FeatureConfig *config.FeatureConfig
+	Config                  *config.AppConfig
+	FeatureConfig           *config.FeatureConfig
+	SSOOAuthDemoCredentials *config.SSOOAuthDemoCredentials
 
 	Clock      clock.Clock
 	RemoteIP   httputil.RemoteIP

--- a/pkg/lib/authn/sso/oauth_provider.go
+++ b/pkg/lib/authn/sso/oauth_provider.go
@@ -21,6 +21,7 @@ type StandardAttributesNormalizer interface {
 type OAuthProviderFactory struct {
 	IdentityConfig               *config.IdentityConfig
 	Credentials                  *config.OAuthSSOProviderCredentials
+	SSOOAuthDemoCredentials      *config.SSOOAuthDemoCredentials
 	Clock                        clock.Clock
 	StandardAttributesNormalizer StandardAttributesNormalizer
 	HTTPClient                   OAuthHTTPClient
@@ -42,13 +43,26 @@ func (p *OAuthProviderFactory) getActiveOrDemoProvider(alias string) (provider o
 	}
 
 	if config.OAuthSSOProviderConfig(providerConfig).IsMissingCredentialAllowed() {
-		// TODO(tung): handle demo status
-
-		details := apierrors.Details{
-			"OAuthProviderAlias": alias,
-			"OAuthProviderType":  providerConfig.Type(),
+		if p.SSOOAuthDemoCredentials == nil {
+			err = newOAuthProviderMissingCredentialsError(alias, providerConfig.Type(), false)
+			return
 		}
-		err = api.OAuthProviderMissingCredentials.NewWithInfo("oauth provider is missing credentials", details)
+
+		demoItem, ok := p.SSOOAuthDemoCredentials.LookupByProviderType(providerConfig.Type())
+		if !ok {
+			err = newOAuthProviderMissingCredentialsError(alias, providerConfig.Type(), true)
+			return
+		}
+
+		deps = &oauthrelyingparty.Dependencies{
+			Clock:          p.Clock,
+			ProviderConfig: demoItem.ProviderConfig,
+			ClientSecret:   demoItem.ClientSecret,
+			HTTPClient:     p.HTTPClient.Client,
+			SimpleStore:    p.SimpleStoreRedisFactory.GetStoreByProvider(providerConfig.Type(), alias),
+		}
+
+		provider = demoItem.ProviderConfig.MustGetProvider()
 		return
 	}
 
@@ -102,4 +116,12 @@ func (p *OAuthProviderFactory) GetUserProfile(ctx context.Context, alias string,
 	}
 
 	return
+}
+
+func newOAuthProviderMissingCredentialsError(alias string, providerType string, isDemo bool) error {
+	details := apierrors.Details{
+		"OAuthProviderAlias": alias,
+		"OAuthProviderType":  providerType,
+	}
+	return api.OAuthProviderMissingCredentials.NewWithInfo("oauth provider is missing credentials", details)
 }

--- a/pkg/lib/authn/sso/oauth_provider.go
+++ b/pkg/lib/authn/sso/oauth_provider.go
@@ -59,7 +59,7 @@ func (p *OAuthProviderFactory) getActiveOrDemoProvider(alias string) (provider o
 			ProviderConfig: demoItem.ProviderConfig,
 			ClientSecret:   demoItem.ClientSecret,
 			HTTPClient:     p.HTTPClient.Client,
-			SimpleStore:    p.SimpleStoreRedisFactory.GetStoreByProvider(providerConfig.Type(), alias),
+			SimpleStore:    p.SimpleStoreRedisFactory.GetStoreByProvider(demoItem.ProviderConfig.Type(), alias),
 		}
 
 		provider = demoItem.ProviderConfig.MustGetProvider()

--- a/pkg/lib/config/configsource/loader.go
+++ b/pkg/lib/config/configsource/loader.go
@@ -42,7 +42,7 @@ func LoadConfig(ctx context.Context, res *resource.Manager) (*config.Config, err
 		SecretConfig:  secretConfig,
 		FeatureConfig: featureConfig,
 	}
-	if err = cfg.SecretConfig.Validate(cfg.AppConfig); err != nil {
+	if err = cfg.SecretConfig.Validate(ctx, cfg.AppConfig); err != nil {
 		return nil, fmt.Errorf("invalid secret config: %w", err)
 	}
 

--- a/pkg/lib/config/identity.go
+++ b/pkg/lib/config/identity.go
@@ -352,6 +352,29 @@ func (c OAuthSSOProviderConfig) IsMissingCredentialAllowed() bool {
 	return v
 }
 
+type OAuthProviderStatus string
+
+const (
+	OAuthProviderStatusActive               OAuthProviderStatus = "active"
+	OAuthProviderStatusMissingCredentials   OAuthProviderStatus = "missing_credentials"
+	OAuthProviderStatusUsingDemoCredentials OAuthProviderStatus = "using_demo_credentials" // nolint: gosec
+)
+
+func (c OAuthSSOProviderConfig) ComputeProviderStatus(demoCredentials *SSOOAuthDemoCredentials) OAuthProviderStatus {
+	if !c.IsMissingCredentialAllowed() {
+		return OAuthProviderStatusActive
+	}
+	if demoCredentials == nil {
+		return OAuthProviderStatusMissingCredentials
+	}
+	typ := c.AsProviderConfig().Type()
+	_, ok := demoCredentials.LookupByProviderType(typ)
+	if ok {
+		return OAuthProviderStatusUsingDemoCredentials
+	}
+	return OAuthProviderStatusMissingCredentials
+}
+
 type OAuthSSOConfig struct {
 	Providers []OAuthSSOProviderConfig `json:"providers,omitempty"`
 }

--- a/pkg/lib/config/secret.go
+++ b/pkg/lib/config/secret.go
@@ -347,8 +347,9 @@ const (
 	AdminAPIAuthKeyKey          SecretKey = "admin-api.auth"
 	// nolint: gosec
 	OAuthSSOProviderCredentialsKey SecretKey = "sso.oauth.client"
-	SSOOAuthDemoCredentialsKey     SecretKey = "sso.oauth.demo_credentials"
-	SMTPServerCredentialsKey       SecretKey = "mail.smtp"
+	// nolint: gosec
+	SSOOAuthDemoCredentialsKey SecretKey = "sso.oauth.demo_credentials"
+	SMTPServerCredentialsKey   SecretKey = "mail.smtp"
 	// nolint: gosec
 	TwilioCredentialsKey SecretKey = "sms.twilio"
 	// nolint: gosec

--- a/pkg/lib/config/secret.go
+++ b/pkg/lib/config/secret.go
@@ -331,6 +331,7 @@ const (
 	AdminAPIAuthKeyKey          SecretKey = "admin-api.auth"
 	// nolint: gosec
 	OAuthSSOProviderCredentialsKey SecretKey = "sso.oauth.client"
+	SSOOAuthDemoCredentialsKey     SecretKey = "sso.oauth.demo_credentials"
 	SMTPServerCredentialsKey       SecretKey = "mail.smtp"
 	// nolint: gosec
 	TwilioCredentialsKey SecretKey = "sms.twilio"
@@ -383,6 +384,7 @@ var secretItemKeys = map[SecretKey]secretKeyDef{
 	AnalyticRedisCredentialsKey:                {"AnalyticRedisCredentials", func() SecretItemData { return &AnalyticRedisCredentials{} }},
 	AdminAPIAuthKeyKey:                         {"AdminAPIAuthKey", func() SecretItemData { return &AdminAPIAuthKey{} }},
 	OAuthSSOProviderCredentialsKey:             {"OAuthSSOProviderCredentials", func() SecretItemData { return &OAuthSSOProviderCredentials{} }},
+	SSOOAuthDemoCredentialsKey:                 {"SSOOAuthDemoCredentials", func() SecretItemData { return &SSOOAuthDemoCredentials{} }},
 	SMTPServerCredentialsKey:                   {"SMTPServerCredentials", func() SecretItemData { return &SMTPServerCredentials{} }},
 	TwilioCredentialsKey:                       {"TwilioCredentials", func() SecretItemData { return &TwilioCredentials{} }},
 	NexmoCredentialsKey:                        {"NexmoCredentials", func() SecretItemData { return &NexmoCredentials{} }},

--- a/pkg/lib/config/secret.go
+++ b/pkg/lib/config/secret.go
@@ -265,7 +265,7 @@ func (c *SecretConfig) validateSSOOAuthDemoCredentials(ctx context.Context, vctx
 		providerConfig := item.ProviderConfig
 		provider := providerConfig.MustGetProvider()
 		schema := validation.SchemaBuilder(provider.GetJSONSchema()).ToSimpleSchema()
-		itemCtx := vctx.Child("items", strconv.Itoa(i))
+		itemCtx := vctx.Child("items", strconv.Itoa(i), "provider_config")
 		itemCtx.AddError(schema.Validator().ValidateValue(ctx, providerConfig))
 	}
 }
@@ -320,9 +320,10 @@ func (c *SecretConfig) Validate(ctx context.Context, appConfig *AppConfig) error
 		c.validateSAMLSigningKey(vctx, appConfig.SAML.Signing.KeyID)
 	}
 
-	demoCredentials, ok := c.LookupData(SSOOAuthDemoCredentialsKey).(*SSOOAuthDemoCredentials)
+	idx, demoCredentials, ok := c.LookupDataWithIndex(SSOOAuthDemoCredentialsKey)
 	if ok {
-		c.validateSSOOAuthDemoCredentials(ctx, vctx, demoCredentials)
+		childCtx := vctx.Child("secrets", strconv.Itoa(idx), "data")
+		c.validateSSOOAuthDemoCredentials(ctx, childCtx, demoCredentials.(*SSOOAuthDemoCredentials))
 	}
 
 	return vctx.Error("invalid secrets")

--- a/pkg/lib/config/secret_sso_oauth_demo_credentials.go
+++ b/pkg/lib/config/secret_sso_oauth_demo_credentials.go
@@ -32,10 +32,10 @@ var _ = SecretConfigSchema.Add("SSOOAuthDemoCredentials", `
 `)
 
 type SSOOAuthDemoCredentials struct {
-	Items []OauthDemoCredentialsItems `json:"items,omitempty"`
+	Items []SSOOAuthDemoCredentialsItems `json:"items,omitempty"`
 }
 
-type OauthDemoCredentialsItems struct {
+type SSOOAuthDemoCredentialsItems struct {
 	ProviderConfig oauthrelyingparty.ProviderConfig `json:"provider_config,omitempty"`
 	ClientSecret   string                           `json:"client_secret,omitempty"`
 }
@@ -48,4 +48,13 @@ func (c *SSOOAuthDemoCredentials) SensitiveStrings() []string {
 		}
 	}
 	return secrets
+}
+
+func (c *SSOOAuthDemoCredentials) LookupByProviderType(providerType string) (*SSOOAuthDemoCredentialsItems, bool) {
+	for _, item := range c.Items {
+		if item.ProviderConfig.Type() == providerType {
+			return &item, true
+		}
+	}
+	return nil, false
 }

--- a/pkg/lib/config/secret_sso_oauth_demo_credentials.go
+++ b/pkg/lib/config/secret_sso_oauth_demo_credentials.go
@@ -1,0 +1,51 @@
+package config
+
+import (
+	"github.com/authgear/oauthrelyingparty/pkg/api/oauthrelyingparty"
+)
+
+var _ = SecretConfigSchema.Add("SSOOAuthDemoCredentials", `
+{
+	"type": "object",
+	"additionalProperties": false,
+	"properties": {
+		"items": {
+			"type": "array",
+			"items": {
+				"type": "object",
+				"additionalProperties": false,
+				"properties": {
+					"provider_config": {
+						"type": "object",
+						"additionalProperties": true
+					},
+					"client_secret": {
+						"type": "string"
+					}
+				},
+				"required": ["provider_config", "client_secret"]
+			}
+		}
+	},
+	"required": ["items"]
+}
+`)
+
+type SSOOAuthDemoCredentials struct {
+	Items []OauthDemoCredentialsItems `json:"items,omitempty"`
+}
+
+type OauthDemoCredentialsItems struct {
+	ProviderConfig oauthrelyingparty.ProviderConfig `json:"provider_config,omitempty"`
+	ClientSecret   string                           `json:"client_secret,omitempty"`
+}
+
+func (c *SSOOAuthDemoCredentials) SensitiveStrings() []string {
+	var secrets []string
+	for _, item := range c.Items {
+		if item.ClientSecret != "" {
+			secrets = append(secrets, item.ClientSecret)
+		}
+	}
+	return secrets
+}

--- a/pkg/lib/config/secret_test.go
+++ b/pkg/lib/config/secret_test.go
@@ -103,7 +103,7 @@ func TestSecretConfigValidate(t *testing.T) {
 					panic(err)
 				}
 
-				err = secretConfig.Validate(appConfig)
+				err = secretConfig.Validate(ctx, appConfig)
 				if testCase.Error != nil {
 					So(err, ShouldBeError, *testCase.Error)
 				} else {

--- a/pkg/lib/config/testdata/parse_secret_tests.yaml
+++ b/pkg/lib/config/testdata/parse_secret_tests.yaml
@@ -8,7 +8,7 @@ name: unknown-secret-key
 error: |-
   invalid secrets:
   /secrets/0/key: enum
-    map[actual:unknown-secret expected:[admin-api.auth analytic.redis audit.db bot_protection.provider captcha.cloudflare csrf db elasticsearch images ldap mail.smtp oauth oauth.client_secrets redis saml.idp.signing saml.service_providers.signing search.db sms.custom sms.nexmo sms.twilio sso.oauth.client webhook whatsapp.cloud-api whatsapp.on-premises whatsapp.wati]]
+    map[actual:unknown-secret expected:[admin-api.auth analytic.redis audit.db bot_protection.provider captcha.cloudflare csrf db elasticsearch images ldap mail.smtp oauth oauth.client_secrets redis saml.idp.signing saml.service_providers.signing search.db sms.custom sms.nexmo sms.twilio sso.oauth.client sso.oauth.demo_credentials webhook whatsapp.cloud-api whatsapp.on-premises whatsapp.wati]]
 config:
   secrets:
     - key: unknown-secret
@@ -519,3 +519,20 @@ config:
           name: ""
           languages:
           - ""
+
+---
+name: sso-oauth-demo-credential/valid
+error: null
+config:
+  secrets:
+    - key: sso.oauth.demo_credentials
+      data:
+        items:
+          - provider_config:
+              claims:
+                email:
+                  assume_verified: true
+                  required: true
+              client_id: test
+              type: google
+            client_secret: testsecret

--- a/pkg/lib/config/testdata/secret_config_validate_tests.yaml
+++ b/pkg/lib/config/testdata/secret_config_validate_tests.yaml
@@ -501,3 +501,31 @@ secret_config:
         - name: default
           dn: "cn=admin,dc=localhost"
           password: "password"
+
+---
+name: sso-oauth-demo-credential/invalid-provider-config
+error: |-
+  invalid secrets:
+  <root>: database credentials (secret 'db') is required
+  <root>: redis credentials (secret 'redis') is required
+  <root>: admin API auth key materials (secret 'admin-api.auth') is required
+  <root>: OAuth key materials (secret 'oauth') is required
+  <root>: CSRF key materials (secret 'csrf') is required
+  /secrets/0/data/items/0/provider_config: required
+    map[actual:[claims type] expected:[client_id type] missing:[client_id]]
+app_config:
+  id: app
+  http:
+    public_origin: "http://test"
+secret_config:
+  secrets:
+    - key: sso.oauth.demo_credentials
+      data:
+        items:
+          - provider_config:
+              claims:
+                email:
+                  assume_verified: true
+                  required: true
+              type: google
+            client_secret: testsecret

--- a/pkg/lib/deps/deps_config.go
+++ b/pkg/lib/deps/deps_config.go
@@ -137,6 +137,7 @@ var secretDeps = wire.NewSet(
 	ProvideLDAPServerUserCredentials,
 	ProvideSAMLIdpSigningMaterials,
 	ProvideSAMLSpSigningMaterials,
+	ProvideSSOOAuthDemoCredentials,
 )
 
 func ProvideDatabaseCredentials(c *config.SecretConfig) *config.DatabaseCredentials {
@@ -245,6 +246,11 @@ func ProvideBotProtectionProvidersCredentials(c *config.SecretConfig) *config.Bo
 
 func ProvideWhatsappOnPremisesCredentials(c *config.SecretConfig) *config.WhatsappOnPremisesCredentials {
 	s, _ := c.LookupData(config.WhatsappOnPremisesCredentialsKey).(*config.WhatsappOnPremisesCredentials)
+	return s
+}
+
+func ProvideSSOOAuthDemoCredentials(c *config.SecretConfig) *config.SSOOAuthDemoCredentials {
+	s, _ := c.LookupData(config.SSOOAuthDemoCredentialsKey).(*config.SSOOAuthDemoCredentials)
 	return s
 }
 


### PR DESCRIPTION
ref DEV-2719

requires https://github.com/authgear/authgear-server/pull/5191

## How to test

1. Add demo credentials to `authgear.secrets.yaml`.
```yaml
- data:
    items:
      - provider_config:
          claims:
            email:
              assume_verified: true
              required: true
          client_id: {CLIENT_ID}
          type: google
        client_secret:  {CLIENT_SECRET}
  key: sso.oauth.demo_credentials
```

2. Set `missing_credential_allowed` in the corresponding provider:
```yaml
    - alias: google
      create_disabled: false
      delete_disabled: false
      type: google
      missing_credential_allowed: true
```

3. Use authflow api to test oauth.