### PR TITLE
Move access token hook outside transaction

### DIFF
--- a/.vettedpositions
+++ b/.vettedpositions
@@ -13,7 +13,7 @@
 /pkg/auth/handler/api/accountmanagement_v1_identification.go:64:9: requestcontext
 /pkg/auth/handler/api/accountmanagement_v1_identification_oauth.go:55:9: requestcontext
 /pkg/auth/handler/api/anonymous_user_promotion_code.go:78:9: requestcontext
-/pkg/auth/handler/api/anonymous_user_signup.go:84:9: requestcontext
+/pkg/auth/handler/api/anonymous_user_signup.go:93:9: requestcontext
 /pkg/auth/handler/api/authenticationflow_v1_create.go:81:9: requestcontext
 /pkg/auth/handler/api/authenticationflow_v1_get.go:40:9: requestcontext
 /pkg/auth/handler/api/authenticationflow_v1_input.go:68:9: requestcontext
@@ -24,9 +24,9 @@
 /pkg/auth/handler/api/workflow_v2.go:205:9: requestcontext
 /pkg/auth/handler/api/workflow_websocket.go:52:9: requestcontext
 /pkg/auth/handler/oauth/app_session_token.go:68:9: requestcontext
-/pkg/auth/handler/oauth/authorize.go:48:68: requestcontext
-/pkg/auth/handler/oauth/authorize.go:66:46: requestcontext
-/pkg/auth/handler/oauth/authorize.go:67:31: requestcontext
+/pkg/auth/handler/oauth/authorize.go:46:68: requestcontext
+/pkg/auth/handler/oauth/authorize.go:60:46: requestcontext
+/pkg/auth/handler/oauth/authorize.go:61:31: requestcontext
 /pkg/auth/handler/oauth/challenge.go:88:9: requestcontext
 /pkg/auth/handler/oauth/consent.go:80:27: requestcontext
 /pkg/auth/handler/oauth/consent.go:100:28: requestcontext
@@ -247,7 +247,7 @@
 /pkg/auth/handler/webapp/sso_callback.go:61:44: requestcontext
 /pkg/auth/handler/webapp/sso_callback.go:72:44: requestcontext
 /pkg/auth/handler/webapp/sso_callback.go:83:28: requestcontext
-/pkg/auth/handler/webapp/tester.go:278:27: requestcontext
+/pkg/auth/handler/webapp/tester.go:279:27: requestcontext
 /pkg/auth/handler/webapp/turbo_response_writer.go:33:29: requestcontext
 /pkg/auth/handler/webapp/use_passkey.go:53:27: requestcontext
 /pkg/auth/handler/webapp/verify_identity.go:161:27: requestcontext

