### PR TITLE
[Portal] Fix inline text links rendering as plain text inside WidgetDescription

### DIFF
--- a/.claude/skills/update-portal-ui/SKILL.md
+++ b/.claude/skills/update-portal-ui/SKILL.md
@@ -1,0 +1,85 @@
+---
+name: update-portal-ui
+description: Guidelines for updating or designing pages in the portal React frontend (portal/src). Covers component conventions, link rendering rules, i18n patterns, and common pitfalls.
+---
+
+Follow this skill when adding, editing, or reviewing UI in `portal/src`.
+
+## Link components
+
+The portal has three link components. Use the right one — using the wrong one causes links to render as unstyled plain text inside certain wrappers.
+
+| Component | Import path | Use when |
+|---|---|---|
+| `Link` | `../../Link` (or relative path to `portal/src/Link.tsx`) | Internal navigation (React Router) |
+| `ExternalLink` | `../../ExternalLink` | External URLs (`href`, opens in new tab) |
+| `LinkButton` | `../../LinkButton` | A button that visually looks like a link |
+
+**Never** use `Link` from `react-router-dom` directly — it renders a plain `<a>` tag with no FluentUI styling.
+
+### Why this matters: the WidgetDescription / Text trap
+
+`WidgetDescription` wraps its children in a FluentUI `Text` component. FluentUI's `Text` overrides the colour of plain `<a>` tags to match surrounding text, making links invisible as links.
+
+- `portal/src/Link.tsx` and `portal/src/ExternalLink.tsx` both wrap FluentUI's `FluentLink`, which keeps its own link styling even inside `Text`. ✓
+- `react-router-dom`'s `Link` renders a bare `<a>` — styling is stripped inside `Text`. ✗
+
+**Rule:** Whenever a link appears inside `WidgetDescription`, `Text` (FluentUI), or any component that internally wraps FluentUI `Text`, use `Link` or `ExternalLink` from `portal/src`, not from `react-router-dom`.
+
+### Inline links inside FormattedMessage (i18n)
+
+To embed a clickable link inside a translated string:
+
+1. In the translation string (`portal/src/locale-data/en.json`), use an XML-like tag:
+   ```
+   "my-key": "Read the <docLink>documentation</docLink> for details."
+   ```
+
+2. In the component, pass a render function in `FormattedMessage` `values` whose key matches the tag name exactly:
+   ```tsx
+   <FormattedMessage
+     id="my-key"
+     values={{
+       // eslint-disable-next-line react/no-unstable-nested-components
+       docLink: (chunks: React.ReactNode) => (
+         <ExternalLink href="https://docs.authgear.com/...">
+           {chunks}
+         </ExternalLink>
+       ),
+     }}
+   />
+   ```
+
+3. Use `Link` for internal routes, `ExternalLink` for external URLs. **Never** use react-router-dom's `Link` here.
+
+### Passing rich content to callbacks that accept descriptions
+
+Some components (e.g. FluentUI `ChoiceGroup` via `onRenderLabel`) accept a label-render callback. If the description contains a link, the callback must accept `React.ReactNode`, not `string`:
+
+```tsx
+// Correct — accepts ReactNode so JSX can be passed
+const onRenderLabel = useCallback((description: React.ReactNode) => {
+  return (option?: IChoiceGroupOption) => (
+    <div>
+      <Text>{option?.text}</Text>
+      <Text>{description}</Text>
+    </div>
+  );
+}, []);
+
+// Then pass FormattedMessage directly — no cast needed
+onRenderLabel(
+  <FormattedMessage id="..." values={{ reactRouterLink: ... }} />
+)
+```
+
+**Never** cast JSX to string with `as any as string` — the link will not render correctly.
+
+## Verification checklist
+
+Before submitting a portal UI change:
+
+- [ ] Links inside `WidgetDescription` or FluentUI `Text` use `Link` or `ExternalLink` from `portal/src`, not from `react-router-dom`.
+- [ ] Inline links in `FormattedMessage` `values` use `Link` or `ExternalLink` from `portal/src`.
+- [ ] Callbacks that may receive rich content (links, JSX) are typed `React.ReactNode`, not `string`.
+- [ ] Run `cd portal && npm run typecheck` — must pass clean.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,6 +26,7 @@ Use existing repo skills instead of one-off instructions when they fit:
 - `api-design`
 - `dep-audit`
 - `new-siteadmin-api`
+- `update-portal-ui` — **use this before adding or editing any portal UI page** (link components, i18n inline links, FluentUI Text pitfalls)
 - `write-e2e-test`
 - Repo-local skills for Go tests, Portal GraphQL operations, Go version updates, important-module updates, and vetted-position updates
 

--- a/portal/src/graphql/portal/CreateOAuthClientScreen.tsx
+++ b/portal/src/graphql/portal/CreateOAuthClientScreen.tsx
@@ -6,7 +6,8 @@ import {
   IChoiceGroupOptionProps,
   Text,
 } from "@fluentui/react";
