### PR TITLE
Fix layout of usage alert email

### DIFF
--- a/resources/authgear/templates/de/messages/usage_alert_email.html
+++ b/resources/authgear/templates/de/messages/usage_alert_email.html
@@ -171,7 +171,7 @@
                               </tr>
 
                               <tr>
-                                <td align="left" style="font-size: 0px; padding: 0; word-break: break-word">
+                                <td align="left" style="font-size: 0px; padding: 10px 25px; padding-top: 16px; word-break: break-word">
                                   <div
                                     style="
                                       font-family:
@@ -193,7 +193,7 @@
                               </tr>
 
                               <tr>
-                                <td align="left" style="font-size: 0px; padding: 0; word-break: break-word">
+                                <td align="left" style="font-size: 0px; padding: 10px 25px; padding-top: 16px; word-break: break-word">
                                   <div
                                     style="
                                       font-family:

--- a/resources/authgear/templates/de/messages/usage_alert_email.mjml
+++ b/resources/authgear/templates/de/messages/usage_alert_email.mjml
@@ -11,8 +11,8 @@
       <mj-divider border-width="1px" border-color="#c7c7c7" />
       <mj-text font-size="14px" color="#201F1E" align="left" line-height="20px">{{ template "app.name" }} hat den konfigurierten Schwellenwert für {{ .Usage.Period }} {{ .Usage.Name }} erreicht.</mj-text>
       <mj-text font-size="14px" color="#201F1E" align="left" line-height="20px" padding-top="16px">Aktion: {{ .Usage.Action }}</mj-text>
-      <mj-text font-size="14px" color="#201F1E" align="left" line-height="20px" padding="0">Kontingent: {{ .Usage.Quota }}</mj-text>
-      <mj-text font-size="14px" color="#201F1E" align="left" line-height="20px" padding="0">Aktueller Wert: {{ .Usage.CurrentValue }}</mj-text>
+      <mj-text font-size="14px" color="#201F1E" align="left" line-height="20px" padding-top="16px">Kontingent: {{ .Usage.Quota }}</mj-text>
+      <mj-text font-size="14px" color="#201F1E" align="left" line-height="20px" padding-top="16px">Aktueller Wert: {{ .Usage.CurrentValue }}</mj-text>
     </mj-column>
   </mj-section>
 </mj-body>

--- a/resources/authgear/templates/el/messages/usage_alert_email.html
+++ b/resources/authgear/templates/el/messages/usage_alert_email.html
@@ -171,7 +171,7 @@
                               </tr>
 
                               <tr>
-                                <td align="left" style="font-size: 0px; padding: 0; word-break: break-word">
+                                <td align="left" style="font-size: 0px; padding: 10px 25px; padding-top: 16px; word-break: break-word">
                                   <div
                                     style="
                                       font-family:
@@ -193,7 +193,7 @@
                               </tr>
 
                               <tr>
-                                <td align="left" style="font-size: 0px; padding: 0; word-break: break-word">
+                                <td align="left" style="font-size: 0px; padding: 10px 25px; padding-top: 16px; word-break: break-word">
                                   <div
                                     style="
                                       font-family:

--- a/resources/authgear/templates/el/messages/usage_alert_email.mjml
+++ b/resources/authgear/templates/el/messages/usage_alert_email.mjml
@@ -11,8 +11,8 @@
       <mj-divider border-width="1px" border-color="#c7c7c7" />
       <mj-text font-size="14px" color="#201F1E" align="left" line-height="20px">Το {{ template "app.name" }} έφτασε το ρυθμισμένο όριο χρήσης για {{ .Usage.Period }} {{ .Usage.Name }}.</mj-text>
       <mj-text font-size="14px" color="#201F1E" align="left" line-height="20px" padding-top="16px">Ενέργεια: {{ .Usage.Action }}</mj-text>
-      <mj-text font-size="14px" color="#201F1E" align="left" line-height="20px" padding="0">Ποσόστωση: {{ .Usage.Quota }}</mj-text>
-      <mj-text font-size="14px" color="#201F1E" align="left" line-height="20px" padding="0">Τρέχουσα τιμή: {{ .Usage.CurrentValue }}</mj-text>
+      <mj-text font-size="14px" color="#201F1E" align="left" line-height="20px" padding-top="16px">Ποσόστωση: {{ .Usage.Quota }}</mj-text>
+      <mj-text font-size="14px" color="#201F1E" align="left" line-height="20px" padding-top="16px">Τρέχουσα τιμή: {{ .Usage.CurrentValue }}</mj-text>
     </mj-column>
   </mj-section>
 </mj-body>

--- a/resources/authgear/templates/en/messages/usage_alert_email.html
+++ b/resources/authgear/templates/en/messages/usage_alert_email.html
@@ -171,7 +171,7 @@
                               </tr>
 
                               <tr>
-                                <td align="left" style="font-size: 0px; padding: 0; word-break: break-word">
+                                <td align="left" style="font-size: 0px; padding: 10px 25px; padding-top: 16px; word-break: break-word">
                                   <div
                                     style="
                                       font-family:
@@ -193,7 +193,7 @@
                               </tr>
 
                               <tr>
-                                <td align="left" style="font-size: 0px; padding: 0; word-break: break-word">
+                                <td align="left" style="font-size: 0px; padding: 10px 25px; padding-top: 16px; word-break: break-word">
                                   <div
                                     style="
                                       font-family:

--- a/resources/authgear/templates/en/messages/usage_alert_email.mjml
+++ b/resources/authgear/templates/en/messages/usage_alert_email.mjml
@@ -11,8 +11,8 @@
       <mj-divider border-width="1px" border-color="#c7c7c7" />
       <mj-text font-size="14px" color="#201F1E" align="left" line-height="20px">{{ template "app.name" }} has reached the configured {{ .Usage.Period }} {{ .Usage.Name }} usage threshold.</mj-text>
       <mj-text font-size="14px" color="#201F1E" align="left" line-height="20px" padding-top="16px">Action: {{ .Usage.Action }}</mj-text>
-      <mj-text font-size="14px" color="#201F1E" align="left" line-height="20px" padding="0">Quota: {{ .Usage.Quota }}</mj-text>
-      <mj-text font-size="14px" color="#201F1E" align="left" line-height="20px" padding="0">Current value: {{ .Usage.CurrentValue }}</mj-text>
+      <mj-text font-size="14px" color="#201F1E" align="left" line-height="20px" padding-top="16px">Quota: {{ .Usage.Quota }}</mj-text>
+      <mj-text font-size="14px" color="#201F1E" align="left" line-height="20px" padding-top="16px">Current value: {{ .Usage.CurrentValue }}</mj-text>
     </mj-column>
   </mj-section>
 </mj-body>

