### PR TITLE
[Portal] Show Endpoint field for all application types including OIDC/SAML

### DIFF
--- a/portal/src/graphql/portal/EditOAuthClientForm.tsx
+++ b/portal/src/graphql/portal/EditOAuthClientForm.tsx
@@ -471,15 +471,6 @@ const EditOAuthClientForm: React.VFC<EditOAuthClientFormProps> =
       [clientConfig.x_application_type]
     );
 
-    const showEndpoint = useMemo(
-      () =>
-        !clientConfig.x_application_type ||
-        clientConfig.x_application_type === "spa" ||
-        clientConfig.x_application_type === "traditional_webapp" ||
-        clientConfig.x_application_type === "native",
-      [clientConfig.x_application_type]
-    );
-
     const refreshTokenHelpText = useMemo(() => {
       if (clientConfig.refresh_token_idle_timeout_enabled) {
         return renderToString(
@@ -598,13 +589,11 @@ const EditOAuthClientForm: React.VFC<EditOAuthClientFormProps> =
             value={clientConfig.client_id}
             readOnly={true}
           />
-          {showEndpoint ? (
-            <TextFieldWithCopyButton
-              label={renderToString("EditOAuthClientForm.endpoint.label")}
-              value={publicOrigin}
-              readOnly={true}
-            />
-          ) : null}
+          <TextFieldWithCopyButton
+            label={renderToString("EditOAuthClientForm.endpoint.label")}
+            value={publicOrigin}
+            readOnly={true}
+          />
           <TextField
             label={renderToString("EditOAuthClientForm.application-type.label")}
             value={applicationTypeLabel}


### PR DESCRIPTION
## Summary

- The **Endpoint** field was hidden for `confidential`, `third_party_app`, and `m2m` application types. OIDC and SAML clients both use the `confidential` type, so they were affected.
- Removed the `showEndpoint` conditional so the Endpoint field is always rendered, regardless of application type.
- No new components, translation keys, or GraphQL changes needed — everything was already wired up.

ref DEV-2381

<img width="1194" height="953" alt="image" src="https://github.com/user-attachments/assets/17633f1b-452c-463a-9ec2-dbba1c35ae71" />


## Test plan

- [ ] Open a **confidential** (OIDC/SAML) application in the portal — Endpoint field should now appear with the `publicOrigin` value and a working copy button
- [ ] Confirm `spa`, `traditional_webapp`, and `native` types still show the Endpoint field (no regression)
- [ ] `npm run typecheck` passes in `portal/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)