### PR TITLE
Use claude CLI for generate-translations instead of Anthropic API key

### DIFF
--- a/.claude/skills/update-email-templates/SKILL.md
+++ b/.claude/skills/update-email-templates/SKILL.md
@@ -40,8 +40,8 @@ Follow this workflow whenever updating email templates.
    - Run once per changed top-level key.
 5. In a separate commit, generate non-English translations:
    - `make -C scripts/python generate-translations`
-   - `ANTHROPIC_API_KEY` must be set.
-   - If `ANTHROPIC_API_KEY` is not set, stop and ask the user to run this step.
+   - Requires being logged in to Claude: `claude login`
+   - If not logged in, stop and ask the user to run `claude login` first.
 6. Finally, generate HTML emails:
    - `make html-email`
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -466,14 +466,16 @@ Scripts are located at `scripts/python/generate_translations.py`.
 +++  "v2-error-new-error": "Translate me"
 ```
 
-2. Obtain your Anthropic api key. The translation is performed via `claude-3-sonnet-20240229` model
+2. Log in to Claude (uses your Claude.ai subscription quota, no API key required)
 
-   If you are located in regions blocked by Anthropic, please make use of a VPN to access the holy Anthropic API.
+```bash
+claude login
+```
 
 3. Generate translations
 
 ```bash
-make -C scripts/python generate-translations ANTHROPIC_API_KEY=<REPLACE_ME>
+make -C scripts/python generate-translations
 ```
 
 4. You should see

--- a/scripts/python/Makefile
+++ b/scripts/python/Makefile
@@ -17,10 +17,8 @@ generate-material-icons: venv
 generate-twemoji-icons: venv
 	$(PYTHON) ./subset_fonts/subset_twemoji_icons.py
 
-# `make generate-translations` expects the environment variable ANTHROPIC_API_KEY to be set.
-# You can set it at the CLI with
-# ANTHROPIC_API_KEY=your_key make generate-translations
-# Or create a .env file next to the Makefile. The .env file will be loaded dotenv in the script.
+# `make generate-translations` uses the claude CLI with your Claude.ai subscription quota.
+# Make sure you are logged in first: claude login
 .PHONY: generate-translations
 generate-translations: venv
 	$(PYTHON) ./generate_translations.py

--- a/scripts/python/generate_translations.py
+++ b/scripts/python/generate_translations.py
@@ -2,18 +2,15 @@ import collections
 import concurrent.futures
 import os
 import re
-import anthropic
+import subprocess
 import json
 import json_repair
 import regex
 import logging
-from dotenv import load_dotenv
 
 logging.basicConfig(
     level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s"
 )
-
-load_dotenv()
 
 LOCALE_DICT = {
     "zh-HK": {"name": "Traditional Chinese", "cldr": "zh-Hant-HK"},
@@ -88,21 +85,15 @@ def auto_translate(messages: dict[str, str | dict[str, str]], locale, chunk_size
     - Escape astrophes (') with double astrophes ('')
     """
 
-        client = anthropic.Anthropic()
-        # Replace model claude-3-haiku-20240307 as it failed to return special characters: electrónico -> electr??nico
-        message = client.messages.create(
-            model="claude-haiku-4-5",
-            max_tokens=4000,
-            temperature=0,
-            system=prompt,
-            messages=[
-                {
-                    "role": "user",
-                    "content": [{"type": "text", "text": json.dumps(chunk, indent=2)}],
-                }
-            ],
+        full_prompt = f"{prompt}\n\n{json.dumps(chunk, indent=2)}"
+        # Use claude CLI so calls run against the user's Claude.ai subscription quota
+        proc = subprocess.run(
+            ["claude", "-p", full_prompt],
+            capture_output=True,
+            text=True,
+            check=True,
         )
-        result = message.content[0].text
+        result = proc.stdout
 
         logging.info(f"{locale} | Translation result: {result}")
 

--- a/scripts/python/requirements.txt
+++ b/scripts/python/requirements.txt
@@ -1,6 +1,4 @@
-anthropic==0.50.0
 brotli==1.2.0
-python-dotenv==1.2.2
 fonttools==4.61.0
 json-repair==0.42.0
 lxml==6.1.0


### PR DESCRIPTION
Reuses the existing Claude.ai subscription instead of requiring a separate API key