--- a/resources/authgear/templates/en/messages/usage_alert_email.mjml.gotemplate
+++ b/resources/authgear/templates/en/messages/usage_alert_email.mjml.gotemplate
@@ -11,8 +11,8 @@
       <mj-divider border-width="1px" border-color="#c7c7c7" />
       <mj-text font-size="14px" color="#201F1E" align="left" line-height="20px">[[ .T.UsageAlertEmail.Body ]]</mj-text>
       <mj-text font-size="14px" color="#201F1E" align="left" line-height="20px" padding-top="16px">[[ .T.UsageAlertEmail.Action ]]</mj-text>
-      <mj-text font-size="14px" color="#201F1E" align="left" line-height="20px" padding="0">[[ .T.UsageAlertEmail.Quota ]]</mj-text>
-      <mj-text font-size="14px" color="#201F1E" align="left" line-height="20px" padding="0">[[ .T.UsageAlertEmail.CurrentValue ]]</mj-text>
+      <mj-text font-size="14px" color="#201F1E" align="left" line-height="20px" padding-top="16px">[[ .T.UsageAlertEmail.Quota ]]</mj-text>
+      <mj-text font-size="14px" color="#201F1E" align="left" line-height="20px" padding-top="16px">[[ .T.UsageAlertEmail.CurrentValue ]]</mj-text>
     </mj-column>
   </mj-section>
 </mj-body>

--- a/resources/authgear/templates/es-419/messages/usage_alert_email.html
+++ b/resources/authgear/templates/es-419/messages/usage_alert_email.html
@@ -171,7 +171,7 @@
                               </tr>
 
                               <tr>
-                                <td align="left" style="font-size: 0px; padding: 0; word-break: break-word">
+                                <td align="left" style="font-size: 0px; padding: 10px 25px; padding-top: 16px; word-break: break-word">
                                   <div
                                     style="
                                       font-family:
@@ -193,7 +193,7 @@
                               </tr>
 
                               <tr>
-                                <td align="left" style="font-size: 0px; padding: 0; word-break: break-word">
+                                <td align="left" style="font-size: 0px; padding: 10px 25px; padding-top: 16px; word-break: break-word">
                                   <div
                                     style="
                                       font-family:

--- a/resources/authgear/templates/es-419/messages/usage_alert_email.mjml
+++ b/resources/authgear/templates/es-419/messages/usage_alert_email.mjml
@@ -11,8 +11,8 @@
       <mj-divider border-width="1px" border-color="#c7c7c7" />
       <mj-text font-size="14px" color="#201F1E" align="left" line-height="20px">{{ template "app.name" }} ha alcanzado el umbral de uso configurado para {{ .Usage.Period }} {{ .Usage.Name }}.</mj-text>
       <mj-text font-size="14px" color="#201F1E" align="left" line-height="20px" padding-top="16px">Acción: {{ .Usage.Action }}</mj-text>
-      <mj-text font-size="14px" color="#201F1E" align="left" line-height="20px" padding="0">Cuota: {{ .Usage.Quota }}</mj-text>
-      <mj-text font-size="14px" color="#201F1E" align="left" line-height="20px" padding="0">Valor actual: {{ .Usage.CurrentValue }}</mj-text>
+      <mj-text font-size="14px" color="#201F1E" align="left" line-height="20px" padding-top="16px">Cuota: {{ .Usage.Quota }}</mj-text>
+      <mj-text font-size="14px" color="#201F1E" align="left" line-height="20px" padding-top="16px">Valor actual: {{ .Usage.CurrentValue }}</mj-text>
     </mj-column>
   </mj-section>
 </mj-body>

--- a/resources/authgear/templates/es-ES/messages/usage_alert_email.html
+++ b/resources/authgear/templates/es-ES/messages/usage_alert_email.html
@@ -171,7 +171,7 @@
                               </tr>
 
                               <tr>
-                                <td align="left" style="font-size: 0px; padding: 0; word-break: break-word">
+                                <td align="left" style="font-size: 0px; padding: 10px 25px; padding-top: 16px; word-break: break-word">
                                   <div
                                     style="
                                       font-family:
@@ -193,7 +193,7 @@
                               </tr>
 
                               <tr>
-                                <td align="left" style="font-size: 0px; padding: 0; word-break: break-word">
+                                <td align="left" style="font-size: 0px; padding: 10px 25px; padding-top: 16px; word-break: break-word">
                                   <div
                                     style="
                                       font-family:

--- a/resources/authgear/templates/es-ES/messages/usage_alert_email.mjml
+++ b/resources/authgear/templates/es-ES/messages/usage_alert_email.mjml
@@ -11,8 +11,8 @@
       <mj-divider border-width="1px" border-color="#c7c7c7" />
       <mj-text font-size="14px" color="#201F1E" align="left" line-height="20px">{{ template "app.name" }} ha alcanzado el umbral de uso configurado para {{ .Usage.Period }} {{ .Usage.Name }}.</mj-text>
       <mj-text font-size="14px" color="#201F1E" align="left" line-height="20px" padding-top="16px">Acción: {{ .Usage.Action }}</mj-text>
-      <mj-text font-size="14px" color="#201F1E" align="left" line-height="20px" padding="0">Cuota: {{ .Usage.Quota }}</mj-text>
-      <mj-text font-size="14px" color="#201F1E" align="left" line-height="20px" padding="0">Valor actual: {{ .Usage.CurrentValue }}</mj-text>
+      <mj-text font-size="14px" color="#201F1E" align="left" line-height="20px" padding-top="16px">Cuota: {{ .Usage.Quota }}</mj-text>
+      <mj-text font-size="14px" color="#201F1E" align="left" line-height="20px" padding-top="16px">Valor actual: {{ .Usage.CurrentValue }}</mj-text>
     </mj-column>
   </mj-section>
 </mj-body>

--- a/resources/authgear/templates/es/messages/usage_alert_email.html
+++ b/resources/authgear/templates/es/messages/usage_alert_email.html
@@ -171,7 +171,7 @@
                               </tr>
 
                               <tr>
-                                <td align="left" style="font-size: 0px; padding: 0; word-break: break-word">
+                                <td align="left" style="font-size: 0px; padding: 10px 25px; padding-top: 16px; word-break: break-word">
                                   <div
                                     style="
                                       font-family:
@@ -193,7 +193,7 @@
                               </tr>
 
                               <tr>
