### PR TITLE
Explicitly install bashInteractive in flake

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -74,6 +74,8 @@
             pkgs.vips
             # file includes libmagic.
             pkgs.file
+            # https://discourse.nixos.org/t/non-interactive-bash-errors-from-flake-nix-mkshell/33310
+            pkgs.bashInteractive
           ];
           nativeBuildInputs = [
             pkgs.pkg-config


### PR DESCRIPTION
Otherwise the effective bash is the minimal one, lacking features like vi-mode and completion.