### PR TITLE
[Auth UI] Allow {AppName} and {ClientName} in translation overrides

### DIFF
--- a/resources/authgear/templates/en/web/authflowv2/select_account.html
+++ b/resources/authgear/templates/en/web/authflowv2/select_account.html
@@ -6,12 +6,14 @@
   <i class="screen-icon material-icons">account_circle</i>
   <header class="screen-title-description">
     <h1 class="screen-title">
-      {{ if $.ClientName }}
-        {{ include "v2.page.select-account.default.title" (dict "AppOrClientName" $.ClientName) }}
-      {{ else }}
-        {{ $appName := (translate "app.name" nil) }}
-        {{ include "v2.page.select-account.default.title" (dict "AppOrClientName" $appName) }}
-      {{ end }}
+      {{ $appName := (translate "app.name" nil) }}
+      {{ $appOrClientName := $.ClientName }}
+      {{ if not $appOrClientName }}{{ $appOrClientName = $appName }}{{ end }}
+      {{ include "v2.page.select-account.default.title" (dict
+        "AppName" $appName
+        "ClientName" $.ClientName
+        "AppOrClientName" $appOrClientName
+      ) }}
     </h1>
     <p class="screen-description">
       {{ include "v2.page.select-account.default.description" (merge (dict) $.UserProfile (dict "IdentityDisplayName" $.IdentityDisplayName)) }}

--- a/resources/authgear/templates/en/web/authflowv2/select_account.html
+++ b/resources/authgear/templates/en/web/authflowv2/select_account.html
@@ -7,11 +7,11 @@
   <header class="screen-title-description">
     <h1 class="screen-title">
       {{ $appName := (translate "app.name" nil) }}
-      {{ $appOrClientName := $.ClientName }}
-      {{ if not $appOrClientName }}{{ $appOrClientName = $appName }}{{ end }}
+      {{ $clientName := or $.ClientName "null" }}
+      {{ $appOrClientName := or $.ClientName $appName }}
       {{ include "v2.page.select-account.default.title" (dict
         "AppName" $appName
-        "ClientName" $.ClientName
+        "ClientName" $clientName
         "AppOrClientName" $appOrClientName
       ) }}
     </h1>

--- a/resources/authgear/templates/en/web/authflowv2/verify_login_link.html
+++ b/resources/authgear/templates/en/web/authflowv2/verify_login_link.html
@@ -2,6 +2,13 @@
 {{ define "page-content" }}
 
   {{ $appName := (translate "app.name" nil) }}
+  {{ $clientName := or $.ClientName "null" }}
+  {{ $appOrClientName := or $.ClientName $appName }}
+  {{ $nameDict := (dict
+    "AppName" $appName
+    "ClientName" $clientName
+    "AppOrClientName" $appOrClientName
+  ) }}
 
   {{ if eq .State "invalid_code" }}
     {{ template "authflowv2/__error_page_layout.html"
@@ -18,7 +25,7 @@
         {{ include "v2.page.verify-login-link.approved.title" nil }}
       </h1>
       <p class="screen-description">
-        {{ include "v2.page.verify-login-link.approved.description" (dict "AppOrClientName" $appName) }}
+        {{ include "v2.page.verify-login-link.approved.description" $nameDict }}
       </p>
       {{ template "authflowv2/__alert_message.html"
         (dict
@@ -39,7 +46,7 @@
     >
       <input type="hidden" name="x_oob_otp_code" value="{{ .Code }}">
       <h1 class="screen-title">{{ include "v2.page.verify-login-link.default.title" nil }}</h1>
-      <p class="screen-description">{{ include "v2.page.verify-login-link.default.description" (dict "AppOrClientName" $appName) }}</p>
+      <p class="screen-description">{{ include "v2.page.verify-login-link.default.description" $nameDict }}</p>
       {{ template "authflowv2/__alert_message.html"
         (dict
           "Type" "error"


### PR DESCRIPTION
## Summary
- Pass `AppName` and `ClientName` alongside `AppOrClientName` at the 3 `include` call sites that currently receive only the combined variable, so users overriding these translation keys can reference each name individually.
- Affects translation keys `v2.page.select-account.default.title`, `v2.page.verify-login-link.approved.description`, `v2.page.verify-login-link.default.description`.
- `ClientName` uses the `or $.ClientName "null"` convention shared with `login.html`, `signup.html`, `consent.html`, `logout.html` — so custom translations can use ICU `select` to branch on the `null` case.
- `AppOrClientName` falls back to `AppName` when no OAuth client is in context, preserving the current default rendering.
- Default English translation strings are unchanged — fully backward compatible.

ref DEV-3431

Given this translation file:
<img width="892" height="581" alt="SCR-20260421-nqbv" src="https://github.com/user-attachments/assets/d866684c-0b5b-4279-8d9e-6bffe107a96c" />

It yields:
<img width="729" height="745" alt="SCR-20260421-npwm" src="https://github.com/user-attachments/assets/2df5a800-d570-4a99-b872-f7c4ed8dd2a9" />


## Test plan
- [x] Local: override `v2.page.select-account.default.title` with `{AppName}`, `{ClientName}`, `{AppOrClientName}` and confirm each variable renders as expected, with and without an OAuth client in context.
- [ ] Staging (needs SMTP): override `v2.page.verify-login-link.approved.description` and `v2.page.verify-login-link.default.description` and confirm the magic-link flow renders each variable correctly in both the approve and approved states.
- [x] Default (unmodified) translations still render unchanged.