### PR TITLE
[Portal] Link to billing in phone country allowlist restriction message

### DIFF
--- a/portal/src/graphql/portal/LoginMethodConfigurationScreen.tsx
+++ b/portal/src/graphql/portal/LoginMethodConfigurationScreen.tsx
@@ -2544,6 +2544,7 @@ function EmailSettings(props: EmailSettingsProps) {
 }
 
 interface PhoneSettingsProps {
+  appID: string;
   loginIDKeyConfigsControl: ControlList<LoginIDKeyConfig>;
   phoneInputConfig: Required<PhoneInputConfig>;
   phoneInputFeatureConfig?: PhoneInputFeatureConfig;
@@ -2552,6 +2553,7 @@ interface PhoneSettingsProps {
 
 function PhoneSettings(props: PhoneSettingsProps) {
   const {
+    appID,
     phoneInputConfig,
     loginIDKeyConfigsControl,
     phoneInputFeatureConfig,
@@ -2671,10 +2673,14 @@ function PhoneSettings(props: PhoneSettingsProps) {
                 id="FeatureConfig.phone-input.allowlist.restricted"
                 values={{
                   // eslint-disable-next-line react/no-unstable-nested-components
-                  externalLink: (chunks: React.ReactNode) => (
+                  applicationLink: (chunks: React.ReactNode) => (
                     <ExternalLink href="https://go.authgear.com/portal-support">
                       {chunks}
                     </ExternalLink>
+                  ),
+                  // eslint-disable-next-line react/no-unstable-nested-components
+                  billingLink: (chunks: React.ReactNode) => (
+                    <Link to={`/project/${appID}/billing`}>{chunks}</Link>
                   ),
                 }}
               />
@@ -3793,6 +3799,7 @@ const LoginMethodConfigurationContent: React.VFC<LoginMethodConfigurationContent
                 itemKey="phone"
               >
                 <PhoneSettings
+                  appID={appID}
                   loginIDKeyConfigsControl={loginIDKeyConfigsControl}
                   phoneInputConfig={phoneInputConfig}
                   phoneInputFeatureConfig={state.phoneInputFeatureConfig}

--- a/portal/src/locale-data/en.json
+++ b/portal/src/locale-data/en.json
@@ -1525,7 +1525,7 @@
   "AuditLogActivityType.PROJECT_DOMAIN_VERIFIED": "Project: Domain verified",
   "AuditLogActivityType.M2M_TOKEN_CREATED": "M2M Token Created",
   "FeatureConfig.disabled": "The grayed out features are not available for your project plan. <ReactRouterLink>Upgrade your project plan</ReactRouterLink>.",
-  "FeatureConfig.phone-input.allowlist.restricted": "To send SMS/WhatsApp to other countries, please complete <externalLink>the application form</externalLink>.",
+  "FeatureConfig.phone-input.allowlist.restricted": "To send SMS/WhatsApp to other countries, please <applicationLink>complete the application form</applicationLink> or <billingLink>subscribe to a paid plan</billingLink>.",
   "FeatureConfig.custom-domain.disabled": "Custom domains are not available for your project plan. <ReactRouterLink>Upgrade your project plan</ReactRouterLink>.",
   "FeatureConfig.white-labeling.disabled": "To hide Authgear branding in your app. <ReactRouterLink>Upgrade your project plan</ReactRouterLink>.",
   "FeatureConfig.oauth-clients.maximum.upgrade": "You have reached the maximum limit of {maximum, plural, one{1 application} other{# applications}}. Please <ReactRouterLink>upgrade your project plan</ReactRouterLink> to create additional applications.",


### PR DESCRIPTION
## Problem
On the phone **Allowed Country Codes** section (Login Methods → Custom → Phone), when the project's plan restricts the phone-input country allowlist, the notice only pointed users to the external application form. There was no in-portal path to unlock more countries by upgrading.

<img width="824" height="547" alt="SCR-20260624-pvod" src="https://github.com/user-attachments/assets/b55bbccb-e59d-4e63-a2d0-d0e27083499f" />


## Change
The message now offers both options:

> To send SMS/WhatsApp to other countries, please **complete the application form** or **subscribe to a paid plan**.

- "complete the application form" → `https://go.authgear.com/portal-support` (external, unchanged)
- "subscribe to a paid plan" → `/project/<appID>/billing` (internal Billing page)

Implementation:
- `portal/src/locale-data/en.json` — updated `FeatureConfig.phone-input.allowlist.restricted` with `<applicationLink>` and `<billingLink>` tags
- `LoginMethodConfigurationScreen.tsx` — `FormattedMessage` provides both render functions (`ExternalLink` / internal `Link`); `PhoneSettings` receives `appID` from `LoginMethodConfigurationContent`

## Test plan
- `npm run typecheck` passes
- Verified locally by temporarily setting `ui.phone_input.allowlist` on a project: banner renders, both links styled correctly inside `BlueMessageBar`, and targets resolve to the support form and `/project/<appID>/billing`

ref DEV-3657