-                                <td align="left" style="font-size: 0px; padding: 0; word-break: break-word">
+                                <td align="left" style="font-size: 0px; padding: 10px 25px; padding-top: 16px; word-break: break-word">
                                   <div
                                     style="
                                       font-family:

--- a/resources/authgear/templates/es/messages/usage_alert_email.mjml
+++ b/resources/authgear/templates/es/messages/usage_alert_email.mjml
@@ -11,8 +11,8 @@
       <mj-divider border-width="1px" border-color="#c7c7c7" />
       <mj-text font-size="14px" color="#201F1E" align="left" line-height="20px">{{ template "app.name" }} ha alcanzado el umbral de uso configurado para {{ .Usage.Period }} {{ .Usage.Name }}.</mj-text>
       <mj-text font-size="14px" color="#201F1E" align="left" line-height="20px" padding-top="16px">Acción: {{ .Usage.Action }}</mj-text>
-      <mj-text font-size="14px" color="#201F1E" align="left" line-height="20px" padding="0">Cuota: {{ .Usage.Quota }}</mj-text>
-      <mj-text font-size="14px" color="#201F1E" align="left" line-height="20px" padding="0">Valor actual: {{ .Usage.CurrentValue }}</mj-text>
+      <mj-text font-size="14px" color="#201F1E" align="left" line-height="20px" padding-top="16px">Cuota: {{ .Usage.Quota }}</mj-text>
+      <mj-text font-size="14px" color="#201F1E" align="left" line-height="20px" padding-top="16px">Valor actual: {{ .Usage.CurrentValue }}</mj-text>
     </mj-column>
   </mj-section>
 </mj-body>

--- a/resources/authgear/templates/fil/messages/usage_alert_email.html
+++ b/resources/authgear/templates/fil/messages/usage_alert_email.html
@@ -171,7 +171,7 @@
                               </tr>
 
                               <tr>
-                                <td align="left" style="font-size: 0px; padding: 0; word-break: break-word">
+                                <td align="left" style="font-size: 0px; padding: 10px 25px; padding-top: 16px; word-break: break-word">
                                   <div
                                     style="
                                       font-family:
@@ -193,7 +193,7 @@
                               </tr>
 
                               <tr>
-                                <td align="left" style="font-size: 0px; padding: 0; word-break: break-word">
+                                <td align="left" style="font-size: 0px; padding: 10px 25px; padding-top: 16px; word-break: break-word">
                                   <div
                                     style="
                                       font-family:

--- a/resources/authgear/templates/fil/messages/usage_alert_email.mjml
+++ b/resources/authgear/templates/fil/messages/usage_alert_email.mjml
@@ -11,8 +11,8 @@
       <mj-divider border-width="1px" border-color="#c7c7c7" />
       <mj-text font-size="14px" color="#201F1E" align="left" line-height="20px">Naabot ng {{ template "app.name" }} ang nakatakdang limitasyon sa paggamit para sa {{ .Usage.Period }} {{ .Usage.Name }}.</mj-text>
       <mj-text font-size="14px" color="#201F1E" align="left" line-height="20px" padding-top="16px">Aksyon: {{ .Usage.Action }}</mj-text>
-      <mj-text font-size="14px" color="#201F1E" align="left" line-height="20px" padding="0">Quota: {{ .Usage.Quota }}</mj-text>
-      <mj-text font-size="14px" color="#201F1E" align="left" line-height="20px" padding="0">Kasalukuyang halaga: {{ .Usage.CurrentValue }}</mj-text>
+      <mj-text font-size="14px" color="#201F1E" align="left" line-height="20px" padding-top="16px">Quota: {{ .Usage.Quota }}</mj-text>
+      <mj-text font-size="14px" color="#201F1E" align="left" line-height="20px" padding-top="16px">Kasalukuyang halaga: {{ .Usage.CurrentValue }}</mj-text>
     </mj-column>
   </mj-section>
 </mj-body>

--- a/resources/authgear/templates/fr/messages/usage_alert_email.html
+++ b/resources/authgear/templates/fr/messages/usage_alert_email.html
@@ -171,7 +171,7 @@
                               </tr>
 
                               <tr>
-                                <td align="left" style="font-size: 0px; padding: 0; word-break: break-word">
+                                <td align="left" style="font-size: 0px; padding: 10px 25px; padding-top: 16px; word-break: break-word">
                                   <div
                                     style="
                                       font-family:
@@ -193,7 +193,7 @@
                               </tr>
 
                               <tr>
-                                <td align="left" style="font-size: 0px; padding: 0; word-break: break-word">
+                                <td align="left" style="font-size: 0px; padding: 10px 25px; padding-top: 16px; word-break: break-word">
                                   <div
                                     style="
                                       font-family:

--- a/resources/authgear/templates/fr/messages/usage_alert_email.mjml
+++ b/resources/authgear/templates/fr/messages/usage_alert_email.mjml
@@ -11,8 +11,8 @@
       <mj-divider border-width="1px" border-color="#c7c7c7" />
       <mj-text font-size="14px" color="#201F1E" align="left" line-height="20px">{{ template "app.name" }} a atteint le seuil d’utilisation configuré pour {{ .Usage.Period }} {{ .Usage.Name }}.</mj-text>
       <mj-text font-size="14px" color="#201F1E" align="left" line-height="20px" padding-top="16px">Action : {{ .Usage.Action }}</mj-text>
-      <mj-text font-size="14px" color="#201F1E" align="left" line-height="20px" padding="0">Quota : {{ .Usage.Quota }}</mj-text>
-      <mj-text font-size="14px" color="#201F1E" align="left" line-height="20px" padding="0">Valeur actuelle : {{ .Usage.CurrentValue }}</mj-text>
+      <mj-text font-size="14px" color="#201F1E" align="left" line-height="20px" padding-top="16px">Quota : {{ .Usage.Quota }}</mj-text>
+      <mj-text font-size="14px" color="#201F1E" align="left" line-height="20px" padding-top="16px">Valeur actuelle : {{ .Usage.CurrentValue }}</mj-text>
     </mj-column>
   </mj-section>
 </mj-body>

--- a/resources/authgear/templates/id/messages/usage_alert_email.html
+++ b/resources/authgear/templates/id/messages/usage_alert_email.html
@@ -171,7 +171,7 @@
                               </tr>
 
                               <tr>
-                                <td align="left" style="font-size: 0px; padding: 0; word-break: break-word">
+                                <td align="left" style="font-size: 0px; padding: 10px 25px; padding-top: 16px; word-break: break-word">
                                   <div
                                     style="
                                       font-family:
@@ -193,7 +193,7 @@
                               </tr>
 
                               <tr>
