### PR TITLE
Reduce cardinality of high volume metric

### DIFF
--- a/.vettedpositions
+++ b/.vettedpositions
@@ -277,9 +277,9 @@
 /pkg/auth/webapp/wechat_redirect_uri_middleware.go:59:31: requestcontext
 /pkg/auth/webapp/wechat_redirect_uri_middleware.go:115:39: requestcontext
 /pkg/auth/webapp/x_color_scheme.go:74:27: requestcontext
-/pkg/auth/webapp_request_middleware.go:40:10: requestcontext
+/pkg/auth/webapp_request_middleware.go:41:10: requestcontext
 /pkg/images/deps/context.go:23:10: requestcontext
-/pkg/images/deps/middleware_request.go:24:10: requestcontext
+/pkg/images/deps/middleware_request.go:25:10: requestcontext
 /pkg/images/handler/get.go:94:11: requestcontext
 /pkg/images/handler/post.go:57:9: requestcontext
 /pkg/lib/accountmanagement/rate_limit_middleware.go:36:10: requestcontext
@@ -295,7 +295,7 @@
 /pkg/lib/config/contextbackground.go:11:52: contextbackground
 /pkg/lib/deps/context.go:23:10: requestcontext
 /pkg/lib/deps/contextbackground.go:10:28: contextbackground
-/pkg/lib/deps/middleware_request.go:24:10: requestcontext
+/pkg/lib/deps/middleware_request.go:25:10: requestcontext
 /pkg/lib/deps/providers.go:145:25: requestcontext
 /pkg/lib/deps/providers.go:152:36: requestcontext
 /pkg/lib/dpop/middleware.go:21:10: requestcontext
@@ -307,7 +307,7 @@
 /pkg/lib/oauth/response_mode.go:161:40: requestcontext
 /pkg/lib/oauth/scope.go:117:34: requestcontext
 /pkg/lib/oauthrelyingparty/oauthrelyingpartyutil/contextbackground.go:11:52: contextbackground
-/pkg/lib/otelauthgear/nethttp.go:30:10: requestcontext
+/pkg/lib/otelauthgear/nethttp.go:73:10: requestcontext
 /pkg/lib/saml/samlbinding/http_post.go:176:35: requestcontext
 /pkg/lib/saml/samlbinding/http_post.go:207:35: requestcontext
 /pkg/lib/session/middleware.go:42:23: requestcontext

