### PR TITLE
[Portal] Hide Switch Project heading when there are no other projects

### DIFF
--- a/portal/src/components/header/ProjectSelector.tsx
+++ b/portal/src/components/header/ProjectSelector.tsx
@@ -301,26 +301,30 @@ const ProjectSelector: React.VFC<ProjectSelectorProps> =
                   />
                 </div>
               </section>
-              <hr className={styles.divider} />
-              <section className={styles.section}>
-                <div className={styles.sectionHeader}>
-                  <FormattedMessage id="ScreenHeader.projectSelector.switch-project" />
-                </div>
-                <div className={styles.projectList}>
-                  {otherApps.map((app) => (
-                    <button
-                      key={app.appID}
-                      type="button"
-                      className={styles.projectListItem}
-                      onClick={() => onSelectProject(app.appID)}
-                    >
-                      <span className={styles.projectListItemLabel}>
-                        {app.appID}
-                      </span>
-                    </button>
-                  ))}
-                </div>
-              </section>
+              {otherApps.length > 0 ? (
+                <>
+                  <hr className={styles.divider} />
+                  <section className={styles.section}>
+                    <div className={styles.sectionHeader}>
+                      <FormattedMessage id="ScreenHeader.projectSelector.switch-project" />
+                    </div>
+                    <div className={styles.projectList}>
+                      {otherApps.map((app) => (
+                        <button
+                          key={app.appID}
+                          type="button"
+                          className={styles.projectListItem}
+                          onClick={() => onSelectProject(app.appID)}
+                        >
+                          <span className={styles.projectListItemLabel}>
+                            {app.appID}
+                          </span>
+                        </button>
+                      ))}
+                    </div>
+                  </section>
+                </>
+              ) : null}
               {!isAuthgearOnce ? (
                 <>
                   <hr className={styles.divider} />


### PR DESCRIPTION
## Problem
When the signed-in user belongs to only one project, the project-selector dropdown still rendered a "Switch Project" section header with no items beneath it.

## Change
Hide the "Switch Project" section (and its preceding divider) when there are no other projects to switch to. `otherApps` already excludes the current project, so the section only renders when `otherApps.length > 0`. The dropdown then shows just **Current Project** and **Create Project**.

Single project | Multiple projects
--- | ---
Current Project + Create Project | Current Project + Switch Project + Create Project

## Test plan
- `cd portal && npm run typecheck` passes
- Verified locally: with one project the heading is gone; with multiple projects the Switch Project list still renders

Before
<img width="433" height="216" alt="SCR-20260623-pfcd" src="https://github.com/user-attachments/assets/993b8e72-acca-43f1-a81d-a10bd002c26c" />


After

<img width="456" height="269" alt="SCR-20260623-plff" src="https://github.com/user-attachments/assets/188df728-c94e-4e81-b965-2643357c27c1" />


ref DEV-3657