### PR TITLE
[Portal] Allow non-ASCII sender name in custom SMTP provider

### DIFF
--- a/pkg/lib/infra/mail/sender.go
+++ b/pkg/lib/infra/mail/sender.go
@@ -2,6 +2,8 @@ package mail
 
 import (
 	"errors"
+	"fmt"
+	netmail "net/mail"
 
 	"gopkg.in/gomail.v2"
 
@@ -80,9 +82,39 @@ func (s *Sender) Send(message *gomail.Message) (err error) {
 	return nil
 }
 
-func (s *Sender) applyFrom(opts *SendOptions, message *gomail.Message) error {
-	message.SetHeader("From", opts.Sender)
+// SetFromHeader sets the RFC 5322 From header so that only the display
+// name is RFC 2047 encoded, not the angle-addr literal.
+//
+// gomail's SetHeader("From", sender) encodes the whole value as one encoded
+// word when it contains non-ASCII, turning
+//
+//	"範例 <noreply@example.com>"
+//
+// into
+//
+//	=?UTF-8?q?=E7=AF=84=E4=BE=8B_<noreply@example.com>?=
+//
+// which is invalid — RFC 5322 §3.4 requires the addr-spec to appear outside
+// any encoded word. SetAddressHeader encodes only the display name, producing:
+//
+//	=?UTF-8?q?=E7=AF=84=E4=BE=8B?= <noreply@example.com>
+//
+// See RFC 5322 §3.4 (https://datatracker.ietf.org/doc/html/rfc5322#section-3.4) and
+// RFC 2047 (https://datatracker.ietf.org/doc/html/rfc2047) for the encoding rules.
+// RFC 6532 (https://datatracker.ietf.org/doc/html/rfc6532) would allow raw UTF-8
+// in headers, but requires the SMTPUTF8 extension (RFC 6531) on the relay; RFC 2047
+// encoded words are used here for compatibility with all SMTP servers.
+func SetFromHeader(message *gomail.Message, sender string) error {
+	addr, err := netmail.ParseAddress(sender)
+	if err != nil {
+		return fmt.Errorf("invalid sender address %q: %w", sender, err)
+	}
+	message.SetAddressHeader("From", addr.Address, addr.Name)
 	return nil
+}
+
+func (s *Sender) applyFrom(opts *SendOptions, message *gomail.Message) error {
+	return SetFromHeader(message, opts.Sender)
 }
 
 func applyTo(opts *SendOptions, message *gomail.Message) error {

--- a/pkg/lib/infra/mail/sender_test.go
+++ b/pkg/lib/infra/mail/sender_test.go
@@ -1,0 +1,94 @@
+package mail
+
+import (
+	"strings"
+	"testing"
+
+	. "github.com/smartystreets/goconvey/convey"
+	"gopkg.in/gomail.v2"
+)
+
+func TestSetFromHeader(t *testing.T) {
+	Convey("SetFromHeader", t, func() {
+		newMsg := func() *gomail.Message { return gomail.NewMessage() }
+
+		Convey("no display name", func() {
+			msg := newMsg()
+			err := SetFromHeader(msg, "noreply@example.com")
+			So(err, ShouldBeNil)
+			from := msg.GetHeader("From")
+			So(len(from), ShouldEqual, 1)
+			So(from[0], ShouldEqual, "noreply@example.com")
+		})
+
+		Convey("angle-bracket addr-spec without display name", func() {
+			msg := newMsg()
+			err := SetFromHeader(msg, "<noreply@example.com>")
+			So(err, ShouldBeNil)
+			from := msg.GetHeader("From")
+			So(len(from), ShouldEqual, 1)
+			So(from[0], ShouldContainSubstring, "noreply@example.com")
+		})
+
+		Convey("ASCII-only display name", func() {
+			msg := newMsg()
+			err := SetFromHeader(msg, "Acme Corp <noreply@example.com>")
+			So(err, ShouldBeNil)
+			from := msg.GetHeader("From")
+			So(len(from), ShouldEqual, 1)
+			So(from[0], ShouldContainSubstring, "<noreply@example.com>")
+		})
+
+		Convey("display name requiring quoting (comma)", func() {
+			msg := newMsg()
+			err := SetFromHeader(msg, `"Doe, John" <noreply@example.com>`)
+			So(err, ShouldBeNil)
+			from := msg.GetHeader("From")
+			So(len(from), ShouldEqual, 1)
+			So(from[0], ShouldContainSubstring, "<noreply@example.com>")
+		})
+
+		// RFC 5322 display names may contain any Unicode text; non-ASCII must be
+		// encoded as RFC 2047 encoded words covering only the name, not the address.
+		nonASCIICases := []struct {
+			name   string
+			sender string
+		}{
+			// CJK
+			{"Traditional Chinese", "範例公司 <noreply@example.com>"},
+			{"Simplified Chinese", "示例公司 <noreply@example.com>"},
+			{"Japanese hiragana/katakana/kanji", "テスト株式会社 <noreply@example.com>"},
+			{"Korean", "테스트 회사 <noreply@example.com>"},
+			// RTL scripts
+			{"Arabic", "شركة اختبار <noreply@example.com>"},
+			{"Hebrew", "חברת בדיקה <noreply@example.com>"},
+			// Emoji (outside BMP — multi-byte UTF-8)
+			{"Emoji", "Test 🚀 Company <noreply@example.com>"},
+			// Mixed ASCII + non-ASCII
+			{"Mixed ASCII and CJK", "Acme Corp 有限公司 <noreply@example.com>"},
+		}
+
+		for _, tc := range nonASCIICases {
+			tc := tc
+			Convey(tc.name, func() {
+				msg := newMsg()
+				err := SetFromHeader(msg, tc.sender)
+				So(err, ShouldBeNil)
+				from := msg.GetHeader("From")
+				So(len(from), ShouldEqual, 1)
+				// Email address must appear as a literal outside any encoded word.
+				// The original bug encoded the entire string including "<addr>" inside
+				// an RFC 2047 word, making the header unparseable.
+				So(from[0], ShouldContainSubstring, "<noreply@example.com>")
+				// Display name must be RFC 2047 encoded (UTF-8).
+				So(strings.HasPrefix(from[0], "=?UTF-8?"), ShouldBeTrue)
+			})
+		}
+
+		Convey("invalid address returns error", func() {
+			msg := newMsg()
+			err := SetFromHeader(msg, "not-an-email-address")
+			So(err, ShouldNotBeNil)
+		})
+	})
+}

--- a/pkg/portal/smtp/service.go
+++ b/pkg/portal/smtp/service.go
@@ -60,8 +60,18 @@ func (s *Service) SendRealEmail(ctx context.Context, opts mail.SendOptions) (err
 	return
 }
 
-func (s *Service) SendTestEmail(ctx context.Context, app *model.App, options SendTestEmailOptions) (err error) {
+func buildTestMessage(appID string, options SendTestEmailOptions) (*gomail.Message, error) {
+	message := gomail.NewMessage()
+	if err := mail.SetFromHeader(message, options.SMTPSender); err != nil {
+		return nil, err
+	}
+	message.SetHeader("To", options.To)
+	message.SetHeader("Subject", "[Test] Authgear email")
+	message.SetBody("text/plain", fmt.Sprintf("This email was successfully sent from %s", appID))
+	return message, nil
+}
 
+func (s *Service) SendTestEmail(ctx context.Context, app *model.App, options SendTestEmailOptions) (err error) {
 	dialer := gomail.NewDialer(
 		options.SMTPHost,
 		options.SMTPPort,
@@ -70,11 +80,10 @@ func (s *Service) SendTestEmail(ctx context.Context, app *model.App, options Sen
 	)
 	// Do not set dialer.SSL so that SSL mode is inferred from the given port.
 
-	message := gomail.NewMessage()
-	message.SetHeader("From", options.SMTPSender)
-	message.SetHeader("To", options.To)
-	message.SetHeader("Subject", "[Test] Authgear email")
-	message.SetBody("text/plain", fmt.Sprintf("This email was successfully sent from %s", app.ID))
+	message, err := buildTestMessage(app.ID, options)
+	if err != nil {
+		return
+	}
 
 	err = dialer.DialAndSend(message)
 	if err != nil {

--- a/pkg/portal/smtp/service_test.go
+++ b/pkg/portal/smtp/service_test.go
@@ -1,0 +1,45 @@
+package smtp
+
+import (
+	"strings"
+	"testing"
+
+	. "github.com/smartystreets/goconvey/convey"
+)
+
+func TestBuildTestMessage(t *testing.T) {
+	Convey("buildTestMessage", t, func() {
+		baseOpts := SendTestEmailOptions{
+			To:           "user@example.com",
+			SMTPHost:     "localhost",
+			SMTPPort:     587,
+			SMTPUsername: "user",
+			SMTPPassword: "pass",
+		}
+
+		Convey("ASCII sender name", func() {
+			baseOpts.SMTPSender = "Acme Corp <noreply@example.com>"
+			msg, err := buildTestMessage("test-app", baseOpts)
+			So(err, ShouldBeNil)
+			from := msg.GetHeader("From")
+			So(len(from), ShouldEqual, 1)
+			So(from[0], ShouldContainSubstring, "<noreply@example.com>")
+		})
+
+		Convey("non-ASCII sender name", func() {
+			baseOpts.SMTPSender = "Acme Corp 有限公司 <noreply@example.com>"
+			msg, err := buildTestMessage("test-app", baseOpts)
+			So(err, ShouldBeNil)
+			from := msg.GetHeader("From")
+			So(len(from), ShouldEqual, 1)
+			So(from[0], ShouldContainSubstring, "<noreply@example.com>")
+			So(strings.HasPrefix(from[0], "=?UTF-8?"), ShouldBeTrue)
+		})
+
+		Convey("invalid sender returns error", func() {
+			baseOpts.SMTPSender = "not-an-email"
+			_, err := buildTestMessage("test-app", baseOpts)
+			So(err, ShouldNotBeNil)
+		})
+	})
+}

--- a/portal/src/graphql/portal/SMTPConfigurationScreen.tsx
+++ b/portal/src/graphql/portal/SMTPConfigurationScreen.tsx
@@ -52,6 +52,7 @@ import { ErrorParseRule, ErrorParseRuleResult } from "../../error/parse";
 import { APIError, APISMTPTestFailedError } from "../../error/error";
 import { useSystemConfig } from "../../context/SystemConfigContext";
 import { RedMessageBar_RemindConfigureSMTPInSMTPConfigurationScreen } from "../../RedMessageBar";
+import { useCalloutToast } from "../../components/v2/Callout/Callout";
 
 interface LocationState {
   isEdit: boolean;
@@ -285,6 +286,7 @@ const SMTPConfigurationScreenContent: React.VFC<SMTPConfigurationScreenContentPr
     const { sendTestEmail, loading } = sendTestEmailHandle;
 
     const { isAuthgearOnce } = useSystemConfig();
+    const { showToast } = useCalloutToast();
 
     const [isDialogHidden, setIsDialogHidden] = useState(true);
     const [toAddress, setToAddress] = useState("");
@@ -470,6 +472,12 @@ const SMTPConfigurationScreenContent: React.VFC<SMTPConfigurationScreenContentPr
 
         sendTestEmail(input).then(
           () => {
+            showToast({
+              type: "success",
+              text: (
+                <FormattedMessage id="SMTPConfigurationScreen.send-test-email.toast.success" />
+              ),
+            });
             setIsDialogHidden(true);
           },
           () => {
@@ -477,7 +485,7 @@ const SMTPConfigurationScreenContent: React.VFC<SMTPConfigurationScreenContentPr
           }
         );
       },
-      [sendTestEmail, state, toAddress]
+      [sendTestEmail, showToast, state, toAddress]
     );
 
     const onChangeToAddress = useCallback((_, value?: string) => {

--- a/portal/src/locale-data/en.json
+++ b/portal/src/locale-data/en.json
@@ -1592,6 +1592,7 @@
   "SMTPConfigurationScreen.send-test-email.label": "Send Test Email",
   "SMTPConfigurationScreen.send-test-email-dialog.title": "Enter the recipient email address",
   "SMTPConfigurationScreen.send-test-email-dialog.description": "Test your SMTP configuration by sending an email to the given address.",
+  "SMTPConfigurationScreen.send-test-email.toast.success": "Test email sent successfully!",
   "SMTPConfigurationScreen.provider.sendgrid": "SendGrid",
   "SMTPConfigurationScreen.provider.custom": "SMTP Provider",
   "SMTPConfigurationScreen.sendgrid.description": "Sign up for a SendGrid account and generate a SendGrid API Key. Check <DocLink>our instructions</DocLink> if you need help.",


### PR DESCRIPTION
## Preview - send test email with non-ASCII display name show success

https://github.com/user-attachments/assets/94d6de9e-99c3-4e9f-b2c3-67a2f19768ff

<img width="365" height="201" alt="image" src="https://github.com/user-attachments/assets/25b2549f-ca51-459f-9538-236528604c08" />

## Motivation

Got below error when sending a test email with non-ASCII display name

### `中文` error


https://github.com/user-attachments/assets/ad0881ee-c649-4901-b7ca-2ecf8688fa94


<img width="1233" height="812" alt="Screenshot 2026-04-11 at 02 16 46" src="https://github.com/user-attachments/assets/dcec8865-ccf5-44ab-a831-71f90828d0e2" />


### `english` ok

https://github.com/user-attachments/assets/9c9bfa1b-f97c-4096-b31c-e1643dcb4537

<img width="399" height="295" alt="Screenshot 2026-04-11 at 02 15 34" src="https://github.com/user-attachments/assets/2d6417eb-2f81-4d22-a67e-1b23ac030d67" />
