### PR TITLE
[Portal] Show login-link templates in MFA via Email tab

### DIFF
--- a/portal/src/graphql/portal/LocalizationConfigurationScreen.tsx
+++ b/portal/src/graphql/portal/LocalizationConfigurationScreen.tsx
@@ -60,6 +60,12 @@ import {
   TRANSLATION_JSON_KEY_EMAIL_SETUP_SECONDARY_OOB_SUBJECT,
   TRANSLATION_JSON_KEY_EMAIL_AUTHENTICATE_SECONDARY_OOB_SUBJECT,
   TRANSLATION_JSON_KEY_EMAIL_VERIFICATION_SUBJECT,
+  RESOURCE_SETUP_SECONDARY_LOGIN_LINK_HTML,
+  RESOURCE_SETUP_SECONDARY_LOGIN_LINK_TXT,
+  RESOURCE_AUTHENTICATE_SECONDARY_LOGIN_LINK_HTML,
+  RESOURCE_AUTHENTICATE_SECONDARY_LOGIN_LINK_TXT,
+  TRANSLATION_JSON_KEY_EMAIL_SETUP_SECONDARY_LOGIN_LINK_SUBJECT,
+  TRANSLATION_JSON_KEY_EMAIL_AUTHENTICATE_SECONDARY_LOGIN_LINK_SUBJECT,
 } from "../../resources";
 import {
   LanguageTag,
@@ -728,6 +734,38 @@ const ResourcesConfigurationContent: React.VFC<ResourcesConfigurationContentProp
       },
     ];
 
+    // email_otp_mode is a single shared config; the same value that drives the
+    // primary (Passwordless) tab also drives the secondary (MFA) tab.
+    const mfaViaEmailOTPMode = passwordlessViaEmailOTPMode;
+
+    const mfaViaEmailTemplates = {
+      code: {
+        setupHtml: RESOURCE_SETUP_SECONDARY_OOB_EMAIL_HTML,
+        setupPlainText: RESOURCE_SETUP_SECONDARY_OOB_EMAIL_TXT,
+        authenticateHtml: RESOURCE_AUTHENTICATE_SECONDARY_OOB_EMAIL_HTML,
+        authenticatePlainText: RESOURCE_AUTHENTICATE_SECONDARY_OOB_EMAIL_TXT,
+      },
+      login_link: {
+        setupHtml: RESOURCE_SETUP_SECONDARY_LOGIN_LINK_HTML,
+        setupPlainText: RESOURCE_SETUP_SECONDARY_LOGIN_LINK_TXT,
+        authenticateHtml: RESOURCE_AUTHENTICATE_SECONDARY_LOGIN_LINK_HTML,
+        authenticatePlainText: RESOURCE_AUTHENTICATE_SECONDARY_LOGIN_LINK_TXT,
+      },
+    }[mfaViaEmailOTPMode];
+
+    const mfaViaEmailSubject = {
+      code: {
+        setup: TRANSLATION_JSON_KEY_EMAIL_SETUP_SECONDARY_OOB_SUBJECT,
+        authenticate:
+          TRANSLATION_JSON_KEY_EMAIL_AUTHENTICATE_SECONDARY_OOB_SUBJECT,
+      },
+      login_link: {
+        setup: TRANSLATION_JSON_KEY_EMAIL_SETUP_SECONDARY_LOGIN_LINK_SUBJECT,
+        authenticate:
+          TRANSLATION_JSON_KEY_EMAIL_AUTHENTICATE_SECONDARY_LOGIN_LINK_SUBJECT,
+      },
+    }[mfaViaEmailOTPMode];
+
     const sectionsMFAViaEmail: EditTemplatesWidgetSection[] = [
       {
         key: "setup",
@@ -737,12 +775,8 @@ const ResourcesConfigurationContent: React.VFC<ResourcesConfigurationContentProp
             key: "email-subject",
             title: <FormattedMessage id="EditTemplatesWidget.email-subject" />,
             language: "plaintext",
-            value: getTranslationValue(
-              TRANSLATION_JSON_KEY_EMAIL_SETUP_SECONDARY_OOB_SUBJECT
-            ),
-            onChange: getTranslationOnChange(
-              TRANSLATION_JSON_KEY_EMAIL_SETUP_SECONDARY_OOB_SUBJECT
-            ),
+            value: getTranslationValue(mfaViaEmailSubject.setup),
+            onChange: getTranslationOnChange(mfaViaEmailSubject.setup),
             editor: "textfield",
             readOnly: isTemplateCustomizationDisabled,
           },
@@ -750,8 +784,8 @@ const ResourcesConfigurationContent: React.VFC<ResourcesConfigurationContentProp
             key: "html-email",
             title: <FormattedMessage id="EditTemplatesWidget.html-email" />,
             language: "html",
-            value: getValue(RESOURCE_SETUP_SECONDARY_OOB_EMAIL_HTML),
-            onChange: getOnChange(RESOURCE_SETUP_SECONDARY_OOB_EMAIL_HTML),
+            value: getValue(mfaViaEmailTemplates.setupHtml),
+            onChange: getOnChange(mfaViaEmailTemplates.setupHtml),
             editor: "code",
             readOnly: isTemplateCustomizationDisabled,
           },
