### PR TITLE
Enable vite dev server debug log

### DIFF
--- a/portal/package.json
+++ b/portal/package.json
@@ -8,7 +8,7 @@
   "scripts": {
     "postinstall": "./scripts/npm-postinstall.sh",
     "test": "jest",
-    "start": "vite",
+    "start": "vite --debug",
     "build": "vite build",
     "clean": "rm -rf ./dist/ && mkdir ./dist/ && touch ./dist/.gitkeep",
     "typecheck": "tsc",


### PR DESCRIPTION
Continue from https://github.com/authgear/authgear-server/pull/5329#discussion_r2275244867

If the change worked for you, then the vite dev server may have problem when the request has `Connection: close`.

I enabled the debug log for the dev server. Let's see if we have any insights from the log when the problem occurs again.