### PR TITLE
Fix buttons being disabled after clicking Download on the recovery code page

### DIFF
--- a/authui/src/authflowv2/loading.ts
+++ b/authui/src/authflowv2/loading.ts
@@ -62,7 +62,8 @@ export class LoadingController extends Controller {
         );
       // Detect if the form is controlled by turbo-form.
       // We only step in if the form is NOT controlled by turbo-form.
-      if (turboFormController == null) {
+      // We also do not step in if the form is submitted to a new tab.
+      if (turboFormController == null && form.target !== "_blank") {
         makeAllButtonPointerEventsNone();
       }
     }


### PR DESCRIPTION
ref DEV-3323

If the form is submitted in a new tab, the buttons in the original tab should remain clickable