### PR TITLE
chore: Update Go to 1.26.4

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,3 +1,3 @@
-golang 1.26.3
+golang 1.26.4
 nodejs 20.19.5
 python 3.12.1

--- a/cmd/authgear/Dockerfile
+++ b/cmd/authgear/Dockerfile
@@ -15,7 +15,7 @@ COPY Makefile .
 RUN make authui
 
 # Stage 1: Build the Go binary
-FROM quay.io/theauthgear/golang:1.26.3-noble AS authgear-stage-1
+FROM quay.io/theauthgear/golang:1.26.4-noble AS authgear-stage-1
 
 # Install build time C dependencies
 RUN set -eux; \

--- a/cmd/portal/Dockerfile
+++ b/cmd/portal/Dockerfile
@@ -26,7 +26,7 @@ COPY ./portal .
 RUN npm run build
 
 # Stage 2: Build the Go binary
-FROM quay.io/theauthgear/golang:1.26.3-noble AS authgear-portal-stage-2
+FROM quay.io/theauthgear/golang:1.26.4-noble AS authgear-portal-stage-2
 
 # Install build time C dependencies
 RUN set -eux; \

--- a/custombuild/cmd/authgearx/Dockerfile
+++ b/custombuild/cmd/authgearx/Dockerfile
@@ -15,7 +15,7 @@ COPY Makefile .
 RUN make authui
 
 # Stage 1: Build the Go binary
-FROM quay.io/theauthgear/golang:1.26.3-noble AS authgear-stage-1
+FROM quay.io/theauthgear/golang:1.26.4-noble AS authgear-stage-1
 
 # Install build time C dependencies
 RUN set -eux; \

--- a/custombuild/cmd/portalx/Dockerfile
+++ b/custombuild/cmd/portalx/Dockerfile
@@ -26,7 +26,7 @@ COPY ./portal .
 RUN npm run build
 
 # Stage 2: Build the Go binary
-FROM quay.io/theauthgear/golang:1.26.3-noble AS authgear-portal-stage-2
+FROM quay.io/theauthgear/golang:1.26.4-noble AS authgear-portal-stage-2
 
 # Install build time C dependencies
 RUN set -eux; \

--- a/custombuild/go.mod
+++ b/custombuild/go.mod
@@ -1,6 +1,6 @@
 module github.com/authgear/authgear-server/custombuild
 
-go 1.26.3
+go 1.26.4
 
 replace github.com/authgear/authgear-server v0.0.0 => ../
 

--- a/e2e/go.mod
+++ b/e2e/go.mod
@@ -1,6 +1,6 @@
 module github.com/authgear/authgear-server/e2e
 
-go 1.26.3
+go 1.26.4
 
 replace github.com/authgear/authgear-server v0.0.0 => ../
 

--- a/flake.nix
+++ b/flake.nix
@@ -19,10 +19,10 @@
             (final: prev: {
               go = (
                 prev.go.overrideAttrs {
-                  version = "1.26.3";
+                  version = "1.26.4";
                   src = prev.fetchurl {
-                    url = "https://go.dev/dl/go1.26.3.src.tar.gz";
-                    hash = "sha256-LpHrtpR6lulDb7KzkmqIAu/mOm03Xf/sT4Kqnb1v1Ds=";
+                    url = "https://go.dev/dl/go1.26.4.src.tar.gz";
+                    hash = "sha256-T2aKMvv8ETLmqIH7lowvHa2mMUkqM5IRc1+7JVpCYC0=";
                   };
                 }
               );

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/authgear/authgear-server
 
 // go1.21 supports toolchain
 // See https://go.dev/doc/toolchain
-go 1.26.3
+go 1.26.4
 
 require (
 	github.com/Masterminds/sprig v2.22.0+incompatible

--- a/k6/go.mod
+++ b/k6/go.mod
@@ -2,7 +2,7 @@ module github.com/authgear/authgear-server/k6
 
 // go1.21 supports toolchain
 // See https://go.dev/doc/toolchain
-go 1.26.3
+go 1.26.4
 
 require (
 	github.com/google/uuid v1.6.0

--- a/once/Dockerfile
+++ b/once/Dockerfile
@@ -22,7 +22,7 @@ COPY Makefile .
 RUN make authui
 
 # Stage 1: Build the Go binary
-FROM quay.io/theauthgear/golang:1.26.3-noble AS authgear-stage-1
+FROM quay.io/theauthgear/golang:1.26.4-noble AS authgear-stage-1
 
 # Install build time C dependencies
 RUN set -eux; \
@@ -128,7 +128,7 @@ COPY ./portal .
 RUN npm run build
 
 # Stage 2: Build the Go binary
-FROM quay.io/theauthgear/golang:1.26.3-noble AS authgear-portal-stage-2
+FROM quay.io/theauthgear/golang:1.26.4-noble AS authgear-portal-stage-2
 
 # Install build time C dependencies
 RUN set -eux; \
@@ -201,7 +201,7 @@ EXPOSE 13003
 CMD ["authgear-portal", "start"]
 
 
-FROM quay.io/theauthgear/golang:1.26.3-noble AS authgear-once-stage-wrapper
+FROM quay.io/theauthgear/golang:1.26.4-noble AS authgear-once-stage-wrapper
 WORKDIR /src
 COPY go.mod go.sum ./
 RUN go mod download

--- a/once/partial.dockerfile
+++ b/once/partial.dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 
-FROM quay.io/theauthgear/golang:1.26.3-noble AS authgear-once-stage-wrapper
+FROM quay.io/theauthgear/golang:1.26.4-noble AS authgear-once-stage-wrapper
 WORKDIR /src
 COPY go.mod go.sum ./
 RUN go mod download

--- a/packagetracker/go.mod.tpl
+++ b/packagetracker/go.mod.tpl
@@ -2,7 +2,7 @@ module github.com/authgear/authgear-server/packagetracker
 
 // go1.21 supports toolchain
 // See https://go.dev/doc/toolchain
-go 1.26.3
+go 1.26.4
 
 require (
 	github.com/crewjam/saml v0.5.1


### PR DESCRIPTION
I tried updating the Go version to fix the CI, but it seems the Docker image (`quay.io/theauthgear/golang:1.26.4-noble`) is missing.

I think the image needs to be created by rebasing https://github.com/authgear/docker-library-golang, but I’m not very familiar with the process.

Could you help take a look? Or feel free to let me know as well, so I can help with it next time 🙂