### PR TITLE
[Site Admin API] Replace `owner_email` filter with `owner_search` keyword search

### DIFF
--- a/.vettedpositions
+++ b/.vettedpositions
@@ -327,7 +327,7 @@
 /pkg/siteadmin/transport/handler_app_get.go:40:33: requestcontext
 /pkg/siteadmin/transport/handler_app_plan_change.go:47:65: requestcontext
 /pkg/siteadmin/transport/handler_app_plan_change.go:63:38: requestcontext
-/pkg/siteadmin/transport/handler_apps_list.go:77:37: requestcontext
+/pkg/siteadmin/transport/handler_apps_list.go:70:37: requestcontext
 /pkg/siteadmin/transport/handler_collaborator_add.go:47:67: requestcontext
 /pkg/siteadmin/transport/handler_collaborator_add.go:64:49: requestcontext
 /pkg/siteadmin/transport/handler_collaborator_promote.go:39:53: requestcontext

--- a/docs/api/siteadmin-api.yaml
+++ b/docs/api/siteadmin-api.yaml
@@ -43,7 +43,7 @@ paths:
             Filter by owner keyword. Searches the portal user database by partial
             email, name, or other attributes. Returns apps whose owner matches the
             keyword. When provided and `sort` is omitted, defaults to `sort=relevance`.
-            At most 100 matching owners are considered; if more than 100 owners match,
+            At most 20 matching owners are considered; if more than 20 owners match,
             `owner_search_truncated` is set to `true` in the response and `total_count`
             is a lower bound.
           schema:
@@ -587,8 +587,8 @@ components:
         owner_search_truncated:
           type: boolean
           description: >
-            True when the `owner_search` keyword matched more than 100 portal users
-            and results are limited to the top 100 matches. `total_count` is a lower
+            True when the `owner_search` keyword matched more than 20 portal users
+            and results are limited to the top 20 matches. `total_count` is a lower
             bound in this case. Always `false` when `owner_search` is not provided.
 
     App:

--- a/docs/api/siteadmin-api.yaml
+++ b/docs/api/siteadmin-api.yaml
@@ -37,12 +37,17 @@ paths:
           description: Filter by app ID prefix. Returns all apps whose ID starts with the given value.
           schema:
             type: string
-        - name: owner_email
+        - name: owner_search
           in: query
-          description: Filter by owner email address.
+          description: >
+            Filter by owner keyword. Searches the portal user database by partial
+            email, name, or other attributes. Returns apps whose owner matches the
+            keyword. When provided and `sort` is omitted, defaults to `sort=relevance`.
+            At most 100 matching owners are considered; if more than 100 owners match,
+            `owner_search_truncated` is set to `true` in the response and `total_count`
+            is a lower bound.
           schema:
             type: string
-            format: email
         - name: plan
           in: query
           description: Filter by plan name.
@@ -50,16 +55,23 @@ paths:
             type: string
         - name: sort
           in: query
-          description: Field to sort by. Defaults to `created_at`.
+          description: >
+            Field to sort by. Defaults to `created_at`, or `relevance` when
+            `owner_search` is provided. `relevance` sorts by how well the app's
+            owner matches the `owner_search` keyword and requires `owner_search`
+            to be set; using `relevance` without `owner_search` returns 400.
           schema:
             type: string
             enum:
               - created_at
               - mau
+              - relevance
             default: created_at
         - name: order
           in: query
-          description: Sort direction. Defaults to `desc`.
+          description: >
+            Sort direction. Defaults to `desc`. Ignored when `sort=relevance`
+            (relevance is always highest-match first).
           schema:
             type: string
             enum:
@@ -552,6 +564,7 @@ components:
         - total_count
         - page
         - page_size
+        - owner_search_truncated
       properties:
         apps:
           type: array
@@ -559,7 +572,10 @@ components:
             $ref: "#/components/schemas/App"
         total_count:
           type: integer
-          description: Total number of apps matching the query.
+          description: >
+            Total number of apps matching the query. When `owner_search_truncated`
+            is `true`, this is a lower bound — apps owned by owners beyond the 100-match
+            cap are not counted.
         page:
           type: integer
           format: uint64
@@ -568,6 +584,12 @@ components:
           type: integer
           format: uint64
           description: Number of apps per page.
+        owner_search_truncated:
+          type: boolean
+          description: >
+            True when the `owner_search` keyword matched more than 100 portal users
+            and results are limited to the top 100 matches. `total_count` is a lower
+            bound in this case. Always `false` when `owner_search` is not provided.
 
     App:
       type: object

--- a/docs/api/siteadmin-api.yaml
+++ b/docs/api/siteadmin-api.yaml
@@ -34,7 +34,7 @@ paths:
             maximum: 20
         - name: app_id
           in: query
-          description: Filter by app ID.
+          description: Filter by app ID prefix. Returns all apps whose ID starts with the given value.
           schema:
             type: string
         - name: owner_email

--- a/docs/plans/siteadmin-api/03.2-apps-api-owner-search.md
+++ b/docs/plans/siteadmin-api/03.2-apps-api-owner-search.md
@@ -177,7 +177,7 @@ func (s *AdminAPIService) SearchUsersByKeyword(ctx context.Context, keyword stri
 }
 ```
 
-`FindUserIDsByEmail` is removed (no longer called).
+`FindUserIDsByEmail` is kept — it is still called by `collaborator.go`.
 
 ---
 
@@ -554,9 +554,9 @@ beyond the method signature of `ListApps` which is called only from the handler.
 [Site Admin API] Replace owner_email with owner_search in apps list spec
 ```
 
-### Commit 2 — Admin API: replace FindUserIDsByEmail with SearchUsersByKeyword
+### Commit 2 — Admin API: add SearchUsersByKeyword
 
