### PR TITLE
[DB] [Migration Needed] Add indexes on `_portal_domain (domain, app_id)`

### DIFF
--- a/cmd/portal/cmd/cmddatabase/migrations/portal/20260518120000-add_portal_domain_indexes.sql
+++ b/cmd/portal/cmd/cmddatabase/migrations/portal/20260518120000-add_portal_domain_indexes.sql
@@ -1,0 +1,17 @@
+-- +migrate Up notransaction
+
+-- _portal_domain has no indexes on `domain` or `app_id`. Every request
+-- resolves the tenant via GetAppIDByDomain (WHERE domain = ?) and then
+-- loads all domains via GetDomainsByAppID (WHERE app_id = ?). Both do
+-- full table scans. At cloud scale the table grows to tens of thousands
+-- of rows and cache-miss resolution becomes measurably slow.
+--
+-- CONCURRENTLY builds the index without taking a ShareLock, so reads and
+-- writes continue uninterrupted during the build. notransaction above is
+-- required because CONCURRENTLY cannot run inside a transaction.
+CREATE INDEX CONCURRENTLY _portal_domain_domain ON _portal_domain (domain);
+CREATE INDEX CONCURRENTLY _portal_domain_app_id ON _portal_domain (app_id);
+
+-- +migrate Down notransaction
+DROP INDEX CONCURRENTLY _portal_domain_domain;
+DROP INDEX CONCURRENTLY _portal_domain_app_id;


### PR DESCRIPTION
## Motivation
`GetAppIDByDomain` `(WHERE domain = ?)` and `GetDomainsByAppID` `(WHERE app_id = ?)` both do full table scans on `_portal_domain` because no index exists on either column. 

The table `_portal_domain` grows with tenant count
- at 50k rows (in shared buffers) the domain lookup costs 1788 planner units vs 8 with the index (~210x).


## Downtime
- Uses `CREATE INDEX CONCURRENTLY` + `notransaction` so the build holds no ShareLock and writes are uninterrupted — safe to apply without a downtime window. 
- Drop also uses `DROP INDEX CONCURRENTLY`.

## Tests

I asked claude to write [some integration tests](https://github.com/pkong-ds/authgear-server/tree/index-portal-domain-integration-test) - which was TDD and highly detailed.'

But I think those are maintenance burden rather than helpful, so did not include in this PR