--- a/pkg/admin/deps.go
+++ b/pkg/admin/deps.go
@@ -77,8 +77,8 @@ var DependencySet = wire.NewSet(
 	wire.Bind(new(facade.AuthorizationService), new(*oauth.AuthorizationService)),
 	wire.Bind(new(facade.OAuthAuthorizationService), new(*oauth.AuthorizationService)),
 	wire.Bind(new(facade.OAuthTokenService), new(*oauthhandler.TokenService)),
-
 	wire.Bind(new(facade.OAuthClientResolver), new(*oauthclient.Resolver)),
+	wire.Bind(new(facade.OAuthAccessTokenEncoding), new(*oauth.AccessTokenEncoding)),
 
 	graphql.DependencySet,
 	wire.Bind(new(graphql.UserLoader), new(*loader.UserLoader)),

--- a/pkg/admin/facade/oauth.go
+++ b/pkg/admin/facade/oauth.go
@@ -126,7 +126,6 @@ func (f *OAuthFacade) CreateSession(ctx context.Context, clientID string, userID
 
 	result2, err := f.AccessTokenCoding.MakeUserAccessTokenFromPreparationResult(ctx, oauth.MakeUserAccessTokenFromPreparationOptions{
 		PreparationResult: result1.PreparationResult,
-		ClientConfig:      client,
 	})
 	if err != nil {
 		return nil, nil, err

--- a/pkg/admin/facade/oauth.go
+++ b/pkg/admin/facade/oauth.go
@@ -29,10 +29,10 @@ type OAuthTokenService interface {
 		opts handler.IssueOfflineGrantOptions,
 		resp protocol.TokenResponse,
 	) (offlineGrant *oauth.OfflineGrant, tokenHash string, err error)
-	IssueAccessGrantByRefreshToken(
+	PrepareUserAccessGrantByRefreshToken(
 		ctx context.Context,
-		options handler.IssueAccessGrantByRefreshTokenOptions,
-	) (*handler.IssueAccessGrantByRefreshTokenResult, error)
+		options handler.PrepareUserAccessGrantByRefreshTokenOptions,
+	) (*handler.PrepareUserAccessGrantByRefreshTokenResult, error)
 }
 
 type OAuthAccessTokenEncoding interface {
@@ -106,9 +106,9 @@ func (f *OAuthFacade) CreateSession(ctx context.Context, clientID string, userID
 		return nil, nil, err
 	}
 
-	result1, err := f.Tokens.IssueAccessGrantByRefreshToken(
+	result1, err := f.Tokens.PrepareUserAccessGrantByRefreshToken(
 		ctx,
-		handler.IssueAccessGrantByRefreshTokenOptions{
+		handler.PrepareUserAccessGrantByRefreshTokenOptions{
 			PrepareUserAccessGrantOptions: oauth.PrepareUserAccessGrantOptions{
 				ClientConfig:            client,
 				Scopes:                  scopes,

--- a/pkg/admin/facade/oauth.go
+++ b/pkg/admin/facade/oauth.go
@@ -109,7 +109,7 @@ func (f *OAuthFacade) CreateSession(ctx context.Context, clientID string, userID
 	result1, err := f.Tokens.IssueAccessGrantByRefreshToken(
 		ctx,
 		handler.IssueAccessGrantByRefreshTokenOptions{
-			IssueAccessGrantOptions: oauth.IssueAccessGrantOptions{
+			PrepareUserAccessGrantOptions: oauth.PrepareUserAccessGrantOptions{
 				ClientConfig:            client,
 				Scopes:                  scopes,
 				AuthorizationID:         authz.ID,

--- a/pkg/admin/wire_gen.go
+++ b/pkg/admin/wire_gen.go
@@ -1234,6 +1234,7 @@ func newGraphQLHandler(p *deps.RequestProvider) http.Handler {
 		Users:               userFacade,
 		Authorizations:      authorizationService,
 		Tokens:              tokenService,
+		AccessTokenCoding:   accessTokenEncoding,
 		Clock:               clockClock,
 		OAuthClientResolver: oauthclientResolver,
 	}

--- a/pkg/auth/deps.go
+++ b/pkg/auth/deps.go
@@ -73,6 +73,7 @@ var DependencySet = wire.NewSet(
 	nonce.DependencySet,
 
 	wire.Bind(new(oauthhandler.TokenHandlerAppDatabase), new(*appdb.Handle)),
+	wire.Bind(new(oauthhandler.AuthorizationHandlerDatabase), new(*appdb.Handle)),
 
 	wire.Bind(new(interaction.NonceService), new(*nonce.Service)),
 

--- a/pkg/auth/deps.go
+++ b/pkg/auth/deps.go
@@ -163,6 +163,7 @@ var DependencySet = wire.NewSet(
 	handlerapi.DependencySet,
 	wire.Bind(new(handlerapi.TurboResponseWriter), new(*handlerwebapp.ResponseWriter)),
 	wire.Bind(new(handlerapi.AnonymousUserHandler), new(*oauthhandler.AnonymousUserHandler)),
+	wire.Bind(new(handlerapi.AnonymousUserSignupAPIHandlerAccessTokenEncoding), new(*oauth.AccessTokenEncoding)),
 	wire.Bind(new(handlerapi.PromotionCodeIssuer), new(*oauthhandler.AnonymousUserHandler)),
 	wire.Bind(new(handlerapi.RateLimiter), new(*ratelimit.Limiter)),
 	wire.Bind(new(handlerapi.PresignProvider), new(*presign.Provider)),

--- a/pkg/auth/handler/api/anonymous_user_signup.go
+++ b/pkg/auth/handler/api/anonymous_user_signup.go
@@ -136,7 +136,6 @@ func (h *AnonymousUserSignupAPIHandler) ServeHTTP(resp http.ResponseWriter, req 
 			result.PrepareUserAccessGrantByRefreshTokenResult.RotateRefreshTokenResult.WriteTo(result.Response)
 
 			a, err := h.AccessTokenEncoding.MakeUserAccessTokenFromPreparationResult(ctx, oauth.MakeUserAccessTokenFromPreparationOptions{
-				ClientConfig:      result.Client,
 				PreparationResult: result.PrepareUserAccessGrantByRefreshTokenResult.PreparationResult,
 			})
 			if err != nil {

--- a/pkg/auth/handler/api/anonymous_user_signup.go
+++ b/pkg/auth/handler/api/anonymous_user_signup.go
@@ -132,12 +132,12 @@ func (h *AnonymousUserSignupAPIHandler) ServeHTTP(resp http.ResponseWriter, req 
 	} else {
 		// refresh token
 
-		if result.IssueAccessGrantByRefreshTokenResult != nil {
-			result.IssueAccessGrantByRefreshTokenResult.RotateRefreshTokenResult.WriteTo(result.Response)
+		if result.PrepareUserAccessGrantByRefreshTokenResult != nil {
+			result.PrepareUserAccessGrantByRefreshTokenResult.RotateRefreshTokenResult.WriteTo(result.Response)
 
 			a, err := h.AccessTokenEncoding.MakeUserAccessTokenFromPreparationResult(ctx, oauth.MakeUserAccessTokenFromPreparationOptions{
 				ClientConfig:      result.Client,
-				PreparationResult: result.IssueAccessGrantByRefreshTokenResult.PreparationResult,
+				PreparationResult: result.PrepareUserAccessGrantByRefreshTokenResult.PreparationResult,
 			})
 			if err != nil {
 				handleError(err)

--- a/pkg/auth/handler/api/anonymous_user_signup.go
+++ b/pkg/auth/handler/api/anonymous_user_signup.go
@@ -7,6 +7,7 @@ import (
 	"github.com/authgear/authgear-server/pkg/api"
 	"github.com/authgear/authgear-server/pkg/api/apierrors"
 	"github.com/authgear/authgear-server/pkg/lib/infra/db/appdb"
+	"github.com/authgear/authgear-server/pkg/lib/oauth"
 	oauthhandler "github.com/authgear/authgear-server/pkg/lib/oauth/handler"
 	"github.com/authgear/authgear-server/pkg/util/httproute"
 	"github.com/authgear/authgear-server/pkg/util/httputil"
@@ -75,21 +76,36 @@ type AnonymousUserSignupAPIRequest struct {
 
 var AnonymousUserSignupAPIHandlerLogger = slogutil.NewLogger("handler-anonymous-user-signup")
 
+type AnonymousUserSignupAPIHandlerAccessTokenEncoding interface {
+	MakeUserAccessTokenFromPreparationResult(
+		ctx context.Context,
+		options oauth.MakeUserAccessTokenFromPreparationOptions,
+	) (*oauth.IssueAccessGrantResult, error)
+}
+
 type AnonymousUserSignupAPIHandler struct {
 	Database             *appdb.Handle
 	AnonymousUserHandler AnonymousUserHandler
+	AccessTokenEncoding  AnonymousUserSignupAPIHandlerAccessTokenEncoding
 }
 
 func (h *AnonymousUserSignupAPIHandler) ServeHTTP(resp http.ResponseWriter, req *http.Request) {
 	ctx := req.Context()
+	logger := AnonymousUserSignupAPIHandlerLogger.GetLogger(ctx)
 	var payload AnonymousUserSignupAPIRequest
-	err := httputil.BindJSONBody(req, resp, AnonymousUserSignupAPIRequestSchema.Validator(), &payload)
-	if err != nil {
+
+	handleError := func(err error) {
+		if !apierrors.IsAPIError(err) {
+			logger.WithError(err).Error(ctx, "anonymous user signup handler failed")
+		}
 		httputil.WriteJSONResponse(ctx, resp, &api.Response{Error: err})
-		return
 	}
 
-	logger := AnonymousUserSignupAPIHandlerLogger.GetLogger(ctx)
+	err := httputil.BindJSONBody(req, resp, AnonymousUserSignupAPIRequestSchema.Validator(), &payload)
+	if err != nil {
+		handleError(err)
+		return
+	}
 
 	var result *oauthhandler.SignupAnonymousUserResult
 	err = h.Database.WithTx(ctx, func(ctx context.Context) error {
@@ -102,22 +118,35 @@ func (h *AnonymousUserSignupAPIHandler) ServeHTTP(resp http.ResponseWriter, req 
 		)
 		return err
 	})
+	if err != nil {
+		handleError(err)
+		return
+	}
 
-	if err == nil {
-		if result.Cookies != nil {
-			// cookie
-			for _, cookie := range result.Cookies {
-				httputil.UpdateCookie(resp, cookie)
-			}
-			httputil.WriteJSONResponse(ctx, resp, &api.Response{Result: struct{}{}})
-		} else {
-			// refresh token
-			httputil.WriteJSONResponse(ctx, resp, &api.Response{Result: result.TokenResponse})
+	if result.Cookies != nil {
+		// cookie
+		for _, cookie := range result.Cookies {
+			httputil.UpdateCookie(resp, cookie)
 		}
+		httputil.WriteJSONResponse(ctx, resp, &api.Response{Result: struct{}{}})
 	} else {
-		if !apierrors.IsAPIError(err) {
-			logger.WithError(err).Error(ctx, "anonymous user signup handler failed")
+		// refresh token
+
+		if result.IssueAccessGrantByRefreshTokenResult != nil {
+			result.IssueAccessGrantByRefreshTokenResult.RotateRefreshTokenResult.WriteTo(result.Response)
+
+			a, err := h.AccessTokenEncoding.MakeUserAccessTokenFromPreparationResult(ctx, oauth.MakeUserAccessTokenFromPreparationOptions{
+				ClientConfig:      result.Client,
+				PreparationResult: result.IssueAccessGrantByRefreshTokenResult.PreparationResult,
+			})
+			if err != nil {
+				handleError(err)
+				return
+			}
+
+			a.WriteTo(result.Response)
 		}
-		httputil.WriteJSONResponse(ctx, resp, &api.Response{Error: err})
+
+		httputil.WriteJSONResponse(ctx, resp, &api.Response{Result: result.Response})
 	}
 }

--- a/pkg/auth/handler/oauth/authorize.go
+++ b/pkg/auth/handler/oauth/authorize.go
@@ -22,7 +22,7 @@ var AuthorizeHandlerLogger = slogutil.NewLogger("handler-authz")
 
 type ProtocolAuthorizeHandler interface {
 	ValidateRequestWithoutTx(ctx context.Context, r protocol.AuthorizationRequest) (context.Context, *handler.AuthorizationParams, *handler.AuthorizationResultError)
-	HandleRequestWithTx(ctx context.Context, r protocol.AuthorizationRequest, params *handler.AuthorizationParams) httputil.Result
+	HandleRequest(ctx context.Context, r protocol.AuthorizationRequest, params *handler.AuthorizationParams) httputil.Result
 }
 
 var errAuthzInternalError = errors.New("internal error")
@@ -50,7 +50,7 @@ func (h *AuthorizeHandler) ServeHTTP(rw http.ResponseWriter, r *http.Request) {
 	}
 
 	var result httputil.Result
-	result = h.AuthzHandler.HandleRequestWithTx(ctx, req, params)
+	result = h.AuthzHandler.HandleRequest(ctx, req, params)
 	if result.IsInternalError() {
 		err = errAuthzInternalError
 	}

--- a/pkg/auth/handler/webapp/tester.go
+++ b/pkg/auth/handler/webapp/tester.go
@@ -14,6 +14,7 @@ import (
 	"github.com/authgear/authgear-server/pkg/auth/handler/webapp/viewmodels"
 	"github.com/authgear/authgear-server/pkg/lib/config"
 	"github.com/authgear/authgear-server/pkg/lib/oauth"
+	oauthhandler "github.com/authgear/authgear-server/pkg/lib/oauth/handler"
 	"github.com/authgear/authgear-server/pkg/lib/oauth/protocol"
 	"github.com/authgear/authgear-server/pkg/lib/oauthclient"
 	"github.com/authgear/authgear-server/pkg/lib/session"
@@ -63,7 +64,7 @@ type TesterAuthTokensIssuer interface {
 		ctx context.Context,
 		client *config.OAuthClientConfig,
 		r protocol.TokenRequest,
-	) (protocol.TokenResponse, error)
+	) (*oauthhandler.HandleResult, error)
 	IssueAppSessionToken(ctx context.Context, refreshToken string) (string, *oauth.AppSessionToken, error)
 }
 
@@ -194,7 +195,7 @@ func (h *TesterHandler) doCodeExchange(ctx context.Context, code string, stateb6
 	tokenRequest["code_verifier"] = []string{testerToken.PKCEVerifier.CodeVerifier}
 	tokenRequest["redirect_uri"] = []string{h.TesterEndpointsProvider.TesterURL().String()}
 
-	tokenResp, err := h.TesterTokenIssuer.IssueTokensForAuthorizationCode(
+	handleResult, err := h.TesterTokenIssuer.IssueTokensForAuthorizationCode(
 		ctx,
 		client,
 		tokenRequest,
@@ -204,7 +205,7 @@ func (h *TesterHandler) doCodeExchange(ctx context.Context, code string, stateb6
 		return err
 	}
 
-	refreshToken, ok := tokenResp["refresh_token"].(string)
+	refreshToken, ok := handleResult.Response["refresh_token"].(string)
 	if !ok {
 		return fmt.Errorf("tester: refresh_token is not string")
 	}

--- a/pkg/lib/deps/deps_common.go
+++ b/pkg/lib/deps/deps_common.go
@@ -459,6 +459,7 @@ var CommonDependencySet = wire.NewSet(
 		wire.Bind(new(oauthhandler.AppSessionTokenService), new(*oauth.AppSessionTokenService)),
 		wire.Bind(new(sessionlisting.OfflineGrantService), new(*oauth.OfflineGrantService)),
 		wire.Bind(new(handler.TokenHandlerOfflineGrantService), new(*oauth.OfflineGrantService)),
+		wire.Bind(new(handler.TokenHandlerAccessTokenEncoding), new(*oauth.AccessTokenEncoding)),
 		wire.Bind(new(oauth.ResolverOfflineGrantService), new(*oauth.OfflineGrantService)),
 		wire.Value(oauthhandler.TokenGenerator(oauth.GenerateToken)),
 		wire.Bind(new(oauthhandler.AuthorizationService), new(*oauth.AuthorizationService)),

--- a/pkg/lib/deps/deps_common.go
+++ b/pkg/lib/deps/deps_common.go
@@ -477,6 +477,7 @@ var CommonDependencySet = wire.NewSet(
 
 		oauthhandler.DependencySet,
 		wire.Bind(new(oauthhandler.AuthorizationHandlerPreAuthenticatedURLTokenService), new(*oauthhandler.PreAuthenticatedURLTokenServiceImpl)),
+		wire.Bind(new(oauthhandler.AnonymousUserHandlerTokenService), new(*oauthhandler.TokenService)),
 
 		oidc.DependencySet,
 		wire.Bind(new(oauthhandler.UIInfoResolver), new(*oidc.UIInfoResolver)),

--- a/pkg/lib/deps/deps_common.go
+++ b/pkg/lib/deps/deps_common.go
@@ -462,6 +462,7 @@ var CommonDependencySet = wire.NewSet(
 		wire.Bind(new(oauth.ResolverOfflineGrantService), new(*oauth.OfflineGrantService)),
 		wire.Value(oauthhandler.TokenGenerator(oauth.GenerateToken)),
 		wire.Bind(new(oauthhandler.AuthorizationService), new(*oauth.AuthorizationService)),
+		wire.Bind(new(oauthhandler.AuthorizationHandlerAccessTokenEncoding), new(*oauth.AccessTokenEncoding)),
 		wire.Bind(new(interaction.OfflineGrantStore), new(*oauthredis.Store)),
 		wire.Bind(new(workflow.OfflineGrantStore), new(*oauthredis.Store)),
 		wire.Bind(new(authenticationflow.OfflineGrantStore), new(*oauthredis.Store)),
@@ -474,6 +475,7 @@ var CommonDependencySet = wire.NewSet(
 		wire.Bind(new(handler.TokenServiceAccessGrantService), new(*oauth.AccessGrantService)),
 
 		oauthhandler.DependencySet,
+		wire.Bind(new(oauthhandler.AuthorizationHandlerPreAuthenticatedURLTokenService), new(*oauthhandler.PreAuthenticatedURLTokenServiceImpl)),
 
 		oidc.DependencySet,
 		wire.Bind(new(oauthhandler.UIInfoResolver), new(*oidc.UIInfoResolver)),

--- a/pkg/lib/deps/deps_common.go
+++ b/pkg/lib/deps/deps_common.go
@@ -479,7 +479,7 @@ var CommonDependencySet = wire.NewSet(
 		wire.Bind(new(oauthhandler.UIInfoResolver), new(*oidc.UIInfoResolver)),
 		wire.Bind(new(authenticationflow.IDTokenService), new(*oidc.IDTokenIssuer)),
 		wire.Bind(new(oauthhandler.IDTokenIssuer), new(*oidc.IDTokenIssuer)),
-		wire.Bind(new(oauthhandler.AccessTokenIssuer), new(*oauth.AccessTokenEncoding)),
+		wire.Bind(new(oauthhandler.TokenServiceAccessTokenIssuer), new(*oauth.AccessTokenEncoding)),
 		wire.Bind(new(oauth.IDTokenIssuer), new(*oidc.IDTokenIssuer)),
 		wire.Bind(new(oauthhandler.UIURLBuilder), new(*oidc.UIURLBuilder)),
 		wire.Bind(new(saml.SAMLUserInfoProvider), new(*oidc.IDTokenIssuer)),

--- a/pkg/lib/oauth/grant_access_service.go
+++ b/pkg/lib/oauth/grant_access_service.go
@@ -34,7 +34,7 @@ type IssueAccessGrantResult struct {
 func (s *AccessGrantService) IssueAccessGrant(
 	ctx context.Context,
 	options IssueAccessGrantOptions,
-) (*IssueAccessGrantResult, error) {
+) (PrepareUserAccessTokenResult, error) {
 	token := GenerateToken()
 	now := s.Clock.NowUTC()
 
@@ -55,7 +55,7 @@ func (s *AccessGrantService) IssueAccessGrant(
 	}
 
 	clientLike := ClientClientLike(options.ClientConfig, options.Scopes)
-	at, err := s.AccessTokenIssuer.EncodeUserAccessToken(ctx, EncodeUserAccessTokenOptions{
+	preparation, err := s.AccessTokenIssuer.PrepareUserAccessToken(ctx, EncodeUserAccessTokenOptions{
 		OriginalToken:      token,
 		ClientConfig:       options.ClientConfig,
 		ClientLike:         clientLike,
@@ -66,11 +66,5 @@ func (s *AccessGrantService) IssueAccessGrant(
 		return nil, err
 	}
 
-	result := &IssueAccessGrantResult{
-		Token:     at,
-		TokenType: "Bearer",
-		ExpiresIn: int(options.ClientConfig.AccessTokenLifetime),
-	}
-
-	return result, nil
+	return preparation, nil
 }

--- a/pkg/lib/oauth/grant_access_service.go
+++ b/pkg/lib/oauth/grant_access_service.go
@@ -17,7 +17,7 @@ type AccessGrantService struct {
 	Clock             clock.Clock
 }
 
-type IssueAccessGrantOptions struct {
+type PrepareUserAccessGrantOptions struct {
 	ClientConfig            *config.OAuthClientConfig
 	Scopes                  []string
 	AuthorizationID         string
@@ -40,9 +40,9 @@ func (r *IssueAccessGrantResult) WriteTo(resp protocol.TokenResponse) {
 	}
 }
 
-func (s *AccessGrantService) IssueAccessGrant(
+func (s *AccessGrantService) PrepareUserAccessGrant(
 	ctx context.Context,
-	options IssueAccessGrantOptions,
+	options PrepareUserAccessGrantOptions,
 ) (PrepareUserAccessTokenResult, error) {
 	token := GenerateToken()
 	now := s.Clock.NowUTC()

--- a/pkg/lib/oauth/grant_access_service.go
+++ b/pkg/lib/oauth/grant_access_service.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/authgear/authgear-server/pkg/lib/authn/authenticationinfo"
 	"github.com/authgear/authgear-server/pkg/lib/config"
+	"github.com/authgear/authgear-server/pkg/lib/oauth/protocol"
 	"github.com/authgear/authgear-server/pkg/util/clock"
 )
 
@@ -29,6 +30,14 @@ type IssueAccessGrantResult struct {
 	Token     string
 	TokenType string
 	ExpiresIn int
+}
+
+func (r *IssueAccessGrantResult) WriteTo(resp protocol.TokenResponse) {
+	if r != nil && resp != nil {
+		resp.TokenType(r.TokenType)
+		resp.AccessToken(r.Token)
+		resp.ExpiresIn(r.ExpiresIn)
+	}
 }
 
 func (s *AccessGrantService) IssueAccessGrant(

--- a/pkg/lib/oauth/grant_offline_service.go
+++ b/pkg/lib/oauth/grant_offline_service.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/authgear/authgear-server/pkg/lib/config"
+	"github.com/authgear/authgear-server/pkg/lib/oauth/protocol"
 	"github.com/authgear/authgear-server/pkg/lib/session/access"
 	"github.com/authgear/authgear-server/pkg/lib/session/idpsession"
 	"github.com/authgear/authgear-server/pkg/util/clock"
@@ -181,8 +182,15 @@ type RotateRefreshTokenOptions struct {
 }
 
 type RotateRefreshTokenResult struct {
+	GrantID   string
 	Token     string
 	TokenHash string
+}
+
+func (r *RotateRefreshTokenResult) WriteTo(resp protocol.TokenResponse) {
+	if r != nil && resp != nil {
+		resp.RefreshToken(EncodeRefreshToken(r.Token, r.GrantID))
+	}
 }
 
 func (s *OfflineGrantService) CreateNewRefreshToken(
@@ -267,6 +275,7 @@ func (s *OfflineGrantService) RotateRefreshToken(
 	}
 
 	result := &RotateRefreshTokenResult{
+		GrantID:   options.OfflineGrant.ID,
 		Token:     newToken,
 		TokenHash: newTokenHash,
 	}

--- a/pkg/lib/oauth/handler/handler_anonymous_user.go
+++ b/pkg/lib/oauth/handler/handler_anonymous_user.go
@@ -59,7 +59,6 @@ type CookiesGetter interface {
 }
 
 type SignupAnonymousUserResult struct {
-	Client                                     *config.OAuthClientConfig
 	PrepareUserAccessGrantByRefreshTokenResult *PrepareUserAccessGrantByRefreshTokenResult
 	Response                                   protocol.TokenResponse
 
@@ -204,7 +203,6 @@ func (h *AnonymousUserHandler) signupAnonymousUserWithRefreshTokenSessionType(
 		}
 
 		return &SignupAnonymousUserResult{
-			Client: client,
 			PrepareUserAccessGrantByRefreshTokenResult: result1,
 			Response: protocol.TokenResponse{},
 		}, nil
@@ -264,7 +262,6 @@ func (h *AnonymousUserHandler) signupAnonymousUserWithRefreshTokenSessionType(
 	}
 
 	return &SignupAnonymousUserResult{
-		Client: client,
 		PrepareUserAccessGrantByRefreshTokenResult: result1,
 		Response: resp,
 	}, nil

--- a/pkg/lib/oauth/handler/handler_anonymous_user.go
+++ b/pkg/lib/oauth/handler/handler_anonymous_user.go
@@ -187,7 +187,7 @@ func (h *AnonymousUserHandler) signupAnonymousUserWithRefreshTokenSessionType(
 			panic(fmt.Errorf("unexpected: failed to resolve offline grant session"))
 		}
 
-		issueAccessGrantOptions := oauth.IssueAccessGrantOptions{
+		prepareUserAccessGrantOptions := oauth.PrepareUserAccessGrantOptions{
 			ClientConfig:            client,
 			Scopes:                  scopes,
 			AuthorizationID:         authz.ID,
@@ -196,8 +196,8 @@ func (h *AnonymousUserHandler) signupAnonymousUserWithRefreshTokenSessionType(
 			InitialRefreshTokenHash: session.InitialTokenHash,
 		}
 		result1, err := h.TokenService.IssueAccessGrantByRefreshToken(ctx, IssueAccessGrantByRefreshTokenOptions{
-			IssueAccessGrantOptions:  issueAccessGrantOptions,
-			ShouldRotateRefreshToken: false, // We do not rotate refresh tokens in anonymous user.
+			PrepareUserAccessGrantOptions: prepareUserAccessGrantOptions,
+			ShouldRotateRefreshToken:      false, // We do not rotate refresh tokens in anonymous user.
 		})
 		if err != nil {
 			return nil, err
@@ -247,7 +247,7 @@ func (h *AnonymousUserHandler) signupAnonymousUserWithRefreshTokenSessionType(
 		return nil, err
 	}
 
-	issueAccessGrantOptions := oauth.IssueAccessGrantOptions{
+	prepareUserAccessGrantOptions := oauth.PrepareUserAccessGrantOptions{
 		ClientConfig:            client,
 		Scopes:                  scopes,
 		AuthorizationID:         authz.ID,
@@ -256,8 +256,8 @@ func (h *AnonymousUserHandler) signupAnonymousUserWithRefreshTokenSessionType(
 		InitialRefreshTokenHash: newTokenHash,
 	}
 	result1, err := h.TokenService.IssueAccessGrantByRefreshToken(ctx, IssueAccessGrantByRefreshTokenOptions{
-		IssueAccessGrantOptions:  issueAccessGrantOptions,
-		ShouldRotateRefreshToken: false, // We do not rotate refresh tokens in anonymous user.
+		PrepareUserAccessGrantOptions: prepareUserAccessGrantOptions,
+		ShouldRotateRefreshToken:      false, // We do not rotate refresh tokens in anonymous user.
 	})
 	if err != nil {
 		return nil, err

--- a/pkg/lib/oauth/handler/handler_anonymous_user.go
+++ b/pkg/lib/oauth/handler/handler_anonymous_user.go
@@ -59,9 +59,9 @@ type CookiesGetter interface {
 }
 
 type SignupAnonymousUserResult struct {
-	Client                               *config.OAuthClientConfig
-	IssueAccessGrantByRefreshTokenResult *IssueAccessGrantByRefreshTokenResult
-	Response                             protocol.TokenResponse
+	Client                                     *config.OAuthClientConfig
+	PrepareUserAccessGrantByRefreshTokenResult *PrepareUserAccessGrantByRefreshTokenResult
+	Response                                   protocol.TokenResponse
 
 	Cookies []*http.Cookie
 }
@@ -74,10 +74,10 @@ type AnonymousUserHandlerTokenService interface {
 		opts IssueOfflineGrantOptions,
 		resp protocol.TokenResponse,
 	) (offlineGrant *oauth.OfflineGrant, tokenHash string, err error)
-	IssueAccessGrantByRefreshToken(
+	PrepareUserAccessGrantByRefreshToken(
 		ctx context.Context,
-		options IssueAccessGrantByRefreshTokenOptions,
-	) (*IssueAccessGrantByRefreshTokenResult, error)
+		options PrepareUserAccessGrantByRefreshTokenOptions,
+	) (*PrepareUserAccessGrantByRefreshTokenResult, error)
 }
 
 type AnonymousUserHandler struct {
@@ -195,7 +195,7 @@ func (h *AnonymousUserHandler) signupAnonymousUserWithRefreshTokenSessionType(
 			SessionLike:             grant,
 			InitialRefreshTokenHash: session.InitialTokenHash,
 		}
-		result1, err := h.TokenService.IssueAccessGrantByRefreshToken(ctx, IssueAccessGrantByRefreshTokenOptions{
+		result1, err := h.TokenService.PrepareUserAccessGrantByRefreshToken(ctx, PrepareUserAccessGrantByRefreshTokenOptions{
 			PrepareUserAccessGrantOptions: prepareUserAccessGrantOptions,
 			ShouldRotateRefreshToken:      false, // We do not rotate refresh tokens in anonymous user.
 		})
@@ -204,9 +204,9 @@ func (h *AnonymousUserHandler) signupAnonymousUserWithRefreshTokenSessionType(
 		}
 
 		return &SignupAnonymousUserResult{
-			Client:                               client,
-			IssueAccessGrantByRefreshTokenResult: result1,
-			Response:                             protocol.TokenResponse{},
+			Client: client,
+			PrepareUserAccessGrantByRefreshTokenResult: result1,
+			Response: protocol.TokenResponse{},
 		}, nil
 	}
 
@@ -255,7 +255,7 @@ func (h *AnonymousUserHandler) signupAnonymousUserWithRefreshTokenSessionType(
 		SessionLike:             offlineGrant,
 		InitialRefreshTokenHash: newTokenHash,
 	}
-	result1, err := h.TokenService.IssueAccessGrantByRefreshToken(ctx, IssueAccessGrantByRefreshTokenOptions{
+	result1, err := h.TokenService.PrepareUserAccessGrantByRefreshToken(ctx, PrepareUserAccessGrantByRefreshTokenOptions{
 		PrepareUserAccessGrantOptions: prepareUserAccessGrantOptions,
 		ShouldRotateRefreshToken:      false, // We do not rotate refresh tokens in anonymous user.
 	})
@@ -264,9 +264,9 @@ func (h *AnonymousUserHandler) signupAnonymousUserWithRefreshTokenSessionType(
 	}
 
 	return &SignupAnonymousUserResult{
-		Client:                               client,
-		IssueAccessGrantByRefreshTokenResult: result1,
-		Response:                             resp,
+		Client: client,
+		PrepareUserAccessGrantByRefreshTokenResult: result1,
+		Response: resp,
 	}, nil
 }
 

--- a/pkg/lib/oauth/handler/handler_authz.go
+++ b/pkg/lib/oauth/handler/handler_authz.go
@@ -615,7 +615,6 @@ func (h *AuthorizationHandler) doHandlePreAuthenticatedURLAfterTx(
 	preparationResult oauth.PrepareUserAccessTokenResult,
 ) (httputil.Result, error) {
 	accessTokenResult, err := h.AuthorizationHandlerAccessTokenEncoding.MakeUserAccessTokenFromPreparationResult(ctx, oauth.MakeUserAccessTokenFromPreparationOptions{
-		ClientConfig:      client,
 		PreparationResult: preparationResult,
 	})
 	if err != nil {

--- a/pkg/lib/oauth/handler/handler_authz.go
+++ b/pkg/lib/oauth/handler/handler_authz.go
@@ -368,7 +368,7 @@ func (h *AuthorizationHandler) prepareConsentRequest(ctx context.Context, req *h
 	}, nil
 }
 
-func (h *AuthorizationHandler) HandleRequestWithTx(
+func (h *AuthorizationHandler) HandleRequest(
 	ctx context.Context,
 	r protocol.AuthorizationRequest,
 	params *AuthorizationParams,

--- a/pkg/lib/oauth/handler/handler_authz.go
+++ b/pkg/lib/oauth/handler/handler_authz.go
@@ -110,6 +110,26 @@ type AuthorizationService interface {
 	) (*oauth.Authorization, error)
 }
 
+type AuthorizationHandlerAccessTokenEncoding interface {
+	MakeUserAccessTokenFromPreparationResult(
+		ctx context.Context,
+		options oauth.MakeUserAccessTokenFromPreparationOptions,
+	) (*oauth.IssueAccessGrantResult, error)
+}
+
+type AuthorizationHandlerPreAuthenticatedURLTokenService interface {
+	ExchangeForAccessToken(
+		ctx context.Context,
+		client *config.OAuthClientConfig,
+		sessionID string,
+		token string,
+	) (oauth.PrepareUserAccessTokenResult, error)
+}
+
+type AuthorizationHandlerDatabase interface {
+	WithTx(ctx context.Context, do func(ctx context.Context) error) (err error)
+}
+
 var AuthorizationHandlerLogger = slogutil.NewLogger("oauth-authz")
 
 type AuthorizationHandler struct {
@@ -121,20 +141,23 @@ type AuthorizationHandler struct {
 	HTTPOrigin            httputil.HTTPOrigin
 	AppDomains            config.AppDomains
 
-	UIURLBuilder                    UIURLBuilder
-	UIInfoResolver                  UIInfoResolver
-	AuthenticationInfoResolver      AuthenticationInfoResolver
-	Authorizations                  AuthorizationService
-	AppSessionTokenService          AppSessionTokenService
-	AuthenticationInfoService       AuthenticationInfoService
-	Clock                           clock.Clock
-	Cookies                         CookieManager
-	OAuthSessionService             OAuthSessionService
-	CodeGrantService                CodeGrantService
-	SettingsActionGrantService      SettingsActionGrantService
-	ClientResolver                  OAuthClientResolver
-	PreAuthenticatedURLTokenService PreAuthenticatedURLTokenService
-	IDTokenIssuer                   IDTokenIssuer
+	Database AuthorizationHandlerDatabase
+
+	UIURLBuilder                            UIURLBuilder
+	UIInfoResolver                          UIInfoResolver
+	AuthenticationInfoResolver              AuthenticationInfoResolver
+	Authorizations                          AuthorizationService
+	AppSessionTokenService                  AppSessionTokenService
+	AuthenticationInfoService               AuthenticationInfoService
+	Clock                                   clock.Clock
+	Cookies                                 CookieManager
+	OAuthSessionService                     OAuthSessionService
+	CodeGrantService                        CodeGrantService
+	SettingsActionGrantService              SettingsActionGrantService
+	ClientResolver                          OAuthClientResolver
+	PreAuthenticatedURLTokenService         AuthorizationHandlerPreAuthenticatedURLTokenService
+	IDTokenIssuer                           IDTokenIssuer
+	AuthorizationHandlerAccessTokenEncoding AuthorizationHandlerAccessTokenEncoding
 }
 
 func (h *AuthorizationHandler) HandleConsentWithoutUserConsent(ctx context.Context, req *http.Request) (httputil.Result, *ConsentRequired) {
@@ -349,30 +372,56 @@ func (h *AuthorizationHandler) HandleRequestWithTx(
 	ctx context.Context,
 	r protocol.AuthorizationRequest,
 	params *AuthorizationParams,
-) httputil.Result {
+) (result httputil.Result) {
 	logger := AuthorizationHandlerLogger.GetLogger(ctx)
-	result, err := h.doHandleRequestWithTx(ctx, params.RedirectURI, params.Client, r)
-	if err != nil {
-		var oauthError *protocol.OAuthProtocolError
-		resultErr := AuthorizationResultError{
-			RedirectURI:  params.RedirectURI,
-			ResponseMode: r.ResponseMode(),
+	var err error
+
+	defer func() {
+		if err != nil {
+			var oauthError *protocol.OAuthProtocolError
+			resultErr := AuthorizationResultError{
+				RedirectURI:  params.RedirectURI,
+				ResponseMode: r.ResponseMode(),
+			}
+			if errors.As(err, &oauthError) {
+				resultErr.Response = oauthError.Response
+			} else {
+				logger.WithError(err).Error(ctx, "authz handler failed")
+				resultErr.Response = protocol.NewErrorResponse("server_error", "internal server error")
+				resultErr.InternalError = true
+			}
+			state := r.State()
+			if state != "" {
+				resultErr.Response.State(r.State())
+			}
+			result = resultErr
 		}
-		if errors.As(err, &oauthError) {
-			resultErr.Response = oauthError.Response
-		} else {
-			logger.WithError(err).Error(ctx, "authz handler failed")
-			resultErr.Response = protocol.NewErrorResponse("server_error", "internal server error")
-			resultErr.InternalError = true
+	}()
+
+	if r.ResponseType().Equal(PreAuthenticatedURLTokenResponseType) {
+		var preparationResult oauth.PrepareUserAccessTokenResult
+		err = h.Database.WithTx(ctx, func(ctx context.Context) error {
+			preparationResult, err = h.doHandlePreAuthenticatedURLWithTx(ctx, params.RedirectURI, params.Client, r)
+			return err
+		})
+		if err != nil {
+			return
 		}
-		state := r.State()
-		if state != "" {
-			resultErr.Response.State(r.State())
+		result, err = h.doHandlePreAuthenticatedURLAfterTx(ctx, params.RedirectURI, params.Client, r, preparationResult)
+		if err != nil {
+			return
 		}
-		result = resultErr
+	} else {
+		err = h.Database.WithTx(ctx, func(ctx context.Context) error {
+			result, err = h.doHandleRequestWithTx(ctx, params.RedirectURI, params.Client, r)
+			return err
+		})
+		if err != nil {
+			return
+		}
 	}
 
-	return result
+	return
 }
 
 // nolint: gocognit
@@ -382,10 +431,6 @@ func (h *AuthorizationHandler) doHandleRequestWithTx(
 	client *config.OAuthClientConfig,
 	r protocol.AuthorizationRequest,
 ) (httputil.Result, error) {
-	if r.ResponseType().Equal(PreAuthenticatedURLTokenResponseType) {
-		return h.doHandlePreAuthenticatedURL(ctx, redirectURI, client, r)
-	}
-
 	err := oauth.ValidateScopesByClientConfig(client, r.Scope())
 	if err != nil {
 		return nil, err
@@ -513,12 +558,12 @@ func (h *AuthorizationHandler) doHandleRequestWithTx(
 	return result, nil
 }
 
-func (h *AuthorizationHandler) doHandlePreAuthenticatedURL(
+func (h *AuthorizationHandler) doHandlePreAuthenticatedURLWithTx(
 	ctx context.Context,
 	redirectURI *url.URL,
 	client *config.OAuthClientConfig,
 	r protocol.AuthorizationRequest,
-) (httputil.Result, error) {
+) (oauth.PrepareUserAccessTokenResult, error) {
 	idTokenHint, ok := r.IDTokenHint()
 	if !ok {
 		panic("cannot get id_token_hint, the request should be validated")
@@ -540,7 +585,7 @@ func (h *AuthorizationHandler) doHandlePreAuthenticatedURL(
 		return nil, protocol.NewError("invalid_request", "invalid sid format id_token_hint")
 	}
 
-	accessToken, err := h.PreAuthenticatedURLTokenService.ExchangeForAccessToken(
+	preparationResult, err := h.PreAuthenticatedURLTokenService.ExchangeForAccessToken(
 		ctx,
 		client,
 		sessionID,
@@ -558,7 +603,26 @@ func (h *AuthorizationHandler) doHandlePreAuthenticatedURL(
 		}
 		return nil, err
 	}
-	cookie := h.Cookies.ValueCookie(session.AppAccessTokenCookieDef, accessToken)
+
+	return preparationResult, nil
+}
+
+func (h *AuthorizationHandler) doHandlePreAuthenticatedURLAfterTx(
+	ctx context.Context,
+	redirectURI *url.URL,
+	client *config.OAuthClientConfig,
+	r protocol.AuthorizationRequest,
+	preparationResult oauth.PrepareUserAccessTokenResult,
+) (httputil.Result, error) {
+	accessTokenResult, err := h.AuthorizationHandlerAccessTokenEncoding.MakeUserAccessTokenFromPreparationResult(ctx, oauth.MakeUserAccessTokenFromPreparationOptions{
+		ClientConfig:      client,
+		PreparationResult: preparationResult,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	cookie := h.Cookies.ValueCookie(session.AppAccessTokenCookieDef, accessTokenResult.Token)
 
 	resp := protocol.AuthorizationResponse{}
 	state := r.State()
@@ -572,7 +636,6 @@ func (h *AuthorizationHandler) doHandlePreAuthenticatedURL(
 		Response:     resp,
 		Cookies:      []*http.Cookie{cookie},
 	}, nil
-
 }
 
 func (h *AuthorizationHandler) handleSettingsAction(

--- a/pkg/lib/oauth/handler/handler_authz_mock_test.go
+++ b/pkg/lib/oauth/handler/handler_authz_mock_test.go
@@ -515,3 +515,40 @@ func (mr *MockAuthorizationHandlerPreAuthenticatedURLTokenServiceMockRecorder) E
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ExchangeForAccessToken", reflect.TypeOf((*MockAuthorizationHandlerPreAuthenticatedURLTokenService)(nil).ExchangeForAccessToken), ctx, client, sessionID, token)
 }
+
+// MockAuthorizationHandlerDatabase is a mock of AuthorizationHandlerDatabase interface.
+type MockAuthorizationHandlerDatabase struct {
+	ctrl     *gomock.Controller
+	recorder *MockAuthorizationHandlerDatabaseMockRecorder
+}
+
+// MockAuthorizationHandlerDatabaseMockRecorder is the mock recorder for MockAuthorizationHandlerDatabase.
+type MockAuthorizationHandlerDatabaseMockRecorder struct {
+	mock *MockAuthorizationHandlerDatabase
+}
+
+// NewMockAuthorizationHandlerDatabase creates a new mock instance.
+func NewMockAuthorizationHandlerDatabase(ctrl *gomock.Controller) *MockAuthorizationHandlerDatabase {
+	mock := &MockAuthorizationHandlerDatabase{ctrl: ctrl}
+	mock.recorder = &MockAuthorizationHandlerDatabaseMockRecorder{mock}
+	return mock
+}
+
+// EXPECT returns an object that allows the caller to indicate expected use.
+func (m *MockAuthorizationHandlerDatabase) EXPECT() *MockAuthorizationHandlerDatabaseMockRecorder {
+	return m.recorder
+}
+
+// WithTx mocks base method.
+func (m *MockAuthorizationHandlerDatabase) WithTx(ctx context.Context, do func(context.Context) error) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "WithTx", ctx, do)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// WithTx indicates an expected call of WithTx.
+func (mr *MockAuthorizationHandlerDatabaseMockRecorder) WithTx(ctx, do interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WithTx", reflect.TypeOf((*MockAuthorizationHandlerDatabase)(nil).WithTx), ctx, do)
+}

--- a/pkg/lib/oauth/handler/handler_authz_mock_test.go
+++ b/pkg/lib/oauth/handler/handler_authz_mock_test.go
@@ -439,3 +439,79 @@ func (mr *MockAuthorizationServiceMockRecorder) GetByID(ctx, id interface{}) *go
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetByID", reflect.TypeOf((*MockAuthorizationService)(nil).GetByID), ctx, id)
 }
+
+// MockAuthorizationHandlerAccessTokenEncoding is a mock of AuthorizationHandlerAccessTokenEncoding interface.
+type MockAuthorizationHandlerAccessTokenEncoding struct {
+	ctrl     *gomock.Controller
+	recorder *MockAuthorizationHandlerAccessTokenEncodingMockRecorder
+}
+
+// MockAuthorizationHandlerAccessTokenEncodingMockRecorder is the mock recorder for MockAuthorizationHandlerAccessTokenEncoding.
+type MockAuthorizationHandlerAccessTokenEncodingMockRecorder struct {
+	mock *MockAuthorizationHandlerAccessTokenEncoding
+}
+
+// NewMockAuthorizationHandlerAccessTokenEncoding creates a new mock instance.
+func NewMockAuthorizationHandlerAccessTokenEncoding(ctrl *gomock.Controller) *MockAuthorizationHandlerAccessTokenEncoding {
+	mock := &MockAuthorizationHandlerAccessTokenEncoding{ctrl: ctrl}
+	mock.recorder = &MockAuthorizationHandlerAccessTokenEncodingMockRecorder{mock}
+	return mock
+}
+
+// EXPECT returns an object that allows the caller to indicate expected use.
+func (m *MockAuthorizationHandlerAccessTokenEncoding) EXPECT() *MockAuthorizationHandlerAccessTokenEncodingMockRecorder {
+	return m.recorder
+}
+
+// MakeUserAccessTokenFromPreparationResult mocks base method.
+func (m *MockAuthorizationHandlerAccessTokenEncoding) MakeUserAccessTokenFromPreparationResult(ctx context.Context, options oauth.MakeUserAccessTokenFromPreparationOptions) (*oauth.IssueAccessGrantResult, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "MakeUserAccessTokenFromPreparationResult", ctx, options)
+	ret0, _ := ret[0].(*oauth.IssueAccessGrantResult)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// MakeUserAccessTokenFromPreparationResult indicates an expected call of MakeUserAccessTokenFromPreparationResult.
+func (mr *MockAuthorizationHandlerAccessTokenEncodingMockRecorder) MakeUserAccessTokenFromPreparationResult(ctx, options interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MakeUserAccessTokenFromPreparationResult", reflect.TypeOf((*MockAuthorizationHandlerAccessTokenEncoding)(nil).MakeUserAccessTokenFromPreparationResult), ctx, options)
+}
+
+// MockAuthorizationHandlerPreAuthenticatedURLTokenService is a mock of AuthorizationHandlerPreAuthenticatedURLTokenService interface.
+type MockAuthorizationHandlerPreAuthenticatedURLTokenService struct {
+	ctrl     *gomock.Controller
+	recorder *MockAuthorizationHandlerPreAuthenticatedURLTokenServiceMockRecorder
+}
+
+// MockAuthorizationHandlerPreAuthenticatedURLTokenServiceMockRecorder is the mock recorder for MockAuthorizationHandlerPreAuthenticatedURLTokenService.
+type MockAuthorizationHandlerPreAuthenticatedURLTokenServiceMockRecorder struct {
+	mock *MockAuthorizationHandlerPreAuthenticatedURLTokenService
+}
+
+// NewMockAuthorizationHandlerPreAuthenticatedURLTokenService creates a new mock instance.
+func NewMockAuthorizationHandlerPreAuthenticatedURLTokenService(ctrl *gomock.Controller) *MockAuthorizationHandlerPreAuthenticatedURLTokenService {
+	mock := &MockAuthorizationHandlerPreAuthenticatedURLTokenService{ctrl: ctrl}
+	mock.recorder = &MockAuthorizationHandlerPreAuthenticatedURLTokenServiceMockRecorder{mock}
+	return mock
+}
+
+// EXPECT returns an object that allows the caller to indicate expected use.
+func (m *MockAuthorizationHandlerPreAuthenticatedURLTokenService) EXPECT() *MockAuthorizationHandlerPreAuthenticatedURLTokenServiceMockRecorder {
+	return m.recorder
+}
+
+// ExchangeForAccessToken mocks base method.
+func (m *MockAuthorizationHandlerPreAuthenticatedURLTokenService) ExchangeForAccessToken(ctx context.Context, client *config.OAuthClientConfig, sessionID, token string) (oauth.PrepareUserAccessTokenResult, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ExchangeForAccessToken", ctx, client, sessionID, token)
+	ret0, _ := ret[0].(oauth.PrepareUserAccessTokenResult)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ExchangeForAccessToken indicates an expected call of ExchangeForAccessToken.
+func (mr *MockAuthorizationHandlerPreAuthenticatedURLTokenServiceMockRecorder) ExchangeForAccessToken(ctx, client, sessionID, token interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ExchangeForAccessToken", reflect.TypeOf((*MockAuthorizationHandlerPreAuthenticatedURLTokenService)(nil).ExchangeForAccessToken), ctx, client, sessionID, token)
+}

--- a/pkg/lib/oauth/handler/handler_authz_test.go
+++ b/pkg/lib/oauth/handler/handler_authz_test.go
@@ -106,7 +106,7 @@ func TestAuthorizationHandler(t *testing.T) {
 			if errResult != nil {
 				result = errResult
 			} else {
-				result = h.HandleRequestWithTx(ctx, r, params)
+				result = h.HandleRequest(ctx, r, params)
 			}
 
 			req, _ := http.NewRequest("GET", "/authorize", nil)

--- a/pkg/lib/oauth/handler/handler_authz_test.go
+++ b/pkg/lib/oauth/handler/handler_authz_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/authgear/authgear-server/pkg/api/model"
 	"github.com/authgear/authgear-server/pkg/lib/authn/authenticationinfo"
 	"github.com/authgear/authgear-server/pkg/lib/config"
+	"github.com/authgear/authgear-server/pkg/lib/infra/db"
 	"github.com/authgear/authgear-server/pkg/lib/oauth"
 	"github.com/authgear/authgear-server/pkg/lib/oauth/handler"
 	"github.com/authgear/authgear-server/pkg/lib/oauth/oidc"
@@ -69,14 +70,17 @@ func TestAuthorizationHandler(t *testing.T) {
 		clientResolver := &multiClientResolver{
 			ClientConfigs: make(map[string]*config.OAuthClientConfig),
 		}
-		preAuthenticatedURLTokenService := NewMockPreAuthenticatedURLTokenService(ctrl)
+		preAuthenticatedURLTokenService := NewMockAuthorizationHandlerPreAuthenticatedURLTokenService(ctrl)
 		idTokenIssuer := NewMockIDTokenIssuer(ctrl)
+		accessTokenEncoding := NewMockAuthorizationHandlerAccessTokenEncoding(ctrl)
 
 		appID := config.AppID("app-id")
 		h := &handler.AuthorizationHandler{
 			AppID:      appID,
 			Config:     &config.OAuthConfig{},
 			HTTPOrigin: "http://accounts.example.com",
+
+			Database: &db.MockHandle{},
 
 			UIURLBuilder:              uiURLBuilder,
 			UIInfoResolver:            uiInfoResolver,
@@ -91,9 +95,10 @@ func TestAuthorizationHandler(t *testing.T) {
 				CodeGenerator: func() string { return "authz-code" },
 				CodeGrants:    codeGrantStore,
 			},
-			ClientResolver:                  clientResolver,
-			PreAuthenticatedURLTokenService: preAuthenticatedURLTokenService,
-			IDTokenIssuer:                   idTokenIssuer,
+			ClientResolver:                          clientResolver,
+			PreAuthenticatedURLTokenService:         preAuthenticatedURLTokenService,
+			IDTokenIssuer:                           idTokenIssuer,
+			AuthorizationHandlerAccessTokenEncoding: accessTokenEncoding,
 		}
 		handle := func(ctx context.Context, r protocol.AuthorizationRequest) *httptest.ResponseRecorder {
 			ctx, params, errResult := h.ValidateRequestWithoutTx(ctx, r)
@@ -487,7 +492,10 @@ func TestAuthorizationHandler(t *testing.T) {
 					testPreAuthenticatedURLToken,
 				).
 					Times(1).
-					Return(testAccessToken, nil)
+					Return(nil, nil)
+				accessTokenEncoding.EXPECT().MakeUserAccessTokenFromPreparationResult(gomock.Any(), gomock.Any()).Times(1).Return(&oauth.IssueAccessGrantResult{
+					Token: testAccessToken,
+				}, nil)
 
 				req := protocol.AuthorizationRequest{
 					"client_id":                     "client-id",

--- a/pkg/lib/oauth/handler/handler_token.go
+++ b/pkg/lib/oauth/handler/handler_token.go
@@ -1072,7 +1072,7 @@ func (h *TokenHandler) handleAnonymousRequest(
 		return nil, err
 	}
 
-	issueAccessGrantOptions := oauth.IssueAccessGrantOptions{
+	prepareUserAccessGrantOptions := oauth.PrepareUserAccessGrantOptions{
 		ClientConfig:            client,
 		Scopes:                  scopes,
 		AuthorizationID:         authz.ID,
@@ -1081,8 +1081,8 @@ func (h *TokenHandler) handleAnonymousRequest(
 		InitialRefreshTokenHash: newTokenHash,
 	}
 	result1, err := h.TokenService.IssueAccessGrantByRefreshToken(ctx, IssueAccessGrantByRefreshTokenOptions{
-		IssueAccessGrantOptions:  issueAccessGrantOptions,
-		ShouldRotateRefreshToken: false, // We do not rotate refresh tokens in anonymous user.
+		PrepareUserAccessGrantOptions: prepareUserAccessGrantOptions,
+		ShouldRotateRefreshToken:      false, // We do not rotate refresh tokens in anonymous user.
 	})
 	if err != nil {
 		return nil, err
@@ -1352,7 +1352,7 @@ func (h *TokenHandler) handleBiometricAuthenticate(
 		return nil, err
 	}
 
-	issueAccessGrantOptions := oauth.IssueAccessGrantOptions{
+	prepareUserAccessGrantOptions := oauth.PrepareUserAccessGrantOptions{
 		ClientConfig:            client,
 		Scopes:                  scopes,
 		AuthorizationID:         authz.ID,
@@ -1361,8 +1361,8 @@ func (h *TokenHandler) handleBiometricAuthenticate(
 		InitialRefreshTokenHash: newTokenHash,
 	}
 	result1, err := h.TokenService.IssueAccessGrantByRefreshToken(ctx, IssueAccessGrantByRefreshTokenOptions{
-		IssueAccessGrantOptions:  issueAccessGrantOptions,
-		ShouldRotateRefreshToken: false, // New refresh token, no need to rotate
+		PrepareUserAccessGrantOptions: prepareUserAccessGrantOptions,
+		ShouldRotateRefreshToken:      false, // New refresh token, no need to rotate
 	})
 	if err != nil {
 		return nil, err
@@ -1861,7 +1861,7 @@ func (h *TokenHandler) doIssueTokensForAuthorizationCode(
 		return nil, protocol.NewError("invalid_request", "cannot issue access token")
 	}
 
-	issueAccessGrantOptions := oauth.IssueAccessGrantOptions{
+	prepareUserAccessGrantOptions := oauth.PrepareUserAccessGrantOptions{
 		ClientConfig:       client,
 		Scopes:             code.AuthorizationRequest.Scope(),
 		AuthorizationID:    authz.ID,
@@ -1875,8 +1875,8 @@ func (h *TokenHandler) doIssueTokensForAuthorizationCode(
 	result1, err := h.TokenService.IssueAccessGrantByRefreshToken(
 		ctx,
 		IssueAccessGrantByRefreshTokenOptions{
-			IssueAccessGrantOptions:  issueAccessGrantOptions,
-			ShouldRotateRefreshToken: false, // New refresh token, no need to rotate
+			PrepareUserAccessGrantOptions: prepareUserAccessGrantOptions,
+			ShouldRotateRefreshToken:      false, // New refresh token, no need to rotate
 		})
 	if err != nil {
 		return nil, err
@@ -1946,7 +1946,7 @@ func (h *TokenHandler) issueTokensForRefreshToken(
 		resp.IDToken(idToken)
 	}
 
-	issueAccessGrantOptions := oauth.IssueAccessGrantOptions{
+	prepareUserAccessGrantOptions := oauth.PrepareUserAccessGrantOptions{
 		ClientConfig:            client,
 		Scopes:                  offlineGrantSession.Scopes,
 		AuthorizationID:         authz.ID,
@@ -1955,8 +1955,8 @@ func (h *TokenHandler) issueTokensForRefreshToken(
 		InitialRefreshTokenHash: offlineGrantSession.InitialTokenHash,
 	}
 	result1, err := h.TokenService.IssueAccessGrantByRefreshToken(ctx, IssueAccessGrantByRefreshTokenOptions{
-		IssueAccessGrantOptions:  issueAccessGrantOptions,
-		ShouldRotateRefreshToken: client.RefreshTokenRotationEnabled,
+		PrepareUserAccessGrantOptions: prepareUserAccessGrantOptions,
+		ShouldRotateRefreshToken:      client.RefreshTokenRotationEnabled,
 	})
 	if err != nil {
 		return nil, err

--- a/pkg/lib/oauth/handler/handler_token.go
+++ b/pkg/lib/oauth/handler/handler_token.go
@@ -169,12 +169,6 @@ type PreAuthenticatedURLTokenService interface {
 		ctx context.Context,
 		options *IssuePreAuthenticatedURLTokenOptions,
 	) (*IssuePreAuthenticatedURLTokenResult, error)
-	ExchangeForAccessToken(
-		ctx context.Context,
-		client *config.OAuthClientConfig,
-		sessionID string,
-		token string,
-	) (string, error)
 }
 
 type SimpleSessionLike struct {

--- a/pkg/lib/oauth/handler/handler_token.go
+++ b/pkg/lib/oauth/handler/handler_token.go
@@ -288,7 +288,6 @@ func (h *TokenHandler) Handle(ctx context.Context, rw http.ResponseWriter, req *
 		handleResult.PrepareUserAccessGrantByRefreshTokenResult.RotateRefreshTokenResult.WriteTo(handleResult.Response)
 
 		result2, err := h.AccessTokenEncoding.MakeUserAccessTokenFromPreparationResult(ctx, oauth.MakeUserAccessTokenFromPreparationOptions{
-			ClientConfig:      client,
 			PreparationResult: handleResult.PrepareUserAccessGrantByRefreshTokenResult.PreparationResult,
 		})
 		if err != nil {

--- a/pkg/lib/oauth/handler/handler_token.go
+++ b/pkg/lib/oauth/handler/handler_token.go
@@ -71,10 +71,6 @@ type IDTokenIssuer interface {
 	VerifyIDToken(idToken string) (token jwt.Token, err error)
 }
 
-type AccessTokenIssuer interface {
-	EncodeClientAccessToken(ctx context.Context, options oauth.EncodeClientAccessTokenOptions) (string, error)
-}
-
 type EventService interface {
 	DispatchEventOnCommit(ctx context.Context, payload event.Payload) error
 }

--- a/pkg/lib/oauth/handler/handler_token.go
+++ b/pkg/lib/oauth/handler/handler_token.go
@@ -72,7 +72,6 @@ type IDTokenIssuer interface {
 }
 
 type AccessTokenIssuer interface {
-	EncodeUserAccessToken(ctx context.Context, options oauth.EncodeUserAccessTokenOptions) (string, error)
 	EncodeClientAccessToken(ctx context.Context, options oauth.EncodeClientAccessTokenOptions) (string, error)
 }
 

--- a/pkg/lib/oauth/handler/handler_token_mock_test.go
+++ b/pkg/lib/oauth/handler/handler_token_mock_test.go
@@ -643,17 +643,18 @@ func (m *MockTokenHandlerTokenService) EXPECT() *MockTokenHandlerTokenServiceMoc
 }
 
 // IssueAccessGrantByRefreshToken mocks base method.
-func (m *MockTokenHandlerTokenService) IssueAccessGrantByRefreshToken(ctx context.Context, options handler.IssueAccessGrantByRefreshTokenOptions, resp protocol.TokenResponse) error {
+func (m *MockTokenHandlerTokenService) IssueAccessGrantByRefreshToken(ctx context.Context, options handler.IssueAccessGrantByRefreshTokenOptions) (*handler.IssueAccessGrantByRefreshTokenResult, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "IssueAccessGrantByRefreshToken", ctx, options, resp)
-	ret0, _ := ret[0].(error)
-	return ret0
+	ret := m.ctrl.Call(m, "IssueAccessGrantByRefreshToken", ctx, options)
+	ret0, _ := ret[0].(*handler.IssueAccessGrantByRefreshTokenResult)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
 }
 
 // IssueAccessGrantByRefreshToken indicates an expected call of IssueAccessGrantByRefreshToken.
-func (mr *MockTokenHandlerTokenServiceMockRecorder) IssueAccessGrantByRefreshToken(ctx, options, resp interface{}) *gomock.Call {
+func (mr *MockTokenHandlerTokenServiceMockRecorder) IssueAccessGrantByRefreshToken(ctx, options interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IssueAccessGrantByRefreshToken", reflect.TypeOf((*MockTokenHandlerTokenService)(nil).IssueAccessGrantByRefreshToken), ctx, options, resp)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IssueAccessGrantByRefreshToken", reflect.TypeOf((*MockTokenHandlerTokenService)(nil).IssueAccessGrantByRefreshToken), ctx, options)
 }
 
 // IssueClientCredentialsAccessToken mocks base method.
@@ -792,21 +793,6 @@ func NewMockPreAuthenticatedURLTokenService(ctrl *gomock.Controller) *MockPreAut
 // EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockPreAuthenticatedURLTokenService) EXPECT() *MockPreAuthenticatedURLTokenServiceMockRecorder {
 	return m.recorder
-}
-
-// ExchangeForAccessToken mocks base method.
-func (m *MockPreAuthenticatedURLTokenService) ExchangeForAccessToken(ctx context.Context, client *config.OAuthClientConfig, sessionID, token string) (string, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ExchangeForAccessToken", ctx, client, sessionID, token)
-	ret0, _ := ret[0].(string)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// ExchangeForAccessToken indicates an expected call of ExchangeForAccessToken.
-func (mr *MockPreAuthenticatedURLTokenServiceMockRecorder) ExchangeForAccessToken(ctx, client, sessionID, token interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ExchangeForAccessToken", reflect.TypeOf((*MockPreAuthenticatedURLTokenService)(nil).ExchangeForAccessToken), ctx, client, sessionID, token)
 }
 
 // IssuePreAuthenticatedURLToken mocks base method.
@@ -951,4 +937,42 @@ func (m *MockTokenHandlerCodeGrantService) CreateCodeGrant(ctx context.Context, 
 func (mr *MockTokenHandlerCodeGrantServiceMockRecorder) CreateCodeGrant(ctx, opts interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateCodeGrant", reflect.TypeOf((*MockTokenHandlerCodeGrantService)(nil).CreateCodeGrant), ctx, opts)
+}
+
+// MockTokenHandlerAccessTokenEncoding is a mock of TokenHandlerAccessTokenEncoding interface.
+type MockTokenHandlerAccessTokenEncoding struct {
+	ctrl     *gomock.Controller
+	recorder *MockTokenHandlerAccessTokenEncodingMockRecorder
+}
+
+// MockTokenHandlerAccessTokenEncodingMockRecorder is the mock recorder for MockTokenHandlerAccessTokenEncoding.
+type MockTokenHandlerAccessTokenEncodingMockRecorder struct {
+	mock *MockTokenHandlerAccessTokenEncoding
+}
+
+// NewMockTokenHandlerAccessTokenEncoding creates a new mock instance.
+func NewMockTokenHandlerAccessTokenEncoding(ctrl *gomock.Controller) *MockTokenHandlerAccessTokenEncoding {
+	mock := &MockTokenHandlerAccessTokenEncoding{ctrl: ctrl}
+	mock.recorder = &MockTokenHandlerAccessTokenEncodingMockRecorder{mock}
+	return mock
+}
+
+// EXPECT returns an object that allows the caller to indicate expected use.
+func (m *MockTokenHandlerAccessTokenEncoding) EXPECT() *MockTokenHandlerAccessTokenEncodingMockRecorder {
+	return m.recorder
+}
+
+// MakeUserAccessTokenFromPreparationResult mocks base method.
+func (m *MockTokenHandlerAccessTokenEncoding) MakeUserAccessTokenFromPreparationResult(ctx context.Context, options oauth.MakeUserAccessTokenFromPreparationOptions) (*oauth.IssueAccessGrantResult, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "MakeUserAccessTokenFromPreparationResult", ctx, options)
+	ret0, _ := ret[0].(*oauth.IssueAccessGrantResult)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// MakeUserAccessTokenFromPreparationResult indicates an expected call of MakeUserAccessTokenFromPreparationResult.
+func (mr *MockTokenHandlerAccessTokenEncodingMockRecorder) MakeUserAccessTokenFromPreparationResult(ctx, options interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MakeUserAccessTokenFromPreparationResult", reflect.TypeOf((*MockTokenHandlerAccessTokenEncoding)(nil).MakeUserAccessTokenFromPreparationResult), ctx, options)
 }

--- a/pkg/lib/oauth/handler/handler_token_mock_test.go
+++ b/pkg/lib/oauth/handler/handler_token_mock_test.go
@@ -94,44 +94,6 @@ func (mr *MockIDTokenIssuerMockRecorder) VerifyIDToken(idToken interface{}) *gom
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "VerifyIDToken", reflect.TypeOf((*MockIDTokenIssuer)(nil).VerifyIDToken), idToken)
 }
 
-// MockAccessTokenIssuer is a mock of AccessTokenIssuer interface.
-type MockAccessTokenIssuer struct {
-	ctrl     *gomock.Controller
-	recorder *MockAccessTokenIssuerMockRecorder
-}
-
-// MockAccessTokenIssuerMockRecorder is the mock recorder for MockAccessTokenIssuer.
-type MockAccessTokenIssuerMockRecorder struct {
-	mock *MockAccessTokenIssuer
-}
-
-// NewMockAccessTokenIssuer creates a new mock instance.
-func NewMockAccessTokenIssuer(ctrl *gomock.Controller) *MockAccessTokenIssuer {
-	mock := &MockAccessTokenIssuer{ctrl: ctrl}
-	mock.recorder = &MockAccessTokenIssuerMockRecorder{mock}
-	return mock
-}
-
-// EXPECT returns an object that allows the caller to indicate expected use.
-func (m *MockAccessTokenIssuer) EXPECT() *MockAccessTokenIssuerMockRecorder {
-	return m.recorder
-}
-
-// EncodeClientAccessToken mocks base method.
-func (m *MockAccessTokenIssuer) EncodeClientAccessToken(ctx context.Context, options oauth.EncodeClientAccessTokenOptions) (string, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "EncodeClientAccessToken", ctx, options)
-	ret0, _ := ret[0].(string)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// EncodeClientAccessToken indicates an expected call of EncodeClientAccessToken.
-func (mr *MockAccessTokenIssuerMockRecorder) EncodeClientAccessToken(ctx, options interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EncodeClientAccessToken", reflect.TypeOf((*MockAccessTokenIssuer)(nil).EncodeClientAccessToken), ctx, options)
-}
-
 // MockEventService is a mock of EventService interface.
 type MockEventService struct {
 	ctrl     *gomock.Controller

--- a/pkg/lib/oauth/handler/handler_token_mock_test.go
+++ b/pkg/lib/oauth/handler/handler_token_mock_test.go
@@ -132,21 +132,6 @@ func (mr *MockAccessTokenIssuerMockRecorder) EncodeClientAccessToken(ctx, option
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EncodeClientAccessToken", reflect.TypeOf((*MockAccessTokenIssuer)(nil).EncodeClientAccessToken), ctx, options)
 }
 
-// EncodeUserAccessToken mocks base method.
-func (m *MockAccessTokenIssuer) EncodeUserAccessToken(ctx context.Context, options oauth.EncodeUserAccessTokenOptions) (string, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "EncodeUserAccessToken", ctx, options)
-	ret0, _ := ret[0].(string)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// EncodeUserAccessToken indicates an expected call of EncodeUserAccessToken.
-func (mr *MockAccessTokenIssuerMockRecorder) EncodeUserAccessToken(ctx, options interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EncodeUserAccessToken", reflect.TypeOf((*MockAccessTokenIssuer)(nil).EncodeUserAccessToken), ctx, options)
-}
-
 // MockEventService is a mock of EventService interface.
 type MockEventService struct {
 	ctrl     *gomock.Controller

--- a/pkg/lib/oauth/handler/handler_token_mock_test.go
+++ b/pkg/lib/oauth/handler/handler_token_mock_test.go
@@ -642,21 +642,6 @@ func (m *MockTokenHandlerTokenService) EXPECT() *MockTokenHandlerTokenServiceMoc
 	return m.recorder
 }
 
-// IssueAccessGrantByRefreshToken mocks base method.
-func (m *MockTokenHandlerTokenService) IssueAccessGrantByRefreshToken(ctx context.Context, options handler.IssueAccessGrantByRefreshTokenOptions) (*handler.IssueAccessGrantByRefreshTokenResult, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "IssueAccessGrantByRefreshToken", ctx, options)
-	ret0, _ := ret[0].(*handler.IssueAccessGrantByRefreshTokenResult)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// IssueAccessGrantByRefreshToken indicates an expected call of IssueAccessGrantByRefreshToken.
-func (mr *MockTokenHandlerTokenServiceMockRecorder) IssueAccessGrantByRefreshToken(ctx, options interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IssueAccessGrantByRefreshToken", reflect.TypeOf((*MockTokenHandlerTokenService)(nil).IssueAccessGrantByRefreshToken), ctx, options)
-}
-
 // IssueClientCredentialsAccessToken mocks base method.
 func (m *MockTokenHandlerTokenService) IssueClientCredentialsAccessToken(ctx context.Context, options handler.ClientCredentialsAccessTokenOptions, resp protocol.TokenResponse) error {
 	m.ctrl.T.Helper()
@@ -732,6 +717,21 @@ func (m *MockTokenHandlerTokenService) ParseRefreshToken(ctx context.Context, to
 func (mr *MockTokenHandlerTokenServiceMockRecorder) ParseRefreshToken(ctx, token interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ParseRefreshToken", reflect.TypeOf((*MockTokenHandlerTokenService)(nil).ParseRefreshToken), ctx, token)
+}
+
+// PrepareUserAccessGrantByRefreshToken mocks base method.
+func (m *MockTokenHandlerTokenService) PrepareUserAccessGrantByRefreshToken(ctx context.Context, options handler.PrepareUserAccessGrantByRefreshTokenOptions) (*handler.PrepareUserAccessGrantByRefreshTokenResult, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "PrepareUserAccessGrantByRefreshToken", ctx, options)
+	ret0, _ := ret[0].(*handler.PrepareUserAccessGrantByRefreshTokenResult)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// PrepareUserAccessGrantByRefreshToken indicates an expected call of PrepareUserAccessGrantByRefreshToken.
+func (mr *MockTokenHandlerTokenServiceMockRecorder) PrepareUserAccessGrantByRefreshToken(ctx, options interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PrepareUserAccessGrantByRefreshToken", reflect.TypeOf((*MockTokenHandlerTokenService)(nil).PrepareUserAccessGrantByRefreshToken), ctx, options)
 }
 
 // MockTokenHandlerIDPSessionProvider is a mock of TokenHandlerIDPSessionProvider interface.

--- a/pkg/lib/oauth/handler/handler_token_test.go
+++ b/pkg/lib/oauth/handler/handler_token_test.go
@@ -145,9 +145,9 @@ func TestTokenHandler(t *testing.T) {
 				}).Return(nil, nil)
 				tokenService.EXPECT().ParseRefreshToken(gomock.Any(), "asdf").Return(&oauth.Authorization{}, offlineGrant, refreshTokenHash, nil)
 				idTokenIssuer.EXPECT().IssueIDToken(gomock.Any(), gomock.Any()).Return("id-token", nil)
-				tokenService.EXPECT().IssueAccessGrantByRefreshToken(gomock.Any(), gomock.Any()).DoAndReturn(
-					func(ctx context.Context, options handler.IssueAccessGrantByRefreshTokenOptions) (*handler.IssueAccessGrantByRefreshTokenResult, error) {
-						result := &handler.IssueAccessGrantByRefreshTokenResult{
+				tokenService.EXPECT().PrepareUserAccessGrantByRefreshToken(gomock.Any(), gomock.Any()).DoAndReturn(
+					func(ctx context.Context, options handler.PrepareUserAccessGrantByRefreshTokenOptions) (*handler.PrepareUserAccessGrantByRefreshTokenResult, error) {
+						result := &handler.PrepareUserAccessGrantByRefreshTokenResult{
 							// The value is unimportant.
 							PreparationResult: nil,
 						}
@@ -203,9 +203,9 @@ func TestTokenHandler(t *testing.T) {
 				rateLimiter.EXPECT().Allow(gomock.Any(), gomock.Any()).AnyTimes().Return(nil, nil)
 				tokenService.EXPECT().ParseRefreshToken(gomock.Any(), "asdf").Return(&oauth.Authorization{}, offlineGrant, refreshTokenHash, nil)
 				idTokenIssuer.EXPECT().IssueIDToken(gomock.Any(), gomock.Any()).Return("id-token", nil)
-				tokenService.EXPECT().IssueAccessGrantByRefreshToken(gomock.Any(), gomock.Any()).DoAndReturn(
-					func(ctx context.Context, options handler.IssueAccessGrantByRefreshTokenOptions) (*handler.IssueAccessGrantByRefreshTokenResult, error) {
-						result := &handler.IssueAccessGrantByRefreshTokenResult{
+				tokenService.EXPECT().PrepareUserAccessGrantByRefreshToken(gomock.Any(), gomock.Any()).DoAndReturn(
+					func(ctx context.Context, options handler.PrepareUserAccessGrantByRefreshTokenOptions) (*handler.PrepareUserAccessGrantByRefreshTokenResult, error) {
+						result := &handler.PrepareUserAccessGrantByRefreshTokenResult{
 							// The value is unimportant.
 							PreparationResult: nil,
 						}
@@ -266,9 +266,9 @@ func TestTokenHandler(t *testing.T) {
 				rateLimiter.EXPECT().Allow(gomock.Any(), gomock.Any()).AnyTimes().Return(nil, nil)
 				tokenService.EXPECT().ParseRefreshToken(gomock.Any(), "asdf").Return(&oauth.Authorization{}, offlineGrant, refreshTokenHash, nil)
 				idTokenIssuer.EXPECT().IssueIDToken(gomock.Any(), gomock.Any()).Return("id-token", nil)
-				tokenService.EXPECT().IssueAccessGrantByRefreshToken(gomock.Any(), gomock.Any()).DoAndReturn(
-					func(ctx context.Context, options handler.IssueAccessGrantByRefreshTokenOptions) (*handler.IssueAccessGrantByRefreshTokenResult, error) {
-						result := &handler.IssueAccessGrantByRefreshTokenResult{
+				tokenService.EXPECT().PrepareUserAccessGrantByRefreshToken(gomock.Any(), gomock.Any()).DoAndReturn(
+					func(ctx context.Context, options handler.PrepareUserAccessGrantByRefreshTokenOptions) (*handler.PrepareUserAccessGrantByRefreshTokenResult, error) {
+						result := &handler.PrepareUserAccessGrantByRefreshTokenResult{
 							// The value is unimportant.
 							PreparationResult: nil,
 						}

--- a/pkg/lib/oauth/handler/service_preauthenticated_url.go
+++ b/pkg/lib/oauth/handler/service_preauthenticated_url.go
@@ -103,7 +103,7 @@ func (s *PreAuthenticatedURLTokenServiceImpl) ExchangeForAccessToken(
 	}
 	offlineGrant = newOfflineGrant
 
-	issueAccessGrantOptions := oauth.IssueAccessGrantOptions{
+	prepareUserAccessGrantOptions := oauth.PrepareUserAccessGrantOptions{
 		ClientConfig:            client,
 		Scopes:                  tokenModel.Scopes,
 		AuthorizationID:         tokenModel.AuthorizationID,
@@ -111,9 +111,9 @@ func (s *PreAuthenticatedURLTokenServiceImpl) ExchangeForAccessToken(
 		SessionLike:             offlineGrant,
 		InitialRefreshTokenHash: newRefreshTokenResult.TokenHash,
 	}
-	preparationResult, err := s.AccessGrantService.IssueAccessGrant(
+	preparationResult, err := s.AccessGrantService.PrepareUserAccessGrant(
 		ctx,
-		issueAccessGrantOptions,
+		prepareUserAccessGrantOptions,
 	)
 	if err != nil {
 		return nil, err

--- a/pkg/lib/oauth/handler/service_preauthenticated_url.go
+++ b/pkg/lib/oauth/handler/service_preauthenticated_url.go
@@ -66,22 +66,22 @@ func (s *PreAuthenticatedURLTokenServiceImpl) ExchangeForAccessToken(
 	client *config.OAuthClientConfig,
 	sessionID string,
 	token string,
-) (string, error) {
+) (oauth.PrepareUserAccessTokenResult, error) {
 	tokenHash := oauth.HashToken(token)
 	tokenModel, err := s.PreAuthenticatedURLTokens.ConsumePreAuthenticatedURLToken(ctx, tokenHash)
 	if err != nil {
-		return "", err
+		return nil, err
 	}
 	if tokenModel.ClientID != client.ClientID {
-		return "", oauth.ErrUnmatchedClient
+		return nil, oauth.ErrUnmatchedClient
 	}
 	if tokenModel.OfflineGrantID != sessionID {
-		return "", oauth.ErrUnmatchedSession
+		return nil, oauth.ErrUnmatchedSession
 	}
 
 	offlineGrant, err := s.OfflineGrantService.GetOfflineGrant(ctx, tokenModel.OfflineGrantID)
 	if err != nil {
-		return "", err
+		return nil, err
 	}
 
 	// DPoP is not important here, because the refresh token is not exposed
@@ -99,7 +99,7 @@ func (s *PreAuthenticatedURLTokenServiceImpl) ExchangeForAccessToken(
 		ShortLivedRefreshTokenExpireAt: &shortLivedRefreshTokenExpireAt,
 	})
 	if err != nil {
-		return "", err
+		return nil, err
 	}
 	offlineGrant = newOfflineGrant
 
@@ -111,14 +111,13 @@ func (s *PreAuthenticatedURLTokenServiceImpl) ExchangeForAccessToken(
 		SessionLike:             offlineGrant,
 		InitialRefreshTokenHash: newRefreshTokenResult.TokenHash,
 	}
-	result, err := s.AccessGrantService.IssueAccessGrant(
+	preparationResult, err := s.AccessGrantService.IssueAccessGrant(
 		ctx,
 		issueAccessGrantOptions,
 	)
-
 	if err != nil {
-		return "", err
+		return nil, err
 	}
 
-	return result.Token, nil
+	return preparationResult, nil
 }

--- a/pkg/lib/oauth/handler/service_token.go
+++ b/pkg/lib/oauth/handler/service_token.go
@@ -58,7 +58,7 @@ type ClientCredentialsAccessTokenOptions struct {
 	Resource           *resourcescope.Resource
 }
 
-type IssueAccessGrantByRefreshTokenOptions struct {
+type PrepareUserAccessGrantByRefreshTokenOptions struct {
 	oauth.PrepareUserAccessGrantOptions
 	ShouldRotateRefreshToken bool
 }
@@ -234,16 +234,16 @@ func (s *TokenService) IssueRefreshTokenForOfflineGrant(
 	return newOfflineGrant, newRefreshTokenResult.TokenHash, nil
 }
 
-type IssueAccessGrantByRefreshTokenResult struct {
+type PrepareUserAccessGrantByRefreshTokenResult struct {
 	RotateRefreshTokenResult *oauth.RotateRefreshTokenResult
 	PreparationResult        oauth.PrepareUserAccessTokenResult
 }
 
-func (s *TokenService) IssueAccessGrantByRefreshToken(
+func (s *TokenService) PrepareUserAccessGrantByRefreshToken(
 	ctx context.Context,
-	options IssueAccessGrantByRefreshTokenOptions,
-) (*IssueAccessGrantByRefreshTokenResult, error) {
-	result := &IssueAccessGrantByRefreshTokenResult{}
+	options PrepareUserAccessGrantByRefreshTokenOptions,
+) (*PrepareUserAccessGrantByRefreshTokenResult, error) {
+	result := &PrepareUserAccessGrantByRefreshTokenResult{}
 
 	if options.ShouldRotateRefreshToken &&
 		options.SessionLike.SessionType() == session.TypeOfflineGrant &&

--- a/pkg/lib/oauth/handler/service_token.go
+++ b/pkg/lib/oauth/handler/service_token.go
@@ -95,6 +95,11 @@ type TokenServiceAccessGrantService interface {
 		options oauth.IssueAccessGrantOptions,
 	) (*oauth.IssueAccessGrantResult, error)
 }
+
+type TokenServiceAccessTokenIssuer interface {
+	EncodeClientAccessToken(ctx context.Context, options oauth.EncodeClientAccessTokenOptions) (string, error)
+}
+
 type TokenService struct {
 	RemoteIP        httputil.RemoteIP
 	UserAgentString httputil.UserAgentString
@@ -106,7 +111,7 @@ type TokenService struct {
 	AccessGrants        TokenServiceAccessGrantStore
 	OfflineGrantService TokenServiceOfflineGrantService
 	AccessEvents        *access.EventProvider
-	AccessTokenIssuer   AccessTokenIssuer
+	AccessTokenIssuer   TokenServiceAccessTokenIssuer
 	GenerateToken       TokenGenerator
 	Clock               clock.Clock
 	Users               TokenHandlerUserFacade

--- a/pkg/lib/oauth/handler/service_token.go
+++ b/pkg/lib/oauth/handler/service_token.go
@@ -59,7 +59,7 @@ type ClientCredentialsAccessTokenOptions struct {
 }
 
 type IssueAccessGrantByRefreshTokenOptions struct {
-	oauth.IssueAccessGrantOptions
+	oauth.PrepareUserAccessGrantOptions
 	ShouldRotateRefreshToken bool
 }
 
@@ -90,9 +90,9 @@ type TokenServiceOfflineGrantService interface {
 }
 
 type TokenServiceAccessGrantService interface {
-	IssueAccessGrant(
+	PrepareUserAccessGrant(
 		ctx context.Context,
-		options oauth.IssueAccessGrantOptions,
+		options oauth.PrepareUserAccessGrantOptions,
 	) (oauth.PrepareUserAccessTokenResult, error)
 }
 
@@ -243,8 +243,6 @@ func (s *TokenService) IssueAccessGrantByRefreshToken(
 	ctx context.Context,
 	options IssueAccessGrantByRefreshTokenOptions,
 ) (*IssueAccessGrantByRefreshTokenResult, error) {
-	issueOptions := options.IssueAccessGrantOptions
-
 	result := &IssueAccessGrantByRefreshTokenResult{}
 
 	if options.ShouldRotateRefreshToken &&
@@ -267,8 +265,8 @@ func (s *TokenService) IssueAccessGrantByRefreshToken(
 		result.RotateRefreshTokenResult = rotateResult
 	}
 
-	preparationResult, err := s.AccessGrantService.IssueAccessGrant(
-		ctx, issueOptions,
+	preparationResult, err := s.AccessGrantService.PrepareUserAccessGrant(
+		ctx, options.PrepareUserAccessGrantOptions,
 	)
 	if err != nil {
 		return nil, err

--- a/pkg/lib/oauth/handler/service_token_mock_test.go
+++ b/pkg/lib/oauth/handler/service_token_mock_test.go
@@ -556,19 +556,19 @@ func (m *MockTokenServiceAccessGrantService) EXPECT() *MockTokenServiceAccessGra
 	return m.recorder
 }
 
-// IssueAccessGrant mocks base method.
-func (m *MockTokenServiceAccessGrantService) IssueAccessGrant(ctx context.Context, options oauth.IssueAccessGrantOptions) (oauth.PrepareUserAccessTokenResult, error) {
+// PrepareUserAccessGrant mocks base method.
+func (m *MockTokenServiceAccessGrantService) PrepareUserAccessGrant(ctx context.Context, options oauth.PrepareUserAccessGrantOptions) (oauth.PrepareUserAccessTokenResult, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "IssueAccessGrant", ctx, options)
+	ret := m.ctrl.Call(m, "PrepareUserAccessGrant", ctx, options)
 	ret0, _ := ret[0].(oauth.PrepareUserAccessTokenResult)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// IssueAccessGrant indicates an expected call of IssueAccessGrant.
-func (mr *MockTokenServiceAccessGrantServiceMockRecorder) IssueAccessGrant(ctx, options interface{}) *gomock.Call {
+// PrepareUserAccessGrant indicates an expected call of PrepareUserAccessGrant.
+func (mr *MockTokenServiceAccessGrantServiceMockRecorder) PrepareUserAccessGrant(ctx, options interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IssueAccessGrant", reflect.TypeOf((*MockTokenServiceAccessGrantService)(nil).IssueAccessGrant), ctx, options)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PrepareUserAccessGrant", reflect.TypeOf((*MockTokenServiceAccessGrantService)(nil).PrepareUserAccessGrant), ctx, options)
 }
 
 // MockTokenServiceAccessTokenIssuer is a mock of TokenServiceAccessTokenIssuer interface.

--- a/pkg/lib/oauth/handler/service_token_mock_test.go
+++ b/pkg/lib/oauth/handler/service_token_mock_test.go
@@ -557,10 +557,10 @@ func (m *MockTokenServiceAccessGrantService) EXPECT() *MockTokenServiceAccessGra
 }
 
 // IssueAccessGrant mocks base method.
-func (m *MockTokenServiceAccessGrantService) IssueAccessGrant(ctx context.Context, options oauth.IssueAccessGrantOptions) (*oauth.IssueAccessGrantResult, error) {
+func (m *MockTokenServiceAccessGrantService) IssueAccessGrant(ctx context.Context, options oauth.IssueAccessGrantOptions) (oauth.PrepareUserAccessTokenResult, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "IssueAccessGrant", ctx, options)
-	ret0, _ := ret[0].(*oauth.IssueAccessGrantResult)
+	ret0, _ := ret[0].(oauth.PrepareUserAccessTokenResult)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }

--- a/pkg/lib/oauth/handler/service_token_mock_test.go
+++ b/pkg/lib/oauth/handler/service_token_mock_test.go
@@ -570,3 +570,41 @@ func (mr *MockTokenServiceAccessGrantServiceMockRecorder) IssueAccessGrant(ctx, 
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IssueAccessGrant", reflect.TypeOf((*MockTokenServiceAccessGrantService)(nil).IssueAccessGrant), ctx, options)
 }
+
+// MockTokenServiceAccessTokenIssuer is a mock of TokenServiceAccessTokenIssuer interface.
+type MockTokenServiceAccessTokenIssuer struct {
+	ctrl     *gomock.Controller
+	recorder *MockTokenServiceAccessTokenIssuerMockRecorder
+}
+
+// MockTokenServiceAccessTokenIssuerMockRecorder is the mock recorder for MockTokenServiceAccessTokenIssuer.
+type MockTokenServiceAccessTokenIssuerMockRecorder struct {
+	mock *MockTokenServiceAccessTokenIssuer
+}
+
+// NewMockTokenServiceAccessTokenIssuer creates a new mock instance.
+func NewMockTokenServiceAccessTokenIssuer(ctrl *gomock.Controller) *MockTokenServiceAccessTokenIssuer {
+	mock := &MockTokenServiceAccessTokenIssuer{ctrl: ctrl}
+	mock.recorder = &MockTokenServiceAccessTokenIssuerMockRecorder{mock}
+	return mock
+}
+
+// EXPECT returns an object that allows the caller to indicate expected use.
+func (m *MockTokenServiceAccessTokenIssuer) EXPECT() *MockTokenServiceAccessTokenIssuerMockRecorder {
+	return m.recorder
+}
+
+// EncodeClientAccessToken mocks base method.
+func (m *MockTokenServiceAccessTokenIssuer) EncodeClientAccessToken(ctx context.Context, options oauth.EncodeClientAccessTokenOptions) (string, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "EncodeClientAccessToken", ctx, options)
+	ret0, _ := ret[0].(string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// EncodeClientAccessToken indicates an expected call of EncodeClientAccessToken.
+func (mr *MockTokenServiceAccessTokenIssuerMockRecorder) EncodeClientAccessToken(ctx, options interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EncodeClientAccessToken", reflect.TypeOf((*MockTokenServiceAccessTokenIssuer)(nil).EncodeClientAccessToken), ctx, options)
+}

--- a/pkg/lib/oauth/handler/service_token_test.go
+++ b/pkg/lib/oauth/handler/service_token_test.go
@@ -34,43 +34,51 @@ func TestTokenService(t *testing.T) {
 					ID: "grant-id",
 				}, nil)
 				offlineGrants.EXPECT().RotateRefreshToken(gomock.Any(), gomock.Any()).Return(&oauth.RotateRefreshTokenResult{
+					GrantID:   "grant-id",
 					Token:     "new-refresh-token",
 					TokenHash: "new-refresh-token-hash",
 				}, &oauth.OfflineGrant{
 					ID: "grant-id",
 				}, nil)
-				accessGrants.EXPECT().IssueAccessGrant(gomock.Any(), gomock.Any()).Return(&oauth.IssueAccessGrantResult{}, nil)
+				accessGrants.EXPECT().IssueAccessGrant(gomock.Any(), gomock.Any()).Return(nil, nil)
 
-				resp := protocol.TokenResponse{}
-				err := s.IssueAccessGrantByRefreshToken(context.Background(), handler.IssueAccessGrantByRefreshTokenOptions{
+				result1, err := s.IssueAccessGrantByRefreshToken(context.Background(), handler.IssueAccessGrantByRefreshTokenOptions{
 					ShouldRotateRefreshToken: true,
 					IssueAccessGrantOptions: oauth.IssueAccessGrantOptions{
 						SessionLike: &oauth.OfflineGrant{
 							ID: "grant-id",
 						},
-						InitialRefreshTokenHash: "refresh-token-hash",
+						InitialRefreshTokenHash: "initial-refresh-token-hash",
 					},
-				}, resp)
+				})
 
+				resp := protocol.TokenResponse{}
 				So(err, ShouldBeNil)
-				So(resp, ShouldContainKey, "refresh_token")
+				So(result1.RotateRefreshTokenResult, ShouldNotBeNil)
+				So(result1.RotateRefreshTokenResult.TokenHash, ShouldEqual, "new-refresh-token-hash")
+				So(result1.RotateRefreshTokenResult.GrantID, ShouldEqual, "grant-id")
+
+				result1.RotateRefreshTokenResult.WriteTo(resp)
 				So(resp["refresh_token"], ShouldEqual, "grant-id.new-refresh-token")
 			})
 
 			Convey("should not rotate refresh token", func() {
-				accessGrants.EXPECT().IssueAccessGrant(gomock.Any(), gomock.Any()).Return(&oauth.IssueAccessGrantResult{}, nil)
+				accessGrants.EXPECT().IssueAccessGrant(gomock.Any(), gomock.Any()).Return(nil, nil)
 
 				resp := protocol.TokenResponse{}
-				err := s.IssueAccessGrantByRefreshToken(context.Background(), handler.IssueAccessGrantByRefreshTokenOptions{
+				result1, err := s.IssueAccessGrantByRefreshToken(context.Background(), handler.IssueAccessGrantByRefreshTokenOptions{
 					ShouldRotateRefreshToken: false,
 					IssueAccessGrantOptions: oauth.IssueAccessGrantOptions{
 						SessionLike: &oauth.OfflineGrant{
 							ID: "grant-id",
 						},
 					},
-				}, resp)
+				})
 
 				So(err, ShouldBeNil)
+				So(result1.RotateRefreshTokenResult, ShouldBeNil)
+
+				result1.RotateRefreshTokenResult.WriteTo(resp)
 				So(resp, ShouldNotContainKey, "refresh_token")
 			})
 		})

--- a/pkg/lib/oauth/handler/service_token_test.go
+++ b/pkg/lib/oauth/handler/service_token_test.go
@@ -28,7 +28,7 @@ func TestTokenService(t *testing.T) {
 			AccessGrantService:  accessGrants,
 		}
 
-		Convey("IssueAccessGrantByRefreshToken", func() {
+		Convey("PrepareUserAccessGrantByRefreshToken", func() {
 			Convey("should rotate refresh token", func() {
 				offlineGrants.EXPECT().GetOfflineGrant(gomock.Any(), "grant-id").Return(&oauth.OfflineGrant{
 					ID: "grant-id",
@@ -42,7 +42,7 @@ func TestTokenService(t *testing.T) {
 				}, nil)
 				accessGrants.EXPECT().PrepareUserAccessGrant(gomock.Any(), gomock.Any()).Return(nil, nil)
 
-				result1, err := s.IssueAccessGrantByRefreshToken(context.Background(), handler.IssueAccessGrantByRefreshTokenOptions{
+				result1, err := s.PrepareUserAccessGrantByRefreshToken(context.Background(), handler.PrepareUserAccessGrantByRefreshTokenOptions{
 					ShouldRotateRefreshToken: true,
 					PrepareUserAccessGrantOptions: oauth.PrepareUserAccessGrantOptions{
 						SessionLike: &oauth.OfflineGrant{
@@ -66,7 +66,7 @@ func TestTokenService(t *testing.T) {
 				accessGrants.EXPECT().PrepareUserAccessGrant(gomock.Any(), gomock.Any()).Return(nil, nil)
 
 				resp := protocol.TokenResponse{}
-				result1, err := s.IssueAccessGrantByRefreshToken(context.Background(), handler.IssueAccessGrantByRefreshTokenOptions{
+				result1, err := s.PrepareUserAccessGrantByRefreshToken(context.Background(), handler.PrepareUserAccessGrantByRefreshTokenOptions{
 					ShouldRotateRefreshToken: false,
 					PrepareUserAccessGrantOptions: oauth.PrepareUserAccessGrantOptions{
 						SessionLike: &oauth.OfflineGrant{

--- a/pkg/lib/oauth/handler/service_token_test.go
+++ b/pkg/lib/oauth/handler/service_token_test.go
@@ -40,11 +40,11 @@ func TestTokenService(t *testing.T) {
 				}, &oauth.OfflineGrant{
 					ID: "grant-id",
 				}, nil)
-				accessGrants.EXPECT().IssueAccessGrant(gomock.Any(), gomock.Any()).Return(nil, nil)
+				accessGrants.EXPECT().PrepareUserAccessGrant(gomock.Any(), gomock.Any()).Return(nil, nil)
 
 				result1, err := s.IssueAccessGrantByRefreshToken(context.Background(), handler.IssueAccessGrantByRefreshTokenOptions{
 					ShouldRotateRefreshToken: true,
-					IssueAccessGrantOptions: oauth.IssueAccessGrantOptions{
+					PrepareUserAccessGrantOptions: oauth.PrepareUserAccessGrantOptions{
 						SessionLike: &oauth.OfflineGrant{
 							ID: "grant-id",
 						},
@@ -63,12 +63,12 @@ func TestTokenService(t *testing.T) {
 			})
 
 			Convey("should not rotate refresh token", func() {
-				accessGrants.EXPECT().IssueAccessGrant(gomock.Any(), gomock.Any()).Return(nil, nil)
+				accessGrants.EXPECT().PrepareUserAccessGrant(gomock.Any(), gomock.Any()).Return(nil, nil)
 
 				resp := protocol.TokenResponse{}
 				result1, err := s.IssueAccessGrantByRefreshToken(context.Background(), handler.IssueAccessGrantByRefreshTokenOptions{
 					ShouldRotateRefreshToken: false,
-					IssueAccessGrantOptions: oauth.IssueAccessGrantOptions{
+					PrepareUserAccessGrantOptions: oauth.PrepareUserAccessGrantOptions{
 						SessionLike: &oauth.OfflineGrant{
 							ID: "grant-id",
 						},

--- a/pkg/lib/oauth/pre_authenticated_url_token.go
+++ b/pkg/lib/oauth/pre_authenticated_url_token.go
@@ -27,7 +27,7 @@ type PreAuthenticatedURLTokenAccessGrantService interface {
 	IssueAccessGrant(
 		ctx context.Context,
 		options IssueAccessGrantOptions,
-	) (*IssueAccessGrantResult, error)
+	) (PrepareUserAccessTokenResult, error)
 }
 
 type PreAuthenticatedURLTokenOfflineGrantService interface {

--- a/pkg/lib/oauth/pre_authenticated_url_token.go
+++ b/pkg/lib/oauth/pre_authenticated_url_token.go
@@ -24,9 +24,9 @@ type PreAuthenticatedURLToken struct {
 }
 
 type PreAuthenticatedURLTokenAccessGrantService interface {
-	IssueAccessGrant(
+	PrepareUserAccessGrant(
 		ctx context.Context,
-		options IssueAccessGrantOptions,
+		options PrepareUserAccessGrantOptions,
 	) (PrepareUserAccessTokenResult, error)
 }
 

--- a/pkg/lib/oauth/token_encoding_mock_test.go
+++ b/pkg/lib/oauth/token_encoding_mock_test.go
@@ -140,6 +140,35 @@ func (mr *MockEventServiceMockRecorder) DispatchEventOnCommit(ctx, payload inter
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DispatchEventOnCommit", reflect.TypeOf((*MockEventService)(nil).DispatchEventOnCommit), ctx, payload)
 }
 
+// DispatchEventWithoutTx mocks base method.
+func (m *MockEventService) DispatchEventWithoutTx(ctx context.Context, e *event.Event) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DispatchEventWithoutTx", ctx, e)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// DispatchEventWithoutTx indicates an expected call of DispatchEventWithoutTx.
+func (mr *MockEventServiceMockRecorder) DispatchEventWithoutTx(ctx, e interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DispatchEventWithoutTx", reflect.TypeOf((*MockEventService)(nil).DispatchEventWithoutTx), ctx, e)
+}
+
+// PrepareBlockingEventWithTx mocks base method.
+func (m *MockEventService) PrepareBlockingEventWithTx(ctx context.Context, payload event.BlockingPayload) (*event.Event, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "PrepareBlockingEventWithTx", ctx, payload)
+	ret0, _ := ret[0].(*event.Event)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// PrepareBlockingEventWithTx indicates an expected call of PrepareBlockingEventWithTx.
+func (mr *MockEventServiceMockRecorder) PrepareBlockingEventWithTx(ctx, payload interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PrepareBlockingEventWithTx", reflect.TypeOf((*MockEventService)(nil).PrepareBlockingEventWithTx), ctx, payload)
+}
+
 // MockAccessTokenEncodingIdentityService is a mock of AccessTokenEncodingIdentityService interface.
 type MockAccessTokenEncodingIdentityService struct {
 	ctrl     *gomock.Controller
@@ -176,4 +205,39 @@ func (m *MockAccessTokenEncodingIdentityService) ListIdentitiesThatHaveStandardA
 func (mr *MockAccessTokenEncodingIdentityServiceMockRecorder) ListIdentitiesThatHaveStandardAttributes(ctx, userID interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListIdentitiesThatHaveStandardAttributes", reflect.TypeOf((*MockAccessTokenEncodingIdentityService)(nil).ListIdentitiesThatHaveStandardAttributes), ctx, userID)
+}
+
+// MockPrepareUserAccessTokenResult is a mock of PrepareUserAccessTokenResult interface.
+type MockPrepareUserAccessTokenResult struct {
+	ctrl     *gomock.Controller
+	recorder *MockPrepareUserAccessTokenResultMockRecorder
+}
+
+// MockPrepareUserAccessTokenResultMockRecorder is the mock recorder for MockPrepareUserAccessTokenResult.
+type MockPrepareUserAccessTokenResultMockRecorder struct {
+	mock *MockPrepareUserAccessTokenResult
+}
+
+// NewMockPrepareUserAccessTokenResult creates a new mock instance.
+func NewMockPrepareUserAccessTokenResult(ctrl *gomock.Controller) *MockPrepareUserAccessTokenResult {
+	mock := &MockPrepareUserAccessTokenResult{ctrl: ctrl}
+	mock.recorder = &MockPrepareUserAccessTokenResultMockRecorder{mock}
+	return mock
+}
+
+// EXPECT returns an object that allows the caller to indicate expected use.
+func (m *MockPrepareUserAccessTokenResult) EXPECT() *MockPrepareUserAccessTokenResultMockRecorder {
+	return m.recorder
+}
+
+// prepareUserAccessTokenResult mocks base method.
+func (m *MockPrepareUserAccessTokenResult) prepareUserAccessTokenResult() {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "prepareUserAccessTokenResult")
+}
+
+// prepareUserAccessTokenResult indicates an expected call of prepareUserAccessTokenResult.
+func (mr *MockPrepareUserAccessTokenResultMockRecorder) prepareUserAccessTokenResult() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "prepareUserAccessTokenResult", reflect.TypeOf((*MockPrepareUserAccessTokenResult)(nil).prepareUserAccessTokenResult))
 }

--- a/pkg/lib/oauth/token_encoding_test.go
+++ b/pkg/lib/oauth/token_encoding_test.go
@@ -125,7 +125,6 @@ func TestAccessToken(t *testing.T) {
 
 		tokenResult, err := encoding.MakeUserAccessTokenFromPreparationResult(ctx, MakeUserAccessTokenFromPreparationOptions{
 			PreparationResult: preparation,
-			ClientConfig:      client,
 		})
 		So(err, ShouldBeNil)
 


### PR DESCRIPTION
ref DEV-3061

Manually tested the following cases:

- Sign in with mobile SDK
- Anonymous user sign in with mobile SDK
- Biometric login with mobile SDK
- Sign in with web SDK
- Anonymous user sign in with web SDK
- Pre-authenticated URL with mobile SDK
- Refresh access token
- The /tester endpoint