-                                <td align="left" style="font-size: 0px; padding: 0; word-break: break-word">
+                                <td align="left" style="font-size: 0px; padding: 10px 25px; padding-top: 16px; word-break: break-word">
                                   <div
                                     style="
                                       font-family:

--- a/resources/authgear/templates/id/messages/usage_alert_email.mjml
+++ b/resources/authgear/templates/id/messages/usage_alert_email.mjml
@@ -11,8 +11,8 @@
       <mj-divider border-width="1px" border-color="#c7c7c7" />
       <mj-text font-size="14px" color="#201F1E" align="left" line-height="20px">{{ template "app.name" }} telah mencapai ambang penggunaan yang dikonfigurasi untuk {{ .Usage.Period }} {{ .Usage.Name }}.</mj-text>
       <mj-text font-size="14px" color="#201F1E" align="left" line-height="20px" padding-top="16px">Tindakan: {{ .Usage.Action }}</mj-text>
-      <mj-text font-size="14px" color="#201F1E" align="left" line-height="20px" padding="0">Kuota: {{ .Usage.Quota }}</mj-text>
-      <mj-text font-size="14px" color="#201F1E" align="left" line-height="20px" padding="0">Nilai saat ini: {{ .Usage.CurrentValue }}</mj-text>
+      <mj-text font-size="14px" color="#201F1E" align="left" line-height="20px" padding-top="16px">Kuota: {{ .Usage.Quota }}</mj-text>
+      <mj-text font-size="14px" color="#201F1E" align="left" line-height="20px" padding-top="16px">Nilai saat ini: {{ .Usage.CurrentValue }}</mj-text>
     </mj-column>
   </mj-section>
 </mj-body>

--- a/resources/authgear/templates/it/messages/usage_alert_email.html
+++ b/resources/authgear/templates/it/messages/usage_alert_email.html
@@ -171,7 +171,7 @@
                               </tr>
 
                               <tr>
-                                <td align="left" style="font-size: 0px; padding: 0; word-break: break-word">
+                                <td align="left" style="font-size: 0px; padding: 10px 25px; padding-top: 16px; word-break: break-word">
                                   <div
                                     style="
                                       font-family:
@@ -193,7 +193,7 @@
                               </tr>
 
                               <tr>
-                                <td align="left" style="font-size: 0px; padding: 0; word-break: break-word">
+                                <td align="left" style="font-size: 0px; padding: 10px 25px; padding-top: 16px; word-break: break-word">
                                   <div
                                     style="
                                       font-family:

--- a/resources/authgear/templates/it/messages/usage_alert_email.mjml
+++ b/resources/authgear/templates/it/messages/usage_alert_email.mjml
@@ -11,8 +11,8 @@
       <mj-divider border-width="1px" border-color="#c7c7c7" />
       <mj-text font-size="14px" color="#201F1E" align="left" line-height="20px">{{ template "app.name" }} ha raggiunto la soglia di utilizzo configurata per {{ .Usage.Period }} {{ .Usage.Name }}.</mj-text>
       <mj-text font-size="14px" color="#201F1E" align="left" line-height="20px" padding-top="16px">Azione: {{ .Usage.Action }}</mj-text>
-      <mj-text font-size="14px" color="#201F1E" align="left" line-height="20px" padding="0">Quota: {{ .Usage.Quota }}</mj-text>
-      <mj-text font-size="14px" color="#201F1E" align="left" line-height="20px" padding="0">Valore attuale: {{ .Usage.CurrentValue }}</mj-text>
+      <mj-text font-size="14px" color="#201F1E" align="left" line-height="20px" padding-top="16px">Quota: {{ .Usage.Quota }}</mj-text>
+      <mj-text font-size="14px" color="#201F1E" align="left" line-height="20px" padding-top="16px">Valore attuale: {{ .Usage.CurrentValue }}</mj-text>
     </mj-column>
   </mj-section>
 </mj-body>

--- a/resources/authgear/templates/ja/messages/usage_alert_email.html
+++ b/resources/authgear/templates/ja/messages/usage_alert_email.html
@@ -171,7 +171,7 @@
                               </tr>
 
                               <tr>
-                                <td align="left" style="font-size: 0px; padding: 0; word-break: break-word">
+                                <td align="left" style="font-size: 0px; padding: 10px 25px; padding-top: 16px; word-break: break-word">
                                   <div
                                     style="
                                       font-family:
@@ -193,7 +193,7 @@
                               </tr>
 
                               <tr>
-                                <td align="left" style="font-size: 0px; padding: 0; word-break: break-word">
+                                <td align="left" style="font-size: 0px; padding: 10px 25px; padding-top: 16px; word-break: break-word">
                                   <div
                                     style="
                                       font-family:

--- a/resources/authgear/templates/ja/messages/usage_alert_email.mjml
+++ b/resources/authgear/templates/ja/messages/usage_alert_email.mjml
@@ -11,8 +11,8 @@
       <mj-divider border-width="1px" border-color="#c7c7c7" />
       <mj-text font-size="14px" color="#201F1E" align="left" line-height="20px">{{ template "app.name" }} は、設定された {{ .Usage.Period }} {{ .Usage.Name }} の使用量しきい値に達しました。</mj-text>
       <mj-text font-size="14px" color="#201F1E" align="left" line-height="20px" padding-top="16px">アクション: {{ .Usage.Action }}</mj-text>
-      <mj-text font-size="14px" color="#201F1E" align="left" line-height="20px" padding="0">クォータ: {{ .Usage.Quota }}</mj-text>
-      <mj-text font-size="14px" color="#201F1E" align="left" line-height="20px" padding="0">現在値: {{ .Usage.CurrentValue }}</mj-text>
+      <mj-text font-size="14px" color="#201F1E" align="left" line-height="20px" padding-top="16px">クォータ: {{ .Usage.Quota }}</mj-text>
+      <mj-text font-size="14px" color="#201F1E" align="left" line-height="20px" padding-top="16px">現在値: {{ .Usage.CurrentValue }}</mj-text>
     </mj-column>
   </mj-section>
 </mj-body>

--- a/resources/authgear/templates/ko/messages/usage_alert_email.html
+++ b/resources/authgear/templates/ko/messages/usage_alert_email.html
@@ -171,7 +171,7 @@
                               </tr>
 
                               <tr>
-                                <td align="left" style="font-size: 0px; padding: 0; word-break: break-word">
+                                <td align="left" style="font-size: 0px; padding: 10px 25px; padding-top: 16px; word-break: break-word">
                                   <div
                                     style="
                                       font-family:
@@ -193,7 +193,7 @@
                               </tr>
 
                               <tr>