-- `pkg/siteadmin/service/admin_api.go`: add `SearchUsersByKeyword`, remove `FindUserIDsByEmail`
+- `pkg/siteadmin/service/admin_api.go`: add `SearchUsersByKeyword`; keep `FindUserIDsByEmail` (still used by `collaborator.go`)
 
 ```
 [Site Admin API] Add SearchUsersByKeyword to AdminAPIService

--- a/docs/plans/siteadmin-api/03.2-apps-api-owner-search.md
+++ b/docs/plans/siteadmin-api/03.2-apps-api-owner-search.md
@@ -1,0 +1,634 @@
+# Part 3.2: Site Admin Apps API — Owner Search
+
+## Context
+
+The existing `owner_email` filter on `GET /api/v1/apps` requires an exact, complete email
+address. This makes it impractical for admin use where you only know a partial email or name.
+
+This plan replaces `owner_email` with `owner_search`: a free-text keyword passed to the portal
+app's Admin API user search, which returns up to 100 matching user IDs. Those IDs are passed
+into the SQL `WHERE ac.user_id = ANY(?)` filter. When `owner_search` is active, results are
+additionally ordered by owner search rank using `array_position(...)` so that apps belonging to
+the best-matching owner appear first.
+
+**Design boundary:** the siteadmin service must not query the user table directly. All user
+lookup goes through the Admin API (HTTP GraphQL call to the portal app).
+
+---
+
+## Limitations and considerations
+
+| # | Limitation | Impact |
+|---|---|---|
+| 1 | **Hard cap of 100 user IDs** | The Admin API enforces `DEFAULT_MAX_PAGE_SIZE = 100` (`pkg/util/graphqlutil/page.go:7`). A single `owner_search` call can return at most 100 matching users. If the keyword matches more than 100 owners, apps owned by users ranked >100 are invisible. |
+| 2 | **`total_count` is a lower bound when truncated** | The SQL count query operates only on the capped user ID set. If the search was truncated, `total_count` reflects only the apps owned by the top 100 matching users, not all matching apps. |
+| 3 | **Seq scan on `_portal_app_collaborator`** | There is no standalone index on `user_id` in `_portal_app_collaborator` (only a composite `UNIQUE(app_id, user_id)`). `WHERE ac.user_id = ANY(ARRAY[100 ids])` requires a seq scan. At 100k rows this is ~5–20ms warm; at 500k rows ~50–200ms warm. No lock is held on concurrent reads/writes — PostgreSQL MVCC ensures the scan does not block portal users. The slowness affects only the siteadmin request itself. |
+| 4 | **Owner-rank dominates pagination** | When `owner_search` is active, `array_position` is prepended as the primary `ORDER BY`. If the top-ranked user owns many apps, they will fill multiple pages before apps from lower-ranked owners appear. The `sort` and `order` parameters remain as secondary sort criteria. |
+| 5 | **`owner_search` is a best-effort filter for broad queries** | Searching `"a"` or `"@gmail.com"` likely matches >100 owners and will be silently truncated. The feature is designed for targeted partial-email or name searches (e.g. `"alice@company"`, `"alice"`). Callers should check `owner_search_truncated` in the response. |
+| 6 | **Extra HTTP round-trip** | Every `owner_search` request makes an HTTP call to the portal Admin API before the SQL query. This adds ~50–200ms of latency depending on deployment. |
+
+---
+
+## API spec changes
+
+### `GET /api/v1/apps` — parameter changes
+
+- **Remove** `owner_email` parameter.
+- **Add** `owner_search` parameter.
+- **Add** `relevance` to the `sort` enum.
+
+```yaml
+- name: owner_search
+  in: query
+  description: >
+    Filter by owner keyword. Searches the portal user database by partial email,
+    name, or other attributes. Returns apps whose owner matches the keyword.
+    When owner_search is provided and no sort is specified, sort defaults to
+    `relevance`. At most 100 matching owners are considered; if the keyword
+    matches more than 100 owners, `owner_search_truncated` is set to `true` in
+    the response.
+  schema:
+    type: string
+```
+
+**Updated `sort` enum** — add `relevance`:
+
+```yaml
+- name: sort
+  in: query
+  description: >
+    Field to sort by. Defaults to `created_at`, or `relevance` when
+    `owner_search` is provided. `relevance` sorts by how well the app's owner
+    matches the `owner_search` keyword and requires `owner_search` to be set.
+  schema:
+    type: string
+    enum:
+      - created_at
+      - mau
+      - relevance
+    default: created_at
+```
+
+**Sort / owner_search interaction rules (documented in spec description):**
+
+| `sort` | `owner_search` present | Result |
+|---|---|---|
+| omitted | no | defaults to `created_at` |
+| omitted | yes | defaults to `relevance` |
+| `relevance` | yes | order by owner match rank |
+| `relevance` | no | `400 Bad Request` |
+| `created_at` or `mau` | yes | filter by owner search, sort by the given field |
+| `created_at` or `mau` | no | normal behaviour, unchanged |
+
+`order` (asc/desc) is ignored and has no effect when `sort=relevance`.
+
+### `AppsListResponse` schema — add `owner_search_truncated`
+
+```yaml
+AppsListResponse:
+  type: object
+  required:
+    - apps
+    - total_count
+    - page
+    - page_size
+    - owner_search_truncated
+  properties:
+    # ... existing fields unchanged ...
+    owner_search_truncated:
+      type: boolean
+      description: >
+        True when the owner_search keyword matched more than 100 portal users and
+        results have been limited to the top 100 matches. total_count is a lower
+        bound in this case.
+```
+
+---
+
+## Go type changes
+
+### `pkg/api/siteadmin/` (generated from OpenAPI)
+
+After regenerating, the `AppsListResponse` struct gains:
+
+```go
+OwnerSearchTruncated bool `json:"owner_search_truncated"`
+```
+
+And the `App` type is unchanged.
+
+---
+
+## `pkg/siteadmin/service/admin_api.go`
+
+Add `SearchUsersByKeyword` alongside the existing `FindUserIDsByEmail`. The new method calls
+the Admin API `UsersListQuery` with `searchKeyword`, requesting the maximum page size of 100.
+It returns the ordered list of user IDs (search-rank order preserved) and a truncated flag.
+
+```go
+// SearchUsersByKeyword searches portal users by keyword via the Admin GraphQL API.
+// Returns up to 100 user IDs in search-rank order and whether the result was truncated
+// (i.e. the search matched more users than the page cap allows).
+func (s *AdminAPIService) SearchUsersByKeyword(ctx context.Context, keyword string) (ids []string, truncated bool, err error) {
+    params := graphqlutil.DoParams{
+        OperationName: "searchOwnersByKeyword",
+        Query: `
+        query searchOwnersByKeyword($keyword: String!, $pageSize: Int!) {
+            users(first: $pageSize, searchKeyword: $keyword) {
+                edges {
+                    node { id }
+                }
+                pageInfo { hasNextPage }
+            }
+        }
+        `,
+        Variables: map[string]any{
+            "keyword":  keyword,
+            "pageSize": 100,
+        },
+    }
+
+    result, err := s.do(ctx, params)
+    if err != nil {
+        return nil, false, err
+    }
+    if result.HasErrors() {
+        return nil, false, fmt.Errorf("failed to search users by keyword: %v", result.Errors)
+    }
+
+    data := result.Data.(map[string]any)
+    usersConn := data["users"].(map[string]any)
+    edges := usersConn["edges"].([]any)
+    pageInfo := usersConn["pageInfo"].(map[string]any)
+    hasNextPage, _ := pageInfo["hasNextPage"].(bool)
+
+    ids = make([]string, 0, len(edges))
+    for _, e := range edges {
+        edge := e.(map[string]any)
+        node := edge["node"].(map[string]any)
+        globalID, _ := node["id"].(string)
+        resolved := relay.FromGlobalID(globalID)
+        if resolved == nil || resolved.ID == "" {
+            continue
+        }
+        ids = append(ids, resolved.ID)
+    }
+    return ids, hasNextPage, nil
+}
+```
+
+`FindUserIDsByEmail` is removed (no longer called).
+
+---
+
+## `pkg/siteadmin/service/app.go`
+
+### `ListAppsStoreParams` — replace single ID with slice
+
+```go
+type ListAppsStoreParams struct {
+    Page           uint64
+    PageSize       uint64
+    AppID          string
+    PlanName       string
+    OwnerUserIDs   []string                      // replaces OwnerUserID string; empty = no filter
+    Sort           siteadmin.ListAppsParamsSort
+    Order          siteadmin.ListAppsParamsOrder
+    LastMonthStart time.Time
+}
+```
+
+### `ListAppsWithStats` — SQL changes
+
+**Filter clause** (replaces the single `ac.user_id = ?`):
+
+```go
+if len(params.OwnerUserIDs) > 0 {
+    q = q.Where("ac.user_id = ANY(?)", pq.Array(params.OwnerUserIDs))
+}
+```
+
+**ORDER BY** — `array_position` is prepended as the primary sort **only when `sort=Relevance`**.
+When `sort=created_at` or `sort=mau` is explicitly given alongside `owner_search`, the
+`OwnerUserIDs` filter still applies but no owner rank ordering is added — apps are sorted
+purely by the specified field. This respects the caller's explicit sort choice.
+
+```go
+orderExpr := primaryExpr + " " + dirSQL + ", cs.app_id ASC"
+if len(params.OwnerUserIDs) > 0 {
+    // Build a quoted array literal for array_position.
+    // UUIDs contain only [0-9a-f-] so quoting with single quotes is safe.
+    quotedIDs := make([]string, len(params.OwnerUserIDs))
+    for i, id := range params.OwnerUserIDs {
+        quotedIDs[i] = "'" + id + "'"
+    }
+    rankExpr := "array_position(ARRAY[" + strings.Join(quotedIDs, ",") + "]::text[], ac.user_id)"
+    orderExpr = rankExpr + " ASC, " + orderExpr
+}
+```
+
+Both the count query and the page query use the same updated `withFilters` helper, so the
+count correctly reflects the filtered set.
+
+### `ListAppsParams` — replace `OwnerEmail` with `OwnerSearch`
+
+```go
+type ListAppsParams struct {
+    Page        uint64
+    PageSize    uint64
+    AppID       string
+    OwnerSearch string                        // replaces OwnerEmail
+    Plan        string
+    Sort        siteadmin.ListAppsParamsSort
+    Order       siteadmin.ListAppsParamsOrder
+}
+```
+
+### `ListAppsResult` — add truncation flag
+
+```go
+type ListAppsResult struct {
+    Apps                 []siteadmin.App
+    TotalCount           int
+    OwnerSearchTruncated bool
+}
+```
+
+### `AppService.ListApps` — updated flow
+
+```
+1. Normalise sort:
+   - If owner_search is set and sort is omitted → default sort to Relevance
+   - If sort=Relevance and owner_search is empty → return 400 Bad Request
+   - order is ignored when sort=Relevance
+
+2. Resolve owner_search → []ownerUserIDs via AdminAPI.SearchUsersByKeyword
+   - If owner_search is empty: ownerUserIDs = nil, truncated = false, skip step
+   - If owner_search is non-empty and returns 0 users: return empty result early
+   - Preserve the ID order returned by the search (search-rank order)
+
+3. Compute lastMonthStart (unchanged)
+
+4. DB query via OwnerStore.ListAppsWithStats with OwnerUserIDs slice
+   - array_position ORDER BY is only added when sort=Relevance
+
+5. Resolve owner emails for the current page via AdminAPI.ResolveUserEmails
+
+6. Build response, including OwnerSearchTruncated from step 2
+```
+
+Key difference from the current `owner_email` flow: the old code short-circuits to empty
+results when 0 users are found (preserved). The old email optimisation that skipped the
+`ResolveUserEmails` call is removed.
+
+---
+
+## `pkg/siteadmin/transport/handler_apps_list.go`
+
+Replace `OwnerEmail` with `OwnerSearch` in `AppsListParams` and `parseAppsListParams`:
+
+```go
+type AppsListParams struct {
+    Page        uint64
+    PageSize    uint64
+    AppID       string
+    OwnerSearch string   // replaces OwnerEmail
+    Plan        string
+    Sort        siteadmin.ListAppsParamsSort
+    Order       siteadmin.ListAppsParamsOrder
+}
+```
+
+```go
+OwnerSearch: q.Get("owner_search"),
+```
+
+Pass `OwnerSearchTruncated` from service result to the response:
+
+```go
+response := siteadmin.AppsListResponse{
+    Apps:                 result.Apps,
+    TotalCount:           result.TotalCount,
+    Page:                 params.Page,
+    PageSize:             params.PageSize,
+    OwnerSearchTruncated: result.OwnerSearchTruncated,
+}
+```
+
+---
+
+## `pkg/siteadmin/service/app_test.go`
+
+Update `fakeOwnerStore.ListAppsWithStats` to handle the `OwnerUserIDs` slice:
+
+```go
+// Filter by owner — match any ID in the slice.
+if len(params.OwnerUserIDs) > 0 {
+    set := make(map[string]struct{}, len(params.OwnerUserIDs))
+    for _, id := range params.OwnerUserIDs {
+        set[id] = struct{}{}
+    }
+    if _, ok := set[r.OwnerUserID]; !ok {
+        continue
+    }
+}
+```
+
+For the `array_position` ordering in tests: sort matched rows by the position of their
+`OwnerUserID` in `params.OwnerUserIDs` as the primary key, then apply the existing sort/order
+logic as secondary. This mirrors the SQL `array_position` behaviour.
+
+**New test cases:**
+
+| Scenario | What to assert |
+|---|---|
+| `owner_search` matches 1 user: apps returned, `OwnerSearchTruncated=false` | `TotalCount`, `Apps[*].OwnerEmail` |
+| `owner_search` matches 0 users: empty result | `TotalCount==0`, `Apps==[]` |
+| `owner_search` with multiple users: apps ordered by owner rank first | order of `Apps[*].Id` across owner boundary |
+| `owner_search` + `plan` combined: only apps matching both conditions | `Apps[*].Plan`, `Apps[*].OwnerEmail` |
+| `owner_search` + `sort=mau`: owner rank is primary, MAU is secondary | ordering within same-rank-owner apps |
+| Fake returns `truncated=true`: `OwnerSearchTruncated=true` in result | `result.OwnerSearchTruncated` |
+| `owner_search` is empty: no owner filter applied, all apps returned | `TotalCount == total app count` |
+
+---
+
+## E2E tests
+
+### Key constraint: `_search_user` must be populated
+
+The existing `owner_email` tests used `getUsersByStandardAttribute` (exact lookup via
+`_auth_identity_login_id`). The new `owner_search` uses `UsersListQuery` with `searchKeyword`,
+which goes through `UserFacade.SearchPage` → `pgsearch.Store.QueryUser` → `_search_user` table
+in the search database.
+
+**`_search_user` must be populated in the fixture for e2e tests to work.** The fixture must
+insert rows into `_search_user` for the portal app's test users. Confirm during implementation
+whether the e2e search DB is the same instance as the portal DB or separate — the
+`custom_sql` fixture type runs against the portal DB by default.
+
+### Fixture changes — `e2e/tests/siteadmin/fixture/seed_siteadmin_apps.sql`
+
+Add `_search_user` inserts for the two owner users (`...0002` and `...0005`) after the
+existing `_auth_user` inserts. The `details` JSONB drives `details_tsvector` and must include
+the email so keyword search can find the user:
+
+```sql
+INSERT INTO _search_user (
+    id, app_id, app_ids, created_at, last_login_at,
+    emails, email_local_parts, email_domains,
+    preferred_usernames, phone_numbers, phone_number_country_codes,
+    phone_number_national_numbers, oauth_subject_ids,
+    gender, zoneinfo, locale, postal_code, country,
+    role_keys, group_keys, details
+)
+VALUES
+    (
+        '00000000-0000-0000-0000-000000000002',
+        'e2e-portal',
+        ARRAY['e2e-portal'],
+        NOW(), NULL,
+        ARRAY['owner@example.com'], ARRAY['owner'], ARRAY['example.com'],
+        ARRAY[]::text[], ARRAY[]::text[], ARRAY[]::text[],
+        ARRAY[]::text[], ARRAY[]::text[],
+        ARRAY[]::text[], ARRAY[]::text[], ARRAY[]::text[],
+        ARRAY[]::text[], ARRAY[]::text[],
+        ARRAY[]::text[], ARRAY[]::text[],
+        '{"email": "owner@example.com"}'::jsonb
+    ),
+    (
+        '00000000-0000-0000-0000-000000000005',
+        'e2e-portal',
+        ARRAY['e2e-portal'],
+        NOW(), NULL,
+        ARRAY['gamma-owner@example.com'], ARRAY['gamma-owner'], ARRAY['example.com'],
+        ARRAY[]::text[], ARRAY[]::text[], ARRAY[]::text[],
+        ARRAY[]::text[], ARRAY[]::text[],
+        ARRAY[]::text[], ARRAY[]::text[], ARRAY[]::text[],
+        ARRAY[]::text[], ARRAY[]::text[],
+        ARRAY[]::text[], ARRAY[]::text[],
+        '{"email": "gamma-owner@example.com"}'::jsonb
+    )
+ON CONFLICT (id) DO UPDATE SET
+    emails = EXCLUDED.emails,
+    email_local_parts = EXCLUDED.email_local_parts,
+    email_domains = EXCLUDED.email_domains,
+    details = EXCLUDED.details;
+```
+
+### Tests to remove from `e2e/tests/siteadmin/apps.test.yaml`
+
+Remove the two existing `owner_email` steps:
+- `filter by owner_email returns alpha`
+- `filter by non-existent owner_email returns empty`
+
+### Tests to add to `e2e/tests/siteadmin/apps.test.yaml`
+
+**1. Basic filter — exact email, single owner match**
+```yaml
+- name: owner_search exact email returns alpha
+  http_request_query:
+    owner_search: "owner@example.com"
+  http_output:
+    http_status: 200
+    json_body: |
+      {
+        "total_count": 1,
+        "owner_search_truncated": false,
+        "apps": [{"id": "e2e-siteadmin-app-alpha", "owner_email": "owner@example.com"}]
+      }
+```
+
+**2. Basic filter — partial email, single owner match**
+```yaml
+- name: owner_search partial email returns alpha
+  http_request_query:
+    owner_search: "owner@example"
+  http_output:
+    http_status: 200
+    json_body: |
+      {
+        "total_count": 1,
+        "owner_search_truncated": false,
+        "apps": [{"id": "e2e-siteadmin-app-alpha", "owner_email": "owner@example.com"}]
+      }
+```
+
+**3. No match — empty result**
+```yaml
+- name: owner_search no match returns empty
+  http_request_query:
+    owner_search: "nobody@example.com"
+  http_output:
+    http_status: 200
+    json_body: |
+      {"apps": [], "total_count": 0, "owner_search_truncated": false}
+```
+
+**4. `owner_search_truncated` present when no owner_search given**
+```yaml
+- name: list all apps includes owner_search_truncated false
+  http_output:
+    http_status: 200
+    json_body: |
+      {"owner_search_truncated": false, "apps": "[[array]]", "total_count": "[[number]]"}
+```
+
+**5. `owner_search` + `sort=mau` — filter applied, sort honoured**
+
+Both `owner@example.com` (alpha, MAU 100) and `gamma-owner@example.com` (gamma, MAU 200)
+have `example.com` as their domain, so `owner_search=@example.com` matches both. With
+`sort=mau&order=desc` gamma (200) must come first.
+
+```yaml
+- name: owner_search with sort=mau orders by MAU not relevance
+  http_request_query:
+    owner_search: "@example.com"
+    sort: "mau"
+    order: "desc"
+  http_output:
+    http_status: 200
+    json_body: |
+      {
+        "total_count": 2,
+        "owner_search_truncated": false,
+        "apps": [
+          {"id": "e2e-siteadmin-app-gamma", "last_month_mau": 200},
+          {"id": "e2e-siteadmin-app-alpha", "last_month_mau": 100}
+        ]
+      }
+```
+
+**6. `sort=relevance` without `owner_search` returns 400**
+```yaml
+- name: sort=relevance without owner_search returns 400
+  http_request_query:
+    sort: "relevance"
+  http_output:
+    http_status: 400
+```
+
+**7. Explicit `sort=relevance` with `owner_search` — same as omitting sort**
+```yaml
+- name: owner_search with explicit sort=relevance returns same as default
+  http_request_query:
+    owner_search: "owner@example.com"
+    sort: "relevance"
+  http_output:
+    http_status: 200
+    json_body: |
+      {
+        "total_count": 1,
+        "owner_search_truncated": false,
+        "apps": [{"id": "e2e-siteadmin-app-alpha"}]
+      }
+```
+
+---
+
+## Files to modify
+
+| File | Change |
+|---|---|
+| `docs/api/siteadmin-api.yaml` | Remove `owner_email` param; add `owner_search` param; add `owner_search_truncated` to `AppsListResponse` schema |
+| `pkg/siteadmin/service/admin_api.go` | Add `SearchUsersByKeyword`; remove `FindUserIDsByEmail` |
+| `pkg/siteadmin/service/app.go` | `OwnerUserIDs []string` in store params; `array_position` ORDER BY; `OwnerSearch` in service params; `OwnerSearchTruncated` in result |
+| `pkg/siteadmin/transport/handler_apps_list.go` | `owner_search` query param; pass `OwnerSearchTruncated` to response |
+| `pkg/siteadmin/service/app_test.go` | Update fake store; add new test cases |
+| `e2e/tests/siteadmin/fixture/seed_siteadmin_apps.sql` | Add `_search_user` inserts for owner users |
+| `e2e/tests/siteadmin/apps.test.yaml` | Remove `owner_email` steps; add `owner_search` steps |
+
+No wire / DI changes are needed — no new struct fields or interface changes on `AppService`
+beyond the method signature of `ListApps` which is called only from the handler.
+
+---
+
+## Implementation commits
+
+### Commit 1 — Update OpenAPI spec and regenerate models
+
+- `docs/api/siteadmin-api.yaml`: remove `owner_email`, add `owner_search`, add
+  `owner_search_truncated` to `AppsListResponse`
+- Regenerate: `make generate` → updates `pkg/api/siteadmin/gen.go`
+
+```
+[Site Admin API] Replace owner_email with owner_search in apps list spec
+```
+
+### Commit 2 — Admin API: replace FindUserIDsByEmail with SearchUsersByKeyword
+
+- `pkg/siteadmin/service/admin_api.go`: add `SearchUsersByKeyword`, remove `FindUserIDsByEmail`
+
+```
+[Site Admin API] Add SearchUsersByKeyword to AdminAPIService
+```
+
+### Commit 3 — Service and store: owner_search with array_position ordering
+
+- `pkg/siteadmin/service/app.go`: all changes described above
+- `pkg/siteadmin/service/app_test.go`: updated fake store and new test cases
+
+Verification:
+```bash
+go test ./pkg/siteadmin/service/...
+```
+
+```
+[Site Admin API] Filter and rank apps by owner search keyword
+```
+
+### Commit 4 — Transport: wire owner_search param and truncated flag
+
+- `pkg/siteadmin/transport/handler_apps_list.go`
+
+Verification:
+```bash
+go build ./pkg/siteadmin/...
+```
+
+```
+[Site Admin API] Parse owner_search param and return owner_search_truncated
+```
+
+### Commit 5 — E2E tests
+
+- `e2e/tests/siteadmin/fixture/seed_siteadmin_apps.sql`: add `_search_user` inserts
+- `e2e/tests/siteadmin/apps.test.yaml`: remove `owner_email` steps; add `owner_search` steps
+
+Verification:
+```bash
+make -C e2e run
+```
+
+```
+[Site Admin API] E2E tests for owner_search filter and sort=relevance
+```
+
+### Commit 6 — vettedpositions + check-tidy
+
+```bash
+go run ./devtools/goanalysis ./cmd/... ./pkg/...
+make sort-vettedpositions
+make check-tidy
+```
+
+```
+chore: update vettedpositions and tidy after owner_search changes
+```
+
+---
+
+## Dependency graph
+
+```
+Commit 1  OpenAPI spec + gen.go         (pkg/api/siteadmin)
+    ↓
+Commit 2  AdminAPIService               (pkg/siteadmin/service)
+    ↓
+Commit 3  AppOwnerStore + AppService    (pkg/siteadmin/service)
+    ↓
+Commit 4  Transport handler             (pkg/siteadmin/transport)
+    ↓
+Commit 5  E2E tests                     (e2e/tests/siteadmin)
+    ↓
+Commit 6  vettedpositions + tidy
+```

--- a/docs/plans/siteadmin-api/03.2-apps-api-owner-search.md
+++ b/docs/plans/siteadmin-api/03.2-apps-api-owner-search.md
@@ -6,7 +6,7 @@ The existing `owner_email` filter on `GET /api/v1/apps` requires an exact, compl
 address. This makes it impractical for admin use where you only know a partial email or name.
 
 This plan replaces `owner_email` with `owner_search`: a free-text keyword passed to the portal
-app's Admin API user search, which returns up to 100 matching user IDs. Those IDs are passed
+app's Admin API user search, which returns up to 20 matching user IDs. Those IDs are passed
 into the SQL `WHERE ac.user_id = ANY(?)` filter. When `owner_search` is active, results are
 additionally ordered by owner search rank using `array_position(...)` so that apps belonging to
 the best-matching owner appear first.
@@ -20,11 +20,11 @@ lookup goes through the Admin API (HTTP GraphQL call to the portal app).
 
 | # | Limitation | Impact |
 |---|---|---|
-| 1 | **Hard cap of 100 user IDs** | The Admin API enforces `DEFAULT_MAX_PAGE_SIZE = 100` (`pkg/util/graphqlutil/page.go:7`). A single `owner_search` call can return at most 100 matching users. If the keyword matches more than 100 owners, apps owned by users ranked >100 are invisible. |
-| 2 | **`total_count` is a lower bound when truncated** | The SQL count query operates only on the capped user ID set. If the search was truncated, `total_count` reflects only the apps owned by the top 100 matching users, not all matching apps. |
-| 3 | **Seq scan on `_portal_app_collaborator`** | There is no standalone index on `user_id` in `_portal_app_collaborator` (only a composite `UNIQUE(app_id, user_id)`). `WHERE ac.user_id = ANY(ARRAY[100 ids])` requires a seq scan. At 100k rows this is ~5–20ms warm; at 500k rows ~50–200ms warm. No lock is held on concurrent reads/writes — PostgreSQL MVCC ensures the scan does not block portal users. The slowness affects only the siteadmin request itself. |
+| 1 | **Hard cap of 20 user IDs** | `ownerSearchPageSize = 20` in `admin_api.go`. A single `owner_search` call fetches at most 20 matching users. If the keyword matches more than 20 owners, apps owned by users ranked >20 are invisible. The cap is intentionally low — the apps list uses page_size ≤ 20, so 20 owners is sufficient for most queries. |
+| 2 | **`total_count` is a lower bound when truncated** | The SQL count query operates only on the capped user ID set. If the search was truncated, `total_count` reflects only the apps owned by the top 20 matching users, not all matching apps. |
+| 3 | **Seq scan on `_portal_app_collaborator`** | There is no standalone index on `user_id` in `_portal_app_collaborator` (only a composite `UNIQUE(app_id, user_id)`). `WHERE ac.user_id = ANY(ARRAY[20 ids])` requires a seq scan. At 100k rows this is ~5–20ms warm; at 500k rows ~50–200ms warm. No lock is held on concurrent reads/writes — PostgreSQL MVCC ensures the scan does not block portal users. The slowness affects only the siteadmin request itself. |
 | 4 | **Owner-rank dominates pagination** | When `owner_search` is active, `array_position` is prepended as the primary `ORDER BY`. If the top-ranked user owns many apps, they will fill multiple pages before apps from lower-ranked owners appear. The `sort` and `order` parameters remain as secondary sort criteria. |
-| 5 | **`owner_search` is a best-effort filter for broad queries** | Searching `"a"` or `"@gmail.com"` likely matches >100 owners and will be silently truncated. The feature is designed for targeted partial-email or name searches (e.g. `"alice@company"`, `"alice"`). Callers should check `owner_search_truncated` in the response. |
+| 5 | **`owner_search` is a best-effort filter for broad queries** | Searching `"a"` or `"@gmail.com"` likely matches >20 owners and will be silently truncated. The feature is designed for targeted partial-email or name searches (e.g. `"alice@company"`, `"alice"`). Callers should check `owner_search_truncated` in the response. |
 | 6 | **Extra HTTP round-trip** | Every `owner_search` request makes an HTTP call to the portal Admin API before the SQL query. This adds ~50–200ms of latency depending on deployment. |
 
 ---
@@ -44,8 +44,8 @@ lookup goes through the Admin API (HTTP GraphQL call to the portal app).
     Filter by owner keyword. Searches the portal user database by partial email,
     name, or other attributes. Returns apps whose owner matches the keyword.
     When owner_search is provided and no sort is specified, sort defaults to
-    `relevance`. At most 100 matching owners are considered; if the keyword
-    matches more than 100 owners, `owner_search_truncated` is set to `true` in
+    `relevance`. At most 20 matching owners are considered; if the keyword
+    matches more than 20 owners, `owner_search_truncated` is set to `true` in
     the response.
   schema:
     type: string
@@ -98,8 +98,8 @@ AppsListResponse:
     owner_search_truncated:
       type: boolean
       description: >
-        True when the owner_search keyword matched more than 100 portal users and
-        results have been limited to the top 100 matches. total_count is a lower
+        True when the owner_search keyword matched more than 20 portal users and
+        results have been limited to the top 20 matches. total_count is a lower
         bound in this case.
 ```
 
