### PR TITLE
Set up Redis TLS locally for testing

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -40,8 +40,17 @@ services:
   redis:
     # Azure cache for Redis supports 6.0 only
     image: redis:6.0.20
+    # NOTE(redis-tls): In case you want to test Redis TLS, uncomment the following lines
+    # command:
+    # - redis-server
+    # - /usr/local/etc/redis/redis.conf
     volumes:
     - redis_data:/data
+    # NOTE(redis-tls): In case you want to test Redis TLS, uncomment the following lines
+    # tls-cert.pem and tls-key.pem are generated with `make mkcert`.
+    # - ./redis.conf:/usr/local/etc/redis/redis.conf
+    # - ./tls-cert.pem:/usr/local/etc/redis/redis.crt
+    # - ./tls-key.pem:/usr/local/etc/redis/redis.key
     ports:
     - "6379:6379"
 

--- a/redis.conf
+++ b/redis.conf
@@ -73,7 +73,8 @@
 # IF YOU ARE SURE YOU WANT YOUR INSTANCE TO LISTEN TO ALL THE INTERFACES
 # JUST COMMENT OUT THE FOLLOWING LINE.
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-bind 127.0.0.1
+#bind 127.0.0.1
+bind 0.0.0.0 ::
 
 # Protected mode is a layer of security protection, in order to avoid that
 # Redis instances left open on the internet are accessed and exploited.
@@ -96,7 +97,7 @@ protected-mode yes
 
 # Accept connections on the specified port, default is 6379 (IANA #815344).
 # If port 0 is specified Redis will not listen on a TCP socket.
-port 6379
+#port 6379
 
 # TCP listen() backlog.
 #
@@ -142,15 +143,15 @@ tcp-keepalive 300
 # directive can be used to define TLS-listening ports. To enable TLS on the
 # default port, use:
 #
-# port 0
-# tls-port 6379
+port 0
+tls-port 6379
 
 # Configure a X.509 certificate and private key to use for authenticating the
 # server to connected clients, masters or cluster peers.  These files should be
 # PEM formatted.
 #
-# tls-cert-file redis.crt 
-# tls-key-file redis.key
+tls-cert-file /usr/local/etc/redis/redis.crt
+tls-key-file /usr/local/etc/redis/redis.key
 
 # Configure a DH parameters file to enable Diffie-Hellman (DH) key exchange:
 #
@@ -170,7 +171,7 @@ tcp-keepalive 300
 # If "optional" is specified, client certificates are accepted and must be
 # valid if provided, but are not required.
 #
-# tls-auth-clients no
+tls-auth-clients no
 # tls-auth-clients optional
 
 # By default, a Redis replica does not attempt to establish a TLS connection
@@ -189,7 +190,7 @@ tcp-keepalive 300
 # and include "TLSv1", "TLSv1.1", "TLSv1.2", "TLSv1.3" (OpenSSL >= 1.1.1) or
 # any combination. To enable only TLSv1.2 and TLSv1.3, use:
 #
-# tls-protocols "TLSv1.2 TLSv1.3"
+tls-protocols "TLSv1.2 TLSv1.3"
 
 # Configure allowed ciphers.  See the ciphers(1ssl) manpage for more information
 # about the syntax of this string.


### PR DESCRIPTION
ref DEV-3039

Since we are using `redis.ParseURL`, and it handles `rediss:` scheme, TLS is already supported if the CA is in the container system certificate store.

In Dockerfile, we have set up entrypoint to be `docker-entrypoint.sh` which installs any custom CA at `/usr/local/share/ca-certificates` So we just need to volume-mount the custom CA there.