### PR TITLE
Improve http metric and logging

### DIFF
--- a/.vettedpositions
+++ b/.vettedpositions
@@ -307,7 +307,7 @@
 /pkg/lib/oauth/response_mode.go:161:40: requestcontext
 /pkg/lib/oauth/scope.go:118:34: requestcontext
 /pkg/lib/oauthrelyingparty/oauthrelyingpartyutil/contextbackground.go:11:52: contextbackground
-/pkg/lib/otelauthgear/nethttp.go:73:10: requestcontext
+/pkg/lib/otelauthgear/nethttp.go:75:10: requestcontext
 /pkg/lib/saml/samlbinding/http_post.go:176:35: requestcontext
 /pkg/lib/saml/samlbinding/http_post.go:207:35: requestcontext
 /pkg/lib/session/middleware.go:42:23: requestcontext
@@ -347,8 +347,8 @@
 /pkg/util/httputil/json.go:96:9: requestcontext
 /pkg/util/httputil/result.go:29:11: requestcontext
 /pkg/util/jwkutil/contextbackground.go:11:52: contextbackground
-/pkg/util/otelutil/nethttp.go:121:46: requestcontext
-/pkg/util/otelutil/nethttp.go:154:49: requestcontext
+/pkg/util/otelutil/nethttp.go:122:46: requestcontext
+/pkg/util/otelutil/nethttp.go:156:49: requestcontext
 /pkg/util/otelutil/oteldatabasesql/instrumentation.go:301:13: contextbackground
 /pkg/util/pubsub/http_handler.go:51:40: requestcontext
 /pkg/util/sentry/request.go:25:9: requestcontext