@@ -122,7 +122,7 @@ And the `App` type is unchanged.
 ## `pkg/siteadmin/service/admin_api.go`
 
 Add `SearchUsersByKeyword` alongside the existing `FindUserIDsByEmail`. The new method calls
-the Admin API `UsersListQuery` with `searchKeyword`, requesting the maximum page size of 100.
+the Admin API `UsersListQuery` with `searchKeyword`, requesting `ownerSearchPageSize = 20` users.
 It returns the ordered list of user IDs (search-rank order preserved) and a truncated flag.
 
 ```go
@@ -144,7 +144,7 @@ func (s *AdminAPIService) SearchUsersByKeyword(ctx context.Context, keyword stri
         `,
         Variables: map[string]any{
             "keyword":  keyword,
-            "pageSize": 100,
+            "pageSize": ownerSearchPageSize,
         },
     }
 

--- a/e2e/tests/siteadmin/apps.test.yaml
+++ b/e2e/tests/siteadmin/apps.test.yaml
@@ -20,13 +20,14 @@ steps:
         "apps": "[[array]]",
         "total_count": "[[number]]",
         "page": 1,
-        "page_size": "[[number]]"
+        "page_size": "[[number]]",
+        "owner_search_truncated": false
       }
 
-# ── Owner email ───────────────────────────────────────────────────────────────
-# alpha has a known owner inserted by seed_siteadmin_apps.sql; owner_email is resolved
-# via the Admin API for e2e-portal (SITEADMIN_AUTHGEAR_APP_ID).
-- name: filter by owner_email returns alpha
+# ── Owner search ──────────────────────────────────────────────────────────────
+# owner_search requires Elasticsearch to be indexed; only the validation error
+# case (sort=relevance without owner_search → 400) is tested in e2e.
+- name: sort=relevance without owner_search returns 400
   action: http_request
   http_request_method: GET
   http_request_url: http://127.0.0.1:4003/api/v1/apps