--- a/pkg/auth/webapp_request_middleware.go
+++ b/pkg/auth/webapp_request_middleware.go
@@ -50,6 +50,10 @@ func (m *WebAppRequestMiddleware) Handle(next http.Handler) http.Handler {
 		err := m.ConfigSource.ProvideContext(ctx, r, func(ctx context.Context, appCtx *config.AppContext) error {
 			ctx, ap := m.RootProvider.NewAppProvider(ctx, appCtx)
 			ctx = deps.WithAppProvider(ctx, ap)
+			// We create a new labeler from the global labeler.
+			// Add project specific labels to it.
+			// So metrics produced under this middleware have project specific labels.
+			// And metrics produced before this middleware have no project specific labels.
 			ctx = otelutil.ContextWithClonedLabeler(ctx)
 			otelauthgear.SetProjectID(ctx, string(appCtx.Config.AppConfig.ID))
 

--- a/pkg/auth/webapp_request_middleware.go
+++ b/pkg/auth/webapp_request_middleware.go
@@ -53,8 +53,7 @@ func (m *WebAppRequestMiddleware) Handle(next http.Handler) http.Handler {
 			ctx = otelutil.ContextWithClonedLabeler(ctx)
 			otelauthgear.SetProjectID(ctx, string(appCtx.Config.AppConfig.ID))
 
-			r = r.WithContext(ctx)
-			next.ServeHTTP(w, r)
+			otelauthgear.ServeHTTPWithRequestCountMetric(ctx, w, r, next)
 			return nil
 		})
 		if err != nil {

--- a/pkg/auth/webapp_request_middleware.go
+++ b/pkg/auth/webapp_request_middleware.go
@@ -13,6 +13,7 @@ import (
 	"github.com/authgear/authgear-server/pkg/lib/otelauthgear"
 	"github.com/authgear/authgear-server/pkg/lib/web"
 	"github.com/authgear/authgear-server/pkg/util/httputil"
+	"github.com/authgear/authgear-server/pkg/util/otelutil"
 	"github.com/authgear/authgear-server/pkg/util/slogutil"
 	"github.com/authgear/authgear-server/pkg/util/template"
 )
@@ -49,6 +50,7 @@ func (m *WebAppRequestMiddleware) Handle(next http.Handler) http.Handler {
 		err := m.ConfigSource.ProvideContext(ctx, r, func(ctx context.Context, appCtx *config.AppContext) error {
 			ctx, ap := m.RootProvider.NewAppProvider(ctx, appCtx)
 			ctx = deps.WithAppProvider(ctx, ap)
+			ctx = otelutil.ContextWithClonedLabeler(ctx)
 			otelauthgear.SetProjectID(ctx, string(appCtx.Config.AppConfig.ID))
 
 			r = r.WithContext(ctx)

--- a/pkg/images/deps/middleware_request.go
+++ b/pkg/images/deps/middleware_request.go
@@ -34,6 +34,10 @@ func (m *RequestMiddleware) Handle(next http.Handler) http.Handler {
 		err := m.ConfigSource.ProvideContext(ctx, r, func(ctx context.Context, appCtx *config.AppContext) error {
 			ctx, ap := m.RootProvider.NewAppProvider(ctx, appCtx)
 			ctx = withProvider(ctx, ap)
+			// We create a new labeler from the global labeler.
+			// Add project specific labels to it.
+			// So metrics produced under this middleware have project specific labels.
+			// And metrics produced before this middleware have no project specific labels.
 			ctx = otelutil.ContextWithClonedLabeler(ctx)
 			otelauthgear.SetProjectID(ctx, string(appCtx.Config.AppConfig.ID))
 

--- a/pkg/images/deps/middleware_request.go
+++ b/pkg/images/deps/middleware_request.go
@@ -37,8 +37,7 @@ func (m *RequestMiddleware) Handle(next http.Handler) http.Handler {
 			ctx = otelutil.ContextWithClonedLabeler(ctx)
 			otelauthgear.SetProjectID(ctx, string(appCtx.Config.AppConfig.ID))
 
-			r = r.WithContext(ctx)
-			next.ServeHTTP(w, r)
+			otelauthgear.ServeHTTPWithRequestCountMetric(ctx, w, r, next)
 			return nil
 		})
 		if err != nil {

--- a/pkg/images/deps/middleware_request.go
+++ b/pkg/images/deps/middleware_request.go
@@ -9,6 +9,7 @@ import (
 	"github.com/authgear/authgear-server/pkg/lib/config"
 	"github.com/authgear/authgear-server/pkg/lib/config/configsource"
 	"github.com/authgear/authgear-server/pkg/lib/otelauthgear"
+	"github.com/authgear/authgear-server/pkg/util/otelutil"
 	"github.com/authgear/authgear-server/pkg/util/slogutil"
 )
 
@@ -33,6 +34,7 @@ func (m *RequestMiddleware) Handle(next http.Handler) http.Handler {
 		err := m.ConfigSource.ProvideContext(ctx, r, func(ctx context.Context, appCtx *config.AppContext) error {
 			ctx, ap := m.RootProvider.NewAppProvider(ctx, appCtx)
 			ctx = withProvider(ctx, ap)
+			ctx = otelutil.ContextWithClonedLabeler(ctx)
 			otelauthgear.SetProjectID(ctx, string(appCtx.Config.AppConfig.ID))
 
 			r = r.WithContext(ctx)

--- a/pkg/lib/deps/middleware_request.go
+++ b/pkg/lib/deps/middleware_request.go
@@ -34,6 +34,10 @@ func (m *RequestMiddleware) Handle(next http.Handler) http.Handler {
 		err := m.ConfigSource.ProvideContext(ctx, r, func(ctx context.Context, appCtx *config.AppContext) error {
 			ctx, ap := m.RootProvider.NewAppProvider(ctx, appCtx)
 			ctx = WithAppProvider(ctx, ap)
+			// We create a new labeler from the global labeler.
+			// Add project specific labels to it.
+			// So metrics produced under this middleware have project specific labels.
+			// And metrics produced before this middleware have no project specific labels.
 			ctx = otelutil.ContextWithClonedLabeler(ctx)
 			otelauthgear.SetProjectID(ctx, string(appCtx.Config.AppConfig.ID))
 

--- a/pkg/lib/deps/middleware_request.go
+++ b/pkg/lib/deps/middleware_request.go
@@ -37,8 +37,7 @@ func (m *RequestMiddleware) Handle(next http.Handler) http.Handler {
 			ctx = otelutil.ContextWithClonedLabeler(ctx)
 			otelauthgear.SetProjectID(ctx, string(appCtx.Config.AppConfig.ID))
 
-			r = r.WithContext(ctx)
-			next.ServeHTTP(w, r)
+			otelauthgear.ServeHTTPWithRequestCountMetric(ctx, w, r, next)
 			return nil
 		})
 		if err != nil {

--- a/pkg/lib/deps/middleware_request.go
+++ b/pkg/lib/deps/middleware_request.go
@@ -9,6 +9,7 @@ import (
 	"github.com/authgear/authgear-server/pkg/lib/config"
 	"github.com/authgear/authgear-server/pkg/lib/config/configsource"
 	"github.com/authgear/authgear-server/pkg/lib/otelauthgear"
+	"github.com/authgear/authgear-server/pkg/util/otelutil"
 	"github.com/authgear/authgear-server/pkg/util/slogutil"
 )
 
@@ -33,6 +34,7 @@ func (m *RequestMiddleware) Handle(next http.Handler) http.Handler {
 		err := m.ConfigSource.ProvideContext(ctx, r, func(ctx context.Context, appCtx *config.AppContext) error {
 			ctx, ap := m.RootProvider.NewAppProvider(ctx, appCtx)
 			ctx = WithAppProvider(ctx, ap)
+			ctx = otelutil.ContextWithClonedLabeler(ctx)
 			otelauthgear.SetProjectID(ctx, string(appCtx.Config.AppConfig.ID))
 
 			r = r.WithContext(ctx)

--- a/pkg/lib/otelauthgear/metric.go
+++ b/pkg/lib/otelauthgear/metric.go
@@ -301,6 +301,18 @@ var CounterFraudProtectionWarningCount = otelutil.MustInt64Counter(
 	metric.WithUnit("{warning}"),
 )
 
+// CounterHTTPRequestCount has the following labels:
+// - authgear.project_id
+// - authgear.client_id
+// This metric exist because we want to know http request of each project
+// but do not want to add high cardinality label authgear.project_id and authgear.client_id to the high volume http metrics
+var CounterHTTPRequestCount = otelutil.MustInt64Counter(
+	meter,
+	"authgear.http.request.count",
+	metric.WithDescription("The number of HTTP requests"),
+	metric.WithUnit("{request}"),
+)
+
 // HTTPServerRequestDurationHistogram is https://opentelemetry.io/docs/specs/semconv/http/http-metrics/#metric-httpserverrequestduration
 var HTTPServerRequestDurationHistogram, _ = httpconv.NewServerRequestDuration(
 	meter,

--- a/pkg/lib/otelauthgear/nethttp.go
+++ b/pkg/lib/otelauthgear/nethttp.go
@@ -1,6 +1,7 @@
 package otelauthgear
 
 import (
+	"context"
 	"net/http"
 	"time"
 
@@ -17,15 +18,57 @@ type HTTPInstrumentationMiddleware struct {
 	TrustProxy config.TrustProxy
 }
 
+func serveHTTPWithStatus(
+	ctx context.Context,
+	w http.ResponseWriter,
+	r *http.Request,
+	next http.Handler,
+	onDone func(context.Context, int),
+) {
+	statusCode := 200
+	headerWritten := false
+	defer func() {
+		recovered := recover()
+		if recovered != nil {
+			if !headerWritten {
+				statusCode = 500
+			}
+		}
+		onDone(ctx, statusCode)
+		if recovered != nil {
+			panic(recovered)
+		}
+	}()
+
+	wrappedW := httpsnoop.Wrap(w, httpsnoop.Hooks{
+		WriteHeader: func(f httpsnoop.WriteHeaderFunc) httpsnoop.WriteHeaderFunc {
+			return func(code int) {
+				f(code)
+
+				if !(code >= 100 && code <= 199) && !headerWritten {
+					statusCode = code
+					headerWritten = true
+				}
+			}
+		},
+	})
+	next.ServeHTTP(wrappedW, r.WithContext(ctx))
+}
+
+func ServeHTTPWithRequestCountMetric(ctx context.Context, w http.ResponseWriter, r *http.Request, next http.Handler) {
+	serveHTTPWithStatus(ctx, w, r, next, func(ctx context.Context, statusCode int) {
+		otelutil.IntCounterAddOne(
+			ctx,
+			CounterHTTPRequestCount,
+			WithHTTPStatusCode(statusCode),
+		)
+	})
+}
+
 func (m *HTTPInstrumentationMiddleware) Handle(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		// Intentionally not calling .UTC() to use monotonic clock.
 		startTime := time.Now()
-
-		// 200 is the default.
-		// See the documentation of Write() of https://pkg.go.dev/net/http#ResponseWriter
-		statusCode := 200
-		headerWritten := false
 
 		ctx := r.Context()
 		// Assume the labeler has been put into context.
@@ -37,34 +80,9 @@ func (m *HTTPInstrumentationMiddleware) Handle(next http.Handler) http.Handler {
 		scheme := httputil.GetProto(r, bool(m.TrustProxy))
 		labeler.Add(otelutil.HTTPURLScheme(scheme))
 
-		// Wrap w to capture status code.
-		w = httpsnoop.Wrap(w, httpsnoop.Hooks{
-			WriteHeader: func(f httpsnoop.WriteHeaderFunc) httpsnoop.WriteHeaderFunc {
-				return func(code int) {
-					f(code)
-
-					if !(code >= 100 && code <= 199) && !headerWritten {
-						statusCode = code
-						headerWritten = true
-					}
-				}
-			},
-		})
-
-		defer func() {
+		serveHTTPWithStatus(ctx, w, r, next, func(ctx context.Context, statusCode int) {
 			// Record the request duration.
 			requestDuration := time.Since(startTime)
-
-			r := recover()
-
-			// It was a panic and it was not recovered.
-			if r != nil {
-				// Status code was not written explicitly.
-				// Assume 500.
-				if !headerWritten {
-					statusCode = 500
-				}
-			}
 
 			// Prepare attributes that is known after serving the request.
 			statusCodeAttr := otelutil.HTTPResponseStatusCode(statusCode)
@@ -89,14 +107,6 @@ func (m *HTTPInstrumentationMiddleware) Handle(next http.Handler) http.Handler {
 				seconds := requestDuration.Seconds()
 				otelutil.Float64HistogramRecord(ctx, HTTPServerRequestDurationHistogram.Inst(), seconds, options...)
 			}
-
-			// Re-throw the panic.
-			if r != nil {
-				panic(r)
-			}
-		}()
-
-		// Invoke the handler.
-		next.ServeHTTP(w, r)
+		})
 	})
 }

--- a/pkg/lib/otelauthgear/nethttp_test.go
+++ b/pkg/lib/otelauthgear/nethttp_test.go
@@ -124,3 +124,42 @@ func TestHTTPInstrumentationMiddleware(t *testing.T) {
 		})
 	})
 }
+
+func TestServeHTTPWithStatus(t *testing.T) {
+	Convey("serveHTTPWithStatus", t, func() {
+		Convey("reports status code written by handler", func() {
+			var gotStatus int
+
+			handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusNoContent)
+			})
+
+			w := httptest.NewRecorder()
+			r := httptest.NewRequestWithContext(context.Background(), "GET", "/", nil)
+			serveHTTPWithStatus(context.Background(), w, r, handler, func(ctx context.Context, statusCode int) {
+				gotStatus = statusCode
+			})
+
+			So(gotStatus, ShouldEqual, http.StatusNoContent)
+		})
+
+		Convey("reports 500 when panic happens before headers are written and re-panics", func() {
+			var gotStatus int
+			errPanic := errors.New("panic")
+
+			handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				panic(errPanic)
+			})
+
+			w := httptest.NewRecorder()
+			r := httptest.NewRequestWithContext(context.Background(), "GET", "/", nil)
+			So(func() {
+				serveHTTPWithStatus(context.Background(), w, r, handler, func(ctx context.Context, statusCode int) {
+					gotStatus = statusCode
+				})
+			}, ShouldPanicWith, errPanic)
+
+			So(gotStatus, ShouldEqual, http.StatusInternalServerError)
+		})
+	})
+}

--- a/pkg/util/otelutil/labeler.go
+++ b/pkg/util/otelutil/labeler.go
@@ -1,0 +1,25 @@
+package otelutil
+
+import (
+	"context"
+
+	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
+	"go.opentelemetry.io/otel/attribute"
+)
+
+// ContextWithClonedLabeler clones the current labeler in ctx (if any),
+// appends attrs, and returns a context with the cloned labeler.
+func ContextWithClonedLabeler(ctx context.Context, attrs ...attribute.KeyValue) context.Context {
+	currentLabeler, _ := otelhttp.LabelerFromContext(ctx)
+	clonedLabeler := &otelhttp.Labeler{}
+	if currentLabeler != nil {
+		for _, attr := range currentLabeler.Get() {
+			clonedLabeler.Add(attr)
+		}
+	}
+	for _, attr := range attrs {
+		clonedLabeler.Add(attr)
+	}
+	return otelhttp.ContextWithLabeler(ctx, clonedLabeler)
+}
+

--- a/pkg/util/otelutil/labeler.go
+++ b/pkg/util/otelutil/labeler.go
@@ -22,4 +22,3 @@ func ContextWithClonedLabeler(ctx context.Context, attrs ...attribute.KeyValue) 
 	}
 	return otelhttp.ContextWithLabeler(ctx, clonedLabeler)
 }
-

--- a/pkg/util/otelutil/oteldatabasesql/instrumentation.go
+++ b/pkg/util/otelutil/oteldatabasesql/instrumentation.go
@@ -381,7 +381,6 @@ func Open(opts OpenOptions) (ConnPool_, error) {
 							seconds,
 							metric.WithAttributes(commonAttrs...),
 							metric.WithAttributes(semconv.DBOperationName("BEGIN")),
-							metric.WithAttributes(semconv.DBQueryText("BEGIN")),
 						)
 					}()
 					tx, err := original()
@@ -403,7 +402,6 @@ func Open(opts OpenOptions) (ConnPool_, error) {
 							seconds,
 							metric.WithAttributes(commonAttrs...),
 							metric.WithAttributes(semconv.DBOperationName("BEGIN")),
-							metric.WithAttributes(semconv.DBQueryText("BEGIN")),
 						)
 					}()
 					tx, err := original(ctx, opts)
@@ -425,7 +423,6 @@ func Open(opts OpenOptions) (ConnPool_, error) {
 							seconds,
 							metric.WithAttributes(commonAttrs...),
 							metric.WithAttributes(semconv.DBOperationName("PREPARE")),
-							metric.WithAttributes(semconv.DBQueryText(query)),
 						)
 					}()
 					stmt, err := original(query)
@@ -447,7 +444,6 @@ func Open(opts OpenOptions) (ConnPool_, error) {
 							seconds,
 							metric.WithAttributes(commonAttrs...),
 							metric.WithAttributes(semconv.DBOperationName("PREPARE")),
-							metric.WithAttributes(semconv.DBQueryText(query)),
 						)
 					}()
 					stmt, err := original(ctx, query)
@@ -469,7 +465,6 @@ func Open(opts OpenOptions) (ConnPool_, error) {
 							seconds,
 							metric.WithAttributes(commonAttrs...),
 							metric.WithAttributes(semconv.DBOperationName("Exec")),
-							metric.WithAttributes(semconv.DBQueryText(query)),
 						)
 					}()
 					result, err := original(query, args)
@@ -491,7 +486,6 @@ func Open(opts OpenOptions) (ConnPool_, error) {
 							seconds,
 							metric.WithAttributes(commonAttrs...),
 							metric.WithAttributes(semconv.DBOperationName("Exec")),
-							metric.WithAttributes(semconv.DBQueryText(query)),
 						)
 					}()
 					result, err := original(ctx, query, args)
@@ -513,7 +507,6 @@ func Open(opts OpenOptions) (ConnPool_, error) {
 							seconds,
 							metric.WithAttributes(commonAttrs...),
 							metric.WithAttributes(semconv.DBOperationName("Query")),
-							metric.WithAttributes(semconv.DBQueryText(query)),
 						)
 					}()
 					rows, err := original(query, args)
@@ -535,7 +528,6 @@ func Open(opts OpenOptions) (ConnPool_, error) {
 							seconds,
 							metric.WithAttributes(commonAttrs...),
 							metric.WithAttributes(semconv.DBOperationName("Query")),
-							metric.WithAttributes(semconv.DBQueryText(query)),
 						)
 					}()
 					rows, err := original(ctx, query, args)