-                                <td align="left" style="font-size: 0px; padding: 0; word-break: break-word">
+                                <td align="left" style="font-size: 0px; padding: 10px 25px; padding-top: 16px; word-break: break-word">
                                   <div
                                     style="
                                       font-family:

--- a/resources/authgear/templates/ko/messages/usage_alert_email.mjml
+++ b/resources/authgear/templates/ko/messages/usage_alert_email.mjml
@@ -11,8 +11,8 @@
       <mj-divider border-width="1px" border-color="#c7c7c7" />
       <mj-text font-size="14px" color="#201F1E" align="left" line-height="20px">{{ template "app.name" }}이 설정된 {{ .Usage.Period }} {{ .Usage.Name }} 사용량 임계값에 도달했습니다.</mj-text>
       <mj-text font-size="14px" color="#201F1E" align="left" line-height="20px" padding-top="16px">작업: {{ .Usage.Action }}</mj-text>
-      <mj-text font-size="14px" color="#201F1E" align="left" line-height="20px" padding="0">할당량: {{ .Usage.Quota }}</mj-text>
-      <mj-text font-size="14px" color="#201F1E" align="left" line-height="20px" padding="0">현재 값: {{ .Usage.CurrentValue }}</mj-text>
+      <mj-text font-size="14px" color="#201F1E" align="left" line-height="20px" padding-top="16px">할당량: {{ .Usage.Quota }}</mj-text>
+      <mj-text font-size="14px" color="#201F1E" align="left" line-height="20px" padding-top="16px">현재 값: {{ .Usage.CurrentValue }}</mj-text>
     </mj-column>
   </mj-section>
 </mj-body>

--- a/resources/authgear/templates/ms/messages/usage_alert_email.html
+++ b/resources/authgear/templates/ms/messages/usage_alert_email.html
@@ -171,7 +171,7 @@
                               </tr>
 
                               <tr>
-                                <td align="left" style="font-size: 0px; padding: 0; word-break: break-word">
+                                <td align="left" style="font-size: 0px; padding: 10px 25px; padding-top: 16px; word-break: break-word">
                                   <div
                                     style="
                                       font-family:
@@ -193,7 +193,7 @@
                               </tr>
 
                               <tr>
-                                <td align="left" style="font-size: 0px; padding: 0; word-break: break-word">
+                                <td align="left" style="font-size: 0px; padding: 10px 25px; padding-top: 16px; word-break: break-word">
                                   <div
                                     style="
                                       font-family:

--- a/resources/authgear/templates/ms/messages/usage_alert_email.mjml
+++ b/resources/authgear/templates/ms/messages/usage_alert_email.mjml
@@ -11,8 +11,8 @@
       <mj-divider border-width="1px" border-color="#c7c7c7" />
       <mj-text font-size="14px" color="#201F1E" align="left" line-height="20px">{{ template "app.name" }} telah mencapai ambang penggunaan yang dikonfigurasikan untuk {{ .Usage.Period }} {{ .Usage.Name }}.</mj-text>
       <mj-text font-size="14px" color="#201F1E" align="left" line-height="20px" padding-top="16px">Tindakan: {{ .Usage.Action }}</mj-text>
-      <mj-text font-size="14px" color="#201F1E" align="left" line-height="20px" padding="0">Kuota: {{ .Usage.Quota }}</mj-text>
-      <mj-text font-size="14px" color="#201F1E" align="left" line-height="20px" padding="0">Nilai semasa: {{ .Usage.CurrentValue }}</mj-text>
+      <mj-text font-size="14px" color="#201F1E" align="left" line-height="20px" padding-top="16px">Kuota: {{ .Usage.Quota }}</mj-text>
+      <mj-text font-size="14px" color="#201F1E" align="left" line-height="20px" padding-top="16px">Nilai semasa: {{ .Usage.CurrentValue }}</mj-text>
     </mj-column>
   </mj-section>
 </mj-body>

--- a/resources/authgear/templates/nl/messages/usage_alert_email.html
+++ b/resources/authgear/templates/nl/messages/usage_alert_email.html
@@ -171,7 +171,7 @@
                               </tr>
 
                               <tr>
-                                <td align="left" style="font-size: 0px; padding: 0; word-break: break-word">
+                                <td align="left" style="font-size: 0px; padding: 10px 25px; padding-top: 16px; word-break: break-word">
                                   <div
                                     style="
                                       font-family:
@@ -193,7 +193,7 @@
                               </tr>
 
                               <tr>
-                                <td align="left" style="font-size: 0px; padding: 0; word-break: break-word">
+                                <td align="left" style="font-size: 0px; padding: 10px 25px; padding-top: 16px; word-break: break-word">
                                   <div
                                     style="
                                       font-family:

--- a/resources/authgear/templates/nl/messages/usage_alert_email.mjml
+++ b/resources/authgear/templates/nl/messages/usage_alert_email.mjml
@@ -11,8 +11,8 @@
       <mj-divider border-width="1px" border-color="#c7c7c7" />
       <mj-text font-size="14px" color="#201F1E" align="left" line-height="20px">{{ template "app.name" }} heeft de geconfigureerde gebruiksdrempel voor {{ .Usage.Period }} {{ .Usage.Name }} bereikt.</mj-text>
       <mj-text font-size="14px" color="#201F1E" align="left" line-height="20px" padding-top="16px">Actie: {{ .Usage.Action }}</mj-text>
-      <mj-text font-size="14px" color="#201F1E" align="left" line-height="20px" padding="0">Quota: {{ .Usage.Quota }}</mj-text>
-      <mj-text font-size="14px" color="#201F1E" align="left" line-height="20px" padding="0">Huidige waarde: {{ .Usage.CurrentValue }}</mj-text>
+      <mj-text font-size="14px" color="#201F1E" align="left" line-height="20px" padding-top="16px">Quota: {{ .Usage.Quota }}</mj-text>
+      <mj-text font-size="14px" color="#201F1E" align="left" line-height="20px" padding-top="16px">Huidige waarde: {{ .Usage.CurrentValue }}</mj-text>
     </mj-column>
   </mj-section>
 </mj-body>

--- a/resources/authgear/templates/pl/messages/usage_alert_email.html
+++ b/resources/authgear/templates/pl/messages/usage_alert_email.html
@@ -171,7 +171,7 @@
                               </tr>
 
                               <tr>
-                                <td align="left" style="font-size: 0px; padding: 0; word-break: break-word">
+                                <td align="left" style="font-size: 0px; padding: 10px 25px; padding-top: 16px; word-break: break-word">
                                   <div
                                     style="
                                       font-family:
@@ -193,7 +193,7 @@
                               </tr>
 
                               <tr>
-                                <td align="left" style="font-size: 0px; padding: 0; word-break: break-word">
+                                <td align="left" style="font-size: 0px; padding: 10px 25px; padding-top: 16px; word-break: break-word">
                                   <div
                                     style="
                                       font-family:

--- a/resources/authgear/templates/pl/messages/usage_alert_email.mjml
+++ b/resources/authgear/templates/pl/messages/usage_alert_email.mjml
@@ -11,8 +11,8 @@
       <mj-divider border-width="1px" border-color="#c7c7c7" />
       <mj-text font-size="14px" color="#201F1E" align="left" line-height="20px">{{ template "app.name" }} osiągnął skonfigurowany próg użycia dla {{ .Usage.Period }} {{ .Usage.Name }}.</mj-text>
       <mj-text font-size="14px" color="#201F1E" align="left" line-height="20px" padding-top="16px">Działanie: {{ .Usage.Action }}</mj-text>
-      <mj-text font-size="14px" color="#201F1E" align="left" line-height="20px" padding="0">Limit: {{ .Usage.Quota }}</mj-text>
-      <mj-text font-size="14px" color="#201F1E" align="left" line-height="20px" padding="0">Bieżąca wartość: {{ .Usage.CurrentValue }}</mj-text>
+      <mj-text font-size="14px" color="#201F1E" align="left" line-height="20px" padding-top="16px">Limit: {{ .Usage.Quota }}</mj-text>
+      <mj-text font-size="14px" color="#201F1E" align="left" line-height="20px" padding-top="16px">Bieżąca wartość: {{ .Usage.CurrentValue }}</mj-text>
     </mj-column>
   </mj-section>
 </mj-body>

--- a/resources/authgear/templates/pt-BR/messages/usage_alert_email.html
+++ b/resources/authgear/templates/pt-BR/messages/usage_alert_email.html
@@ -171,7 +171,7 @@
                               </tr>
 
                               <tr>
-                                <td align="left" style="font-size: 0px; padding: 0; word-break: break-word">
+                                <td align="left" style="font-size: 0px; padding: 10px 25px; padding-top: 16px; word-break: break-word">
                                   <div
                                     style="
                                       font-family:
@@ -193,7 +193,7 @@
                               </tr>
 
                               <tr>
-                                <td align="left" style="font-size: 0px; padding: 0; word-break: break-word">
+                                <td align="left" style="font-size: 0px; padding: 10px 25px; padding-top: 16px; word-break: break-word">
                                   <div
                                     style="
                                       font-family:

--- a/resources/authgear/templates/pt-BR/messages/usage_alert_email.mjml
+++ b/resources/authgear/templates/pt-BR/messages/usage_alert_email.mjml
@@ -11,8 +11,8 @@
       <mj-divider border-width="1px" border-color="#c7c7c7" />
       <mj-text font-size="14px" color="#201F1E" align="left" line-height="20px">{{ template "app.name" }} atingiu o limite de uso configurado para {{ .Usage.Period }} {{ .Usage.Name }}.</mj-text>
       <mj-text font-size="14px" color="#201F1E" align="left" line-height="20px" padding-top="16px">Ação: {{ .Usage.Action }}</mj-text>
-      <mj-text font-size="14px" color="#201F1E" align="left" line-height="20px" padding="0">Cota: {{ .Usage.Quota }}</mj-text>
-      <mj-text font-size="14px" color="#201F1E" align="left" line-height="20px" padding="0">Valor atual: {{ .Usage.CurrentValue }}</mj-text>
+      <mj-text font-size="14px" color="#201F1E" align="left" line-height="20px" padding-top="16px">Cota: {{ .Usage.Quota }}</mj-text>
+      <mj-text font-size="14px" color="#201F1E" align="left" line-height="20px" padding-top="16px">Valor atual: {{ .Usage.CurrentValue }}</mj-text>
     </mj-column>
   </mj-section>
 </mj-body>

--- a/resources/authgear/templates/pt-PT/messages/usage_alert_email.html
+++ b/resources/authgear/templates/pt-PT/messages/usage_alert_email.html
@@ -171,7 +171,7 @@
                               </tr>
 
                               <tr>
-                                <td align="left" style="font-size: 0px; padding: 0; word-break: break-word">
+                                <td align="left" style="font-size: 0px; padding: 10px 25px; padding-top: 16px; word-break: break-word">
                                   <div
                                     style="
                                       font-family:
@@ -193,7 +193,7 @@
                               </tr>
 
                               <tr>
-                                <td align="left" style="font-size: 0px; padding: 0; word-break: break-word">
+                                <td align="left" style="font-size: 0px; padding: 10px 25px; padding-top: 16px; word-break: break-word">
                                   <div
                                     style="
                                       font-family:

--- a/resources/authgear/templates/pt-PT/messages/usage_alert_email.mjml
+++ b/resources/authgear/templates/pt-PT/messages/usage_alert_email.mjml
@@ -11,8 +11,8 @@
       <mj-divider border-width="1px" border-color="#c7c7c7" />
       <mj-text font-size="14px" color="#201F1E" align="left" line-height="20px">{{ template "app.name" }} atingiu o limite de utilização configurado para {{ .Usage.Period }} {{ .Usage.Name }}.</mj-text>
       <mj-text font-size="14px" color="#201F1E" align="left" line-height="20px" padding-top="16px">Ação: {{ .Usage.Action }}</mj-text>
-      <mj-text font-size="14px" color="#201F1E" align="left" line-height="20px" padding="0">Quota: {{ .Usage.Quota }}</mj-text>
-      <mj-text font-size="14px" color="#201F1E" align="left" line-height="20px" padding="0">Valor atual: {{ .Usage.CurrentValue }}</mj-text>
+      <mj-text font-size="14px" color="#201F1E" align="left" line-height="20px" padding-top="16px">Quota: {{ .Usage.Quota }}</mj-text>
+      <mj-text font-size="14px" color="#201F1E" align="left" line-height="20px" padding-top="16px">Valor atual: {{ .Usage.CurrentValue }}</mj-text>
     </mj-column>
   </mj-section>
 </mj-body>

--- a/resources/authgear/templates/pt/messages/usage_alert_email.html
+++ b/resources/authgear/templates/pt/messages/usage_alert_email.html
@@ -171,7 +171,7 @@
                               </tr>
 
                               <tr>
-                                <td align="left" style="font-size: 0px; padding: 0; word-break: break-word">
+                                <td align="left" style="font-size: 0px; padding: 10px 25px; padding-top: 16px; word-break: break-word">
                                   <div
                                     style="
                                       font-family:
@@ -193,7 +193,7 @@
                               </tr>
 
                               <tr>
-                                <td align="left" style="font-size: 0px; padding: 0; word-break: break-word">
+                                <td align="left" style="font-size: 0px; padding: 10px 25px; padding-top: 16px; word-break: break-word">
                                   <div
                                     style="
                                       font-family:

--- a/resources/authgear/templates/pt/messages/usage_alert_email.mjml
+++ b/resources/authgear/templates/pt/messages/usage_alert_email.mjml
@@ -11,8 +11,8 @@
       <mj-divider border-width="1px" border-color="#c7c7c7" />
       <mj-text font-size="14px" color="#201F1E" align="left" line-height="20px">{{ template "app.name" }} atingiu o limite de uso configurado para {{ .Usage.Period }} {{ .Usage.Name }}.</mj-text>
       <mj-text font-size="14px" color="#201F1E" align="left" line-height="20px" padding-top="16px">Ação: {{ .Usage.Action }}</mj-text>
-      <mj-text font-size="14px" color="#201F1E" align="left" line-height="20px" padding="0">Cota: {{ .Usage.Quota }}</mj-text>
-      <mj-text font-size="14px" color="#201F1E" align="left" line-height="20px" padding="0">Valor atual: {{ .Usage.CurrentValue }}</mj-text>
+      <mj-text font-size="14px" color="#201F1E" align="left" line-height="20px" padding-top="16px">Cota: {{ .Usage.Quota }}</mj-text>
+      <mj-text font-size="14px" color="#201F1E" align="left" line-height="20px" padding-top="16px">Valor atual: {{ .Usage.CurrentValue }}</mj-text>
     </mj-column>
   </mj-section>
 </mj-body>

--- a/resources/authgear/templates/th/messages/usage_alert_email.html
+++ b/resources/authgear/templates/th/messages/usage_alert_email.html
@@ -171,7 +171,7 @@
                               </tr>
 
                               <tr>
-                                <td align="left" style="font-size: 0px; padding: 0; word-break: break-word">
+                                <td align="left" style="font-size: 0px; padding: 10px 25px; padding-top: 16px; word-break: break-word">
                                   <div
                                     style="
                                       font-family:
@@ -193,7 +193,7 @@
                               </tr>
 
                               <tr>
-                                <td align="left" style="font-size: 0px; padding: 0; word-break: break-word">
+                                <td align="left" style="font-size: 0px; padding: 10px 25px; padding-top: 16px; word-break: break-word">
                                   <div
                                     style="
                                       font-family:

--- a/resources/authgear/templates/th/messages/usage_alert_email.mjml
+++ b/resources/authgear/templates/th/messages/usage_alert_email.mjml
@@ -11,8 +11,8 @@
       <mj-divider border-width="1px" border-color="#c7c7c7" />
       <mj-text font-size="14px" color="#201F1E" align="left" line-height="20px">{{ template "app.name" }} ถึงเกณฑ์การใช้งานที่กำหนดสำหรับ {{ .Usage.Period }} {{ .Usage.Name }} แล้ว</mj-text>
       <mj-text font-size="14px" color="#201F1E" align="left" line-height="20px" padding-top="16px">การดำเนินการ: {{ .Usage.Action }}</mj-text>
-      <mj-text font-size="14px" color="#201F1E" align="left" line-height="20px" padding="0">โควตา: {{ .Usage.Quota }}</mj-text>
-      <mj-text font-size="14px" color="#201F1E" align="left" line-height="20px" padding="0">ค่าปัจจุบัน: {{ .Usage.CurrentValue }}</mj-text>
+      <mj-text font-size="14px" color="#201F1E" align="left" line-height="20px" padding-top="16px">โควตา: {{ .Usage.Quota }}</mj-text>
+      <mj-text font-size="14px" color="#201F1E" align="left" line-height="20px" padding-top="16px">ค่าปัจจุบัน: {{ .Usage.CurrentValue }}</mj-text>
     </mj-column>
   </mj-section>
 </mj-body>

--- a/resources/authgear/templates/vi/messages/usage_alert_email.html
+++ b/resources/authgear/templates/vi/messages/usage_alert_email.html
@@ -171,7 +171,7 @@
                               </tr>
 
                               <tr>
-                                <td align="left" style="font-size: 0px; padding: 0; word-break: break-word">
+                                <td align="left" style="font-size: 0px; padding: 10px 25px; padding-top: 16px; word-break: break-word">
                                   <div
                                     style="
                                       font-family:
@@ -193,7 +193,7 @@
                               </tr>
 
                               <tr>
-                                <td align="left" style="font-size: 0px; padding: 0; word-break: break-word">
+                                <td align="left" style="font-size: 0px; padding: 10px 25px; padding-top: 16px; word-break: break-word">
                                   <div
                                     style="
                                       font-family:

--- a/resources/authgear/templates/vi/messages/usage_alert_email.mjml
+++ b/resources/authgear/templates/vi/messages/usage_alert_email.mjml
@@ -11,8 +11,8 @@
       <mj-divider border-width="1px" border-color="#c7c7c7" />
       <mj-text font-size="14px" color="#201F1E" align="left" line-height="20px">{{ template "app.name" }} đã đạt ngưỡng sử dụng đã cấu hình cho {{ .Usage.Period }} {{ .Usage.Name }}.</mj-text>
       <mj-text font-size="14px" color="#201F1E" align="left" line-height="20px" padding-top="16px">Hành động: {{ .Usage.Action }}</mj-text>
-      <mj-text font-size="14px" color="#201F1E" align="left" line-height="20px" padding="0">Hạn mức: {{ .Usage.Quota }}</mj-text>
-      <mj-text font-size="14px" color="#201F1E" align="left" line-height="20px" padding="0">Giá trị hiện tại: {{ .Usage.CurrentValue }}</mj-text>
+      <mj-text font-size="14px" color="#201F1E" align="left" line-height="20px" padding-top="16px">Hạn mức: {{ .Usage.Quota }}</mj-text>
+      <mj-text font-size="14px" color="#201F1E" align="left" line-height="20px" padding-top="16px">Giá trị hiện tại: {{ .Usage.CurrentValue }}</mj-text>
     </mj-column>
   </mj-section>
 </mj-body>

--- a/resources/authgear/templates/zh-CN/messages/usage_alert_email.html
+++ b/resources/authgear/templates/zh-CN/messages/usage_alert_email.html
@@ -171,7 +171,7 @@
                               </tr>
 
                               <tr>
