### PR TITLE
chore: Rename skill directories to use hyphens instead of underscores

### DIFF
--- a/.claude/skills/add-go-test/SKILL.md
+++ b/.claude/skills/add-go-test/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: add_go_test
+name: add-go-test
 description: Write or extend Go unit tests in this repo. Use when the user asks to add or update Go tests.
 argument-hint: "<package or behavior>"
 ---

--- a/.claude/skills/add-portal-admin-api-mutation/SKILL.md
+++ b/.claude/skills/add-portal-admin-api-mutation/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: add_portal_admin_api_mutation
+name: add-portal-admin-api-mutation
 description: Add a Portal Admin GraphQL mutation under portal/src/graphql/adminapi/mutations.
 argument-hint: "<mutation name>"
 ---

--- a/.claude/skills/add-portal-admin-api-query/SKILL.md
+++ b/.claude/skills/add-portal-admin-api-query/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: add_portal_admin_api_query
+name: add-portal-admin-api-query
 description: Add a Portal Admin GraphQL query under portal/src/graphql/adminapi/query.
 argument-hint: "<query name>"
 ---

--- a/.claude/skills/api-design/SKILL.md
+++ b/.claude/skills/api-design/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: api_design
+name: api-design
 description: Review or design APIs for Authgear. In review mode, evaluates a design draft against the checklist. In ideation mode, develops a design from a description and self-reviews it.
 argument-hint: "<design draft or feature description>"
 ---

--- a/.claude/skills/dep-audit/SKILL.md
+++ b/.claude/skills/dep-audit/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: dep_audit
+name: dep-audit
 description: Audit and fix dependency vulnerabilities in Go and Node.js packages. Runs govulncheck for Go and npm audit for each package.json directory. Commits fixes directory by directory.
 argument-hint: "--fix"
 ---

--- a/.claude/skills/new-siteadmin-api/SKILL.md
+++ b/.claude/skills/new-siteadmin-api/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: new_siteadmin_api
+name: new-siteadmin-api
 description: Scaffold a new Site Admin API endpoint. Use when adding a new route to the site admin server.
 disable-model-invocation: true
 ---

--- a/.claude/skills/portal-admin-api-graphql/SKILL.md
+++ b/.claude/skills/portal-admin-api-graphql/SKILL.md
@@ -1,0 +1,7 @@
+---
+name: portal-admin-api-graphql
+description: Deprecated alias for add-portal-admin-api-query and add-portal-admin-api-mutation.
+argument-hint: "<query or mutation name>"
+---
+
+Deprecated. Use `add-portal-admin-api-query` for queries and `add-portal-admin-api-mutation` for mutations.

--- a/.claude/skills/portal_admin_api_graphql/SKILL.md
+++ b/.claude/skills/portal_admin_api_graphql/SKILL.md
@@ -1,7 +1,0 @@
----
-name: portal_admin_api_graphql
-description: Deprecated alias for add_portal_admin_api_query and add_portal_admin_api_mutation.
-argument-hint: "<query or mutation name>"
----
-
-Deprecated. Use `add_portal_admin_api_query` for queries and `add_portal_admin_api_mutation` for mutations.

--- a/.claude/skills/update-go-version/SKILL.md
+++ b/.claude/skills/update-go-version/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: update_go_version
+name: update-go-version
 description: Update the Go toolchain version across the repo.
 argument-hint: "<new Go version>"
 ---

--- a/.claude/skills/update-important-modules/SKILL.md
+++ b/.claude/skills/update-important-modules/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: update_important_modules
+name: update-important-modules
 description: Refresh the repo's important Go modules when the dependency set drifts.
 argument-hint: "<module names or audit target>"
 ---

--- a/.claude/skills/update-vettedpositions/SKILL.md
+++ b/.claude/skills/update-vettedpositions/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: update_vettedpositions
+name: update-vettedpositions
 description: Update .vettedpositions after harmless line-number moves in goanalysis output.
 argument-hint: "<changed files or analysis output>"
 ---

--- a/.claude/skills/write-e2e-test/SKILL.md
+++ b/.claude/skills/write-e2e-test/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: write_e2e_test
+name: write-e2e-test
 description: Write end-to-end (e2e) tests for authgear-server. Use when the user asks to write, add, or create e2e tests. The tests live in e2e/tests/ and are YAML-driven.
 ---
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,10 +23,10 @@ This repository is Authgear Server. Use the repo docs and skills below as the so
 
 Use existing repo skills instead of one-off instructions when they fit:
 
-- `api_design`
-- `dep_audit`
-- `new_siteadmin_api`
-- `write_e2e_test`
+- `api-design`
+- `dep-audit`
+- `new-siteadmin-api`
+- `write-e2e-test`
 - Repo-local skills for Go tests, Portal GraphQL operations, Go version updates, important-module updates, and vetted-position updates
 
 ## Verification


### PR DESCRIPTION
Skill names must contain only lowercase letters, numbers, and hyphens. Updated all underscore-named skill directories, their SKILL.md frontmatter, cross-references, and CLAUDE.md to use hyphens.

ref: https://platform.claude.com/docs/en/agents-and-tools/agent-skills/best-practices#skill-structure