@@ -761,8 +795,8 @@ const ResourcesConfigurationContent: React.VFC<ResourcesConfigurationContentProp
               <FormattedMessage id="EditTemplatesWidget.plaintext-email" />
             ),
             language: "plaintext",
-            value: getValue(RESOURCE_SETUP_SECONDARY_OOB_EMAIL_TXT),
-            onChange: getOnChange(RESOURCE_SETUP_SECONDARY_OOB_EMAIL_TXT),
+            value: getValue(mfaViaEmailTemplates.setupPlainText),
+            onChange: getOnChange(mfaViaEmailTemplates.setupPlainText),
             editor: "code",
             readOnly: isTemplateCustomizationDisabled,
           },
@@ -778,12 +812,8 @@ const ResourcesConfigurationContent: React.VFC<ResourcesConfigurationContentProp
             key: "email-subject",
             title: <FormattedMessage id="EditTemplatesWidget.email-subject" />,
             language: "plaintext",
-            value: getTranslationValue(
-              TRANSLATION_JSON_KEY_EMAIL_AUTHENTICATE_SECONDARY_OOB_SUBJECT
-            ),
-            onChange: getTranslationOnChange(
-              TRANSLATION_JSON_KEY_EMAIL_AUTHENTICATE_SECONDARY_OOB_SUBJECT
-            ),
+            value: getTranslationValue(mfaViaEmailSubject.authenticate),
+            onChange: getTranslationOnChange(mfaViaEmailSubject.authenticate),
             editor: "textfield",
             readOnly: isTemplateCustomizationDisabled,
           },
@@ -791,10 +821,8 @@ const ResourcesConfigurationContent: React.VFC<ResourcesConfigurationContentProp
             key: "html-email",
             title: <FormattedMessage id="EditTemplatesWidget.html-email" />,
             language: "html",
-            value: getValue(RESOURCE_AUTHENTICATE_SECONDARY_OOB_EMAIL_HTML),
-            onChange: getOnChange(
-              RESOURCE_AUTHENTICATE_SECONDARY_OOB_EMAIL_HTML
-            ),
+            value: getValue(mfaViaEmailTemplates.authenticateHtml),
+            onChange: getOnChange(mfaViaEmailTemplates.authenticateHtml),
             editor: "code",
             readOnly: isTemplateCustomizationDisabled,
           },
@@ -804,10 +832,8 @@ const ResourcesConfigurationContent: React.VFC<ResourcesConfigurationContentProp
               <FormattedMessage id="EditTemplatesWidget.plaintext-email" />
             ),
             language: "plaintext",
-            value: getValue(RESOURCE_AUTHENTICATE_SECONDARY_OOB_EMAIL_TXT),
-            onChange: getOnChange(
-              RESOURCE_AUTHENTICATE_SECONDARY_OOB_EMAIL_TXT
-            ),
+            value: getValue(mfaViaEmailTemplates.authenticatePlainText),
+            onChange: getOnChange(mfaViaEmailTemplates.authenticatePlainText),
             editor: "code",
             readOnly: isTemplateCustomizationDisabled,
           },

