### PR TITLE
[Site Admin] Isolate collaborators e2e test from shared app IDs

### DIFF
--- a/e2e/tests/siteadmin/collaborators.test.yaml
+++ b/e2e/tests/siteadmin/collaborators.test.yaml
@@ -3,14 +3,14 @@ app_id: e2e-portal
 before:
 - type: custom_sql
   custom_sql:
-    path: fixture/seed_siteadmin_apps.sql
+    path: fixture/seed_siteadmin_collabs.sql
 
 steps:
 # ── List ──────────────────────────────────────────────────────────────────────
 - name: list collaborators - beta has none
   action: http_request
   http_request_method: GET
-  http_request_url: http://127.0.0.1:4003/api/v1/apps/e2e-siteadmin-app-beta/collaborators
+  http_request_url: http://127.0.0.1:4003/api/v1/apps/e2e-collab-beta/collaborators
   http_request_headers:
     X-Authgear-Session-Valid: "true"
     X-Authgear-User-Id: "00000000-0000-0000-0000-000000000001"
@@ -24,7 +24,7 @@ steps:
 - name: list_alpha
   action: http_request
   http_request_method: GET
-  http_request_url: http://127.0.0.1:4003/api/v1/apps/e2e-siteadmin-app-alpha/collaborators
+  http_request_url: http://127.0.0.1:4003/api/v1/apps/e2e-collab-alpha/collaborators
   http_request_headers:
     X-Authgear-Session-Valid: "true"
     X-Authgear-User-Id: "00000000-0000-0000-0000-000000000001"
