### PR TITLE
Improve robustness of auth ui finish handlers

### DIFF
--- a/.vettedpositions
+++ b/.vettedpositions
@@ -58,10 +58,10 @@
 /pkg/auth/handler/webapp/app_static_assets.go:39:33: requestcontext
 /pkg/auth/handler/webapp/auth_entry_point_middleware.go:35:10: requestcontext
 /pkg/auth/handler/webapp/authflow_change_password.go:96:26: requestcontext
-/pkg/auth/handler/webapp/authflow_controller.go:1057:30: requestcontext
-/pkg/auth/handler/webapp/authflow_controller.go:1062:24: requestcontext
-/pkg/auth/handler/webapp/authflow_controller.go:1070:19: requestcontext
-/pkg/auth/handler/webapp/authflow_controller.go:1078:18: requestcontext
+/pkg/auth/handler/webapp/authflow_controller.go:1062:30: requestcontext
+/pkg/auth/handler/webapp/authflow_controller.go:1067:24: requestcontext
+/pkg/auth/handler/webapp/authflow_controller.go:1075:19: requestcontext
+/pkg/auth/handler/webapp/authflow_controller.go:1083:18: requestcontext
 /pkg/auth/handler/webapp/authflow_create_password.go:132:26: requestcontext
 /pkg/auth/handler/webapp/authflow_enter_oob_otp.go:156:26: requestcontext
 /pkg/auth/handler/webapp/authflow_enter_password.go:139:26: requestcontext
@@ -96,7 +96,7 @@
 /pkg/auth/handler/webapp/authflowv2/enter_recovery_code.go:113:26: requestcontext
 /pkg/auth/handler/webapp/authflowv2/enter_totp.go:132:26: requestcontext
 /pkg/auth/handler/webapp/authflowv2/error.go:65:36: requestcontext
-/pkg/auth/handler/webapp/authflowv2/finish_flow.go:36:49: requestcontext
+/pkg/auth/handler/webapp/authflowv2/finish_flow.go:36:56: requestcontext
 /pkg/auth/handler/webapp/authflowv2/forgot_password.go:286:33: requestcontext
 /pkg/auth/handler/webapp/authflowv2/forgot_password_link_sent.go:86:26: requestcontext
 /pkg/auth/handler/webapp/authflowv2/forgot_password_otp.go:208:26: requestcontext

--- a/.vettedpositions
+++ b/.vettedpositions
@@ -58,10 +58,10 @@
 /pkg/auth/handler/webapp/app_static_assets.go:39:33: requestcontext
 /pkg/auth/handler/webapp/auth_entry_point_middleware.go:35:10: requestcontext
 /pkg/auth/handler/webapp/authflow_change_password.go:96:26: requestcontext
-/pkg/auth/handler/webapp/authflow_controller.go:1034:30: requestcontext
-/pkg/auth/handler/webapp/authflow_controller.go:1039:24: requestcontext
-/pkg/auth/handler/webapp/authflow_controller.go:1047:19: requestcontext
-/pkg/auth/handler/webapp/authflow_controller.go:1055:18: requestcontext
+/pkg/auth/handler/webapp/authflow_controller.go:1057:30: requestcontext
+/pkg/auth/handler/webapp/authflow_controller.go:1062:24: requestcontext
+/pkg/auth/handler/webapp/authflow_controller.go:1070:19: requestcontext
+/pkg/auth/handler/webapp/authflow_controller.go:1078:18: requestcontext
 /pkg/auth/handler/webapp/authflow_create_password.go:132:26: requestcontext
 /pkg/auth/handler/webapp/authflow_enter_oob_otp.go:156:26: requestcontext
 /pkg/auth/handler/webapp/authflow_enter_password.go:139:26: requestcontext
@@ -96,7 +96,7 @@
 /pkg/auth/handler/webapp/authflowv2/enter_recovery_code.go:113:26: requestcontext
 /pkg/auth/handler/webapp/authflowv2/enter_totp.go:132:26: requestcontext
 /pkg/auth/handler/webapp/authflowv2/error.go:65:36: requestcontext
