### PR TITLE
Fix required array fields dropping out of YAML round-trip

### DIFF
--- a/pkg/lib/config/config_test.go
+++ b/pkg/lib/config/config_test.go
@@ -2,6 +2,7 @@ package config_test
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"io"
 	"os"
@@ -212,6 +213,66 @@ identity:
 			So(cfg, ShouldResemble, cfg2)
 			So(*cfg2.FraudProtection.SMS.UnverifiedOTPBudget.DailyRatio, ShouldEqual, 0.3)
 			So(*cfg2.FraudProtection.SMS.UnverifiedOTPBudget.HourlyRatio, ShouldEqual, 0.2)
+		})
+
+		// Regression test: empty arrays in required fields must survive JSON→YAML round-trip.
+		// Previously, omitempty caused empty slices to be dropped, turning e.g.
+		// source:{cidrs:[],geo_location_codes:[]} into source:{}, which then
+		// disappeared in YAML serialization and broke the "required" schema check
+		// on all subsequent saves from unrelated pages.
+		Convey("IP filter rule with empty source arrays is valid after JSON-YAML round-trip", func() {
+			// Simulate portal saving an enabled IP blocklist with no entries filled in.
+			inputJSON := `{
+				"id": "test",
+				"http": {"public_origin": "http://test"},
+				"network_protection": {
+					"ip_filter": {
+						"default_action": "allow",
+						"rules": [{"name": "__portal", "action": "deny", "source": {"cidrs": [], "geo_location_codes": []}}]
+					}
+				}
+			}`
+
+			inputYAML, err := yaml.JSONToYAML([]byte(inputJSON))
+			So(err, ShouldBeNil)
+			cfg, err := config.Parse(ctx, inputYAML)
+			So(err, ShouldBeNil)
+
+			// Simulate the server serialising the stored config back to JSON
+			// (as it does when responding to a portal query), then the portal
+			// re-saving from an unrelated page — which sends that JSON verbatim.
+			roundTrippedJSON, err := json.Marshal(cfg)
+			So(err, ShouldBeNil)
+			roundTrippedYAML, err := yaml.JSONToYAML(roundTrippedJSON)
+			So(err, ShouldBeNil)
+			_, err = config.Parse(ctx, roundTrippedYAML)
+			So(err, ShouldBeNil)
+		})
+
+		Convey("fraud protection by-phone-country with empty geo_location_codes is valid after JSON-YAML round-trip", func() {
+			inputJSON := `{
+				"id": "test",
+				"http": {"public_origin": "http://test"},
+				"fraud_protection": {
+					"sms": {
+						"unverified_otp_budget": {
+							"by_phone_country": [{"geo_location_codes": []}]
+						}
+					}
+				}
+			}`
+
+			inputYAML, err := yaml.JSONToYAML([]byte(inputJSON))
+			So(err, ShouldBeNil)
+			cfg, err := config.Parse(ctx, inputYAML)
+			So(err, ShouldBeNil)
+
+			roundTrippedJSON, err := json.Marshal(cfg)
+			So(err, ShouldBeNil)
+			roundTrippedYAML, err := yaml.JSONToYAML(roundTrippedJSON)
+			So(err, ShouldBeNil)
+			_, err = config.Parse(ctx, roundTrippedYAML)
+			So(err, ShouldBeNil)
 		})
 
 		Convey("parse validation", func() {

--- a/pkg/lib/config/fraud_protection.go
+++ b/pkg/lib/config/fraud_protection.go
@@ -210,7 +210,8 @@ func (c *FraudProtectionSMSUnverifiedOTPBudgetConfig) SetDefaults() {
 }
 
 type FraudProtectionSMSUnverifiedOTPBudgetByPhoneCountryConfig struct {
-	GeoLocationCodes []string `json:"geo_location_codes,omitempty"`
+	// Use `omitzero` instead so empty array will be outputted, while nil will still be omitted.
+	GeoLocationCodes []string `json:"geo_location_codes,omitzero"`
 	DailyRatio       *float64 `json:"daily_ratio,omitempty" nullable:"true"`
 	HourlyRatio      *float64 `json:"hourly_ratio,omitempty" nullable:"true"`
 }

--- a/pkg/lib/config/network_protection.go
+++ b/pkg/lib/config/network_protection.go
@@ -90,6 +90,7 @@ type IPFilterRule struct {
 }
 
 type IPFilterSource struct {
-	CIDRs            []string `json:"cidrs,omitempty"`
-	GeoLocationCodes []string `json:"geo_location_codes,omitempty"`
+	// Use `omitzero` instead so empty array will be outputted, while nil will still be omitted.
+	CIDRs            []string `json:"cidrs,omitzero"`
+	GeoLocationCodes []string `json:"geo_location_codes,omitzero"`
 }

--- a/pkg/lib/config/secret_data.go
+++ b/pkg/lib/config/secret_data.go
@@ -172,7 +172,8 @@ var _ = SecretConfigSchema.Add("OAuthSSOProviderCredentials", `
 `)
 
 type OAuthSSOProviderCredentials struct {
-	Items []OAuthSSOProviderCredentialsItem `json:"items,omitempty"`
+	// Use `omitzero` instead so empty array will be outputted, while nil will still be omitted.
+	Items []OAuthSSOProviderCredentialsItem `json:"items,omitzero"`
 }
 
 func (c *OAuthSSOProviderCredentials) Lookup(alias string) (*OAuthSSOProviderCredentialsItem, bool) {
@@ -539,7 +540,8 @@ var _ = SecretConfigSchema.Add("OAuthClientCredentials", `
 `)
 
 type OAuthClientCredentials struct {
-	Items []OAuthClientCredentialsItem `json:"items,omitempty"`
+	// Use `omitzero` instead so empty array will be outputted, while nil will still be omitted.
+	Items []OAuthClientCredentialsItem `json:"items,omitzero"`
 }
 
 func (c *OAuthClientCredentials) Lookup(clientID string) (*OAuthClientCredentialsItem, bool) {

--- a/pkg/lib/config/secret_saml.go
+++ b/pkg/lib/config/secret_saml.go
@@ -93,6 +93,7 @@ var _ = SecretConfigSchema.Add("SAMLSpSigningCertificate", `
 `)
 
 type SAMLSpSigningCertificate struct {
-	ServiceProviderID string            `json:"service_provider_id,omitempty"`
-	Certificates      []X509Certificate `json:"certificates,omitempty"`
+	ServiceProviderID string `json:"service_provider_id,omitempty"`
+	// Use `omitzero` instead so empty array will be outputted, while nil will still be omitted.
+	Certificates []X509Certificate `json:"certificates,omitzero"`
 }


### PR DESCRIPTION
Use `omitzero` instead of `omitempty` on slice fields that are marked `required` in their JSON schema and whose empty value (`[]`) is semantically valid.

With `omitempty`, an empty `[]string{}` is serialized as absent.  This turned e.g. `source:{cidrs:[],geo_location_codes:[]}` into `source:{}` after the first Go marshal, and the empty object `{}` then disappeared entirely in the JSON→YAML conversion on the next portal save.  The stored config therefore had the `source` key missing, which broke the `required: ["action","source"]` schema check on every subsequent `updateApp` call — including saves from completely unrelated pages.

Affected fields fixed:
- IPFilterSource.CIDRs / GeoLocationCodes (network_protection.go)
- FraudProtectionSMSUnverifiedOTPBudgetByPhoneCountryConfig.GeoLocationCodes (fraud_protection.go)
- OAuthSSOProviderCredentials.Items / OAuthClientCredentials.Items (secret_data.go)
- SAMLSpSigningCertificate.Certificates (secret_saml.go)

Regression tests added for the two app-config cases.

ref DEV-3568