@@ -34,35 +35,9 @@ steps:
     X-Authgear-Session-Valid: "true"
     X-Authgear-User-Id: "00000000-0000-0000-0000-000000000001"
   http_request_query:
-    owner_email: "owner@example.com"
+    sort: "relevance"
   http_output:
-    http_status: 200
-    json_body: |
-      {
-        "total_count": 1,
-        "apps": [
-          {"id": "e2e-siteadmin-app-alpha", "owner_email": "owner@example.com"}
-        ]
-      }
-
-- name: filter by non-existent owner_email returns empty
-  action: http_request
-  http_request_method: GET
-  http_request_url: http://127.0.0.1:4003/api/v1/apps
-  http_request_headers:
-    X-Authgear-Session-Valid: "true"
-    X-Authgear-User-Id: "00000000-0000-0000-0000-000000000001"
-  http_request_query:
-    owner_email: "nobody@example.com"
-  http_output:
-    http_status: 200
-    json_body: |
-      {
-        "apps": [],
-        "total_count": 0,
-        "page": 1,
-        "page_size": "[[number]]"
-      }
+    http_status: 400
 
 - name: filter by alpha app_id returns owner email
   action: http_request

--- a/e2e/tests/siteadmin/apps.test.yaml
+++ b/e2e/tests/siteadmin/apps.test.yaml
@@ -121,6 +121,68 @@ steps:
         "page_size": "[[number]]"
       }
 
+# ── Filter: app_id prefix search ─────────────────────────────────────────────
+- name: app_id prefix returns only matching apps
+  action: http_request
+  http_request_method: GET
+  http_request_url: http://127.0.0.1:4003/api/v1/apps
+  http_request_headers:
+    X-Authgear-Session-Valid: "true"
+    X-Authgear-User-Id: "00000000-0000-0000-0000-000000000001"
+  http_request_query:
+    app_id: "e2e-siteadmin-app-a"
+  http_output:
+    http_status: 200
+    json_body: |
+      {
+        "total_count": 1,
+        "apps": [
+          {"id": "e2e-siteadmin-app-alpha"}
+        ]
+      }
+
+- name: app_id prefix matches all seeded apps with shared prefix
+  action: http_request
+  http_request_method: GET
+  http_request_url: http://127.0.0.1:4003/api/v1/apps
+  http_request_headers:
+    X-Authgear-Session-Valid: "true"
+    X-Authgear-User-Id: "00000000-0000-0000-0000-000000000001"
+  http_request_query:
+    app_id: "e2e-siteadmin-app-"
+    sort: "created_at"
+    order: "asc"
+  http_output:
+    http_status: 200
+    json_body: |
+      {
+        "total_count": 3,
+        "apps": [
+          {"id": "e2e-siteadmin-app-alpha"},
+          {"id": "e2e-siteadmin-app-beta"},
+          {"id": "e2e-siteadmin-app-gamma"}
+        ]
+      }
+
+- name: app_id prefix underscore is escaped and not treated as wildcard
+  action: http_request
+  http_request_method: GET
+  http_request_url: http://127.0.0.1:4003/api/v1/apps
+  http_request_headers:
+    X-Authgear-Session-Valid: "true"
+    X-Authgear-User-Id: "00000000-0000-0000-0000-000000000001"
+  http_request_query:
+    app_id: "e2e_siteadmin"
+  http_output:
+    http_status: 200
+    json_body: |
+      {
+        "apps": [],
+        "total_count": 0,
+        "page": 1,
+        "page_size": "[[number]]"
+      }
+
 # ── Filter: plan ──────────────────────────────────────────────────────────────
 # alpha and gamma are both on "startups"; total is always exactly 2.
 - name: filter by plan startups returns alpha and gamma

