### PR TITLE
[Site Admin] Add optional siteadmin OAuth client to authgear init

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -142,6 +142,9 @@ use flake
       --public-origin 'http://accounts.portal.localhost:3100' \
       --portal-origin 'http://portal.localhost:8000' \
       --portal-client-id portal \
+      --siteadmin-client-id siteadmin \
+      --siteadmin-redirect-uri 'http://localhost:8101/oauth2-redirect.html' \
+      --siteadmin-post-logout-redirect-uri 'http://localhost:8101' \
       --phone-otp-mode sms \
       --disable-email-verification true \
       --search-implementation postgresql
@@ -155,6 +158,8 @@ use flake
    oauth:
      clients:
      - client_id: portal
+       issue_jwt_access_token: true
+       name: Portal
        redirect_uris:
        # See nginx.conf for the difference between 8000, 8001, 8010, and 8011
        - "http://portal.localhost:8000/oauth-redirect"
@@ -174,12 +179,15 @@ use flake
        - "http://portal.localhost:8000/"
        # This redirect URI is used by the portal production build.
        - "http://portal.localhost:8010/"
+       x_application_type: traditional_webapp
      - client_id: siteadmin
+       issue_jwt_access_token: true
        name: Site Admin
-       redirect_uris:
-       - "http://localhost:3005/oauth-redirect"
        post_logout_redirect_uris:
