### PR TITLE
[Portal] Fix Admin API documentation link

### DIFF
--- a/portal/src/graphql/portal/AdminAPIConfigurationScreen.tsx
+++ b/portal/src/graphql/portal/AdminAPIConfigurationScreen.tsx
@@ -441,7 +441,7 @@ const AdminAPIConfigurationScreenContent: React.VFC<AdminAPIConfigurationScreenC
                   values={{
                     // eslint-disable-next-line react/no-unstable-nested-components
                     docLink: (chunks: React.ReactNode) => (
-                      <ExternalLink href="https://docs.authgear.com/customization/admin-api">
+                      <ExternalLink href="https://docs.authgear.com/reference/apis/admin-api">
                         {chunks}
                       </ExternalLink>
                     ),
@@ -560,7 +560,7 @@ const AdminAPIConfigurationScreenContent: React.VFC<AdminAPIConfigurationScreenC
 
                     // eslint-disable-next-line react/no-unstable-nested-components
                     docLink: (chunks: React.ReactNode) => (
-                      <ExternalLink href="https://docs.authgear.com/customization/admin-api">
+                      <ExternalLink href="https://docs.authgear.com/reference/apis/admin-api">
                         {chunks}
                       </ExternalLink>
                     ),


### PR DESCRIPTION
## Summary
- Fix the documentation link on the portal Admin API configuration page. The "Read the Admin API documentation for more details" link pointed to `https://docs.authgear.com/customization/admin-api` (404), and now points to `https://docs.authgear.com/reference/apis/admin-api`.

## Test plan
- [ ] Open the Admin API page in the portal and click the documentation links (in the details description and the GraphiQL section); confirm they open the correct page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)