--- a/portal/src/resources.test.ts
+++ b/portal/src/resources.test.ts
@@ -1,0 +1,47 @@
+import {
+  ALL_LANGUAGES_TEMPLATES,
+  RESOURCE_SETUP_SECONDARY_LOGIN_LINK_HTML,
+  RESOURCE_SETUP_SECONDARY_LOGIN_LINK_TXT,
+  RESOURCE_AUTHENTICATE_SECONDARY_LOGIN_LINK_HTML,
+  RESOURCE_AUTHENTICATE_SECONDARY_LOGIN_LINK_TXT,
+} from "./resources";
+
+describe("secondary login-link email resources", () => {
+  it("resolve to the correct template paths", () => {
+    expect(
+      RESOURCE_SETUP_SECONDARY_LOGIN_LINK_HTML.resourcePath.render({
+        locale: "en",
+      })
+    ).toEqual("templates/en/messages/setup_secondary_login_link.html");
+    expect(
+      RESOURCE_SETUP_SECONDARY_LOGIN_LINK_TXT.resourcePath.render({
+        locale: "en",
+      })
+    ).toEqual("templates/en/messages/setup_secondary_login_link.txt");
+    expect(
+      RESOURCE_AUTHENTICATE_SECONDARY_LOGIN_LINK_HTML.resourcePath.render({
+        locale: "en",
+      })
+    ).toEqual("templates/en/messages/authenticate_secondary_login_link.html");
+    expect(
+      RESOURCE_AUTHENTICATE_SECONDARY_LOGIN_LINK_TXT.resourcePath.render({
+        locale: "en",
+      })
+    ).toEqual("templates/en/messages/authenticate_secondary_login_link.txt");
+  });
+
+  it("are registered in ALL_LANGUAGES_TEMPLATES", () => {
+    expect(ALL_LANGUAGES_TEMPLATES).toContain(
+      RESOURCE_SETUP_SECONDARY_LOGIN_LINK_HTML
+    );
+    expect(ALL_LANGUAGES_TEMPLATES).toContain(
+      RESOURCE_SETUP_SECONDARY_LOGIN_LINK_TXT
+    );
+    expect(ALL_LANGUAGES_TEMPLATES).toContain(
+      RESOURCE_AUTHENTICATE_SECONDARY_LOGIN_LINK_HTML
+    );
+    expect(ALL_LANGUAGES_TEMPLATES).toContain(
+      RESOURCE_AUTHENTICATE_SECONDARY_LOGIN_LINK_TXT
+    );
+  });
+});

--- a/portal/src/resources.ts
+++ b/portal/src/resources.ts
@@ -126,6 +126,34 @@ export const RESOURCE_AUTHENTICATE_PRIMARY_LOGIN_LINK_TXT: ResourceDefinition =
     fallback: FALLBACK_EFFECTIVE_DATA,
   };
 