-       - "http://localhost:3005/"
+       - "http://localhost:8101"
+       redirect_uris:
+       - "http://localhost:8101/oauth2-redirect.html"
+       x_application_type: spa
    ```
 
 3. Set up `.localhost`

--- a/cmd/authgear/cmd/cmdinit/init.go
+++ b/cmd/authgear/cmd/cmdinit/init.go
@@ -81,7 +81,7 @@ var cmdInit = &cobra.Command{
 			return err
 		}
 
-		var oauthClientConfigOpts *libconfig.GenerateOAuthClientConfigOptions
+		var oauthClientConfigOpts []libconfig.GenerateOAuthClientConfigOptions
 		if purpose == "portal" {
 			oauthClientConfigOpts, err = config.ReadOAuthClientConfigsFromConsole(ctx, cmd)
 			if err != nil {
@@ -109,8 +109,8 @@ var cmdInit = &cobra.Command{
 		appConfig := libconfig.GenerateAppConfigFromOptions(appConfigOpts)
 
 		// generate oauth client for the portal
-		if oauthClientConfigOpts != nil {
-			oauthClientConfig, err := libconfig.GenerateOAuthConfigFromOptions(oauthClientConfigOpts)
+		for _, opt := range oauthClientConfigOpts {
+			oauthClientConfig, err := libconfig.GenerateOAuthConfigFromOptions(&opt)
 			if err != nil {
 				return err
 			}
@@ -197,6 +197,9 @@ func init() {
 	config.Prompt_PublicOrigin.DefineFlag(cmdInit)
 	config.Prompt_PortalOrigin.DefineFlag(cmdInit)
 	config.Prompt_PortalClientID.DefineFlag(cmdInit)
+	config.Prompt_SiteadminClientID.DefineFlag(cmdInit)
+	config.Prompt_SiteadminRedirectURI.DefineFlag(cmdInit)
+	config.Prompt_SiteadminPostLogoutRedirectURI.DefineFlag(cmdInit)
 	config.Prompt_DisablePublicSignup.DefineFlag(cmdInit)
 	config.Prompt_PhoneOTPMode.DefineFlag(cmdInit)
 	config.Prompt_DisableEmailVerification.DefineFlag(cmdInit)

--- a/cmd/authgear/config/options.go
+++ b/cmd/authgear/config/options.go
@@ -3,6 +3,8 @@ package config
 import (
 	"context"
 	"errors"
+	"fmt"
+	"net/url"
 
 	"github.com/spf13/cobra"
 
@@ -32,6 +34,22 @@ var Prompt_PortalClientID = cliutil.PromptString{
 	Title:                       "The client ID of portal. If left empty, generate a random one.",
 	InteractiveDefaultUserInput: "",
 	NonInteractiveFlagName:      "portal-client-id",
+}
+
+var Prompt_SiteadminClientID = cliutil.PromptString{
+	Title:                       "The client ID of siteadmin. If left empty, do not generate the siteadmin client.",
+	InteractiveDefaultUserInput: "",
+	NonInteractiveFlagName:      "siteadmin-client-id",
+}
+
+var Prompt_SiteadminRedirectURI = cliutil.PromptOptionalURL{
+	Title:                  "Siteadmin redirect URI",
+	NonInteractiveFlagName: "siteadmin-redirect-uri",
+}
+
+var Prompt_SiteadminPostLogoutRedirectURI = cliutil.PromptOptionalURL{
+	Title:                  "Siteadmin post logout redirect URI",
+	NonInteractiveFlagName: "siteadmin-post-logout-redirect-uri",
 }
 
 var Prompt_PhoneOTPMode = cliutil.PromptString{
@@ -183,29 +201,97 @@ func ReadAppConfigOptionsFromConsole(ctx context.Context, cmd *cobra.Command) (*
 	return opts, nil
 }
 
-func ReadOAuthClientConfigsFromConsole(ctx context.Context, cmd *cobra.Command) (*config.GenerateOAuthClientConfigOptions, error) {
-	u, err := Prompt_PortalOrigin.Prompt(ctx, cmd)
+func ReadOAuthClientConfigsFromConsole(ctx context.Context, cmd *cobra.Command) ([]config.GenerateOAuthClientConfigOptions, error) {
+	portalOrigin, err := Prompt_PortalOrigin.Prompt(ctx, cmd)
 	if err != nil {
 		return nil, err
 	}
 
-	u.Path = "/oauth-redirect"
-	redirectURI := u.String()
-
-	u.Path = "/"
-	postLogoutRedirectURI := u.String()
-
-	clientID, err := Prompt_PortalClientID.Prompt(ctx, cmd)
+	portalRedirectURI, portalPostLogoutRedirectURI, err := makePortalOAuthEndpoints(portalOrigin)
 	if err != nil {
 		return nil, err
 	}
 
-	return &config.GenerateOAuthClientConfigOptions{
+	portalClientID, err := Prompt_PortalClientID.Prompt(ctx, cmd)
+	if err != nil {
+		return nil, err
+	}
+
+	siteadminClientID, err := Prompt_SiteadminClientID.Prompt(ctx, cmd)
+	if err != nil {
+		return nil, err
+	}
+
+	siteadminRedirectURI, err := Prompt_SiteadminRedirectURI.Prompt(ctx, cmd)
+	if err != nil {
+		return nil, err
+	}
+
+	siteadminPostLogoutRedirectURI, err := Prompt_SiteadminPostLogoutRedirectURI.Prompt(ctx, cmd)
+	if err != nil {
+		return nil, err
+	}
+
+	var opts []config.GenerateOAuthClientConfigOptions
+
+	opts = append(opts, config.GenerateOAuthClientConfigOptions{
 		Name:                  "Portal",
-		ClientID:              clientID,
-		RedirectURI:           redirectURI,
-		PostLogoutRedirectURI: postLogoutRedirectURI,
+		ClientID:              portalClientID,
+		RedirectURI:           portalRedirectURI,
+		PostLogoutRedirectURI: portalPostLogoutRedirectURI,
 		ApplicationType:       config.OAuthClientApplicationTypeTraditionalWeb,
+	})
+
+	// Siteadmin is opt-in because many deployments do not need it.
+	// Requiring an explicit client ID avoids seeding production configs with
+	// localhost redirect URIs when siteadmin is not actually intended to be used.
+	siteadminOpts, err := makeOAuthClientConfigOptions(
+		"siteadmin",
+		"Site Admin",
+		siteadminClientID,
+		siteadminRedirectURI,
+		siteadminPostLogoutRedirectURI,
+		config.OAuthClientApplicationTypeSPA,
+	)
+	if err != nil {
+		return nil, err
+	}
+	if siteadminOpts != nil {
+		opts = append(opts, *siteadminOpts)
+	}
+
+	return opts, nil
+}
+
+func makePortalOAuthEndpoints(origin *url.URL) (string, string, error) {
+	if origin == nil {
+		return "", "", fmt.Errorf("portal origin is required")
+	}
+	redirectURI := *origin
+	redirectURI.Path = "/oauth-redirect"
+
+	postLogoutRedirectURI := *origin
+	postLogoutRedirectURI.Path = "/"
+
+	return redirectURI.String(), postLogoutRedirectURI.String(), nil
+}
+
+func makeOAuthClientConfigOptions(clientKind string, displayName string, clientID string, redirectURI *url.URL, postLogoutRedirectURI *url.URL, applicationType config.OAuthClientApplicationType) (*config.GenerateOAuthClientConfigOptions, error) {
+	if clientID == "" {
+		return nil, nil
+	}
+	if redirectURI == nil {
+		return nil, fmt.Errorf("%s redirect uri is required when %s-client-id is provided", clientKind, clientKind)
+	}
+	if postLogoutRedirectURI == nil {
+		return nil, fmt.Errorf("%s post logout redirect uri is required when %s-client-id is provided", clientKind, clientKind)
+	}
+	return &config.GenerateOAuthClientConfigOptions{
+		Name:                  displayName,
+		ClientID:              clientID,
+		RedirectURI:           redirectURI.String(),
+		PostLogoutRedirectURI: postLogoutRedirectURI.String(),
+		ApplicationType:       applicationType,
 	}, nil
 }
 

--- a/cmd/authgear/config/options_test.go
+++ b/cmd/authgear/config/options_test.go
@@ -1,0 +1,94 @@
+package config
+
+import (
+	"context"
+	"testing"
+
+	. "github.com/smartystreets/goconvey/convey"
+	"github.com/spf13/cobra"
+
+	libconfig "github.com/authgear/authgear-server/pkg/lib/config"
+	"github.com/authgear/authgear-server/pkg/util/cliutil"
+)
+
+func TestReadOAuthClientConfigsFromConsole(t *testing.T) {
+	Convey("ReadOAuthClientConfigsFromConsole", t, func() {
+		Convey("returns both clients when configured", func() {
+			cmd := newOAuthClientConfigCommand()
+			mustSetFlag(t, cmd, "portal-origin", "http://portal.localhost:8000")
+			mustSetFlag(t, cmd, "portal-client-id", "portal")
+			mustSetFlag(t, cmd, "siteadmin-client-id", "siteadmin")
+			mustSetFlag(t, cmd, "siteadmin-redirect-uri", "http://localhost:3005/oauth-redirect")
+			mustSetFlag(t, cmd, "siteadmin-post-logout-redirect-uri", "http://localhost:3005/")
+
+			opts, err := ReadOAuthClientConfigsFromConsole(context.Background(), cmd)
+			So(err, ShouldBeNil)
+			So(opts, ShouldHaveLength, 2)
+			So(opts[0].ClientID, ShouldEqual, "portal")
+			So(opts[0].RedirectURI, ShouldEqual, "http://portal.localhost:8000/oauth-redirect")
+			So(opts[0].PostLogoutRedirectURI, ShouldEqual, "http://portal.localhost:8000/")
+			So(opts[0].ApplicationType, ShouldEqual, libconfig.OAuthClientApplicationTypeTraditionalWeb)
+			So(opts[1].ClientID, ShouldEqual, "siteadmin")
+			So(opts[1].RedirectURI, ShouldEqual, "http://localhost:3005/oauth-redirect")
+			So(opts[1].PostLogoutRedirectURI, ShouldEqual, "http://localhost:3005/")
+			So(opts[1].ApplicationType, ShouldEqual, libconfig.OAuthClientApplicationTypeSPA)
+		})
+
+		Convey("skips siteadmin when client id is empty", func() {
+			cmd := newOAuthClientConfigCommand()
+			mustSetFlag(t, cmd, "portal-origin", "http://portal.localhost:8000")
+			mustSetFlag(t, cmd, "portal-client-id", "portal")
+
+			opts, err := ReadOAuthClientConfigsFromConsole(context.Background(), cmd)
+			So(err, ShouldBeNil)
+			So(opts, ShouldHaveLength, 1)
+			So(opts[0].ClientID, ShouldEqual, "portal")
+		})
+
+		Convey("generates portal client id randomly when empty", func() {
+			cmd := newOAuthClientConfigCommand()
+			mustSetFlag(t, cmd, "portal-origin", "http://portal.localhost:8000")
+
+			opts, err := ReadOAuthClientConfigsFromConsole(context.Background(), cmd)
+			So(err, ShouldBeNil)
+			So(opts, ShouldHaveLength, 1)
+			So(opts[0].ClientID, ShouldEqual, "")
+
+			generated, err := libconfig.GenerateOAuthConfigFromOptions(&opts[0])
+			So(err, ShouldBeNil)
+			So(generated.ClientID, ShouldNotEqual, "")
+			So(generated.ClientID, ShouldNotEqual, "portal")
+		})
+
+		Convey("requires siteadmin redirect uri when client id is provided", func() {
+			cmd := newOAuthClientConfigCommand()
+			mustSetFlag(t, cmd, "siteadmin-client-id", "siteadmin")
+
+			_, err := ReadOAuthClientConfigsFromConsole(context.Background(), cmd)
+			So(err, ShouldBeError, "siteadmin redirect uri is required when siteadmin-client-id is provided")
+		})
+	})
+}
+
+func newOAuthClientConfigCommand() *cobra.Command {
+	cmd := &cobra.Command{Use: "test"}
+	cliutil.DefineFlagInteractive(cmd)
+	if err := cmd.Flags().Set("interactive", "false"); err != nil {
+		panic(err)
+	}
+	Prompt_PortalOrigin.DefineFlag(cmd)
+	Prompt_PortalClientID.DefineFlag(cmd)
+	Prompt_SiteadminClientID.DefineFlag(cmd)
+	Prompt_SiteadminRedirectURI.DefineFlag(cmd)
+	Prompt_SiteadminPostLogoutRedirectURI.DefineFlag(cmd)
+	return cmd
+}
+
+func mustSetFlag(t *testing.T, cmd *cobra.Command, name string, value string) {
+	if err := cmd.Flags().Set(name, value); err != nil {
+		if t == nil {
+			panic(err)
+		}
+		t.Fatalf("failed to set flag %s: %v", name, err)
+	}
+}

--- a/pkg/util/cliutil/prompt.go
+++ b/pkg/util/cliutil/prompt.go
@@ -170,6 +170,37 @@ func (p PromptURL) DefineFlag(cmd *cobra.Command) {
 	_ = cmd.Flags().String(p.NonInteractiveFlagName, p.InteractiveDefaultUserInput, p.Title)
 }
 
+type PromptOptionalURL struct {
+	Title                  string
+	NonInteractiveFlagName string
+	Validate               func(ctx context.Context, value *url.URL) error
+}
+
+func (p PromptOptionalURL) Prompt(ctx context.Context, cmd *cobra.Command) (*url.URL, error) {
+	return Prompt[*url.URL]{
+		Title:                  p.Title,
+		NonInteractiveFlagName: p.NonInteractiveFlagName,
+		Parse: func(ctx context.Context, userInput string) (*url.URL, error) {
+			if userInput == "" {
+				return nil, nil
+			}
+			u, err := url.Parse(userInput)
+			if err != nil {
+				return nil, err
+			}
+			if u.Scheme == "" || u.Host == "" {
+				return nil, fmt.Errorf("URL must be absolute: %v", userInput)
+			}
+			return u, nil
+		},
+		Validate: p.Validate,
+	}.Prompt(ctx, cmd)
+}
+
+func (p PromptOptionalURL) DefineFlag(cmd *cobra.Command) {
+	_ = cmd.Flags().String(p.NonInteractiveFlagName, "", p.Title)
+}
+
 type PromptBool struct {
 	Title                       string
 	InteractiveDefaultUserInput bool


### PR DESCRIPTION
ref DEV-3490

Site admin oauth client is opt-in because many deployments do not need it. Requiring an explicit client ID avoids seeding production configs with localhost redirect URIs when siteadmin is not actually intended to be used.