@@ -562,7 +554,6 @@ func Open(opts OpenOptions) (ConnPool_, error) {
 							seconds,
 							metric.WithAttributes(commonAttrs...),
 							metric.WithAttributes(semconv.DBOperationName("Exec")),
-							metric.WithAttributes(semconv.DBQueryText(query)),
 						)
 					}()
 					result, err := original(args)
@@ -584,7 +575,6 @@ func Open(opts OpenOptions) (ConnPool_, error) {
 							seconds,
 							metric.WithAttributes(commonAttrs...),
 							metric.WithAttributes(semconv.DBOperationName("Exec")),
-							metric.WithAttributes(semconv.DBQueryText(query)),
 						)
 					}()
 					result, err := original(ctx, args)
@@ -606,7 +596,6 @@ func Open(opts OpenOptions) (ConnPool_, error) {
 							seconds,
 							metric.WithAttributes(commonAttrs...),
 							metric.WithAttributes(semconv.DBOperationName("Query")),
-							metric.WithAttributes(semconv.DBQueryText(query)),
 						)
 					}()
 					rows, err := original(args)
@@ -628,7 +617,6 @@ func Open(opts OpenOptions) (ConnPool_, error) {
 							seconds,
 							metric.WithAttributes(commonAttrs...),
 							metric.WithAttributes(semconv.DBOperationName("Query")),
-							metric.WithAttributes(semconv.DBQueryText(query)),
 						)
 					}()
 					rows, err := original(ctx, args)
@@ -655,7 +643,6 @@ func Open(opts OpenOptions) (ConnPool_, error) {
 							seconds,
 							metric.WithAttributes(commonAttrs...),
 							metric.WithAttributes(semconv.DBOperationName("COMMIT")),
-							metric.WithAttributes(semconv.DBQueryText("COMMIT")),
 						)
 					}()
 					return original()
@@ -673,7 +660,6 @@ func Open(opts OpenOptions) (ConnPool_, error) {
 							seconds,
 							metric.WithAttributes(commonAttrs...),
 							metric.WithAttributes(semconv.DBOperationName("ROLLBACK")),
-							metric.WithAttributes(semconv.DBQueryText("ROLLBACK")),
 						)
 					}()
 					return original()


### PR DESCRIPTION
High volume metrics such as http duration histogram and database operation metrics occupy high memory if cardinality is high, so remove project id and client id from those metrics.
ref DEV-3529