### PR TITLE
Show sms and whatsapp usage only when there is no active subscription

### DIFF
--- a/portal/src/components/billing/CurrentPlanCard.tsx
+++ b/portal/src/components/billing/CurrentPlanCard.tsx
@@ -42,6 +42,7 @@ interface CurrentPlanCardProps {
   thisMonthUsage: Usage | undefined;
   thisMonthSubscriptionUsage: SubscriptionUsage | undefined;
   previousMonthSubscriptionUsage: SubscriptionUsage | undefined;
+  hasSubscription: boolean;
 }
 
 export function CurrentPlanCard({
@@ -49,12 +50,16 @@ export function CurrentPlanCard({
   thisMonthUsage,
   thisMonthSubscriptionUsage,
   previousMonthSubscriptionUsage,
+  hasSubscription,
 }: CurrentPlanCardProps): React.ReactElement {
   const baseAmount = useMemo(() => {
     if (!isStripePlan(planName)) {
       return undefined;
     }
-
+    // show subscription fee only when subscription is active
+    if (!hasSubscription) {
+      return undefined;
+    }
     const amountCent =
       thisMonthSubscriptionUsage?.items.find(
         (a) => a.type === SubscriptionItemPriceType.Fixed
@@ -63,14 +68,18 @@ export function CurrentPlanCard({
       return undefined;
     }
     return amountCent / 100;
-  }, [planName, thisMonthSubscriptionUsage]);
+  }, [planName, thisMonthSubscriptionUsage, hasSubscription]);
 
   const smsCost = useMemo(() => {
     if (thisMonthSubscriptionUsage == null) {
       return undefined;
     }
+    // show sms cost only when subscription is active
+    if (!hasSubscription) {
+      return undefined;
+    }
     return getSMSCost(planName, thisMonthSubscriptionUsage);
-  }, [planName, thisMonthSubscriptionUsage]);
+  }, [planName, thisMonthSubscriptionUsage, hasSubscription]);
 
   const smsUsage = useMemo(() => {
     if (thisMonthUsage == null) {
@@ -83,8 +92,12 @@ export function CurrentPlanCard({
     if (thisMonthSubscriptionUsage == null) {
       return undefined;
     }
+    // show whatsapp cost only when subscription is active
+    if (!hasSubscription) {
+      return undefined;
+    }
     return getWhatsappCost(planName, thisMonthSubscriptionUsage);
-  }, [planName, thisMonthSubscriptionUsage]);
+  }, [planName, thisMonthSubscriptionUsage, hasSubscription]);
 
   const whatsappUsage = useMemo(() => {
     if (thisMonthUsage == null) {

--- a/portal/src/graphql/portal/SubscriptionScreen.tsx
+++ b/portal/src/graphql/portal/SubscriptionScreen.tsx
@@ -470,6 +470,8 @@ function SubscriptionScreenContent(props: SubscriptionScreenContentProps) {
   const { themes } = useSystemConfig();
   const { renderToString } = useContext(Context);
 
+  const hasSubscription = useMemo(() => !!subscription, [subscription]);
+
   const subscriptionCancelled = useMemo(() => {
     return !!subscription?.endedAt;
   }, [subscription?.endedAt]);
@@ -684,6 +686,7 @@ function SubscriptionScreenContent(props: SubscriptionScreenContentProps) {
             thisMonthUsage={thisMonthUsage}
             thisMonthSubscriptionUsage={thisMonthSubscriptionUsage}
             previousMonthSubscriptionUsage={previousMonthSubscriptionUsage}
+            hasSubscription={hasSubscription}
           />
         )}
       </div>
@@ -699,6 +702,7 @@ interface PlanDetailsTabProps {
   thisMonthUsage: Usage | undefined;
   thisMonthSubscriptionUsage: SubscriptionUsage | undefined;
   previousMonthSubscriptionUsage: SubscriptionUsage | undefined;
+  hasSubscription: boolean;
 }
 
 function PlanDetailsTab({
@@ -709,6 +713,7 @@ function PlanDetailsTab({
   thisMonthUsage,
   thisMonthSubscriptionUsage,
   previousMonthSubscriptionUsage,
+  hasSubscription,
 }: PlanDetailsTabProps) {
   const { locale } = useContext(Context);
   const formattedBillingDate = useMemo(
@@ -770,6 +775,7 @@ function PlanDetailsTab({
         thisMonthUsage={thisMonthUsage}
         thisMonthSubscriptionUsage={thisMonthSubscriptionUsage}
         previousMonthSubscriptionUsage={previousMonthSubscriptionUsage}
+        hasSubscription={hasSubscription}
       />
       {formattedBillingDate != null ? (
         <LinkButton


### PR DESCRIPTION
ref DEV-3300

This is for the case where the app plan is changed manually and there is no active subscription in Stripe