+export const RESOURCE_SETUP_SECONDARY_LOGIN_LINK_HTML: ResourceDefinition = {
+  resourcePath: resourcePath`templates/${"locale"}/messages/setup_secondary_login_link.html`,
+  type: "text",
+  extensions: [],
+  fallback: FALLBACK_EFFECTIVE_DATA,
+};
+export const RESOURCE_SETUP_SECONDARY_LOGIN_LINK_TXT: ResourceDefinition = {
+  resourcePath: resourcePath`templates/${"locale"}/messages/setup_secondary_login_link.txt`,
+  type: "text",
+  extensions: [],
+  fallback: FALLBACK_EFFECTIVE_DATA,
+};
+
+export const RESOURCE_AUTHENTICATE_SECONDARY_LOGIN_LINK_HTML: ResourceDefinition =
+  {
+    resourcePath: resourcePath`templates/${"locale"}/messages/authenticate_secondary_login_link.html`,
+    type: "text",
+    extensions: [],
+    fallback: FALLBACK_EFFECTIVE_DATA,
+  };
+export const RESOURCE_AUTHENTICATE_SECONDARY_LOGIN_LINK_TXT: ResourceDefinition =
+  {
+    resourcePath: resourcePath`templates/${"locale"}/messages/authenticate_secondary_login_link.txt`,
+    type: "text",
+    extensions: [],
+    fallback: FALLBACK_EFFECTIVE_DATA,
+  };
+
 export const RESOURCE_FORGOT_PASSWORD_EMAIL_LINK_HTML: ResourceDefinition = {
   resourcePath: resourcePath`templates/${"locale"}/messages/forgot_password_email.html`,
   type: "text",
@@ -273,6 +301,12 @@ export const ALL_LANGUAGES_TEMPLATES = [
   RESOURCE_AUTHENTICATE_PRIMARY_LOGIN_LINK_HTML,
   RESOURCE_AUTHENTICATE_PRIMARY_LOGIN_LINK_TXT,
 
+  RESOURCE_SETUP_SECONDARY_LOGIN_LINK_HTML,
+  RESOURCE_SETUP_SECONDARY_LOGIN_LINK_TXT,
+
+  RESOURCE_AUTHENTICATE_SECONDARY_LOGIN_LINK_HTML,
+  RESOURCE_AUTHENTICATE_SECONDARY_LOGIN_LINK_TXT,
+
   RESOURCE_FORGOT_PASSWORD_EMAIL_LINK_HTML,
   RESOURCE_FORGOT_PASSWORD_EMAIL_LINK_TXT,
   RESOURCE_FORGOT_PASSWORD_SMS_LINK_TXT,
@@ -363,6 +397,10 @@ export const TRANSLATION_JSON_KEY_EMAIL_SETUP_PRIMARY_LOGIN_LINK_SUBJECT =
   "email.setup-primary-login-link.subject";
 export const TRANSLATION_JSON_KEY_EMAIL_AUTHENTICATE_PRIMARY_LOGIN_LINK_SUBJECT =
   "email.authenticate-primary-login-link.subject";
+export const TRANSLATION_JSON_KEY_EMAIL_SETUP_SECONDARY_LOGIN_LINK_SUBJECT =
+  "email.setup-secondary-login-link.subject";
+export const TRANSLATION_JSON_KEY_EMAIL_AUTHENTICATE_SECONDARY_LOGIN_LINK_SUBJECT =
+  "email.authenticate-secondary-login-link.subject";
 export const TRANSLATION_JSON_KEY_EMAIL_AUTHENTICATE_PRIMARY_OOB_SUBJECT =
   "email.authenticate-primary-oob.subject";
 export const TRANSLATION_JSON_KEY_EMAIL_AUTHENTICATE_SECONDARY_OOB_SUBJECT =

--- a/portal/src/resources.ts
+++ b/portal/src/resources.ts
@@ -395,10 +395,10 @@ export const TRANSLATION_JSON_KEY_EMAIL_SETUP_SECONDARY_OOB_SUBJECT =
   "email.setup-secondary-oob.subject";
 export const TRANSLATION_JSON_KEY_EMAIL_SETUP_PRIMARY_LOGIN_LINK_SUBJECT =
   "email.setup-primary-login-link.subject";
-export const TRANSLATION_JSON_KEY_EMAIL_AUTHENTICATE_PRIMARY_LOGIN_LINK_SUBJECT =
-  "email.authenticate-primary-login-link.subject";
 export const TRANSLATION_JSON_KEY_EMAIL_SETUP_SECONDARY_LOGIN_LINK_SUBJECT =
   "email.setup-secondary-login-link.subject";
+export const TRANSLATION_JSON_KEY_EMAIL_AUTHENTICATE_PRIMARY_LOGIN_LINK_SUBJECT =
+  "email.authenticate-primary-login-link.subject";
 export const TRANSLATION_JSON_KEY_EMAIL_AUTHENTICATE_SECONDARY_LOGIN_LINK_SUBJECT =
   "email.authenticate-secondary-login-link.subject";
 export const TRANSLATION_JSON_KEY_EMAIL_AUTHENTICATE_PRIMARY_OOB_SUBJECT =


### PR DESCRIPTION
## Summary

The secondary (2FA) login-link email templates were not editable from the Portal's **Branding → Email/SMS Templates** page. When a project uses email 2FA in Login Link mode (`authenticator.oob_otp.email.email_otp_mode = login_link`), the "Use this link to sign in …" email could only be customized by editing resource files directly, not via the Portal.

This makes the **MFA via Email** tab mode-aware, mirroring the existing **Passwordless via Email** tab:

- Add the four secondary login-link resource definitions (`setup_secondary_login_link.{html,txt}`, `authenticate_secondary_login_link.{html,txt}`) and their two subject-key constants to `portal/src/resources.ts`, and register them in `ALL_LANGUAGES_TEMPLATES`.
- In `LocalizationConfigurationScreen.tsx`, switch the MFA via Email tab between the OOB (code) and login-link templates based on the shared `email_otp_mode`, using the same `{ code, login_link }[mode]` pattern already used for the primary tab.

Server-side templates and subject translation keys already exist, so this is portal-only wiring — no server, schema, or translation changes.

ref DEV-3322

When email verification mode = Link, the MFA via Email tab:

<img width="643" height="705" alt="SCR-20260605-pndf" src="https://github.com/user-attachments/assets/0513e747-d0b9-404e-89d1-eb82b92570e8" />


## Test Plan

- [x] `npm run typecheck`
- [x] `npm run eslint`
- [x] `npm run prettier`
- [x] `npm run test` (added `src/resources.test.ts`; 158/158 pass)
- [x] `npm run build`
- [ ] Manual: with `email_otp_mode = login_link` and `oob_otp_email` as a secondary authenticator, the MFA via Email tab shows the login-link templates; toggling back to `code` shows the OTP templates; edits persist and render in a real 2FA email.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