@@ -35,9 +35,9 @@ steps:
         "collaborators": [
           {
             "id": "[[string]]",
-            "app_id": "e2e-siteadmin-app-alpha",
-            "user_id": "00000000-0000-0000-0000-000000000002",
-            "user_email": "owner@example.com",
+            "app_id": "e2e-collab-alpha",
+            "user_id": "00000000-0000-0000-0000-000000000005",
+            "user_email": "gamma-owner@example.com",
             "role": "owner",
             "created_at": "[[string]]"
           }
@@ -48,7 +48,7 @@ steps:
 - name: add_collaborator
   action: http_request
   http_request_method: POST
-  http_request_url: http://127.0.0.1:4003/api/v1/apps/e2e-siteadmin-app-beta/collaborators
+  http_request_url: http://127.0.0.1:4003/api/v1/apps/e2e-collab-beta/collaborators
   http_request_headers:
     X-Authgear-Session-Valid: "true"
     X-Authgear-User-Id: "00000000-0000-0000-0000-000000000001"
@@ -60,7 +60,7 @@ steps:
     json_body: |
       {
         "id": "[[string]]",
-        "app_id": "e2e-siteadmin-app-beta",
+        "app_id": "e2e-collab-beta",
         "user_id": "00000000-0000-0000-0000-000000000002",
         "user_email": "owner@example.com",
         "role": "editor",
@@ -70,7 +70,7 @@ steps:
 - name: list after add - beta has one editor
   action: http_request
   http_request_method: GET
-  http_request_url: http://127.0.0.1:4003/api/v1/apps/e2e-siteadmin-app-beta/collaborators
+  http_request_url: http://127.0.0.1:4003/api/v1/apps/e2e-collab-beta/collaborators
   http_request_headers:
     X-Authgear-Session-Valid: "true"
     X-Authgear-User-Id: "00000000-0000-0000-0000-000000000001"
@@ -80,7 +80,7 @@ steps:
       {
         "collaborators": [
           {
-            "app_id": "e2e-siteadmin-app-beta",
+            "app_id": "e2e-collab-beta",
             "user_email": "owner@example.com",
             "role": "editor"
           }
@@ -90,7 +90,7 @@ steps:
 - name: add duplicate returns 409
   action: http_request
   http_request_method: POST
-  http_request_url: http://127.0.0.1:4003/api/v1/apps/e2e-siteadmin-app-beta/collaborators
+  http_request_url: http://127.0.0.1:4003/api/v1/apps/e2e-collab-beta/collaborators
   http_request_headers:
     X-Authgear-Session-Valid: "true"
     X-Authgear-User-Id: "00000000-0000-0000-0000-000000000001"
@@ -103,7 +103,7 @@ steps:
 - name: add non-existent user returns 404
   action: http_request
   http_request_method: POST
-  http_request_url: http://127.0.0.1:4003/api/v1/apps/e2e-siteadmin-app-beta/collaborators
+  http_request_url: http://127.0.0.1:4003/api/v1/apps/e2e-collab-beta/collaborators
   http_request_headers:
     X-Authgear-Session-Valid: "true"
     X-Authgear-User-Id: "00000000-0000-0000-0000-000000000001"
@@ -117,7 +117,7 @@ steps:
 - name: remove editor
   action: http_request
   http_request_method: DELETE
-  http_request_url: http://127.0.0.1:4003/api/v1/apps/e2e-siteadmin-app-beta/collaborators/{{ .steps.add_collaborator.result.http_json_body.id }}
+  http_request_url: http://127.0.0.1:4003/api/v1/apps/e2e-collab-beta/collaborators/{{ .steps.add_collaborator.result.http_json_body.id }}
   http_request_headers:
     X-Authgear-Session-Valid: "true"
     X-Authgear-User-Id: "00000000-0000-0000-0000-000000000001"
@@ -129,7 +129,7 @@ steps:
 - name: list after remove - beta empty again
   action: http_request
   http_request_method: GET
-  http_request_url: http://127.0.0.1:4003/api/v1/apps/e2e-siteadmin-app-beta/collaborators
+  http_request_url: http://127.0.0.1:4003/api/v1/apps/e2e-collab-beta/collaborators
   http_request_headers:
     X-Authgear-Session-Valid: "true"
     X-Authgear-User-Id: "00000000-0000-0000-0000-000000000001"
@@ -143,41 +143,19 @@ steps:
 - name: remove non-existent collaborator returns 404
   action: http_request
   http_request_method: DELETE
-  http_request_url: http://127.0.0.1:4003/api/v1/apps/e2e-siteadmin-app-beta/collaborators/00000000-0000-0000-0000-000000000099
+  http_request_url: http://127.0.0.1:4003/api/v1/apps/e2e-collab-beta/collaborators/00000000-0000-0000-0000-000000000099
   http_request_headers:
     X-Authgear-Session-Valid: "true"
     X-Authgear-User-Id: "00000000-0000-0000-0000-000000000001"
   http_output:
     http_status: 404
 
-- name: get_owner_collab
-  action: query
-  query: |
-    SELECT id FROM _portal_app_collaborator
-    WHERE app_id = 'e2e-siteadmin-app-alpha'
-    AND role = 'owner'
-  query_output:
-    rows: |
-      [{"id": "[[string]]"}]
-
-- name: remove owner succeeds
-  action: http_request
-  http_request_method: DELETE
-  http_request_url: http://127.0.0.1:4003/api/v1/apps/e2e-siteadmin-app-alpha/collaborators/{{ index (index .steps.get_owner_collab.result.rows 0) "id" }}
-  http_request_headers:
-    X-Authgear-Session-Valid: "true"
-    X-Authgear-User-Id: "00000000-0000-0000-0000-000000000001"
-  http_output:
-    http_status: 200
-    json_body: |
-      {}
-
 # ── Promote ───────────────────────────────────────────────────────────────────
 - name: get_gamma_editor_collab
   action: query
   query: |
     SELECT id FROM _portal_app_collaborator
-    WHERE app_id = 'e2e-siteadmin-app-gamma'
+    WHERE app_id = 'e2e-collab-gamma'
     AND user_id = '00000000-0000-0000-0000-000000000004'
   query_output:
     rows: |
@@ -186,7 +164,7 @@ steps:
 - name: promote editor to owner
   action: http_request
   http_request_method: POST
-  http_request_url: http://127.0.0.1:4003/api/v1/apps/e2e-siteadmin-app-gamma/collaborators/{{ index (index .steps.get_gamma_editor_collab.result.rows 0) "id" }}/promote
+  http_request_url: http://127.0.0.1:4003/api/v1/apps/e2e-collab-gamma/collaborators/{{ index (index .steps.get_gamma_editor_collab.result.rows 0) "id" }}/promote
   http_request_headers:
     X-Authgear-Session-Valid: "true"
     X-Authgear-User-Id: "00000000-0000-0000-0000-000000000001"
@@ -195,7 +173,7 @@ steps:
     json_body: |
       {
         "id": "[[string]]",
-        "app_id": "e2e-siteadmin-app-gamma",
+        "app_id": "e2e-collab-gamma",
         "user_id": "00000000-0000-0000-0000-000000000004",
         "user_email": "editor@example.com",
         "role": "owner",
@@ -206,7 +184,7 @@ steps:
   action: query
   query: |
     SELECT user_id, role FROM _portal_app_collaborator
-    WHERE app_id = 'e2e-siteadmin-app-gamma'
+    WHERE app_id = 'e2e-collab-gamma'
     ORDER BY role
   query_output:
     rows: |
@@ -218,17 +196,29 @@ steps:
 - name: promote already-owner returns 409
   action: http_request
   http_request_method: POST
-  http_request_url: http://127.0.0.1:4003/api/v1/apps/e2e-siteadmin-app-gamma/collaborators/{{ index (index .steps.get_gamma_editor_collab.result.rows 0) "id" }}/promote
+  http_request_url: http://127.0.0.1:4003/api/v1/apps/e2e-collab-gamma/collaborators/{{ index (index .steps.get_gamma_editor_collab.result.rows 0) "id" }}/promote
   http_request_headers:
     X-Authgear-Session-Valid: "true"
     X-Authgear-User-Id: "00000000-0000-0000-0000-000000000001"
   http_output:
     http_status: 409
 
+- name: remove owner succeeds
+  action: http_request
+  http_request_method: DELETE
+  http_request_url: http://127.0.0.1:4003/api/v1/apps/e2e-collab-gamma/collaborators/{{ index (index .steps.get_gamma_editor_collab.result.rows 0) "id" }}
+  http_request_headers:
+    X-Authgear-Session-Valid: "true"
+    X-Authgear-User-Id: "00000000-0000-0000-0000-000000000001"
+  http_output:
+    http_status: 200
+    json_body: |
+      {}
+
 - name: promote non-existent collaborator returns 404
   action: http_request
   http_request_method: POST
-  http_request_url: http://127.0.0.1:4003/api/v1/apps/e2e-siteadmin-app-gamma/collaborators/00000000-0000-0000-0000-000000000099/promote
+  http_request_url: http://127.0.0.1:4003/api/v1/apps/e2e-collab-gamma/collaborators/00000000-0000-0000-0000-000000000099/promote
   http_request_headers:
     X-Authgear-Session-Valid: "true"
     X-Authgear-User-Id: "00000000-0000-0000-0000-000000000001"

--- a/e2e/tests/siteadmin/fixture/seed_siteadmin_collabs.sql
+++ b/e2e/tests/siteadmin/fixture/seed_siteadmin_collabs.sql
@@ -1,0 +1,154 @@
+-- Seed used exclusively by collaborators.test.yaml.
+-- Uses dedicated app IDs (e2e-collab-*) so this test can freely mutate
+-- collaborator rows without interfering with apps.test.yaml or other tests
+-- that share e2e-siteadmin-app-*.
+
+-- Grant Site Admin access in e2e-portal for the test actor.
+INSERT INTO _portal_app_collaborator (id, app_id, user_id, created_at, updated_at, role)
+VALUES (
+    gen_random_uuid()::text,
+    'e2e-portal',
+    '00000000-0000-0000-0000-000000000001',
+    NOW(),
+    NOW(),
+    'owner'
+)
+ON CONFLICT (app_id, user_id) DO NOTHING;
+
+-- Users (shared with other siteadmin seeds; ON CONFLICT keeps them idempotent).
+INSERT INTO _auth_user (
+    id, app_id, created_at, updated_at, last_login_at, login_at,
+    is_disabled, disable_reason, standard_attributes, custom_attributes,
+    is_deactivated, delete_at, is_anonymized, anonymize_at, anonymized_at,
+    last_indexed_at, require_reindex_after
+)
+VALUES
+    (
+        '00000000-0000-0000-0000-000000000002',
+        'e2e-portal',
+        NOW(), NOW(), NULL, NULL,
+        false, NULL,
+        '{"email": "owner@example.com"}',
+        '{}',
+        false, NULL, false, NULL, NULL,
+        NOW(), NOW()
+    ),
+    (
+        '00000000-0000-0000-0000-000000000004',
+        'e2e-portal',
+        NOW(), NOW(), NULL, NULL,
+        false, NULL,
+        '{"email": "editor@example.com"}',
+        '{}',
+        false, NULL, false, NULL, NULL,
+        NOW(), NOW()
+    ),
+    (
+        '00000000-0000-0000-0000-000000000005',
+        'e2e-portal',
+        NOW(), NOW(), NULL, NULL,
+        false, NULL,
+        '{"email": "gamma-owner@example.com"}',
+        '{}',
+        false, NULL, false, NULL, NULL,
+        NOW(), NOW()
+    )
+ON CONFLICT (id) DO NOTHING;
+
+-- Login ID identity for user 002 so FindUserIDsByEmail("owner@example.com") works.
+INSERT INTO _auth_identity (
+    id, app_id, type, user_id, created_at, updated_at
+)
+VALUES (
+    '00000000-0000-0000-0000-000000000003',
+    'e2e-portal',
+    'login_id',
+    '00000000-0000-0000-0000-000000000002',
+    NOW(),
+    NOW()
+)
+ON CONFLICT DO NOTHING;
+
+INSERT INTO _auth_identity_login_id (
+    id, app_id, login_id_key, login_id, claims, original_login_id, unique_key, login_id_type
+)
+VALUES (
+    '00000000-0000-0000-0000-000000000003',
+    'e2e-portal',
+    'email',
+    'owner@example.com',
+    '{"email": "owner@example.com"}',
+    'owner@example.com',
+    'owner@example.com',
+    'email'
+)
+ON CONFLICT DO NOTHING;
+
+-- Dedicated apps for collaborators.test.yaml — isolated from e2e-siteadmin-app-*.
+INSERT INTO _portal_config_source (id, app_id, data, plan_name, created_at, updated_at)
+VALUES
+    (
+        gen_random_uuid()::text,
+        'e2e-collab-alpha',
+        '{}',
+        'free',
+        NOW(),
+        NOW()
+    ),
+    (
+        gen_random_uuid()::text,
+        'e2e-collab-beta',
+        '{}',
+        'free',
+        NOW(),
+        NOW()
+    ),
+    (
+        gen_random_uuid()::text,
+        'e2e-collab-gamma',
+        '{}',
+        'free',
+        NOW(),
+        NOW()
+    )
+ON CONFLICT (app_id) DO NOTHING;
+
+-- Reset collaborators for all e2e-collab-* apps so previous runs don't leave
+-- stale rows. This is safe because these app IDs are owned exclusively by this
+-- seed file and collaborators.test.yaml.
+DELETE FROM _portal_app_collaborator
+WHERE app_id IN ('e2e-collab-alpha', 'e2e-collab-beta', 'e2e-collab-gamma');
+
+-- e2e-collab-alpha: owner = user 005 (gamma-owner@example.com).
+-- Deliberately NOT user 002 (owner@example.com) to avoid colliding with the
+-- apps.test.yaml "filter by owner_email" step that expects exactly one result
+-- for owner@example.com (e2e-siteadmin-app-alpha).
+INSERT INTO _portal_app_collaborator (id, app_id, user_id, created_at, updated_at, role)
+VALUES (
+    gen_random_uuid()::text,
+    'e2e-collab-alpha',
+    '00000000-0000-0000-0000-000000000005',
+    NOW(),
+    NOW(),
+    'owner'
+);
+
+-- e2e-collab-beta starts with no collaborators (test adds them dynamically).
+
+-- e2e-collab-gamma: owner = user 005, editor = user 004.
+INSERT INTO _portal_app_collaborator (id, app_id, user_id, created_at, updated_at, role)
+VALUES
+    (
+        gen_random_uuid()::text,
+        'e2e-collab-gamma',
+        '00000000-0000-0000-0000-000000000005',
+        NOW(), NOW(),
+        'owner'
+    ),
+    (
+        gen_random_uuid()::text,
+        'e2e-collab-gamma',
+        '00000000-0000-0000-0000-000000000004',
+        NOW(), NOW(),
+        'editor'
+    );


### PR DESCRIPTION
Give collaborators.test.yaml its own dedicated apps (e2e-collab-*) via a new seed file so destructive operations (promote, remove owner) never touch e2e-siteadmin-app-* that other parallel tests depend on.

The previous test was deleting e2e-siteadmin-app-alpha's owner row, which raced with apps.test.yaml reading it, causing owner_email: "".