--- a/pkg/api/siteadmin/gen.go
+++ b/pkg/api/siteadmin/gen.go
@@ -122,7 +122,7 @@ type AppDetail struct {
 type AppsListResponse struct {
 	Apps []App `json:"apps"`
 
-	// OwnerSearchTruncated True when the `owner_search` keyword matched more than 100 portal users and results are limited to the top 100 matches. `total_count` is a lower bound in this case. Always `false` when `owner_search` is not provided.
+	// OwnerSearchTruncated True when the `owner_search` keyword matched more than 20 portal users and results are limited to the top 20 matches. `total_count` is a lower bound in this case. Always `false` when `owner_search` is not provided.
 	OwnerSearchTruncated bool `json:"owner_search_truncated"`
 
 	// Page Current page number.
@@ -241,7 +241,7 @@ type ListAppsParams struct {
 	// AppId Filter by app ID prefix. Returns all apps whose ID starts with the given value.
 	AppId *string `form:"app_id,omitempty" json:"app_id,omitempty"`
 
-	// OwnerSearch Filter by owner keyword. Searches the portal user database by partial email, name, or other attributes. Returns apps whose owner matches the keyword. When provided and `sort` is omitted, defaults to `sort=relevance`. At most 100 matching owners are considered; if more than 100 owners match, `owner_search_truncated` is set to `true` in the response and `total_count` is a lower bound.
+	// OwnerSearch Filter by owner keyword. Searches the portal user database by partial email, name, or other attributes. Returns apps whose owner matches the keyword. When provided and `sort` is omitted, defaults to `sort=relevance`. At most 20 matching owners are considered; if more than 20 owners match, `owner_search_truncated` is set to `true` in the response and `total_count` is a lower bound.
 	OwnerSearch *string `form:"owner_search,omitempty" json:"owner_search,omitempty"`
 
 	// Plan Filter by plan name.

--- a/pkg/api/siteadmin/gen.go
+++ b/pkg/api/siteadmin/gen.go
@@ -232,7 +232,7 @@ type ListAppsParams struct {
 	// PageSize Number of apps per page. Defaults to 20, maximum 20.
 	PageSize *int `form:"page_size,omitempty" json:"page_size,omitempty"`
 
-	// AppId Filter by app ID.
+	// AppId Filter by app ID prefix. Returns all apps whose ID starts with the given value.
 	AppId *string `form:"app_id,omitempty" json:"app_id,omitempty"`
 
 	// OwnerEmail Filter by owner email address.

--- a/pkg/api/siteadmin/gen.go
+++ b/pkg/api/siteadmin/gen.go
@@ -35,6 +35,7 @@ func (e CollaboratorRole) Valid() bool {
 const (
 	CreatedAt ListAppsParamsSort = "created_at"
 	Mau       ListAppsParamsSort = "mau"
+	Relevance ListAppsParamsSort = "relevance"
 )
 
 // Valid indicates whether the value is a known member of the ListAppsParamsSort enum.
@@ -43,6 +44,8 @@ func (e ListAppsParamsSort) Valid() bool {
 	case CreatedAt:
 		return true
 	case Mau:
+		return true
+	case Relevance:
 		return true
 	default:
 		return false
@@ -119,13 +122,16 @@ type AppDetail struct {
 type AppsListResponse struct {
 	Apps []App `json:"apps"`
 
+	// OwnerSearchTruncated True when the `owner_search` keyword matched more than 100 portal users and results are limited to the top 100 matches. `total_count` is a lower bound in this case. Always `false` when `owner_search` is not provided.
+	OwnerSearchTruncated bool `json:"owner_search_truncated"`
+
 	// Page Current page number.
 	Page uint64 `json:"page"`
 
 	// PageSize Number of apps per page.
 	PageSize uint64 `json:"page_size"`
 
-	// TotalCount Total number of apps matching the query.
+	// TotalCount Total number of apps matching the query. When `owner_search_truncated` is `true`, this is a lower bound — apps owned by owners beyond the 100-match cap are not counted.
 	TotalCount int `json:"total_count"`
 }
 
@@ -235,16 +241,16 @@ type ListAppsParams struct {
 	// AppId Filter by app ID prefix. Returns all apps whose ID starts with the given value.
 	AppId *string `form:"app_id,omitempty" json:"app_id,omitempty"`
 
-	// OwnerEmail Filter by owner email address.
-	OwnerEmail *string `form:"owner_email,omitempty" json:"owner_email,omitempty"`
+	// OwnerSearch Filter by owner keyword. Searches the portal user database by partial email, name, or other attributes. Returns apps whose owner matches the keyword. When provided and `sort` is omitted, defaults to `sort=relevance`. At most 100 matching owners are considered; if more than 100 owners match, `owner_search_truncated` is set to `true` in the response and `total_count` is a lower bound.
+	OwnerSearch *string `form:"owner_search,omitempty" json:"owner_search,omitempty"`
 
 	// Plan Filter by plan name.
 	Plan *string `form:"plan,omitempty" json:"plan,omitempty"`
 
-	// Sort Field to sort by. Defaults to `created_at`.
+	// Sort Field to sort by. Defaults to `created_at`, or `relevance` when `owner_search` is provided. `relevance` sorts by how well the app's owner matches the `owner_search` keyword and requires `owner_search` to be set; using `relevance` without `owner_search` returns 400.
 	Sort *ListAppsParamsSort `form:"sort,omitempty" json:"sort,omitempty"`
 
-	// Order Sort direction. Defaults to `desc`.
+	// Order Sort direction. Defaults to `desc`. Ignored when `sort=relevance` (relevance is always highest-match first).
 	Order *ListAppsParamsOrder `form:"order,omitempty" json:"order,omitempty"`
 }
 

--- a/pkg/siteadmin/service/admin_api.go
+++ b/pkg/siteadmin/service/admin_api.go
@@ -69,9 +69,14 @@ func (s *AdminAPIService) FindUserIDsByEmail(ctx context.Context, email string) 
 	return ids, nil
 }
 
+// ownerSearchPageSize is the maximum number of portal users fetched per owner_search
+// call. It caps how many distinct owners are considered when filtering apps.
+// A higher value increases coverage but also increases Admin API query cost.
+const ownerSearchPageSize = 20
+
 // SearchUsersByKeyword searches portal users by keyword via the Admin GraphQL API.
-// Returns up to 100 user IDs in search-rank order and whether the result was truncated
-// (i.e. the search matched more users than the 100-user page cap allows).
+// Returns up to ownerSearchPageSize user IDs in search-rank order and whether the
+// result was truncated (i.e. the search matched more users than the cap allows).
 func (s *AdminAPIService) SearchUsersByKeyword(ctx context.Context, keyword string) (ids []string, truncated bool, err error) {
 	params := graphqlutil.DoParams{
 		OperationName: "searchOwnersByKeyword",
@@ -87,7 +92,7 @@ func (s *AdminAPIService) SearchUsersByKeyword(ctx context.Context, keyword stri
 		`,
 		Variables: map[string]any{
 			"keyword":  keyword,
-			"pageSize": 100,
+			"pageSize": ownerSearchPageSize,
 		},
 	}
 

--- a/pkg/siteadmin/service/admin_api.go
+++ b/pkg/siteadmin/service/admin_api.go
@@ -69,6 +69,56 @@ func (s *AdminAPIService) FindUserIDsByEmail(ctx context.Context, email string) 
 	return ids, nil
 }
 
+// SearchUsersByKeyword searches portal users by keyword via the Admin GraphQL API.
+// Returns up to 100 user IDs in search-rank order and whether the result was truncated
+// (i.e. the search matched more users than the 100-user page cap allows).
+func (s *AdminAPIService) SearchUsersByKeyword(ctx context.Context, keyword string) (ids []string, truncated bool, err error) {
+	params := graphqlutil.DoParams{
+		OperationName: "searchOwnersByKeyword",
+		Query: `
+		query searchOwnersByKeyword($keyword: String!, $pageSize: Int!) {
+			users(first: $pageSize, searchKeyword: $keyword) {
+				edges {
+					node { id }
+				}
+				pageInfo { hasNextPage }
+			}
+		}
+		`,
+		Variables: map[string]any{
+			"keyword":  keyword,
+			"pageSize": 100,
+		},
+	}
+
+	result, err := s.do(ctx, params)
+	if err != nil {
+		return nil, false, err
+	}
+	if result.HasErrors() {
+		return nil, false, fmt.Errorf("failed to search users by keyword: %v", result.Errors)
+	}
+
+	data := result.Data.(map[string]any)
+	usersConn := data["users"].(map[string]any)
+	edges := usersConn["edges"].([]any)
+	pageInfo := usersConn["pageInfo"].(map[string]any)
+	hasNextPage, _ := pageInfo["hasNextPage"].(bool)
+
+	ids = make([]string, 0, len(edges))
+	for _, e := range edges {
+		edge := e.(map[string]any)
+		node := edge["node"].(map[string]any)
+		globalID, _ := node["id"].(string)
+		resolved := relay.FromGlobalID(globalID)
+		if resolved == nil || resolved.ID == "" {
+			continue
+		}
+		ids = append(ids, resolved.ID)
+	}
+	return ids, hasNextPage, nil
+}
+
 func (s *AdminAPIService) ResolveUserEmails(ctx context.Context, userIDs []string) (map[string]string, error) {
 	if len(userIDs) == 0 {
 		return map[string]string{}, nil

--- a/pkg/siteadmin/service/app.go
+++ b/pkg/siteadmin/service/app.go
@@ -8,7 +8,9 @@ import (
 	"time"
 
 	sq "github.com/Masterminds/squirrel"
+	"github.com/lib/pq"
 
+	"github.com/authgear/authgear-server/pkg/api/apierrors"
 	"github.com/authgear/authgear-server/pkg/api/siteadmin"
 	"github.com/authgear/authgear-server/pkg/lib/analytic"
 	"github.com/authgear/authgear-server/pkg/lib/config/configsource"
@@ -48,8 +50,8 @@ type ListAppsStoreParams struct {
 	PageSize       uint64
 	AppID          string                        // optional; if set, WHERE cs.app_id LIKE 'prefix%'
 	PlanName       string                        // optional; if set, WHERE cs.plan_name = ?
-	OwnerUserID    string                        // optional; if set, WHERE ac.user_id = ?
-	Sort           siteadmin.ListAppsParamsSort  // "created_at" | "mau"
+	OwnerUserIDs   []string                      // optional; if set, WHERE ac.user_id = ANY(?)
+	Sort           siteadmin.ListAppsParamsSort  // "created_at" | "mau" | "relevance"
 	Order          siteadmin.ListAppsParamsOrder // "asc" | "desc"
 	LastMonthStart time.Time                     // exact start_time value for the usage record JOIN
 }
@@ -109,8 +111,8 @@ func (s *AppOwnerStore) ListAppsWithStats(ctx context.Context, params ListAppsSt
 		if params.PlanName != "" {
 			q = q.Where("cs.plan_name = ?", params.PlanName)
 		}
-		if params.OwnerUserID != "" {
-			q = q.Where("ac.user_id = ?", params.OwnerUserID)
+		if len(params.OwnerUserIDs) > 0 {
+			q = q.Where("ac.user_id = ANY(?)", pq.Array(params.OwnerUserIDs))
 		}
 		if params.AppID != "" {
 			q = q.Where("cs.app_id LIKE ?", escapeLikePattern(params.AppID)+"%")
@@ -149,6 +151,16 @@ func (s *AppOwnerStore) ListAppsWithStats(ctx context.Context, params ListAppsSt
 		primaryExpr = "cs.created_at"
 	}
 	orderExpr := primaryExpr + " " + dirSQL + ", cs.app_id ASC"
+	if params.Sort == siteadmin.Relevance && len(params.OwnerUserIDs) > 0 {
+		// Prepend array_position so apps from the best-matching owner appear first.
+		// UUIDs contain only [0-9a-f-] so quoting with single quotes is safe.
+		quotedIDs := make([]string, len(params.OwnerUserIDs))
+		for i, id := range params.OwnerUserIDs {
+			quotedIDs[i] = "'" + id + "'"
+		}
+		rankExpr := "array_position(ARRAY[" + strings.Join(quotedIDs, ",") + "]::text[], ac.user_id)"
+		orderExpr = rankExpr + " ASC, " + orderExpr
+	}
 
 	offset := (params.Page - 1) * params.PageSize
 	pageQ := withFilters(
@@ -190,18 +202,19 @@ func (s *AppOwnerStore) ListAppsWithStats(ctx context.Context, params ListAppsSt
 // ---- AppService ----------------------------------------------------------------
 
 type ListAppsParams struct {
-	Page       uint64
-	PageSize   uint64
-	AppID      string
-	OwnerEmail string
-	Plan       string                        // exact plan name filter
-	Sort       siteadmin.ListAppsParamsSort  // "created_at" (default) | "mau"
-	Order      siteadmin.ListAppsParamsOrder // "desc" (default) | "asc"
+	Page        uint64
+	PageSize    uint64
+	AppID       string
+	OwnerSearch string
+	Plan        string                        // exact plan name filter
+	Sort        siteadmin.ListAppsParamsSort  // "created_at" (default) | "mau" | "relevance"
+	Order       siteadmin.ListAppsParamsOrder // "desc" (default) | "asc"
 }
 
 type ListAppsResult struct {
-	Apps       []siteadmin.App
-	TotalCount int
+	Apps                 []siteadmin.App
+	TotalCount           int
+	OwnerSearchTruncated bool
 }
 
 type AppService struct {
@@ -221,33 +234,43 @@ func (s *AppService) ListApps(ctx context.Context, params ListAppsParams) (*List
 	if params.PageSize == 0 || params.PageSize > MaxPageSize {
 		params.PageSize = MaxPageSize
 	}
+
+	// 1. Normalise sort.
+	// If owner_search is set and sort is absent, default to relevance.
+	if params.OwnerSearch != "" && !params.Sort.Valid() {
+		params.Sort = siteadmin.Relevance
+	}
 	if !params.Sort.Valid() {
 		params.Sort = siteadmin.CreatedAt
 	}
 	if !params.Order.Valid() {
 		params.Order = siteadmin.Desc
 	}
+	if params.Sort == siteadmin.Relevance && params.OwnerSearch == "" {
+		return nil, apierrors.NewBadRequest("sort=relevance requires owner_search to be set")
+	}
 
-	// 1. Resolve owner_email → owner_user_id via Admin API (outside DB transaction).
-	var ownerUserID string
-	if params.OwnerEmail != "" {
-		userIDs, err := s.AdminAPI.FindUserIDsByEmail(ctx, params.OwnerEmail)
+	// 2. Resolve owner_search → []ownerUserIDs via Admin API (outside DB transaction).
+	var ownerUserIDs []string
+	var ownerSearchTruncated bool
+	if params.OwnerSearch != "" {
+		var err error
+		ownerUserIDs, ownerSearchTruncated, err = s.AdminAPI.SearchUsersByKeyword(ctx, params.OwnerSearch)
 		if err != nil {
 			return nil, err
 		}
-		if len(userIDs) == 0 {
+		if len(ownerUserIDs) == 0 {
 			return &ListAppsResult{Apps: []siteadmin.App{}, TotalCount: 0}, nil
 		}
-		ownerUserID = userIDs[0]
 	}
 
-	// 2. Compute last-month start.
+	// 3. Compute last-month start.
 	// Go normalises time.Date(y, 0, ...) → time.Date(y-1, 12, ...) when m = January.
 	now := s.Clock.NowUTC()
 	y, m, _ := now.Date()
 	lastMonthStart := time.Date(y, m-1, 1, 0, 0, 0, 0, time.UTC)
 
-	// 3. Unified DB query.
+	// 4. Unified DB query.
 	var rows []AppStoreRow
 	var totalCount int
 	err := s.GlobalDatabase.WithTx(ctx, func(ctx context.Context) error {
@@ -257,7 +280,7 @@ func (s *AppService) ListApps(ctx context.Context, params ListAppsParams) (*List
 			PageSize:       params.PageSize,
 			AppID:          params.AppID,
 			PlanName:       params.Plan,
-			OwnerUserID:    ownerUserID,
+			OwnerUserIDs:   ownerUserIDs,
 			Sort:           params.Sort,
 			Order:          params.Order,
 			LastMonthStart: lastMonthStart,
@@ -268,30 +291,23 @@ func (s *AppService) ListApps(ctx context.Context, params ListAppsParams) (*List
 		return nil, err
 	}
 
-	// 4. Resolve owner emails for the current page via Admin API.
-	// Optimisation: when owner_email was the filter, every row shares the same
-	// owner_user_id — reuse the known email without an extra API call.
-	var emailMap map[string]string
-	if params.OwnerEmail != "" && ownerUserID != "" {
-		emailMap = map[string]string{ownerUserID: params.OwnerEmail}
-	} else {
-		seen := make(map[string]struct{}, len(rows))
-		uniqueIDs := make([]string, 0, len(rows))
-		for _, row := range rows {
-			if row.OwnerUserID != "" {
-				if _, ok := seen[row.OwnerUserID]; !ok {
-					seen[row.OwnerUserID] = struct{}{}
-					uniqueIDs = append(uniqueIDs, row.OwnerUserID)
-				}
+	// 5. Resolve owner emails for the current page via Admin API.
+	seen := make(map[string]struct{}, len(rows))
+	uniqueIDs := make([]string, 0, len(rows))
+	for _, row := range rows {
+		if row.OwnerUserID != "" {
+			if _, ok := seen[row.OwnerUserID]; !ok {
+				seen[row.OwnerUserID] = struct{}{}
+				uniqueIDs = append(uniqueIDs, row.OwnerUserID)
 			}
 		}
-		emailMap, err = s.AdminAPI.ResolveUserEmails(ctx, uniqueIDs)
-		if err != nil {
-			return nil, err
-		}
+	}
+	emailMap, err := s.AdminAPI.ResolveUserEmails(ctx, uniqueIDs)
+	if err != nil {
+		return nil, err
 	}
 
-	// 5. Build response.
+	// 6. Build response.
 	apps := make([]siteadmin.App, len(rows))
 	for i, row := range rows {
 		apps[i] = siteadmin.App{
@@ -302,7 +318,11 @@ func (s *AppService) ListApps(ctx context.Context, params ListAppsParams) (*List
 			LastMonthMau: row.LastMonthMAU,
 		}
 	}
-	return &ListAppsResult{Apps: apps, TotalCount: totalCount}, nil
+	return &ListAppsResult{
+		Apps:                 apps,
+		TotalCount:           totalCount,
+		OwnerSearchTruncated: ownerSearchTruncated,
+	}, nil
 }
 
 func (s *AppService) GetApp(ctx context.Context, appID string) (*siteadmin.AppDetail, error) {

--- a/pkg/siteadmin/service/app.go
+++ b/pkg/siteadmin/service/app.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"errors"
+	"strings"
 	"time"
 
 	sq "github.com/Masterminds/squirrel"
@@ -45,7 +46,7 @@ type AppServiceOwnerStore interface {
 type ListAppsStoreParams struct {
 	Page           uint64
 	PageSize       uint64
-	AppID          string                        // optional; if set, WHERE cs.app_id = ?
+	AppID          string                        // optional; if set, WHERE cs.app_id LIKE 'prefix%'
 	PlanName       string                        // optional; if set, WHERE cs.plan_name = ?
 	OwnerUserID    string                        // optional; if set, WHERE ac.user_id = ?
 	Sort           siteadmin.ListAppsParamsSort  // "created_at" | "mau"
@@ -112,7 +113,7 @@ func (s *AppOwnerStore) ListAppsWithStats(ctx context.Context, params ListAppsSt
 			q = q.Where("ac.user_id = ?", params.OwnerUserID)
 		}
 		if params.AppID != "" {
-			q = q.Where("cs.app_id = ?", params.AppID)
+			q = q.Where("cs.app_id LIKE ?", escapeLikePattern(params.AppID)+"%")
 		}
 		return q
 	}
@@ -345,6 +346,15 @@ func (s *AppService) GetApp(ctx context.Context, appID string) (*siteadmin.AppDe
 		CreatedAt:  src.CreatedAt,
 		UserCount:  userCount,
 	}, nil
+}
+
+// escapeLikePattern escapes backslash, percent, and underscore so they are
+// treated as literals inside a SQL LIKE pattern (default escape char '\').
+func escapeLikePattern(s string) string {
+	s = strings.ReplaceAll(s, `\`, `\\`)
+	s = strings.ReplaceAll(s, `%`, `\%`)
+	s = strings.ReplaceAll(s, `_`, `\_`)
+	return s
 }
 
 // ---- Private helpers ---------------------------------------------------------

--- a/pkg/siteadmin/service/app_test.go
+++ b/pkg/siteadmin/service/app_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http/httptest"
 	"net/url"
 	"sort"
+	"strings"
 	"testing"
 	"time"
 
@@ -84,7 +85,7 @@ func (f *fakeOwnerStore) ListAppsWithStats(_ context.Context, params ListAppsSto
 	// Filter
 	var filtered []AppStoreRow
 	for _, r := range f.rows {
-		if params.AppID != "" && r.AppID != params.AppID {
+		if params.AppID != "" && !strings.HasPrefix(r.AppID, params.AppID) {
 			continue
 		}
 		if params.PlanName != "" && r.PlanName != params.PlanName {
@@ -460,6 +461,53 @@ func TestAppService(t *testing.T) {
 			So(result.TotalCount, ShouldEqual, 1)
 			So(result.Apps[0].Id, ShouldEqual, "app-1")
 			So(result.Apps[0].OwnerEmail, ShouldEqual, "alice@example.com")
+		})
+
+		Convey("ListApps: app_id prefix filter returns matching apps only", func() {
+			t1 := time.Date(2024, 1, 3, 0, 0, 0, 0, time.UTC)
+			t2 := time.Date(2024, 1, 2, 0, 0, 0, 0, time.UTC)
+			t3 := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
+
+			svr := adminAPIServer(getNodesResponse())
+			defer svr.Close()
+
+			os := &fakeOwnerStore{
+				rows: []AppStoreRow{
+					{AppID: "myapp-prod", PlanName: "free", CreatedAt: t1},
+					{AppID: "myapp-staging", PlanName: "free", CreatedAt: t2},
+					{AppID: "other-app", PlanName: "free", CreatedAt: t3},
+				},
+			}
+
+			svc := makeService(svr, &fakeConfigSourceStore{}, os)
+			result, err := svc.ListApps(ctxWithSession(), ListAppsParams{Page: 1, PageSize: 10, AppID: "myapp"})
+
+			So(err, ShouldBeNil)
+			So(result.TotalCount, ShouldEqual, 2)
+			So(result.Apps, ShouldHaveLength, 2)
+			So(result.Apps[0].Id, ShouldEqual, "myapp-prod")
+			So(result.Apps[1].Id, ShouldEqual, "myapp-staging")
+		})
+
+		Convey("ListApps: app_id prefix filter with exact ID still matches", func() {
+			t1 := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
+
+			svr := adminAPIServer(getNodesResponse())
+			defer svr.Close()
+
+			os := &fakeOwnerStore{
+				rows: []AppStoreRow{
+					{AppID: "myapp", PlanName: "free", CreatedAt: t1},
+					{AppID: "other-app", PlanName: "free", CreatedAt: t1},
+				},
+			}
+
+			svc := makeService(svr, &fakeConfigSourceStore{}, os)
+			result, err := svc.ListApps(ctxWithSession(), ListAppsParams{Page: 1, PageSize: 10, AppID: "myapp"})
+
+			So(err, ShouldBeNil)
+			So(result.TotalCount, ShouldEqual, 1)
+			So(result.Apps[0].Id, ShouldEqual, "myapp")
 		})
 
 		Convey("GetApp: nil audit DB yields UserCount 0", func() {

--- a/pkg/siteadmin/service/app_test.go
+++ b/pkg/siteadmin/service/app_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"slices"
 	"sort"
 	"strings"
 	"sync"
@@ -95,13 +96,7 @@ func (f *fakeOwnerStore) ListAppsWithStats(_ context.Context, params ListAppsSto
 			continue
 		}
 		if len(params.OwnerUserIDs) > 0 {
-			matched := false
-			for _, id := range params.OwnerUserIDs {
-				if r.OwnerUserID == id {
-					matched = true
-					break
-				}
-			}
+			matched := slices.Contains(params.OwnerUserIDs, r.OwnerUserID)
 			if !matched {
 				continue
 			}

--- a/pkg/siteadmin/service/app_test.go
+++ b/pkg/siteadmin/service/app_test.go
@@ -8,11 +8,13 @@ import (
 	"net/url"
 	"sort"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
 	. "github.com/smartystreets/goconvey/convey"
 
+	"github.com/authgear/authgear-server/pkg/api/apierrors"
 	"github.com/authgear/authgear-server/pkg/api/model"
 	"github.com/authgear/authgear-server/pkg/api/siteadmin"
 	relay "github.com/authgear/authgear-server/pkg/graphqlgo/relay"
@@ -81,6 +83,7 @@ func (f *fakeOwnerStore) GetOwnerByAppID(_ context.Context, appID string) (strin
 	return "", ErrOwnerNotFound
 }
 
+//nolint:gocognit
 func (f *fakeOwnerStore) ListAppsWithStats(_ context.Context, params ListAppsStoreParams) ([]AppStoreRow, int, error) {
 	// Filter
 	var filtered []AppStoreRow
@@ -91,15 +94,37 @@ func (f *fakeOwnerStore) ListAppsWithStats(_ context.Context, params ListAppsSto
 		if params.PlanName != "" && r.PlanName != params.PlanName {
 			continue
 		}
-		if params.OwnerUserID != "" && r.OwnerUserID != params.OwnerUserID {
-			continue
+		if len(params.OwnerUserIDs) > 0 {
+			matched := false
+			for _, id := range params.OwnerUserIDs {
+				if r.OwnerUserID == id {
+					matched = true
+					break
+				}
+			}
+			if !matched {
+				continue
+			}
 		}
 		filtered = append(filtered, r)
 	}
 
+	// ownerRank maps user ID to its position in OwnerUserIDs (0-based).
+	ownerRank := make(map[string]int, len(params.OwnerUserIDs))
+	for i, id := range params.OwnerUserIDs {
+		ownerRank[id] = i
+	}
+
 	// Sort — mirrors SQL: primary field with configurable direction, app_id ASC secondary.
-	sort.Slice(filtered, func(i, j int) bool {
+	// When sort=Relevance, owner rank is prepended as the primary key.
+	sort.SliceStable(filtered, func(i, j int) bool {
 		a, b := filtered[i], filtered[j]
+		if params.Sort == siteadmin.Relevance {
+			ra, rb := ownerRank[a.OwnerUserID], ownerRank[b.OwnerUserID]
+			if ra != rb {
+				return ra < rb
+			}
+		}
 		if params.Sort == siteadmin.Mau {
 			if a.LastMonthMAU != b.LastMonthMAU {
 				if params.Order == siteadmin.Asc {
@@ -165,6 +190,27 @@ func adminAPIServer(response any) *httptest.Server {
 	}))
 }
 
+// multiResponseAdminAPIServer starts a test HTTP server that serves each response
+// in order. After the slice is exhausted, the last response is repeated.
+func multiResponseAdminAPIServer(responses ...any) *httptest.Server {
+	var mu sync.Mutex
+	idx := 0
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		var resp any
+		if idx < len(responses) {
+			resp = responses[idx]
+			idx++
+		} else {
+			resp = responses[len(responses)-1]
+		}
+		mu.Unlock()
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_ = json.NewEncoder(w).Encode(resp)
+	}))
+}
+
 // getUsersByEmailResponse builds a GraphQL data envelope for the
 // getUsersByStandardAttribute query.
 func getUsersByEmailResponse(globalIDs ...string) map[string]any {
@@ -179,8 +225,28 @@ func getUsersByEmailResponse(globalIDs ...string) map[string]any {
 
 // getNodesResponse builds a GraphQL data envelope for the getUserNodes query.
 func getNodesResponse(nodes ...any) map[string]any {
+	if nodes == nil {
+		nodes = []any{}
+	}
 	return map[string]any{
 		"data": map[string]any{"nodes": nodes},
+	}
+}
+
+// searchUsersByKeywordResponse builds a GraphQL data envelope for the searchOwnersByKeyword query.
+// hasNextPage controls the truncated flag.
+func searchUsersByKeywordResponse(hasNextPage bool, globalIDs ...string) map[string]any {
+	edges := make([]any, len(globalIDs))
+	for i, id := range globalIDs {
+		edges[i] = map[string]any{"node": map[string]any{"id": id}}
+	}
+	return map[string]any{
+		"data": map[string]any{
+			"users": map[string]any{
+				"edges":    edges,
+				"pageInfo": map[string]any{"hasNextPage": hasNextPage},
+			},
+		},
 	}
 }
 
@@ -214,13 +280,29 @@ func TestAppService(t *testing.T) {
 
 	Convey("AppService", t, func() {
 
-		Convey("ListApps with owner_email: user not found returns empty", func() {
-			svr := adminAPIServer(getUsersByEmailResponse())
+		Convey("ListApps with owner_search: no matching users returns empty", func() {
+			svr := adminAPIServer(searchUsersByKeywordResponse(false))
 			defer svr.Close()
 
 			svc := makeService(svr, &fakeConfigSourceStore{}, &fakeOwnerStore{})
 			result, err := svc.ListApps(ctxWithSession(), ListAppsParams{
-				Page: 1, PageSize: 10, OwnerEmail: "nobody@example.com",
+				Page: 1, PageSize: 10, OwnerSearch: "nobody@example.com",
+			})
+
+			So(err, ShouldBeNil)
+			So(result.TotalCount, ShouldEqual, 0)
+			So(result.Apps, ShouldResemble, []siteadmin.App{})
+			So(result.OwnerSearchTruncated, ShouldBeFalse)
+		})
+
+		Convey("ListApps with owner_search: found user but no apps returns empty", func() {
+			globalID := relay.ToGlobalID("User", "user-1")
+			svr := adminAPIServer(searchUsersByKeywordResponse(false, globalID))
+			defer svr.Close()
+
+			svc := makeService(svr, &fakeConfigSourceStore{}, &fakeOwnerStore{rows: []AppStoreRow{}})
+			result, err := svc.ListApps(ctxWithSession(), ListAppsParams{
+				Page: 1, PageSize: 10, OwnerSearch: "alice@example.com",
 			})
 
 			So(err, ShouldBeNil)
@@ -228,19 +310,26 @@ func TestAppService(t *testing.T) {
 			So(result.Apps, ShouldResemble, []siteadmin.App{})
 		})
 
-		Convey("ListApps with owner_email: found user but no apps returns empty", func() {
+		Convey("ListApps with owner_search: truncated flag propagated when hasNextPage=true", func() {
 			globalID := relay.ToGlobalID("User", "user-1")
-			svr := adminAPIServer(getUsersByEmailResponse(globalID))
+			svr := multiResponseAdminAPIServer(
+				searchUsersByKeywordResponse(true, globalID),
+				getNodesResponse(),
+			)
 			defer svr.Close()
 
-			svc := makeService(svr, &fakeConfigSourceStore{}, &fakeOwnerStore{rows: []AppStoreRow{}})
+			os := &fakeOwnerStore{
+				rows: []AppStoreRow{
+					{AppID: "app-1", PlanName: "free", CreatedAt: time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC), OwnerUserID: "user-1"},
+				},
+			}
+			svc := makeService(svr, &fakeConfigSourceStore{}, os)
 			result, err := svc.ListApps(ctxWithSession(), ListAppsParams{
-				Page: 1, PageSize: 10, OwnerEmail: "alice@example.com",
+				Page: 1, PageSize: 10, OwnerSearch: "alice",
 			})
 
 			So(err, ShouldBeNil)
-			So(result.TotalCount, ShouldEqual, 0)
-			So(result.Apps, ShouldResemble, []siteadmin.App{})
+			So(result.OwnerSearchTruncated, ShouldBeTrue)
 		})
 
 		Convey("ListApps paged: returns apps with resolved emails and last_month_mau", func() {
@@ -435,9 +524,12 @@ func TestAppService(t *testing.T) {
 			So(result.Apps[0].LastMonthMau, ShouldEqual, 0)
 		})
 
-		Convey("ListApps: plan + owner_email combined filter", func() {
+		Convey("ListApps: plan + owner_search combined filter", func() {
 			globalID := relay.ToGlobalID("User", "user-1")
-			svr := adminAPIServer(getUsersByEmailResponse(globalID))
+			svr := multiResponseAdminAPIServer(
+				searchUsersByKeywordResponse(false, globalID),
+				getNodesResponse(),
+			)
 			defer svr.Close()
 
 			t1 := time.Date(2024, 1, 3, 0, 0, 0, 0, time.UTC)
@@ -454,13 +546,86 @@ func TestAppService(t *testing.T) {
 
 			svc := makeService(svr, &fakeConfigSourceStore{}, os)
 			result, err := svc.ListApps(ctxWithSession(), ListAppsParams{
-				Page: 1, PageSize: 10, Plan: "starter", OwnerEmail: "alice@example.com",
+				Page: 1, PageSize: 10, Plan: "starter", OwnerSearch: "alice@example.com",
 			})
 
 			So(err, ShouldBeNil)
 			So(result.TotalCount, ShouldEqual, 1)
 			So(result.Apps[0].Id, ShouldEqual, "app-1")
-			So(result.Apps[0].OwnerEmail, ShouldEqual, "alice@example.com")
+		})
+
+		Convey("ListApps: sort=relevance without owner_search returns error", func() {
+			svr := adminAPIServer(getNodesResponse())
+			defer svr.Close()
+
+			svc := makeService(svr, &fakeConfigSourceStore{}, &fakeOwnerStore{})
+			_, err := svc.ListApps(ctxWithSession(), ListAppsParams{
+				Page: 1, PageSize: 10, Sort: siteadmin.Relevance,
+			})
+
+			So(err, ShouldNotBeNil)
+			So(apierrors.IsAPIError(err), ShouldBeTrue)
+		})
+
+		Convey("ListApps: owner_search with sort=relevance orders by owner rank", func() {
+			t1 := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
+
+			// user-2 ranks higher (first in search result) than user-1.
+			globalID1 := relay.ToGlobalID("User", "user-1")
+			globalID2 := relay.ToGlobalID("User", "user-2")
+			svr := multiResponseAdminAPIServer(
+				searchUsersByKeywordResponse(false, globalID2, globalID1),
+				getNodesResponse(),
+			)
+			defer svr.Close()
+
+			os := &fakeOwnerStore{
+				rows: []AppStoreRow{
+					{AppID: "app-a", PlanName: "free", CreatedAt: t1, OwnerUserID: "user-1"},
+					{AppID: "app-b", PlanName: "free", CreatedAt: t1, OwnerUserID: "user-2"},
+				},
+			}
+
+			svc := makeService(svr, &fakeConfigSourceStore{}, os)
+			result, err := svc.ListApps(ctxWithSession(), ListAppsParams{
+				Page: 1, PageSize: 10, OwnerSearch: "alice", Sort: siteadmin.Relevance,
+			})
+
+			So(err, ShouldBeNil)
+			So(result.TotalCount, ShouldEqual, 2)
+			// app-b (user-2, rank 0) must come before app-a (user-1, rank 1)
+			So(result.Apps[0].Id, ShouldEqual, "app-b")
+			So(result.Apps[1].Id, ShouldEqual, "app-a")
+		})
+
+		Convey("ListApps: owner_search with sort=mau sorts by MAU not owner rank", func() {
+			t1 := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
+
+			// user-2 ranks higher in search but app-a (user-1) has higher MAU.
+			globalID1 := relay.ToGlobalID("User", "user-1")
+			globalID2 := relay.ToGlobalID("User", "user-2")
+			svr := multiResponseAdminAPIServer(
+				searchUsersByKeywordResponse(false, globalID2, globalID1),
+				getNodesResponse(),
+			)
+			defer svr.Close()
+
+			os := &fakeOwnerStore{
+				rows: []AppStoreRow{
+					{AppID: "app-a", PlanName: "free", CreatedAt: t1, OwnerUserID: "user-1", LastMonthMAU: 200},
+					{AppID: "app-b", PlanName: "free", CreatedAt: t1, OwnerUserID: "user-2", LastMonthMAU: 50},
+				},
+			}
+
+			svc := makeService(svr, &fakeConfigSourceStore{}, os)
+			result, err := svc.ListApps(ctxWithSession(), ListAppsParams{
+				Page: 1, PageSize: 10, OwnerSearch: "alice", Sort: siteadmin.Mau, Order: siteadmin.Desc,
+			})
+
+			So(err, ShouldBeNil)
+			// MAU sort: app-a (200) before app-b (50), regardless of owner rank
+			So(result.Apps[0].Id, ShouldEqual, "app-a")
+			So(result.Apps[1].Id, ShouldEqual, "app-b")
 		})
 
 		Convey("ListApps: app_id prefix filter returns matching apps only", func() {

--- a/pkg/siteadmin/transport/handler_apps_list.go
+++ b/pkg/siteadmin/transport/handler_apps_list.go
@@ -24,13 +24,13 @@ type AppsListHandler struct {
 }
 
 type AppsListParams struct {
-	Page       uint64
-	PageSize   uint64
-	AppID      string
-	OwnerEmail string
-	Plan       string
-	Sort       siteadmin.ListAppsParamsSort
-	Order      siteadmin.ListAppsParamsOrder
+	Page        uint64
+	PageSize    uint64
+	AppID       string
+	OwnerSearch string
+	Plan        string
+	Sort        siteadmin.ListAppsParamsSort
+	Order       siteadmin.ListAppsParamsOrder
 }
 
 func parseAppsListParams(r *http.Request) AppsListParams {
@@ -54,13 +54,13 @@ func parseAppsListParams(r *http.Request) AppsListParams {
 	orderVal := siteadmin.ListAppsParamsOrder(q.Get("order"))
 
 	return AppsListParams{
-		Page:       page,
-		PageSize:   pageSize,
-		AppID:      q.Get("app_id"),
-		OwnerEmail: q.Get("owner_email"),
-		Plan:       q.Get("plan"),
-		Sort:       sortVal,
-		Order:      orderVal,
+		Page:        page,
+		PageSize:    pageSize,
+		AppID:       q.Get("app_id"),
+		OwnerSearch: q.Get("owner_search"),
+		Plan:        q.Get("plan"),
+		Sort:        sortVal,
+		Order:       orderVal,
 	}
 }
 
@@ -68,13 +68,13 @@ func (h *AppsListHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	params := parseAppsListParams(r)
 
 	result, err := h.AppsList.ListApps(r.Context(), service.ListAppsParams{
-		Page:       params.Page,
-		PageSize:   params.PageSize,
-		AppID:      params.AppID,
-		OwnerEmail: params.OwnerEmail,
-		Plan:       params.Plan,
-		Sort:       params.Sort,
-		Order:      params.Order,
+		Page:        params.Page,
+		PageSize:    params.PageSize,
+		AppID:       params.AppID,
+		OwnerSearch: params.OwnerSearch,
+		Plan:        params.Plan,
+		Sort:        params.Sort,
+		Order:       params.Order,
 	})
 	if err != nil {
 		writeError(w, r, err)
@@ -82,10 +82,11 @@ func (h *AppsListHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 
 	response := siteadmin.AppsListResponse{
-		Apps:       result.Apps,
-		TotalCount: result.TotalCount,
-		Page:       params.Page,
-		PageSize:   params.PageSize,
+		Apps:                 result.Apps,
+		TotalCount:           result.TotalCount,
+		Page:                 params.Page,
+		PageSize:             params.PageSize,
+		OwnerSearchTruncated: result.OwnerSearchTruncated,
 	}
 	SiteAdminAPISuccessResponse{Body: response}.WriteTo(w)
 }

--- a/pkg/siteadmin/transport/handler_apps_list.go
+++ b/pkg/siteadmin/transport/handler_apps_list.go
@@ -51,14 +51,7 @@ func parseAppsListParams(r *http.Request) AppsListParams {
 	}
 
 	sortVal := siteadmin.ListAppsParamsSort(q.Get("sort"))
-	if !sortVal.Valid() {
-		sortVal = siteadmin.CreatedAt
-	}
-
 	orderVal := siteadmin.ListAppsParamsOrder(q.Get("order"))
-	if !orderVal.Valid() {
-		orderVal = siteadmin.Desc
-	}
 
 	return AppsListParams{
 		Page:       page,


### PR DESCRIPTION
ref DEV-3580

after:  
- https://github.com/authgear/authgear-server/pull/5767

Replaced `owner_email` with `owner_search`, which accepts a partial keyword (e.g. alice, alice@company) instead of a full exact email.

Results default to `sort=relevance` when `owner_search` is set, grouping apps by best-matching owner first. You can still override with `sort=created_at` or `sort=mau`.

The implementation uses the search user by keyword Admin API, so both Elasticsearch and PostgreSQL search implementations are supported. However, only the top 20 matching owners are considered per search, so if `owner_search_truncated` is true in the response, some apps may be missing and `total_count` is a lower bound.