-                                <td align="left" style="font-size: 0px; padding: 0; word-break: break-word">
+                                <td align="left" style="font-size: 0px; padding: 10px 25px; padding-top: 16px; word-break: break-word">
                                   <div
                                     style="
                                       font-family:
@@ -193,7 +193,7 @@
                               </tr>
 
                               <tr>
-                                <td align="left" style="font-size: 0px; padding: 0; word-break: break-word">
+                                <td align="left" style="font-size: 0px; padding: 10px 25px; padding-top: 16px; word-break: break-word">
                                   <div
                                     style="
                                       font-family:

--- a/resources/authgear/templates/zh-CN/messages/usage_alert_email.mjml
+++ b/resources/authgear/templates/zh-CN/messages/usage_alert_email.mjml
@@ -11,8 +11,8 @@
       <mj-divider border-width="1px" border-color="#c7c7c7" />
       <mj-text font-size="14px" color="#201F1E" align="left" line-height="20px">{{ template "app.name" }} 已达到为 {{ .Usage.Period }} {{ .Usage.Name }} 配置的使用阈值。</mj-text>
       <mj-text font-size="14px" color="#201F1E" align="left" line-height="20px" padding-top="16px">操作：{{ .Usage.Action }}</mj-text>
-      <mj-text font-size="14px" color="#201F1E" align="left" line-height="20px" padding="0">配额：{{ .Usage.Quota }}</mj-text>
-      <mj-text font-size="14px" color="#201F1E" align="left" line-height="20px" padding="0">当前值：{{ .Usage.CurrentValue }}</mj-text>
+      <mj-text font-size="14px" color="#201F1E" align="left" line-height="20px" padding-top="16px">配额：{{ .Usage.Quota }}</mj-text>
+      <mj-text font-size="14px" color="#201F1E" align="left" line-height="20px" padding-top="16px">当前值：{{ .Usage.CurrentValue }}</mj-text>
     </mj-column>
   </mj-section>
 </mj-body>

--- a/resources/authgear/templates/zh-HK/messages/usage_alert_email.html
+++ b/resources/authgear/templates/zh-HK/messages/usage_alert_email.html
@@ -171,7 +171,7 @@
                               </tr>
 
                               <tr>
-                                <td align="left" style="font-size: 0px; padding: 0; word-break: break-word">
+                                <td align="left" style="font-size: 0px; padding: 10px 25px; padding-top: 16px; word-break: break-word">
                                   <div
                                     style="
                                       font-family:
@@ -193,7 +193,7 @@
                               </tr>
 
                               <tr>
-                                <td align="left" style="font-size: 0px; padding: 0; word-break: break-word">
+                                <td align="left" style="font-size: 0px; padding: 10px 25px; padding-top: 16px; word-break: break-word">
                                   <div
                                     style="
                                       font-family:

--- a/resources/authgear/templates/zh-HK/messages/usage_alert_email.mjml
+++ b/resources/authgear/templates/zh-HK/messages/usage_alert_email.mjml
@@ -11,8 +11,8 @@
       <mj-divider border-width="1px" border-color="#c7c7c7" />
       <mj-text font-size="14px" color="#201F1E" align="left" line-height="20px">{{ template "app.name" }} 已達到為 {{ .Usage.Period }} {{ .Usage.Name }} 設定的用量門檻。</mj-text>
       <mj-text font-size="14px" color="#201F1E" align="left" line-height="20px" padding-top="16px">動作：{{ .Usage.Action }}</mj-text>
-      <mj-text font-size="14px" color="#201F1E" align="left" line-height="20px" padding="0">配額：{{ .Usage.Quota }}</mj-text>
-      <mj-text font-size="14px" color="#201F1E" align="left" line-height="20px" padding="0">目前值：{{ .Usage.CurrentValue }}</mj-text>
+      <mj-text font-size="14px" color="#201F1E" align="left" line-height="20px" padding-top="16px">配額：{{ .Usage.Quota }}</mj-text>
+      <mj-text font-size="14px" color="#201F1E" align="left" line-height="20px" padding-top="16px">目前值：{{ .Usage.CurrentValue }}</mj-text>
     </mj-column>
   </mj-section>
 </mj-body>

--- a/resources/authgear/templates/zh-TW/messages/usage_alert_email.html
+++ b/resources/authgear/templates/zh-TW/messages/usage_alert_email.html
@@ -171,7 +171,7 @@
                               </tr>
 
                               <tr>
-                                <td align="left" style="font-size: 0px; padding: 0; word-break: break-word">
+                                <td align="left" style="font-size: 0px; padding: 10px 25px; padding-top: 16px; word-break: break-word">
                                   <div
                                     style="
                                       font-family:
@@ -193,7 +193,7 @@
                               </tr>
 
                               <tr>
-                                <td align="left" style="font-size: 0px; padding: 0; word-break: break-word">
+                                <td align="left" style="font-size: 0px; padding: 10px 25px; padding-top: 16px; word-break: break-word">
                                   <div
                                     style="
                                       font-family:

--- a/resources/authgear/templates/zh-TW/messages/usage_alert_email.mjml
+++ b/resources/authgear/templates/zh-TW/messages/usage_alert_email.mjml
@@ -11,8 +11,8 @@
       <mj-divider border-width="1px" border-color="#c7c7c7" />
       <mj-text font-size="14px" color="#201F1E" align="left" line-height="20px">{{ template "app.name" }} 已達到為 {{ .Usage.Period }} {{ .Usage.Name }} 設定的使用量門檻。</mj-text>
       <mj-text font-size="14px" color="#201F1E" align="left" line-height="20px" padding-top="16px">動作：{{ .Usage.Action }}</mj-text>
-      <mj-text font-size="14px" color="#201F1E" align="left" line-height="20px" padding="0">配額：{{ .Usage.Quota }}</mj-text>
-      <mj-text font-size="14px" color="#201F1E" align="left" line-height="20px" padding="0">目前值：{{ .Usage.CurrentValue }}</mj-text>
+      <mj-text font-size="14px" color="#201F1E" align="left" line-height="20px" padding-top="16px">配額：{{ .Usage.Quota }}</mj-text>
+      <mj-text font-size="14px" color="#201F1E" align="left" line-height="20px" padding-top="16px">目前值：{{ .Usage.CurrentValue }}</mj-text>
     </mj-column>
   </mj-section>
 </mj-body>


### PR DESCRIPTION
ref DEV-3442

Althouth it is just a temporary email, just make it looks better.

<img width="824" height="316" alt="Screenshot 2026-04-09 at 7 47 12 PM" src="https://github.com/user-attachments/assets/0c38c335-2bb5-4ef4-922b-3344e4785bd9" />