-import { useNavigate, useParams, Link } from "react-router-dom";
+import { useNavigate, useParams } from "react-router-dom";
+import PortalLink from "../../Link";
 import { produce, createDraft } from "immer";
 import { Context, FormattedMessage } from "../../intl";
 import { SearchBox } from "@fluentui/react/lib/SearchBox";
@@ -197,7 +198,7 @@ const StepSelectApplicationType: React.VFC<StepSelectApplicationTypeProps> =
       );
     });
 
-    const onRenderLabel = useCallback((description: string) => {
+    const onRenderLabel = useCallback((description: React.ReactNode) => {
       return (option?: IChoiceGroupOption | IChoiceGroupOptionProps) => {
         return (
           <div className={styles.optionLabel}>
@@ -267,27 +268,25 @@ const StepSelectApplicationType: React.VFC<StepSelectApplicationTypeProps> =
           key: "m2m",
           text: renderToString("oauth-client.application-type.m2m"),
           onRenderLabel: onRenderLabel(
-            (
-              <FormattedMessage
-                id={
-                  hasNoAPIResources
-                    ? "CreateOAuthClientScreen.application-type.description.m2m.disabled"
-                    : "CreateOAuthClientScreen.application-type.description.m2m"
-                }
-                values={{
-                  // eslint-disable-next-line react/no-unstable-nested-components
-                  reactRouterLink: (chunks: React.ReactNode) => (
-                    <Link
-                      to={`/project/${encodeURIComponent(
-                        appNodeID
-                      )}/api-resources/create`}
-                    >
-                      {chunks}
-                    </Link>
-                  ),
-                }}
-              />
-            ) as any as string
+            <FormattedMessage
+              id={
+                hasNoAPIResources
+                  ? "CreateOAuthClientScreen.application-type.description.m2m.disabled"
+                  : "CreateOAuthClientScreen.application-type.description.m2m"
+              }
+              values={{
+                // eslint-disable-next-line react/no-unstable-nested-components
+                reactRouterLink: (chunks: React.ReactNode) => (
+                  <PortalLink
+                    to={`/project/${encodeURIComponent(
+                      appNodeID
+                    )}/api-resources/create`}
+                  >
+                    {chunks}
+                  </PortalLink>
+                ),
+              }}
+            />
           ),
           disabled: hasNoAPIResources,
         },

--- a/portal/src/graphql/portal/EditOAuthClientForm.tsx
+++ b/portal/src/graphql/portal/EditOAuthClientForm.tsx
@@ -5,6 +5,7 @@ import { DateTime } from "luxon";
 import { Context, FormattedMessage } from "../../intl";
 import { useParams, useNavigate, Link } from "react-router-dom";
 import ExternalLink from "../../ExternalLink";
+import PortalLink from "../../Link";
 
 import { useEndpoints } from "../../hook/useEndpoints";
 
@@ -972,9 +973,9 @@ const EditOAuthClientForm: React.VFC<EditOAuthClientFormProps> =
                   hostname: publicOrigin,
                   // eslint-disable-next-line react/no-unstable-nested-components
                   reactRouterLink: (chunks: React.ReactNode) => (
-                    <Link to={`/project/${appID}/advanced/session`}>
+                    <PortalLink to={`/project/${appID}/advanced/session`}>
                       {chunks}
-                    </Link>
+                    </PortalLink>
                   ),
                 }}
               />


### PR DESCRIPTION
## Summary

- `react-router-dom`'s `Link` renders a plain `<a>` tag whose colour is overridden by FluentUI's `Text` component (used internally by `WidgetDescription`), making links appear as unstyled plain text.
- Replace with the portal's `PortalLink` (`portal/src/Link.tsx`) which wraps FluentUI's `FluentLink` and preserves link styling inside `Text`.
- Also fix `CreateOAuthClientScreen.onRenderLabel` to accept `React.ReactNode` instead of `string`, removing the broken `as any as string` cast on the M2M option's `FormattedMessage`.

**Broken links fixed:**
- "Cookie Session Settings" on the token settings page (`EditOAuthClientForm`)
- "Create an API resource" on the New Application page M2M option (`CreateOAuthClientScreen`)

**Not affected:** `BotProtectionConfigurationScreen` and `AdminAPIConfigurationScreen` already use `ExternalLink` (wraps FluentUI `FluentLink`) and render correctly.

<img width="869" height="687" alt="image" src="https://github.com/user-attachments/assets/5c7bf23e-76cc-4648-af40-ecded4981899" />
<img width="1160" height="692" alt="image" src="https://github.com/user-attachments/assets/3f06d9ae-47d8-42c1-bde5-90fa2987a158" />


## Test plan

- [ ] App → Applications → (any app) → token settings → "Cookie Session Settings" renders as a blue underlined link and navigates to `/advanced/session`
- [ ] Applications → New Application → Machine-to-Machine (with no API resources) → "Create an API resource" renders as a blue underlined link
- [ ] All other application type descriptions still render as plain text (no regression)
- [ ] `npm run typecheck` passes in `portal/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)