--- a/pkg/auth/routes.go
+++ b/pkg/auth/routes.go
@@ -66,6 +66,7 @@ func NewRouter(ctx context.Context, p *deps.RootProvider, configSource *configso
 	// This route is intentionally simple.
 	// This does not check Host and allow any origin.
 	generatedStaticChain := httproute.Chain(
+		p.RootMiddleware(newOtelMiddleware),
 		httproute.MiddlewareFunc(httputil.XContentTypeOptionsNosniff),
 		httproute.MiddlewareFunc(httputil.PermissionsPolicyHeader),
 		httproute.MiddlewareFunc(middleware.CORSStar),

--- a/pkg/lib/otelauthgear/nethttp.go
+++ b/pkg/lib/otelauthgear/nethttp.go
@@ -76,10 +76,11 @@ func (m *HTTPInstrumentationMiddleware) Handle(next http.Handler) http.Handler {
 		// Assume the labeler has been put into context.
 		labeler, _ := otelhttp.LabelerFromContext(ctx)
 
-		// Gather method, path, and scheme before invoking the handler.
+		// Gather method, path, host, and scheme before invoking the handler.
 		// Avoid the rare case of the handler modifying r.Method, r.URL, or r.Header.
 		method := r.Method
 		path := r.URL.Path
+		host := r.Host
 		labeler.Add(otelutil.HTTPRequestMethod(r))
 		scheme := httputil.GetProto(r, bool(m.TrustProxy))
 		labeler.Add(otelutil.HTTPURLScheme(scheme))
@@ -119,6 +120,7 @@ func (m *HTTPInstrumentationMiddleware) Handle(next http.Handler) http.Handler {
 				slog.String("http.path", path),
 				slog.String("http.route", httpRoute),
 				slog.String("url.scheme", scheme),
+				slog.String("server.address", host),
 				slog.Int("http.status_code", statusCode),
 				slog.Int64("duration_ms", requestDuration.Milliseconds()),
 			)

--- a/pkg/lib/otelauthgear/nethttp.go
+++ b/pkg/lib/otelauthgear/nethttp.go
@@ -2,6 +2,7 @@ package otelauthgear
 
 import (
 	"context"
+	"log/slog"
 	"net/http"
 	"time"
 
@@ -12,6 +13,7 @@ import (
 	"github.com/authgear/authgear-server/pkg/lib/config"
 	"github.com/authgear/authgear-server/pkg/util/httputil"
 	"github.com/authgear/authgear-server/pkg/util/otelutil"
+	"github.com/authgear/authgear-server/pkg/util/slogutil"
 )
 
 type HTTPInstrumentationMiddleware struct {
@@ -74,8 +76,10 @@ func (m *HTTPInstrumentationMiddleware) Handle(next http.Handler) http.Handler {
 		// Assume the labeler has been put into context.
 		labeler, _ := otelhttp.LabelerFromContext(ctx)
 
-		// Gather method and scheme before invoking the handler.
-		// Avoid the rare case of the handler modify r.Method or r.Header.
+		// Gather method, path, and scheme before invoking the handler.
+		// Avoid the rare case of the handler modifying r.Method, r.URL, or r.Header.
+		method := r.Method
+		path := r.URL.Path
 		labeler.Add(otelutil.HTTPRequestMethod(r))
 		scheme := httputil.GetProto(r, bool(m.TrustProxy))
 		labeler.Add(otelutil.HTTPURLScheme(scheme))
@@ -88,15 +92,15 @@ func (m *HTTPInstrumentationMiddleware) Handle(next http.Handler) http.Handler {
 			statusCodeAttr := otelutil.HTTPResponseStatusCode(statusCode)
 
 			// Record the metric.
-			httpRouteOK := false
+			httpRoute := ""
 			labeler, _ := otelhttp.LabelerFromContext(ctx)
 			labelerAttrs := labeler.Get()
 			for _, attr := range labelerAttrs {
 				if attr.Key == semconv.HTTPRouteKey {
-					httpRouteOK = true
+					httpRoute = attr.Value.AsString()
 				}
 			}
-			if httpRouteOK {
+			if httpRoute != "" {
 				// By default, we do not include server.address because it depends on
 				// external input like X-Forwarded-Host, Host
 				// If we include server.address, then the attacker can trigger cardinality limits.
@@ -107,6 +111,17 @@ func (m *HTTPInstrumentationMiddleware) Handle(next http.Handler) http.Handler {
 				seconds := requestDuration.Seconds()
 				otelutil.Float64HistogramRecord(ctx, HTTPServerRequestDurationHistogram.Inst(), seconds, options...)
 			}
+
+			// Log the access log.
+			logger := slogutil.GetContextLogger(ctx)
+			logger.LogAttrs(ctx, slog.LevelInfo, "access",
+				slog.String("http.method", method),
+				slog.String("http.path", path),
+				slog.String("http.route", httpRoute),
+				slog.String("url.scheme", scheme),
+				slog.Int("http.status_code", statusCode),
+				slog.Int64("duration_ms", requestDuration.Milliseconds()),
+			)
 		})
 	})
 }

--- a/pkg/util/otelutil/nethttp.go
+++ b/pkg/util/otelutil/nethttp.go
@@ -8,6 +8,7 @@ import (
 
 	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
 	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/metric/noop"
 	semconv "go.opentelemetry.io/otel/semconv/v1.34.0"
 )
 
@@ -127,7 +128,8 @@ func WithHTTPRoute(httpRoute string) func(http.Handler) http.Handler {
 
 func WithOtelContext(httpRoute string) func(http.Handler) http.Handler {
 	return func(next http.Handler) http.Handler {
-		otelHandler := otelhttp.NewHandler(next, httpRoute)
+		// Disable http metric here because it is handled in HTTPInstrumentationMiddleware
+		otelHandler := otelhttp.NewHandler(next, httpRoute, otelhttp.WithMeterProvider(noop.NewMeterProvider()))
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			// Extract trace context from query parameters if not present in headers.
 			// This allows trace propagation through redirects or links.


### PR DESCRIPTION
ref DEV-3578

- Remove duplicated http request metric
- Add access logs so we know which request actually hits the server, which does not