### PR TITLE
Ensure verified otp metric only recorded on code consume

### DIFF
--- a/e2e/tests/fraud_protection/account_recovery_verified_otp_reverts_leaky_bucket.test.yaml
+++ b/e2e/tests/fraud_protection/account_recovery_verified_otp_reverts_leaky_bucket.test.yaml
@@ -158,6 +158,22 @@ steps:
           }
         }
 
+  - name: flow 1 - reset password
+    action: input
+    state_token: |
+      {{ index .steps "flow 1 - verify recovery code" "result" "state_token" }}
+    input: |
+      {
+        "new_password": "Password123!"
+      }
+    output:
+      result: |
+        {
+          "action": {
+            "type": "finished"
+          }
+        }
+
   - name: flow 5 - create
     action: create
     input: |

--- a/e2e/tests/fraud_protection/account_recovery_verified_otp_writes_to_metrics.test.yaml
+++ b/e2e/tests/fraud_protection/account_recovery_verified_otp_writes_to_metrics.test.yaml
@@ -74,6 +74,20 @@ steps:
           }
         }
 
+  - name: reset password
+    action: input
+    input: |
+      {
+        "new_password": "Password123!"
+      }
+    output:
+      result: |
+        {
+          "action": {
+            "type": "finished"
+          }
+        }
+
   - name: check audit metrics rows
     action: audit_query
     audit_query: |

--- a/pkg/lib/authn/otp/service.go
+++ b/pkg/lib/authn/otp/service.go
@@ -112,6 +112,14 @@ func (s *Service) consumeCode(ctx context.Context, purpose Purpose, code *Code) 
 	if err := s.CodeStore.Update(ctx, purpose, code); err != nil {
 		return err
 	}
+
+	if code.OOBChannel == model.AuthenticatorOOBChannelSMS {
+		if err := s.FraudProtection.RecordSMSOTPVerified(ctx, code.Target); err != nil {
+			logger := ServiceLogger.GetLogger(ctx)
+			logger.WithError(err).Error(ctx, "failed to record SMS OTP verified for fraud protection")
+		}
+	}
+
 	// No need delete from lookup store;
 	// lookup entry is invalidated since target is no longer exist.
 	return nil
@@ -331,12 +339,6 @@ func (s *Service) VerifyOTP(ctx context.Context, kind Kind, target string, otp s
 
 	// Set flag to return reserved rate limit tokens
 	isCodeValid = true
-
-	if code.OOBChannel == model.AuthenticatorOOBChannelSMS {
-		if err := s.FraudProtection.RecordSMSOTPVerified(ctx, target); err != nil {
-			logger.WithError(err).Error(ctx, "failed to record SMS OTP verified for fraud protection")
-		}
-	}
 
 	if !opts.SkipConsume {
 		if err := s.consumeCode(ctx, kind.Purpose(), code); err != nil {

--- a/pkg/lib/authn/otp/service_test.go
+++ b/pkg/lib/authn/otp/service_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/authgear/authgear-server/pkg/api/model"
 	"github.com/authgear/authgear-server/pkg/lib/config"
 	"github.com/authgear/authgear-server/pkg/lib/ratelimit"
 	"github.com/authgear/authgear-server/pkg/util/clock"
@@ -73,6 +74,15 @@ func (s *testAttemptTracker) GetFailedAttempts(ctx context.Context, kind Kind, t
 
 func (s *testAttemptTracker) IncrementFailedAttempts(ctx context.Context, kind Kind, target string) (int, error) {
 	return 1, nil
+}
+
+type testFraudProtection struct {
+	recorded []string
+}
+
+func (s *testFraudProtection) RecordSMSOTPVerified(ctx context.Context, phoneNumber string) error {
+	s.recorded = append(s.recorded, phoneNumber)
+	return nil
 }
 
 type testRateLimiter struct {
@@ -183,13 +193,28 @@ func newTestService(rateLimiter *testRateLimiter) *Service {
 			FixedOOBOTP:          &config.TestModeFixedOOBOTPFeatureConfig{},
 			DeterministicLinkOTP: &config.TestModeDeterministicLinkOTPFeatureConfig{},
 		},
-		CodeStore:      newTestCodeStore(),
-		LookupStore:    &testLookupStore{},
-		AttemptTracker: &testAttemptTracker{},
-		RateLimiter:    rateLimiter,
-		FeatureConfig:  &config.FeatureConfig{},
-		EnvConfig:      &config.RateLimitsEnvironmentConfig{},
+		CodeStore:       newTestCodeStore(),
+		LookupStore:     &testLookupStore{},
+		AttemptTracker:  &testAttemptTracker{},
+		RateLimiter:     rateLimiter,
+		FraudProtection: &testFraudProtection{},
+		FeatureConfig:   &config.FeatureConfig{},
+		EnvConfig:       &config.RateLimitsEnvironmentConfig{},
 	}
+}
+
+func seedTestOTPCode(svc *Service, kind Kind, target string, code string, channel model.AuthenticatorOOBChannel) *Code {
+	c := &Code{
+		Target:     target,
+		Purpose:    kind.Purpose(),
+		Form:       FormCode,
+		Code:       code,
+		ExpireAt:   time.Unix(1700000300, 0).UTC(),
+		OOBChannel: channel,
+		Consumed:   false,
+	}
+	svc.CodeStore.(*testCodeStore).codes[svc.CodeStore.(*testCodeStore).key(kind.Purpose(), target)] = c
+	return c
 }
 
 func TestGenerateOTPWithSessionCooldown(t *testing.T) {
@@ -266,5 +291,31 @@ func TestInspectStateWithSessionCooldown(t *testing.T) {
 		state, err = svc.InspectState(context.Background(), kind, "+85265000001", nil)
 		So(err, ShouldBeNil)
 		So(state.CanResendAt, ShouldResemble, targetTime)
+	})
+}
+
+func TestVerifyOTPRecordsSMSOTPVerifiedOnlyOnConsume(t *testing.T) {
+	Convey("VerifyOTP records SMS verified metrics only when the code is consumed", t, func() {
+		cfg := loadTestAppConfig()
+		rateLimiter := newTestRateLimiter()
+		svc := newTestService(rateLimiter)
+		fraud := svc.FraudProtection.(*testFraudProtection)
+		kind := KindVerification(cfg, model.AuthenticatorOOBChannelSMS)
+
+		seedTestOTPCode(svc, kind, "+85265000001", "111111", model.AuthenticatorOOBChannelSMS)
+
+		err := svc.VerifyOTP(context.Background(), kind, "+85265000001", "111111", &VerifyOptions{
+			SkipConsume: true,
+		})
+		So(err, ShouldBeNil)
+		So(fraud.recorded, ShouldBeEmpty)
+
+		err = svc.ConsumeCode(context.Background(), kind.Purpose(), "+85265000001")
+		So(err, ShouldBeNil)
+		So(fraud.recorded, ShouldResemble, []string{"+85265000001"})
+
+		code, err := svc.InspectCode(context.Background(), kind.Purpose(), "+85265000001")
+		So(err, ShouldBeNil)
+		So(code.Consumed, ShouldBeTrue)
 	})
 }


### PR DESCRIPTION
Found this bug during analyzing the recent metrics.