-/pkg/auth/handler/webapp/authflowv2/finish_flow.go:36:35: requestcontext
+/pkg/auth/handler/webapp/authflowv2/finish_flow.go:36:49: requestcontext
 /pkg/auth/handler/webapp/authflowv2/forgot_password.go:286:33: requestcontext
 /pkg/auth/handler/webapp/authflowv2/forgot_password_link_sent.go:86:26: requestcontext
 /pkg/auth/handler/webapp/authflowv2/forgot_password_otp.go:208:26: requestcontext

--- a/pkg/auth/handler/webapp/authflow_controller.go
+++ b/pkg/auth/handler/webapp/authflow_controller.go
@@ -343,6 +343,21 @@ func (c *AuthflowController) HandleWithoutScreen(ctx context.Context, w http.Res
 	handler.ServeHTTP(w, r)
 }
 
+func (c *AuthflowController) HandleWithoutScreenAllowCompleted(ctx context.Context, w http.ResponseWriter, r *http.Request, handlers *AuthflowControllerHandlers) {
+	if handled := c.handleInlinePreviewIfNecessary(ctx, w, r, handlers); handled {
+		return
+	}
+
+	session := webapp.GetSession(ctx)
+	if session == nil {
+		c.renderError(ctx, w, r, webapp.ErrSessionNotFound)
+		return
+	}
+
+	handler := c.makeHTTPHandler(session, nil, handlers)
+	handler.ServeHTTP(w, r)
+}
+
 func (c *AuthflowController) HandleWithoutSession(ctx context.Context, w http.ResponseWriter, r *http.Request, handlers *AuthflowControllerHandlers) {
 	if handled := c.handleInlinePreviewIfNecessary(ctx, w, r, handlers); handled {
 		return
@@ -686,7 +701,7 @@ func (c *AuthflowController) AdvanceWithInputs(
 func (c *AuthflowController) Finish(ctx context.Context, r *http.Request, s *webapp.Session) (*webapp.Result, error) {
 	if s == nil {
 		// This is panic because caller of Finish should have checked session is not nil
-		// Likely by using `HandleWithoutScreen`
+		// Likely by using `HandleWithoutScreenAllowCompleted`
 		panic(fmt.Errorf("unexpected: session is missing in Finish"))
 	}
 	if s.Authflow == nil {

--- a/pkg/auth/handler/webapp/authflow_controller.go
+++ b/pkg/auth/handler/webapp/authflow_controller.go
@@ -303,7 +303,7 @@ func (c *AuthflowController) HandleStep(ctx context.Context, w http.ResponseWrit
 		return
 	}
 
-	s, err := c.getWebSession(ctx)
+	s, err := c.getWebSession(ctx, false)
 	if err != nil {
 		c.renderError(ctx, w, r, err)
 		return
@@ -331,7 +331,7 @@ func (c *AuthflowController) HandleWithoutScreen(ctx context.Context, w http.Res
 	}
 
 	var session *webapp.Session
-	s, err := c.getWebSession(ctx)
+	s, err := c.getWebSession(ctx, false)
 	if err != nil {
 		c.renderError(ctx, w, r, err)
 		return
@@ -343,14 +343,19 @@ func (c *AuthflowController) HandleWithoutScreen(ctx context.Context, w http.Res
 	handler.ServeHTTP(w, r)
 }
 
-func (c *AuthflowController) HandleWithoutScreenAllowCompleted(ctx context.Context, w http.ResponseWriter, r *http.Request, handlers *AuthflowControllerHandlers) {
+// This method can be used by routes which allow a replay request
+// e.g. /finish
+// A completed web session will be allowed instead of error
+func (c *AuthflowController) HandleWithoutScreenAllowCompletedSession(ctx context.Context, w http.ResponseWriter, r *http.Request, handlers *AuthflowControllerHandlers) {
 	if handled := c.handleInlinePreviewIfNecessary(ctx, w, r, handlers); handled {
 		return
 	}
 
-	session := webapp.GetSession(ctx)
-	if session == nil {
-		c.renderError(ctx, w, r, webapp.ErrSessionNotFound)
+	// We allow completed session here to ensure routes using HandleWithoutScreenAllowCompletedSession
+	// such as /finish can be called multiple times with error
+	session, err := c.getWebSession(ctx, true)
+	if err != nil {
+		c.renderError(ctx, w, r, err)
 		return
 	}
 
@@ -377,12 +382,12 @@ func (c *AuthflowController) handleInlinePreviewIfNecessary(ctx context.Context,
 	return false
 }
 
-func (c *AuthflowController) getWebSession(ctx context.Context) (*webapp.Session, error) {
+func (c *AuthflowController) getWebSession(ctx context.Context, allowCompleted bool) (*webapp.Session, error) {
 	s := webapp.GetSession(ctx)
 	if s == nil {
 		return nil, webapp.ErrSessionNotFound
 	}
-	if s.IsCompleted {
+	if !allowCompleted && s.IsCompleted {
 		return nil, webapp.ErrSessionCompleted
 	}
 	return s, nil
@@ -390,7 +395,7 @@ func (c *AuthflowController) getWebSession(ctx context.Context) (*webapp.Session
 
 func (c *AuthflowController) getOrCreateWebSession(ctx context.Context, w http.ResponseWriter, r *http.Request, opts webapp.SessionOptions) (*webapp.Session, error) {
 	now := c.Clock.NowUTC()
-	s, err := c.getWebSession(ctx)
+	s, err := c.getWebSession(ctx, false)
 	if err == nil && s != nil {
 		return s, nil
 	}

--- a/pkg/auth/handler/webapp/authflow_controller.go
+++ b/pkg/auth/handler/webapp/authflow_controller.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"log/slog"
 	"net/http"
 
 	"net/url"
@@ -684,10 +685,17 @@ func (c *AuthflowController) AdvanceWithInputs(
 
 func (c *AuthflowController) Finish(ctx context.Context, r *http.Request, s *webapp.Session) (*webapp.Result, error) {
 	if s == nil {
+		// This is panic because caller of Finish should have checked session is not nil
+		// Likely by using `HandleWithoutScreen`
 		panic(fmt.Errorf("unexpected: session is missing in Finish"))
 	}
 	if s.Authflow == nil {
-		return nil, fmt.Errorf("cannot finish authflow: session is not in a flow")
+		logger := AuthflowControllerLogger.GetLogger(ctx)
+		logger.Warn(ctx, "session is not in a flow",
+			slog.String("web_session_id", s.ID),
+			slog.String("x_step", GetXStepFromQuery(r)),
+		)
+		return nil, webapp.ErrInvalidSession
 	}
 
 	result := &webapp.Result{}

--- a/pkg/auth/handler/webapp/authflow_controller_test.go
+++ b/pkg/auth/handler/webapp/authflow_controller_test.go
@@ -234,6 +234,24 @@ func TestAuthflowControllerGetScreen(t *testing.T) {
 	})
 }
 
+func TestAuthflowControllerFinish(t *testing.T) {
+	Convey("AuthflowController.Finish", t, func() {
+		c := &AuthflowController{}
+
+		Convey("return invalid session if session has no authflow", func() {
+			ctx := context.Background()
+			s := &webapp.Session{
+				ID: "web_session_id",
+			}
+			r, _ := http.NewRequestWithContext(ctx, "GET", "/authflow/v2/finish?x_step=step_0", nil)
+
+			result, err := c.Finish(ctx, r, s)
+			So(result, ShouldBeNil)
+			So(err, ShouldBeError, webapp.ErrInvalidSession)
+		})
+	})
+}
+
 func TestAuthflowControllerCreateScreen(t *testing.T) {
 	Convey("AuthflowController.createScreen", t, func() {
 		ctrl := gomock.NewController(t)

--- a/pkg/auth/handler/webapp/authflowv2/fatal_error_test.go
+++ b/pkg/auth/handler/webapp/authflowv2/fatal_error_test.go
@@ -1,0 +1,71 @@
+package authflowv2
+
+import (
+	"context"
+	"testing"
+
+	runtimeresource "github.com/authgear/authgear-server"
+	"github.com/authgear/authgear-server/pkg/util/resource"
+	"github.com/authgear/authgear-server/pkg/util/template"
+	"github.com/spf13/afero"
+
+	. "github.com/smartystreets/goconvey/convey"
+)
+
+func newFatalErrorTemplateEngine(t *testing.T) *template.Engine {
+	t.Helper()
+
+	manager := resource.NewManagerWithDir(resource.NewManagerWithDirOptions{
+		Registry:              resource.DefaultRegistry,
+		BuiltinResourceFS:     runtimeresource.EmbedFS_resources_authgear,
+		BuiltinResourceFSRoot: runtimeresource.RelativePath_resources_authgear,
+	})
+
+	fs := afero.NewMemMapFs()
+	err := fs.MkdirAll("templates/en/web/authflowv2", 0o777)
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = afero.WriteFile(fs, "templates/en/web/authflowv2/__page_frame.html", []byte(`{{ define "authflowv2/__page_frame.html" }}{{ template "page-content" . }}{{ end }}`), 0o666)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	manager = manager.Overlay(resource.LeveledAferoFs{
+		Fs:      fs,
+		FsLevel: resource.FsLevelCustom,
+	})
+
+	return &template.Engine{
+		Resolver: &template.Resolver{
+			Resources:             manager,
+			DefaultLanguageTag:    template.DefaultLanguageTag("en"),
+			SupportedLanguageTags: template.SupportedLanguageTags{"en"},
+		},
+	}
+}
+
+func renderFatalErrorPage(t *testing.T, reason string) string {
+	t.Helper()
+
+	engine := newFatalErrorTemplateEngine(t)
+	result, err := engine.Render(context.Background(), TemplateWebFatalErrorHTML, []string{"en"}, map[string]interface{}{
+		"Platform": "",
+		"Error": map[string]interface{}{
+			"reason": reason,
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return result.String
+}
+
+func TestFatalErrorTemplateTreatsFlowNotFoundLikeInvalidSession(t *testing.T) {
+	Convey("fatal_error.html", t, func() {
+		invalidSession := renderFatalErrorPage(t, "WebUIInvalidSession")
+		flowNotFound := renderFatalErrorPage(t, "AuthenticationFlowNotFound")
+
+		So(flowNotFound, ShouldEqual, invalidSession)
+	})
+}

--- a/pkg/auth/handler/webapp/authflowv2/fatal_error_test.go
+++ b/pkg/auth/handler/webapp/authflowv2/fatal_error_test.go
@@ -4,10 +4,11 @@ import (
 	"context"
 	"testing"
 
+	"github.com/spf13/afero"
+
 	runtimeresource "github.com/authgear/authgear-server"
 	"github.com/authgear/authgear-server/pkg/util/resource"
 	"github.com/authgear/authgear-server/pkg/util/template"
-	"github.com/spf13/afero"
 
 	. "github.com/smartystreets/goconvey/convey"
 )

--- a/pkg/auth/handler/webapp/authflowv2/finish_flow.go
+++ b/pkg/auth/handler/webapp/authflowv2/finish_flow.go
@@ -33,5 +33,5 @@ func (h *AuthflowV2FinishFlowHandler) ServeHTTP(w http.ResponseWriter, r *http.R
 		result.WriteResponse(w, r)
 		return nil
 	})
-	h.Controller.HandleWithoutScreenAllowCompleted(r.Context(), w, r, &handlers)
+	h.Controller.HandleWithoutScreenAllowCompletedSession(r.Context(), w, r, &handlers)
 }

--- a/pkg/auth/handler/webapp/authflowv2/finish_flow.go
+++ b/pkg/auth/handler/webapp/authflowv2/finish_flow.go
@@ -33,5 +33,5 @@ func (h *AuthflowV2FinishFlowHandler) ServeHTTP(w http.ResponseWriter, r *http.R
 		result.WriteResponse(w, r)
 		return nil
 	})
-	h.Controller.HandleWithoutScreen(r.Context(), w, r, &handlers)
+	h.Controller.HandleWithoutScreenAllowCompleted(r.Context(), w, r, &handlers)
 }

--- a/pkg/auth/handler/webapp/authflowv2/finish_flow_test.go
+++ b/pkg/auth/handler/webapp/authflowv2/finish_flow_test.go
@@ -1,0 +1,85 @@
+package authflowv2
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	handlerwebapp "github.com/authgear/authgear-server/pkg/auth/handler/webapp"
+	"github.com/authgear/authgear-server/pkg/auth/webapp"
+	authflow "github.com/authgear/authgear-server/pkg/lib/authenticationflow"
+	"github.com/authgear/authgear-server/pkg/util/httputil"
+
+	. "github.com/smartystreets/goconvey/convey"
+)
+
+type finishFlowTestSessionStore struct {
+	updateCount int
+}
+
+func (*finishFlowTestSessionStore) Get(ctx context.Context, id string) (*webapp.Session, error) {
+	return nil, errors.New("unexpected Get")
+}
+
+func (*finishFlowTestSessionStore) Create(ctx context.Context, session *webapp.Session) error {
+	return errors.New("unexpected Create")
+}
+
+func (s *finishFlowTestSessionStore) Update(ctx context.Context, session *webapp.Session) error {
+	s.updateCount++
+	return nil
+}
+
+func (*finishFlowTestSessionStore) Delete(ctx context.Context, id string) error {
+	return errors.New("unexpected Delete")
+}
+
+func TestAuthflowV2FinishFlowHandlerAllowsCompletedSession(t *testing.T) {
+	Convey("Finish flow", t, func() {
+		session := &webapp.Session{
+			ID:          "web_session_id",
+			RedirectURI: "/after",
+			Authflow: &webapp.Authflow{
+				AllScreens: map[string]*webapp.AuthflowScreen{
+					"step_0": {
+						StateToken: &webapp.AuthflowStateToken{
+							XStep:      "step_0",
+							StateToken: "state_token",
+						},
+						FinishedUIScreenData: &webapp.AuthflowFinishedUIScreenData{
+							FlowType: authflow.FlowTypeLogin,
+						},
+					},
+				},
+			},
+		}
+
+		req := httptest.NewRequest("GET", "http://example.com/authflow/v2/finish?x_step=step_0", nil)
+		req = req.WithContext(webapp.WithSession(req.Context(), session))
+
+		sessionStore := &finishFlowTestSessionStore{}
+		controller := &handlerwebapp.AuthflowController{
+			Sessions:       sessionStore,
+			Cookies:        &httputil.CookieManager{Request: req},
+			SignedUpCookie: webapp.NewSignedUpCookieDef(),
+		}
+		h := &AuthflowV2FinishFlowHandler{
+			Controller: controller,
+		}
+
+		first := httptest.NewRecorder()
+		h.ServeHTTP(first, req)
+		So(first.Code, ShouldEqual, http.StatusFound)
+		So(first.Header().Get("Location"), ShouldContainSubstring, "/after")
+		So(session.IsCompleted, ShouldBeTrue)
+		So(sessionStore.updateCount, ShouldEqual, 1)
+
+		second := httptest.NewRecorder()
+		h.ServeHTTP(second, req)
+		So(second.Code, ShouldEqual, http.StatusFound)
+		So(second.Header().Get("Location"), ShouldContainSubstring, "/after")
+		So(sessionStore.updateCount, ShouldEqual, 2)
+	})
+}

--- a/resources/authgear/templates/en/web/authflowv2/fatal_error.html
+++ b/resources/authgear/templates/en/web/authflowv2/fatal_error.html
@@ -6,7 +6,7 @@
 
   {{ $title := include "v2.page.fatal-error.default.title" nil }}
   {{ if .Error }}
-    {{ if eq .Error.reason "WebUIInvalidSession" }}
+    {{ if or (eq .Error.reason "WebUIInvalidSession") (eq .Error.reason "AuthenticationFlowNotFound") }}
       {{ $title = include "v2.page.fatal-error.token-invalid.title" nil }}
     {{ end }}
     {{ if eq .Error.reason "AccountManagementTokenInvalid" }}
@@ -37,7 +37,7 @@
 
   {{ $error_message := include "v2.error.server" nil }}
   {{ if .Error }}
-    {{ if eq .Error.reason "WebUIInvalidSession" }}
+    {{ if or (eq .Error.reason "WebUIInvalidSession") (eq .Error.reason "AuthenticationFlowNotFound") }}
       {{ $error_message = include "v2.error.web-ui-invalid-session-return" nil }}
     {{ else if eq .Error.reason "AuthenticationFlowNoPublicSignup" nil }}
       {{ $error_message = include "v2.error.no-public-signup" nil }}


### PR DESCRIPTION
ref DEV-3472
ref DEV-3487

- Display correct error message if the session is invalid
- Allow finish endpoint to be visited multiple times
  - However, in /consent, the authentication info will be consumed (See AuthorizationHandler.doHandleConsent), so you still cannot go to the app redirect uri again by visiting /finish. I am not sure if we should keep the auth info such that this become possible. Maybe we can discuss on this.