### PR TITLE
Support SRI in portal and authui

### DIFF
--- a/authui/vite.config.ts
+++ b/authui/vite.config.ts
@@ -80,6 +80,7 @@ interface OurHTMLElementFontPreload {
 interface OurHTMLElementModulePreload {
   type: "fontpreload";
   name: string;
+  integrity?: string;
 }
 
 function elementsToHTMLString(elements: OurHTMLElement[]): string {
@@ -101,7 +102,10 @@ function elementsToHTMLString(elements: OurHTMLElement[]): string {
       }
     }
     if (element.type === "fontpreload") {
-      const htmlLine = `<link rel="preload" as="font" crossorigin="anonymous" href="{{ call $.GeneratedStaticAssetURL "${element.name}" }}">`;
+      const integrityAttr = element.integrity
+        ? ` integrity="${element.integrity}"`
+        : "";
+      const htmlLine = `<link rel="preload" as="font" crossorigin="anonymous" href="{{ call $.GeneratedStaticAssetURL "${element.name}" }}"${integrityAttr}>`;
       textArray.push(htmlLine);
     }
     if (element.type === "modulepreload") {
@@ -303,6 +307,7 @@ function buildPlugin({ input }: AuthgearAuthUIPluginOptions): Plugin {
           fontPreloadElements.push({
             type: "fontpreload",
             name: assetBaseName,
+            integrity: sriMap[assetBaseName],
           });
         }
       }

--- a/authui/vite.config.ts
+++ b/authui/vite.config.ts
@@ -1,6 +1,7 @@
 import { defineConfig, type Plugin, type ResolvedConfig } from "vite";
 
 import htmlParser, { HTMLElement } from "node-html-parser";
+import crypto from "crypto";
 import path from "path";
 import fs from "fs/promises";
 
@@ -60,17 +61,20 @@ type OurHTMLElement =
 interface OurHTMLElementCSS {
   type: "css";
   name: string;
+  integrity?: string;
 }
 
 interface OurHTMLElementJS {
   type: "js";
   name: string;
   attributes: Record<string, string>;
+  integrity?: string;
 }
 
 interface OurHTMLElementFontPreload {
   type: "modulepreload";
   name: string;
+  integrity?: string;
 }
 
 interface OurHTMLElementModulePreload {
@@ -84,7 +88,10 @@ function elementsToHTMLString(elements: OurHTMLElement[]): string {
   const textArray = [];
   for (const element of elements) {
     if (element.type === "css") {
-      const htmlLine = `<link nonce="{{ $.CSPNonce }}" rel="stylesheet" href="{{ call $.GeneratedStaticAssetURL "${element.name}" }}" data-turbo-track="reload">`;
+      const integrityAttr = element.integrity
+        ? ` integrity="${element.integrity}" crossorigin="anonymous"`
+        : "";
+      const htmlLine = `<link nonce="{{ $.CSPNonce }}" rel="stylesheet" href="{{ call $.GeneratedStaticAssetURL "${element.name}" }}"${integrityAttr} data-turbo-track="reload">`;
       if (element.name === "tailwind-dark-theme.css") {
         textArray.push(`{{ if $.DarkThemeEnabled }}`);
         textArray.push(htmlLine);
@@ -98,7 +105,10 @@ function elementsToHTMLString(elements: OurHTMLElement[]): string {
       textArray.push(htmlLine);
     }
     if (element.type === "modulepreload") {
-      const htmlLine = `<link rel="modulepreload" href="{{ call $.GeneratedStaticAssetURL "${element.name}" }}" data-turbo-track="reload">`;
+      const integrityAttr = element.integrity
+        ? ` integrity="${element.integrity}" crossorigin="anonymous"`
+        : "";
+      const htmlLine = `<link rel="modulepreload" href="{{ call $.GeneratedStaticAssetURL "${element.name}" }}"${integrityAttr} data-turbo-track="reload">`;
       textArray.push(htmlLine);
     }
     if (element.type === "js") {
@@ -108,7 +118,10 @@ function elementsToHTMLString(elements: OurHTMLElement[]): string {
         )
       );
       const attributesString = stringifyHTMLAttributes(attributes);
-      const htmlLine = `<script ${attributesString} nonce="{{ $.CSPNonce }}" src="{{ call $.GeneratedStaticAssetURL "${element.name}" }}" data-turbo-track="reload"></script>`;
+      const integrityAttr = element.integrity
+        ? ` integrity="${element.integrity}" crossorigin="anonymous"`
+        : "";
+      const htmlLine = `<script ${attributesString} nonce="{{ $.CSPNonce }}" src="{{ call $.GeneratedStaticAssetURL "${element.name}" }}"${integrityAttr} data-turbo-track="reload"></script>`;
       textArray.push(htmlLine);
     }
   }
@@ -259,6 +272,27 @@ function buildPlugin({ input }: AuthgearAuthUIPluginOptions): Plugin {
     },
 
     async writeBundle(_options, bundles) {
+      // Build SRI hash map: asset basename (without hash) -> "sha384-<base64>"
+      const sriMap: Record<string, string> = {};
+      for (const [bundleName, bundleInfo] of Object.entries(bundles)) {
+        let content: string | Uint8Array | undefined;
+        if (bundleInfo.type === "asset") {
+          content = bundleInfo.source as string | Uint8Array;
+        } else if (bundleInfo.type === "chunk") {
+          content = bundleInfo.code;
+        }
+        if (content != null) {
+          const bytes =
+            typeof content === "string" ? Buffer.from(content) : content;
+          const hash = crypto
+            .createHash("sha384")
+            .update(bytes)
+            .digest("base64");
+          const key = path.basename(nameWithoutHash(bundleName));
+          sriMap[key] = `sha384-${hash}`;
+        }
+      }
+
       // Handle font preload
       const fontPreloadElements: OurHTMLElement[] = [];
       for (const [bundleName, _bundleInfo] of Object.entries(bundles)) {
@@ -300,12 +334,14 @@ function buildPlugin({ input }: AuthgearAuthUIPluginOptions): Plugin {
                     elements.push({
                       type: "css",
                       name: key,
+                      integrity: sriMap[key],
                     });
                   }
                   if (node.getAttribute("rel") === "modulepreload") {
                     elements.push({
                       type: "modulepreload",
                       name: key,
+                      integrity: sriMap[key],
                     });
                   }
                 }
@@ -324,6 +360,7 @@ function buildPlugin({ input }: AuthgearAuthUIPluginOptions): Plugin {
                     type: "js",
                     attributes: attributes,
                     name: key,
+                    integrity: sriMap[key],
                   });
                 }
               }

--- a/portal/vite.config.ts
+++ b/portal/vite.config.ts
@@ -33,6 +33,30 @@ const plugin: Plugin = {
       }
 
       const html = parse(htmlString);
+      const head = html.querySelector("head")!;
+
+      // Build import map with integrity hashes for all JS chunks.
+      // This covers dynamically imported chunks (lazy-loaded routes/components)
+      // that are not listed as <script> or <link rel="modulepreload"> in the HTML.
+      // The browser verifies each chunk's hash when it is dynamically imported.
+      // Browser support: Chrome 126+, Firefox 127+, Safari 17.4+.
+      if (ctx.bundle != null) {
+        const integrity: Record<string, string> = {};
+        for (const [name, chunk] of Object.entries(ctx.bundle)) {
+          if (chunk.type === "chunk") {
+            const key = "/" + name;
+            if (sriMap[key] != null) {
+              integrity[key] = sriMap[key];
+            }
+          }
+        }
+        // Import map must appear before any <script type="module">.
+        // Insert as first child of <head>; nonce will be added below.
+        head.insertAdjacentHTML(
+          "afterbegin",
+          `<script type="importmap">${JSON.stringify({ integrity })}</script>`
+        );
+      }
 
       const scripts = html.querySelectorAll("script");
       const styles = html.querySelectorAll("style");
@@ -43,7 +67,6 @@ const plugin: Plugin = {
         e.setAttribute("nonce", "{{ $.CSPNonce }}");
       }
 
-      const head = html.querySelector("head")!;
       for (const e of elements) {
         if (e.getAttribute("data-order") === "last") {
           head.removeChild(e);

--- a/portal/vite.config.ts
+++ b/portal/vite.config.ts
@@ -2,61 +2,17 @@ import { defineConfig, type Plugin } from "vite";
 import react from "@vitejs/plugin-react";
 import { parse } from "node-html-parser";
 import crypto from "crypto";
+import fs from "fs/promises";
+import path from "path";
 
-const plugin: Plugin = {
-  name: "vite-plugin-authgear-portal:build",
+// Adds CSP nonces to all inline scripts/styles in index.html.
+const noncePlugin: Plugin = {
+  name: "vite-plugin-authgear-portal:nonce",
   apply: "build",
   transformIndexHtml: {
     order: "post",
-    handler: (htmlString, ctx) => {
-      // Build SRI hash map from bundle: "/path/to/asset" -> "sha384-<base64>"
-      // ctx.bundle is available for order:"post" handlers during build.
-      const sriMap: Record<string, string> = {};
-      if (ctx.bundle != null) {
-        for (const [name, chunk] of Object.entries(ctx.bundle)) {
-          let content: string | Uint8Array | undefined;
-          if (chunk.type === "chunk") {
-            content = chunk.code;
-          } else if (chunk.type === "asset") {
-            content = chunk.source as string | Uint8Array;
-          }
-          if (content != null) {
-            const bytes =
-              typeof content === "string" ? Buffer.from(content) : content;
-            const hash = crypto
-              .createHash("sha384")
-              .update(bytes)
-              .digest("base64");
-            sriMap["/" + name] = `sha384-${hash}`;
-          }
-        }
-      }
-
+    handler: (htmlString) => {
       const html = parse(htmlString);
-      const head = html.querySelector("head")!;
-
-      // Build import map with integrity hashes for all JS chunks.
-      // This covers dynamically imported chunks (lazy-loaded routes/components)
-      // that are not listed as <script> or <link rel="modulepreload"> in the HTML.
-      // The browser verifies each chunk's hash when it is dynamically imported.
-      // Browser support: Chrome 126+, Firefox 127+, Safari 17.4+.
-      if (ctx.bundle != null) {
-        const integrity: Record<string, string> = {};
-        for (const [name, chunk] of Object.entries(ctx.bundle)) {
-          if (chunk.type === "chunk") {
-            const key = "/" + name;
-            if (sriMap[key] != null) {
-              integrity[key] = sriMap[key];
-            }
-          }
-        }
-        // Import map must appear before any <script type="module">.
-        // Insert as first child of <head>; nonce will be added below.
-        head.insertAdjacentHTML(
-          "afterbegin",
-          `<script type="importmap">${JSON.stringify({ integrity })}</script>`
-        );
-      }
 
       const scripts = html.querySelectorAll("script");
       const styles = html.querySelectorAll("style");
@@ -67,32 +23,11 @@ const plugin: Plugin = {
         e.setAttribute("nonce", "{{ $.CSPNonce }}");
       }
 
+      const head = html.querySelector("head")!;
       for (const e of elements) {
         if (e.getAttribute("data-order") === "last") {
           head.removeChild(e);
           head.appendChild(e);
-        }
-      }
-
-      for (const el of html.querySelectorAll("script[src]")) {
-        const src = el.getAttribute("src");
-        if (src != null && sriMap[src] != null) {
-          el.setAttribute("integrity", sriMap[src]);
-          el.setAttribute("crossorigin", "anonymous");
-        }
-      }
-      for (const el of html.querySelectorAll("link[rel=stylesheet]")) {
-        const href = el.getAttribute("href");
-        if (href != null && sriMap[href] != null) {
-          el.setAttribute("integrity", sriMap[href]);
-          el.setAttribute("crossorigin", "anonymous");
-        }
-      }
-      for (const el of html.querySelectorAll("link[rel=modulepreload]")) {
-        const href = el.getAttribute("href");
-        if (href != null && sriMap[href] != null) {
-          el.setAttribute("integrity", sriMap[href]);
-          el.setAttribute("crossorigin", "anonymous");
         }
       }
 
@@ -101,8 +36,84 @@ const plugin: Plugin = {
   },
 };
 
+// Adds SRI integrity attributes and an import map to index.html.
+// Must run in writeBundle (after files are written) because Vite applies
+// additional transforms to some chunks after transformIndexHtml runs,
+// so chunk.code there does not match the final file on disk.
+const sriPlugin: Plugin = {
+  name: "vite-plugin-authgear-portal:sri",
+  apply: "build",
+  async writeBundle(options, bundle) {
+    const outDir = options.dir!;
+
+    // Compute hashes from the final bundle content (matches files on disk).
+    const sriMap: Record<string, string> = {};
+    const importIntegrity: Record<string, string> = {};
+    for (const [name, chunk] of Object.entries(bundle)) {
+      let content: string | Uint8Array | undefined;
+      if (chunk.type === "chunk") {
+        content = chunk.code;
+      } else if (chunk.type === "asset") {
+        content = chunk.source as string | Uint8Array;
+      }
+      if (content != null) {
+        const bytes =
+          typeof content === "string" ? Buffer.from(content) : content;
+        const hash = crypto
+          .createHash("sha384")
+          .update(bytes)
+          .digest("base64");
+        sriMap["/" + name] = `sha384-${hash}`;
+        if (chunk.type === "chunk") {
+          importIntegrity["/" + name] = `sha384-${hash}`;
+        }
+      }
+    }
+
+    // Read index.html (already written by Vite, with nonces from noncePlugin).
+    const indexHtmlPath = path.join(outDir, "index.html");
+    const source = await fs.readFile(indexHtmlPath, "utf-8");
+    const html = parse(source);
+    const head = html.querySelector("head")!;
+
+    // Inject import map as the first child of <head> so it precedes all
+    // <script type="module"> tags. Covers dynamically imported chunks
+    // (lazy-loaded routes/components) not listed in the HTML directly.
+    // Browser support: Chrome 126+, Firefox 127+, Safari 17.4+.
+    head.insertAdjacentHTML(
+      "afterbegin",
+      `<script type="importmap" nonce="{{ $.CSPNonce }}">${JSON.stringify({ integrity: importIntegrity })}</script>`
+    );
+
+    // Add integrity + crossorigin to statically referenced scripts and styles.
+    for (const el of html.querySelectorAll("script[src]")) {
+      const src = el.getAttribute("src");
+      if (src != null && sriMap[src] != null) {
+        el.setAttribute("integrity", sriMap[src]);
+        el.setAttribute("crossorigin", "anonymous");
+      }
+    }
+    for (const el of html.querySelectorAll("link[rel=stylesheet]")) {
+      const href = el.getAttribute("href");
+      if (href != null && sriMap[href] != null) {
+        el.setAttribute("integrity", sriMap[href]);
+        el.setAttribute("crossorigin", "anonymous");
+      }
+    }
+    for (const el of html.querySelectorAll("link[rel=modulepreload]")) {
+      const href = el.getAttribute("href");
+      if (href != null && sriMap[href] != null) {
+        el.setAttribute("integrity", sriMap[href]);
+        el.setAttribute("crossorigin", "anonymous");
+      }
+    }
+
+    await fs.writeFile(indexHtmlPath, html.toString());
+  },
+};
+
 function viteAuthgearPortal() {
-  return [plugin];
+  return [noncePlugin, sriPlugin];
 }
 
 export default defineConfig({

--- a/portal/vite.config.ts
+++ b/portal/vite.config.ts
@@ -1,13 +1,37 @@
 import { defineConfig, type Plugin } from "vite";
 import react from "@vitejs/plugin-react";
 import { parse } from "node-html-parser";
+import crypto from "crypto";
 
 const plugin: Plugin = {
   name: "vite-plugin-authgear-portal:build",
   apply: "build",
   transformIndexHtml: {
     order: "post",
-    handler: (htmlString) => {
+    handler: (htmlString, ctx) => {
+      // Build SRI hash map from bundle: "/path/to/asset" -> "sha384-<base64>"
+      // ctx.bundle is available for order:"post" handlers during build.
+      const sriMap: Record<string, string> = {};
+      if (ctx.bundle != null) {
+        for (const [name, chunk] of Object.entries(ctx.bundle)) {
+          let content: string | Uint8Array | undefined;
+          if (chunk.type === "chunk") {
+            content = chunk.code;
+          } else if (chunk.type === "asset") {
+            content = chunk.source as string | Uint8Array;
+          }
+          if (content != null) {
+            const bytes =
+              typeof content === "string" ? Buffer.from(content) : content;
+            const hash = crypto
+              .createHash("sha384")
+              .update(bytes)
+              .digest("base64");
+            sriMap["/" + name] = `sha384-${hash}`;
+          }
+        }
+      }
+
       const html = parse(htmlString);
 
       const scripts = html.querySelectorAll("script");
@@ -24,6 +48,28 @@ const plugin: Plugin = {
         if (e.getAttribute("data-order") === "last") {
           head.removeChild(e);
           head.appendChild(e);
+        }
+      }
+
+      for (const el of html.querySelectorAll("script[src]")) {
+        const src = el.getAttribute("src");
+        if (src != null && sriMap[src] != null) {
+          el.setAttribute("integrity", sriMap[src]);
+          el.setAttribute("crossorigin", "anonymous");
+        }
+      }
+      for (const el of html.querySelectorAll("link[rel=stylesheet]")) {
+        const href = el.getAttribute("href");
+        if (href != null && sriMap[href] != null) {
+          el.setAttribute("integrity", sriMap[href]);
+          el.setAttribute("crossorigin", "anonymous");
+        }
+      }
+      for (const el of html.querySelectorAll("link[rel=modulepreload]")) {
+        const href = el.getAttribute("href");
+        if (href != null && sriMap[href] != null) {
+          el.setAttribute("integrity", sriMap[href]);
+          el.setAttribute("crossorigin", "anonymous");
         }
       }
 


### PR DESCRIPTION
ref DEV-3475

How to test:

AuthUI:
- Run `make authui`
- Go to localhost:3100. Inspect the html, see `integrity` is set on each asset

Portal:
- Run `make portal`
- Go to localhost:8010 (Not 8000). Inspect the html, see `integrity` is set on the asset tags.
- See `<script type="importmap">` element in the html which contains hashes of all chunks.