### PR TITLE
[Site Admin] Site admin audit log read API

### DIFF
--- a/.vettedpositions
+++ b/.vettedpositions
@@ -328,6 +328,8 @@
 /pkg/siteadmin/transport/handler_app_plan_change.go:47:65: requestcontext
 /pkg/siteadmin/transport/handler_app_plan_change.go:63:38: requestcontext
 /pkg/siteadmin/transport/handler_apps_list.go:70:37: requestcontext
+/pkg/siteadmin/transport/handler_audit_log_get.go:28:42: requestcontext
+/pkg/siteadmin/transport/handler_audit_logs_list.go:84:47: requestcontext
 /pkg/siteadmin/transport/handler_collaborator_add.go:47:67: requestcontext
 /pkg/siteadmin/transport/handler_collaborator_add.go:64:49: requestcontext
 /pkg/siteadmin/transport/handler_collaborator_promote.go:39:53: requestcontext

--- a/docs/api/siteadmin-api.yaml
+++ b/docs/api/siteadmin-api.yaml
@@ -73,11 +73,7 @@ paths:
             Sort direction. Defaults to `desc`. Ignored when `sort=relevance`
             (relevance is always highest-match first).
           schema:
-            type: string
-            enum:
-              - asc
-              - desc
-            default: desc
+            $ref: "#/components/schemas/OrderDirection"
       responses:
         "200":
           description: A list of apps
@@ -89,6 +85,77 @@ paths:
           $ref: "#/components/responses/BadRequest"
         "403":
           $ref: "#/components/responses/Forbidden"
+
+  /api/v1/audit-logs:
+    get:
+      operationId: listAuditLogs
+      summary: List site admin audit log entries
+      description: >
+        Returns audit log entries for actions performed by site admins
+        (e.g. plan changes, collaborator mutations). These are distinct from
+        per-app user-event logs, which will be available at
+        /api/v1/apps/{app_id}/audit-logs in the future.
+      parameters:
+        - name: page
+          in: query
+          description: Page number, 1-based. Defaults to 1.
+          schema:
+            type: integer
+            default: 1
+            minimum: 1
+        - name: page_size
+          in: query
+          description: Number of entries per page. Defaults to 20, maximum 100.
+          schema:
+            type: integer
+            default: 20
+            minimum: 1
+            maximum: 100
+        - name: affected_app_id
+          in: query
+          description: >
+            Filter by the app that was acted on. When provided, only entries
+            whose payload.app_id matches this value are returned.
+          schema:
+            type: string
+        - name: order
+          in: query
+          description: Sort direction for created_at. Defaults to `desc` (newest first).
+          schema:
+            $ref: "#/components/schemas/OrderDirection"
+      responses:
+        "200":
+          description: A list of site admin audit log entries
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/SiteAdminAuditLogsListResponse"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+
+  /api/v1/audit-logs/{id}:
+    get:
+      operationId: getAuditLog
+      summary: Get a site admin audit log entry
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          description: Site admin audit log entry with raw data
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/SiteAdminAuditLogDetail"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          $ref: "#/components/responses/NotFound"
 
   /api/v1/plans:
     get:
@@ -646,6 +713,13 @@ components:
           type: string
           description: The plan to assign to the app
 
+    OrderDirection:
+      type: string
+      description: Sort direction.
+      enum:
+        - asc
+        - desc
+
     AppDetail:
       allOf:
         - $ref: "#/components/schemas/App"
@@ -656,3 +730,75 @@ components:
             user_count:
               type: integer
               description: Number of users in the app
+
+    SiteAdminAuditLogsListResponse:
+      type: object
+      required:
+        - audit_logs
+        - total_count
+        - page
+        - page_size
+      properties:
+        audit_logs:
+          type: array
+          items:
+            $ref: "#/components/schemas/SiteAdminAuditLog"
+        total_count:
+          type: integer
+          description: Total number of entries matching the query.
+        page:
+          type: integer
+          format: uint64
+          description: Current page number.
+        page_size:
+          type: integer
+          format: uint64
+          description: Number of entries per page.
+
+    SiteAdminAuditLog:
+      type: object
+      required:
+        - id
+        - created_at
+        - activity_type
+      properties:
+        id:
+          type: string
+          description: Audit log entry ID (hex-encoded sequence number).
+        created_at:
+          type: string
+          format: date-time
+          description: When the event occurred, in RFC 3339 format.
+        activity_type:
+          type: string
+          description: The site admin activity type (e.g. site_admin.app.plan.updated).
+        ip_address:
+          type: string
+          description: IP address of the actor.
+        user_agent:
+          type: string
+          description: User agent string of the actor's browser.
+        actor_user_id:
+          type: string
+          description: >
+            Portal user ID of the site admin who performed the action,
+            extracted from audit_context.actor_user_id.
+        affected_app_id:
+          type: string
+          description: >
+            ID of the app that was acted on, extracted from
+            data.payload.app_id.
+
+    SiteAdminAuditLogDetail:
+      allOf:
+        - $ref: "#/components/schemas/SiteAdminAuditLog"
+        - type: object
+          required:
+            - data
+          properties:
+            data:
+              type: object
+              description: >
+                Raw audit log data — the full event JSON stored in the
+                _audit_log.data column, including context and payload.
+              additionalProperties: true

--- a/docs/plans/siteadmin-api/08.1-audit-log-api.md
+++ b/docs/plans/siteadmin-api/08.1-audit-log-api.md
@@ -1,0 +1,452 @@
+# 08.1 — Site Admin Audit Log API
+
+## Goal / Scope
+
+Expose two read endpoints so site admin tooling can query the audit log written by `SiteAdminAuditService`:
+
+| Endpoint | Response type |
+|---|---|
+| `GET /api/v1/audit-logs` | `SiteAdminAuditLogsListResponse` |
+| `GET /api/v1/audit-logs/:id` | `SiteAdminAuditLogDetail` |
+
+Handler stubs already exist. `auditdb.ReadHandle` is already wired in `pkg/siteadmin/deps.go`. No schema migration is required.
+
+---
+
+## Data Source
+
+Table `_audit_log` in the audit DB, accessed via `auditdb.ReadHandle`.
+
+All site admin audit records share the same `app_id` column value: `AuthgearConfig.AppID` (`SITEADMIN_AUTHGEAR_APP_ID`).
+
+Base filter applied to every query:
+```sql
+WHERE app_id = $portalAppID
+  AND activity_type LIKE 'site_admin.%'
+```
+
+Optional additional filter when `affected_app_id` is provided:
+```sql
+AND data->'payload'->>'app_id' = $affectedAppID
+```
+
+Sort order: `ORDER BY created_at {ASC|DESC}` — direction driven by the `order` parameter, defaults to `DESC`.
+
+### Index coverage
+
+The existing composite index `_audit_log_idx_app_id_activity_type_created_at ON _audit_log (app_id, activity_type, created_at DESC)` covers `app_id = $portalAppID AND activity_type LIKE 'site_admin.%'` and the sort. The JSON path post-filter (`data->'payload'->>'app_id'`) runs on the already-narrow result set.
+
+No additional index is needed. Site admin actions are performed by cluster operators, not end users — the total row count for `site_admin.*` is naturally tiny (hundreds to low thousands) even over years.
+
+### Column mapping
+
+| Response field | SQL expression |
+|---|---|
+| `id` | `id` |
+| `created_at` | `created_at` |
+| `activity_type` | `activity_type` |
+| `ip_address` | `ip_address::text` (cast inet → text, nullable) |
+| `user_agent` | `user_agent` (nullable text) |
+| `actor_user_id` | `data->'context'->'audit_context'->>'actor_user_id'` |
+| `affected_app_id` | `data->'payload'->>'app_id'` |
+| `data` (detail only) | `data` (full JSONB → `map[string]any`) |
+
+---
+
+## Service Layer
+
+Follows the same store/service split used by `AppOwnerStore`/`AppService` and `CollaboratorStore`/`CollaboratorService` — the store owns all SQL and scanning, the service owns pagination logic and the nil-DB guard.
+
+### New file: `pkg/siteadmin/service/audit_read.go`
+
+#### Shared types
+
+```go
+const AuditLogsMaxPageSize uint64 = 100
+
+type AuditLogEntry struct {
+    ID            string
+    CreatedAt     time.Time
+    ActivityType  string
+    IPAddress     string // empty if null
+    UserAgent     string // empty if null
+    ActorUserID   string // empty if absent in audit_context
+    AffectedAppID string // empty if absent in payload
+}
+
+type AuditLogEntryDetail struct {
+    AuditLogEntry
+    Data map[string]any
+}
+
+type ListAuditLogsParams struct {
+    Page          uint64
+    PageSize      uint64
+    AffectedAppID string                               // empty = no filter
+    Order         siteadmin.OrderDirection   // "asc" | "desc"; defaults to "desc"
+}
+
+type ListAuditLogsResult struct {
+    Entries    []AuditLogEntry
+    TotalCount int
+}
+```
+
+#### `SiteAdminAuditLogStore`
+
+```go
+type SiteAdminAuditLogStore struct {
+    SQLBuilder  *auditdb.SQLBuilderApp   // pre-scoped to portalAppID
+    SQLExecutor *auditdb.ReadSQLExecutor
+}
+```
+
+`SQLBuilderApp` is constructed with `SQLBuilder.WithAppID(portalAppID)` during wiring — it automatically prepends `WHERE app_id = $portalAppID` to every SELECT.
+
+**`Count(ctx, affectedAppID string) (int, error)`**
+
+```go
+q := s.SQLBuilder.
+    Select("COUNT(*)").
+    From(s.SQLBuilder.TableName("_audit_log")).
+    Where("activity_type LIKE ?", "site_admin.%")
+if affectedAppID != "" {
+    q = q.Where("data->'payload'->>'app_id' = ?", affectedAppID)
+}
+// scan single int
+```
+
+**`List(ctx, affectedAppID string, order siteadmin.OrderDirection, limit, offset uint64) ([]AuditLogEntry, error)`**
+
+```go
+dir := "DESC"
+if order == siteadmin.Asc {
+    dir = "ASC"
+}
+q := s.SQLBuilder.
+    Select(
+        "id", "created_at", "activity_type",
+        "ip_address::text", "user_agent",
+        "data->'context'->'audit_context'->>'actor_user_id'",
+        "data->'payload'->>'app_id'",
+    ).
+    From(s.SQLBuilder.TableName("_audit_log")).
+    Where("activity_type LIKE ?", "site_admin.%").
+    OrderBy("created_at "+dir).
+    Limit(limit).
+    Offset(offset)
+if affectedAppID != "" {
+    q = q.Where("data->'payload'->>'app_id' = ?", affectedAppID)
+}
+```
+
+Row scan:
+```go
+var ipAddress, userAgent, actorUserID, affectedAppIDVal sql.NullString
+err := rows.Scan(&e.ID, &e.CreatedAt, &e.ActivityType,
+    &ipAddress, &userAgent, &actorUserID, &affectedAppIDVal)
+e.IPAddress     = ipAddress.String
+e.UserAgent     = userAgent.String
+e.ActorUserID   = actorUserID.String
+e.AffectedAppID = affectedAppIDVal.String
+```
+
+**`Get(ctx, id string) (*AuditLogEntryDetail, error)`**
+
+```go
+q := s.SQLBuilder.
+    Select(
+        "id", "created_at", "activity_type",
+        "ip_address::text", "user_agent",
+        "data->'context'->'audit_context'->>'actor_user_id'",
+        "data->'payload'->>'app_id'",
+        "data",
+    ).
+    From(s.SQLBuilder.TableName("_audit_log")).
+    Where("id = ?", id).
+    Where("activity_type LIKE ?", "site_admin.%")
+```
+
+Scan `data` as `[]byte`, unmarshal into `map[string]any`. If `sql.ErrNoRows` → return `nil, apierrors.NewNotFound("audit log not found")`.
+
+#### Narrow interface
+
+```go
+type SiteAdminAuditLogStoreIface interface {
+    Count(ctx context.Context, affectedAppID string) (int, error)
+    List(ctx context.Context, affectedAppID string, order siteadmin.OrderDirection, limit, offset uint64) ([]AuditLogEntry, error)
+    Get(ctx context.Context, id string) (*AuditLogEntryDetail, error)
+}
+```
+
+#### `SiteAdminAuditReadService`
+
+```go
+type SiteAdminAuditReadService struct {
+    AuditDatabase *auditdb.ReadHandle // nil when audit DB is not configured
+    Store         SiteAdminAuditLogStoreIface
+}
+```
+
+**`ListAuditLogs(ctx, params ListAuditLogsParams) (*ListAuditLogsResult, error)`**
+
+1. If `AuditDatabase == nil` return `&ListAuditLogsResult{Entries: []AuditLogEntry{}}`, nil.
+2. Clamp `params.PageSize` to `AuditLogsMaxPageSize`; default `params.Page` to 1.
+3. `s.AuditDatabase.ReadOnly(ctx, func(ctx) error { ... })`
+4. Normalise `params.Order`: if not `Valid()`, default to `siteadmin.Desc`.
+5. Inside: call `s.Store.Count(ctx, params.AffectedAppID)` → `totalCount`.
+6. If `totalCount == 0` return early with empty result.
+7. Call `s.Store.List(ctx, params.AffectedAppID, params.Order, pageSize, (page-1)*pageSize)`.
+7. Return `&ListAuditLogsResult{Entries: entries, TotalCount: totalCount}`.
+
+**`GetAuditLog(ctx, id string) (*AuditLogEntryDetail, error)`**
+
+1. If `AuditDatabase == nil` return `nil, apierrors.NewNotFound("audit log not found")`.
+2. `s.AuditDatabase.ReadOnly(ctx, func(ctx) error { ... })`
+3. Call `s.Store.Get(ctx, id)`.
+4. Return entry or propagate not-found error.
+
+---
+
+## Transport Layer
+
+### `pkg/siteadmin/transport/handler_audit_logs_list.go`
+
+```go
+type AuditLogsListService interface {
+    ListAuditLogs(ctx context.Context, params service.ListAuditLogsParams) (*service.ListAuditLogsResult, error)
+}
+
+type AuditLogsListHandler struct {
+    AuditLogsList AuditLogsListService
+}
+
+type auditLogsListParams struct {
+    Page          uint64
+    PageSize      uint64
+    AffectedAppID string
+    Order         siteadmin.OrderDirection
+}
+
+func parseAuditLogsListParams(r *http.Request) auditLogsListParams {
+    q := r.URL.Query()
+
+    page := uint64(1)
+    if v := q.Get("page"); v != "" {
+        if n, err := strconv.ParseUint(v, 10, 64); err == nil && n >= 1 {
+            page = n
+        }
+    }
+
+    pageSize := uint64(20)
+    if v := q.Get("page_size"); v != "" {
+        if n, err := strconv.ParseUint(v, 10, 64); err == nil && n >= 1 {
+            pageSize = min(n, service.AuditLogsMaxPageSize)
+        }
+    }
+
+    order := siteadmin.OrderDirection(q.Get("order"))
+
+    return auditLogsListParams{
+        Page:          page,
+        PageSize:      pageSize,
+        AffectedAppID: q.Get("affected_app_id"),
+        Order:         order,
+    }
+}
+
+func (h *AuditLogsListHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+    params := parseAuditLogsListParams(r)
+
+    result, err := h.AuditLogsList.ListAuditLogs(r.Context(), service.ListAuditLogsParams{
+        Page:          params.Page,
+        PageSize:      params.PageSize,
+        AffectedAppID: params.AffectedAppID,
+        Order:         params.Order,
+    })
+    if err != nil {
+        writeError(w, r, err)
+        return
+    }
+
+    entries := make([]siteadmin.SiteAdminAuditLog, len(result.Entries))
+    for i, e := range result.Entries {
+        entries[i] = entryToSiteAdminAuditLog(e)
+    }
+
+    SiteAdminAPISuccessResponse{Body: siteadmin.SiteAdminAuditLogsListResponse{
+        AuditLogs:  entries,
+        TotalCount: result.TotalCount,
+        Page:       params.Page,
+        PageSize:   params.PageSize,
+    }}.WriteTo(w)
+}
+```
+
+Helper shared by both handlers (defined in `handler_audit_logs_list.go`):
+
+```go
+func entryToSiteAdminAuditLog(e service.AuditLogEntry) siteadmin.SiteAdminAuditLog {
+    a := siteadmin.SiteAdminAuditLog{
+        Id:           e.ID,
+        CreatedAt:    e.CreatedAt,
+        ActivityType: e.ActivityType,
+    }
+    if e.IPAddress != ""     { a.IpAddress    = &e.IPAddress }
+    if e.UserAgent != ""     { a.UserAgent    = &e.UserAgent }
+    if e.ActorUserID != ""   { a.ActorUserId  = &e.ActorUserID }
+    if e.AffectedAppID != "" { a.AffectedAppId = &e.AffectedAppID }
+    return a
+}
+```
+
+### `pkg/siteadmin/transport/handler_audit_log_get.go`
+
+```go
+type AuditLogGetService interface {
+    GetAuditLog(ctx context.Context, id string) (*service.AuditLogEntryDetail, error)
+}
+
+type AuditLogGetHandler struct {
+    AuditLogGet AuditLogGetService
+}
+
+func (h *AuditLogGetHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+    id := httproute.GetParam(r, "id")
+
+    entry, err := h.AuditLogGet.GetAuditLog(r.Context(), id)
+    if err != nil {
+        writeError(w, r, err)
+        return
+    }
+
+    a := entryToSiteAdminAuditLog(entry.AuditLogEntry)
+    detail := siteadmin.SiteAdminAuditLogDetail{
+        ActivityType:  a.ActivityType,
+        ActorUserId:   a.ActorUserId,
+        AffectedAppId: a.AffectedAppId,
+        CreatedAt:     a.CreatedAt,
+        Id:            a.Id,
+        IpAddress:     a.IpAddress,
+        UserAgent:     a.UserAgent,
+        Data:          entry.Data,
+    }
+
+    SiteAdminAPISuccessResponse{Body: detail}.WriteTo(w)
+}
+```
+
+---
+
+## DI Wiring
+
+### `pkg/siteadmin/service/deps.go`
+
+Add:
+```go
+wire.Struct(new(SiteAdminAuditLogStore), "*"),
+wire.Bind(new(SiteAdminAuditLogStoreIface), new(*SiteAdminAuditLogStore)),
+wire.Struct(new(SiteAdminAuditReadService), "*"),
+```
+
+### `pkg/siteadmin/deps.go`
+
+`SiteAdminAuditLogStore` needs a `*auditdb.SQLBuilderApp` scoped to the portal app ID. Add a provider:
+
+```go
+func provideSiteAdminAuditSQLBuilderApp(
+    b *auditdb.SQLBuilder,
+    c *portalconfig.AuthgearConfig,
+) *auditdb.SQLBuilderApp {
+    return b.WithAppID(config.AppID(c.AppID))
+}
+```
+
+Add to `DependencySet`:
+```go
+provideSiteAdminAuditSQLBuilderApp,
+wire.Bind(new(siteadminservice.SiteAdminAuditLogStoreIface), new(*siteadminservice.SiteAdminAuditLogStore)),
+wire.Bind(new(transport.AuditLogsListService), new(*siteadminservice.SiteAdminAuditReadService)),
+wire.Bind(new(transport.AuditLogGetService), new(*siteadminservice.SiteAdminAuditReadService)),
+```
+
+`auditdb.ReadHandle`, `auditdb.SQLBuilder`, and `auditdb.ReadSQLExecutor` are already provided by `auditdb.DependencySet` + `auditdb.NewReadHandle`.
+
+After changes: `make generate` + `go build ./pkg/siteadmin/... ./cmd/portal/...`.
+
+---
+
+## Test Plan
+
+**File:** `pkg/siteadmin/service/audit_read_test.go` (new, package `service`, Convey BDD style)
+
+Fake the store — same pattern as `fakeOwnerStore` in `app_test.go`:
+
+```go
+type fakeAuditLogStore struct {
+    rows []AuditLogEntry
+}
+
+func (f *fakeAuditLogStore) Count(_ context.Context, affectedAppID string) (int, error) {
+    return len(f.filtered(affectedAppID)), nil
+}
+
+func (f *fakeAuditLogStore) List(_ context.Context, affectedAppID string, _ siteadmin.OrderDirection, limit, offset uint64) ([]AuditLogEntry, error) {
+    rows := f.filtered(affectedAppID)
+    if offset >= uint64(len(rows)) {
+        return nil, nil
+    }
+    end := min(offset+limit, uint64(len(rows)))
+    return rows[offset:end], nil
+}
+
+func (f *fakeAuditLogStore) Get(_ context.Context, id string) (*AuditLogEntryDetail, error) {
+    for _, r := range f.rows {
+        if r.ID == id {
+            return &AuditLogEntryDetail{AuditLogEntry: r, Data: map[string]any{}}, nil
+        }
+    }
+    return nil, apierrors.NewNotFound("audit log not found")
+}
+
+func (f *fakeAuditLogStore) filtered(affectedAppID string) []AuditLogEntry {
+    if affectedAppID == "" {
+        return f.rows
+    }
+    var out []AuditLogEntry
+    for _, r := range f.rows {
+        if r.AffectedAppID == affectedAppID {
+            out = append(out, r)
+        }
+    }
+    return out
+}
+```
+
+`SiteAdminAuditReadService` is constructed with `AuditDatabase: &auditdb.ReadHandle{...}` (non-nil to pass the nil guard) and `Store: fakeStore`.
+
+**Test cases:**
+
+| Method | Case | Assertion |
+|---|---|---|
+| `ListAuditLogs` | no entries | `TotalCount == 0`, `Entries == []` |
+| `ListAuditLogs` | entries returned, `order=desc` (default) | newest first |
+| `ListAuditLogs` | `order=asc` | oldest first |
+| `ListAuditLogs` | `order` absent or invalid | defaults to `desc` |
+| `ListAuditLogs` | `AffectedAppID` filter | only matching entries |
+| `ListAuditLogs` | page 2 | correct offset slice |
+| `ListAuditLogs` | `AuditDatabase == nil` | empty result, no error |
+| `GetAuditLog` | found | fields populated, `Data` non-nil |
+| `GetAuditLog` | not found | `apierrors.NotFound` |
+| `GetAuditLog` | `AuditDatabase == nil` | `apierrors.NotFound` |
+
+---
+
+## Atomic Commit Plan
+
+| # | Commit message | Files | Verification |
+|---|---|---|---|
+| 1 | `Add SiteAdminAuditLogStore and SiteAdminAuditReadService` | `pkg/siteadmin/service/audit_read.go`, `pkg/siteadmin/service/audit_read_test.go`, `pkg/siteadmin/service/deps.go` | `go test ./pkg/siteadmin/service/...` · `make fmt` |
+| 2 | `Add audit log transport interfaces and param parsing` | `pkg/siteadmin/transport/handler_audit_logs_list.go`, `pkg/siteadmin/transport/handler_audit_log_get.go` | `go build ./pkg/siteadmin/...` · `make fmt` |
+| 3 | `Wire SiteAdminAuditReadService into audit log handlers` | `pkg/siteadmin/deps.go`, `pkg/siteadmin/wire_gen.go` | `go build ./pkg/siteadmin/... ./cmd/portal/...` · `make fmt` |
+| 4 | `Implement audit log handler ServeHTTP bodies` | `pkg/siteadmin/transport/handler_audit_logs_list.go`, `pkg/siteadmin/transport/handler_audit_log_get.go`, `.vettedpositions` | `go test ./pkg/siteadmin/...` · `go run ./devtools/goanalysis ./cmd/... ./pkg/...` · `make sort-vettedpositions` · `make check-tidy` |

--- a/e2e/tests/siteadmin/audit_logs.test.yaml
+++ b/e2e/tests/siteadmin/audit_logs.test.yaml
@@ -1,0 +1,146 @@
+name: Site Admin - Audit Logs
+app_id: e2e-portal
+before:
+- type: custom_audit_sql
+  custom_audit_sql:
+    path: fixture/seed_siteadmin_audit_logs.sql
+
+steps:
+# ── List: basic structure ──────────────────────────────────────────────────
+- name: list_audit_logs
+  action: http_request
+  http_request_method: GET
+  http_request_url: http://127.0.0.1:4003/api/v1/audit-logs
+  http_request_headers:
+    X-Authgear-Session-Valid: "true"
+    X-Authgear-User-Id: "00000000-0000-0000-0000-000000000001"
+  http_output:
+    http_status: 200
+    json_body: |
+      {
+        "audit_logs": "[[array]]",
+        "total_count": "[[number]]",
+        "page": 1,
+        "page_size": "[[number]]"
+      }
+
+# ── List: filter by affected_app_id ───────────────────────────────────────
+# Only the 3 seeded entries belong to e2e-audit-log-app.
+- name: list_audit_logs_filtered_by_app
+  action: http_request
+  http_request_method: GET
+  http_request_url: http://127.0.0.1:4003/api/v1/audit-logs
+  http_request_headers:
+    X-Authgear-Session-Valid: "true"
+    X-Authgear-User-Id: "00000000-0000-0000-0000-000000000001"
+  http_request_query:
+    affected_app_id: "e2e-audit-log-app"
+  http_output:
+    http_status: 200
+    json_body: |
+      {
+        "total_count": 3,
+        "page": 1,
+        "page_size": "[[number]]"
+      }
+
+# ── List: order=desc returns newest first ──────────────────────────────────
+# e2e000000000003 (2026-01-01 12:00) is newest.
+- name: list_audit_logs_order_desc
+  action: http_request
+  http_request_method: GET
+  http_request_url: http://127.0.0.1:4003/api/v1/audit-logs
+  http_request_headers:
+    X-Authgear-Session-Valid: "true"
+    X-Authgear-User-Id: "00000000-0000-0000-0000-000000000001"
+  http_request_query:
+    affected_app_id: "e2e-audit-log-app"
+    order: "desc"
+    page_size: "1"
+  http_output:
+    http_status: 200
+    json_body: |
+      {
+        "audit_logs": [{"id": "e2e000000000003"}],
+        "total_count": 3,
+        "page": 1,
+        "page_size": 1
+      }
+
+# ── List: order=asc returns oldest first ──────────────────────────────────
+# e2e000000000001 (2026-01-01 10:00) is oldest.
+- name: list_audit_logs_order_asc
+  action: http_request
+  http_request_method: GET
+  http_request_url: http://127.0.0.1:4003/api/v1/audit-logs
+  http_request_headers:
+    X-Authgear-Session-Valid: "true"
+    X-Authgear-User-Id: "00000000-0000-0000-0000-000000000001"
+  http_request_query:
+    affected_app_id: "e2e-audit-log-app"
+    order: "asc"
+    page_size: "1"
+  http_output:
+    http_status: 200
+    json_body: |
+      {
+        "audit_logs": [{"id": "e2e000000000001"}],
+        "total_count": 3,
+        "page": 1,
+        "page_size": 1
+      }
+
+# ── List: pagination ───────────────────────────────────────────────────────
+# page_size=1, page=2 → middle entry (e2e000000000002, 11:00) in desc order.
+- name: list_audit_logs_page_2
+  action: http_request
+  http_request_method: GET
+  http_request_url: http://127.0.0.1:4003/api/v1/audit-logs
+  http_request_headers:
+    X-Authgear-Session-Valid: "true"
+    X-Authgear-User-Id: "00000000-0000-0000-0000-000000000001"
+  http_request_query:
+    affected_app_id: "e2e-audit-log-app"
+    page_size: "1"
+    page: "2"
+  http_output:
+    http_status: 200
+    json_body: |
+      {
+        "audit_logs": [{"id": "e2e000000000002"}],
+        "total_count": 3,
+        "page": 2,
+        "page_size": 1
+      }
+
+# ── Get by ID: detail includes raw data ───────────────────────────────────
+- name: get_audit_log_detail
+  action: http_request
+  http_request_method: GET
+  http_request_url: http://127.0.0.1:4003/api/v1/audit-logs/e2e000000000003
+  http_request_headers:
+    X-Authgear-Session-Valid: "true"
+    X-Authgear-User-Id: "00000000-0000-0000-0000-000000000001"
+  http_output:
+    http_status: 200
+    json_body: |
+      {
+        "id": "e2e000000000003",
+        "activity_type": "site_admin.app.plan.updated",
+        "affected_app_id": "e2e-audit-log-app",
+        "actor_user_id": "00000000-0000-0000-0000-000000000001",
+        "ip_address": "127.0.0.1/32",
+        "user_agent": "Mozilla/5.0",
+        "data": "[[object]]"
+      }
+
+# ── Error cases ────────────────────────────────────────────────────────────
+- name: get_non_existent_audit_log_returns_404
+  action: http_request
+  http_request_method: GET
+  http_request_url: http://127.0.0.1:4003/api/v1/audit-logs/0000000000000000
+  http_request_headers:
+    X-Authgear-Session-Valid: "true"
+    X-Authgear-User-Id: "00000000-0000-0000-0000-000000000001"
+  http_output:
+    http_status: 404

--- a/e2e/tests/siteadmin/fixture/seed_siteadmin_audit_logs.sql
+++ b/e2e/tests/siteadmin/fixture/seed_siteadmin_audit_logs.sql
@@ -1,0 +1,118 @@
+-- Seed site admin audit log entries for the audit log API e2e test.
+-- Uses a dedicated affected app (e2e-audit-log-app) that no other test touches.
+-- All entries are stored under app_id = 'e2e-portal' (the portal app),
+-- matching how SiteAdminAuditService writes logs.
+--
+-- IDs are fixed hex sequence numbers; timestamps are spaced 1 hour apart
+-- so ordering assertions are deterministic regardless of wall-clock time.
+
+INSERT INTO _audit_log (id, app_id, created_at, user_id, activity_type, ip_address, user_agent, client_id, data)
+VALUES
+    (
+        'e2e000000000001',
+        'e2e-portal',
+        '2026-01-01 10:00:00',
+        '',
+        'site_admin.app.plan.updated',
+        '127.0.0.1',
+        'Mozilla/5.0',
+        '',
+        '{
+            "id": "e2e000000000001",
+            "seq": 1,
+            "type": "site_admin.app.plan.updated",
+            "context": {
+                "app_id": "e2e-portal",
+                "user_id": null,
+                "timestamp": 1751367600,
+                "triggered_by": "site_admin",
+                "ip_address": "127.0.0.1",
+                "user_agent": "Mozilla/5.0",
+                "audit_context": {
+                    "usage": "internal",
+                    "actor_user_id": "00000000-0000-0000-0000-000000000001",
+                    "http_referer": "",
+                    "http_url": "http://localhost:4003/api/v1/apps/e2e-audit-log-app/plan"
+                },
+                "preferred_languages": []
+            },
+            "payload": {
+                "app_id": "e2e-audit-log-app",
+                "old_plan": "free",
+                "new_plan": "startups"
+            }
+        }'::jsonb
+    ),
+    (
+        'e2e000000000002',
+        'e2e-portal',
+        '2026-01-01 11:00:00',
+        '',
+        'site_admin.app.collaborator.added',
+        '127.0.0.1',
+        'Mozilla/5.0',
+        '',
+        '{
+            "id": "e2e000000000002",
+            "seq": 2,
+            "type": "site_admin.app.collaborator.added",
+            "context": {
+                "app_id": "e2e-portal",
+                "user_id": null,
+                "timestamp": 1751371200,
+                "triggered_by": "site_admin",
+                "ip_address": "127.0.0.1",
+                "user_agent": "Mozilla/5.0",
+                "audit_context": {
+                    "usage": "internal",
+                    "actor_user_id": "00000000-0000-0000-0000-000000000001",
+                    "http_referer": "",
+                    "http_url": "http://localhost:4003/api/v1/apps/e2e-audit-log-app/collaborators"
+                },
+                "preferred_languages": []
+            },
+            "payload": {
+                "app_id": "e2e-audit-log-app",
+                "collaborator_id": "collab-001",
+                "user_id": "00000000-0000-0000-0000-000000000002",
+                "user_email": "editor@example.com",
+                "role": "editor"
+            }
+        }'::jsonb
+    ),
+    (
+        'e2e000000000003',
+        'e2e-portal',
+        '2026-01-01 12:00:00',
+        '',
+        'site_admin.app.plan.updated',
+        '127.0.0.1',
+        'Mozilla/5.0',
+        '',
+        '{
+            "id": "e2e000000000003",
+            "seq": 3,
+            "type": "site_admin.app.plan.updated",
+            "context": {
+                "app_id": "e2e-portal",
+                "user_id": null,
+                "timestamp": 1751374800,
+                "triggered_by": "site_admin",
+                "ip_address": "127.0.0.1",
+                "user_agent": "Mozilla/5.0",
+                "audit_context": {
+                    "usage": "internal",
+                    "actor_user_id": "00000000-0000-0000-0000-000000000001",
+                    "http_referer": "",
+                    "http_url": "http://localhost:4003/api/v1/apps/e2e-audit-log-app/plan"
+                },
+                "preferred_languages": []
+            },
+            "payload": {
+                "app_id": "e2e-audit-log-app",
+                "old_plan": "startups",
+                "new_plan": "enterprise"
+            }
+        }'::jsonb
+    )
+ON CONFLICT DO NOTHING;

--- a/pkg/api/siteadmin/gen.go
+++ b/pkg/api/siteadmin/gen.go
@@ -31,6 +31,24 @@ func (e CollaboratorRole) Valid() bool {
 	}
 }
 
+// Defines values for OrderDirection.
+const (
+	Asc  OrderDirection = "asc"
+	Desc OrderDirection = "desc"
+)
+
+// Valid indicates whether the value is a known member of the OrderDirection enum.
+func (e OrderDirection) Valid() bool {
+	switch e {
+	case Asc:
+		return true
+	case Desc:
+		return true
+	default:
+		return false
+	}
+}
+
 // Defines values for ListAppsParamsSort.
 const (
 	CreatedAt ListAppsParamsSort = "created_at"
@@ -46,24 +64,6 @@ func (e ListAppsParamsSort) Valid() bool {
 	case Mau:
 		return true
 	case Relevance:
-		return true
-	default:
-		return false
-	}
-}
-
-// Defines values for ListAppsParamsOrder.
-const (
-	Asc  ListAppsParamsOrder = "asc"
-	Desc ListAppsParamsOrder = "desc"
-)
-
-// Valid indicates whether the value is a known member of the ListAppsParamsOrder enum.
-func (e ListAppsParamsOrder) Valid() bool {
-	switch e {
-	case Asc:
-		return true
-	case Desc:
 		return true
 	default:
 		return false
@@ -210,6 +210,9 @@ type MonthlyActiveUsersUsage struct {
 	Counts []MonthlyActiveUsersCount `json:"counts"`
 }
 
+// OrderDirection Sort direction.
+type OrderDirection string
+
 // Plan defines model for Plan.
 type Plan struct {
 	// Name The plan name
@@ -219,6 +222,71 @@ type Plan struct {
 // PlansListResponse defines model for PlansListResponse.
 type PlansListResponse struct {
 	Plans []Plan `json:"plans"`
+}
+
+// SiteAdminAuditLog defines model for SiteAdminAuditLog.
+type SiteAdminAuditLog struct {
+	// ActivityType The site admin activity type (e.g. site_admin.app.plan.updated).
+	ActivityType string `json:"activity_type"`
+
+	// ActorUserId Portal user ID of the site admin who performed the action, extracted from audit_context.actor_user_id.
+	ActorUserId *string `json:"actor_user_id,omitempty"`
+
+	// AffectedAppId ID of the app that was acted on, extracted from data.payload.app_id.
+	AffectedAppId *string `json:"affected_app_id,omitempty"`
+
+	// CreatedAt When the event occurred, in RFC 3339 format.
+	CreatedAt time.Time `json:"created_at"`
+
+	// Id Audit log entry ID (hex-encoded sequence number).
+	Id string `json:"id"`
+
+	// IpAddress IP address of the actor.
+	IpAddress *string `json:"ip_address,omitempty"`
+
+	// UserAgent User agent string of the actor's browser.
+	UserAgent *string `json:"user_agent,omitempty"`
+}
+
+// SiteAdminAuditLogDetail defines model for SiteAdminAuditLogDetail.
+type SiteAdminAuditLogDetail struct {
+	// ActivityType The site admin activity type (e.g. site_admin.app.plan.updated).
+	ActivityType string `json:"activity_type"`
+
+	// ActorUserId Portal user ID of the site admin who performed the action, extracted from audit_context.actor_user_id.
+	ActorUserId *string `json:"actor_user_id,omitempty"`
+
+	// AffectedAppId ID of the app that was acted on, extracted from data.payload.app_id.
+	AffectedAppId *string `json:"affected_app_id,omitempty"`
+
+	// CreatedAt When the event occurred, in RFC 3339 format.
+	CreatedAt time.Time `json:"created_at"`
+
+	// Data Raw audit log data — the full event JSON stored in the _audit_log.data column, including context and payload.
+	Data map[string]interface{} `json:"data"`
+
+	// Id Audit log entry ID (hex-encoded sequence number).
+	Id string `json:"id"`
+
+	// IpAddress IP address of the actor.
+	IpAddress *string `json:"ip_address,omitempty"`
+
+	// UserAgent User agent string of the actor's browser.
+	UserAgent *string `json:"user_agent,omitempty"`
+}
+
+// SiteAdminAuditLogsListResponse defines model for SiteAdminAuditLogsListResponse.
+type SiteAdminAuditLogsListResponse struct {
+	AuditLogs []SiteAdminAuditLog `json:"audit_logs"`
+
+	// Page Current page number.
+	Page uint64 `json:"page"`
+
+	// PageSize Number of entries per page.
+	PageSize uint64 `json:"page_size"`
+
+	// TotalCount Total number of entries matching the query.
+	TotalCount int `json:"total_count"`
 }
 
 // BadRequest Error response envelope matching the api.Response struct.
@@ -251,14 +319,11 @@ type ListAppsParams struct {
 	Sort *ListAppsParamsSort `form:"sort,omitempty" json:"sort,omitempty"`
 
 	// Order Sort direction. Defaults to `desc`. Ignored when `sort=relevance` (relevance is always highest-match first).
-	Order *ListAppsParamsOrder `form:"order,omitempty" json:"order,omitempty"`
+	Order *OrderDirection `form:"order,omitempty" json:"order,omitempty"`
 }
 
 // ListAppsParamsSort defines parameters for ListApps.
 type ListAppsParamsSort string
-
-// ListAppsParamsOrder defines parameters for ListApps.
-type ListAppsParamsOrder string
 
 // GetAppMessagingUsageParams defines parameters for GetAppMessagingUsage.
 type GetAppMessagingUsageParams struct {
@@ -282,6 +347,21 @@ type GetAppMonthlyActiveUsersParams struct {
 
 	// EndMonth The end month, inclusive (1-12).
 	EndMonth int `form:"end_month" json:"end_month"`
+}
+
+// ListAuditLogsParams defines parameters for ListAuditLogs.
+type ListAuditLogsParams struct {
+	// Page Page number, 1-based. Defaults to 1.
+	Page *int `form:"page,omitempty" json:"page,omitempty"`
+
+	// PageSize Number of entries per page. Defaults to 20, maximum 100.
+	PageSize *int `form:"page_size,omitempty" json:"page_size,omitempty"`
+
+	// AffectedAppId Filter by the app that was acted on. When provided, only entries whose payload.app_id matches this value are returned.
+	AffectedAppId *string `form:"affected_app_id,omitempty" json:"affected_app_id,omitempty"`
+
+	// Order Sort direction for created_at. Defaults to `desc` (newest first).
+	Order *OrderDirection `form:"order,omitempty" json:"order,omitempty"`
 }
 
 // AddAppCollaboratorJSONRequestBody defines body for AddAppCollaborator for application/json ContentType.

--- a/pkg/siteadmin/deps.go
+++ b/pkg/siteadmin/deps.go
@@ -64,6 +64,7 @@ var DependencySet = wire.NewSet(
 	auditdb.NewReadHandle,
 	auditdb.NewWriteHandle,
 	wire.Struct(new(analytic.AuditDBReadStore), "*"),
+	wire.Bind(new(siteadminservice.SiteAdminAuditReadDatabase), new(*auditdb.ReadHandle)),
 
 	// usage.GlobalDBStore satisfies UsageServiceGlobalDBStore
 	wire.Struct(new(usagepkg.GlobalDBStore), "SQLBuilder", "SQLExecutor"),
@@ -91,4 +92,8 @@ var DependencySet = wire.NewSet(
 	wire.Bind(new(transport.PlansListService), new(*siteadminservice.PlanService)),
 	wire.Bind(new(transport.AppPlanChangeService), new(*siteadminservice.PlanService)),
 	wire.Bind(new(transport.CollaboratorPromoteService), new(*siteadminservice.CollaboratorService)),
+
+	// audit log read service transport bindings
+	wire.Bind(new(transport.AuditLogsListService), new(*siteadminservice.SiteAdminAuditReadService)),
+	wire.Bind(new(transport.AuditLogGetService), new(*siteadminservice.SiteAdminAuditReadService)),
 )

--- a/pkg/siteadmin/routes.go
+++ b/pkg/siteadmin/routes.go
@@ -49,6 +49,8 @@ func NewRouter(p *deps.RootProvider) http.Handler {
 	router.Add(transport.ConfigureMonthlyActiveUsersUsageRoute(route), p.Handler(newMonthlyActiveUsersUsageHandler))
 	router.Add(transport.ConfigurePlansListRoute(route), p.Handler(newPlansListHandler))
 	router.Add(transport.ConfigureAppPlanChangeRoute(route), p.Handler(newAppPlanChangeHandler))
+	router.Add(transport.ConfigureAuditLogsListRoute(route), p.Handler(newAuditLogsListHandler))
+	router.Add(transport.ConfigureAuditLogGetRoute(route), p.Handler(newAuditLogGetHandler))
 
 	return router.HTTPHandler()
 }

--- a/pkg/siteadmin/service/app.go
+++ b/pkg/siteadmin/service/app.go
@@ -48,12 +48,12 @@ type AppServiceOwnerStore interface {
 type ListAppsStoreParams struct {
 	Page           uint64
 	PageSize       uint64
-	AppID          string                        // optional; if set, WHERE cs.app_id LIKE 'prefix%'
-	PlanName       string                        // optional; if set, WHERE cs.plan_name = ?
-	OwnerUserIDs   []string                      // optional; if set, WHERE ac.user_id = ANY(?)
-	Sort           siteadmin.ListAppsParamsSort  // "created_at" | "mau" | "relevance"
-	Order          siteadmin.OrderDirection // "asc" | "desc"
-	LastMonthStart time.Time                     // exact start_time value for the usage record JOIN
+	AppID          string                       // optional; if set, WHERE cs.app_id LIKE 'prefix%'
+	PlanName       string                       // optional; if set, WHERE cs.plan_name = ?
+	OwnerUserIDs   []string                     // optional; if set, WHERE ac.user_id = ANY(?)
+	Sort           siteadmin.ListAppsParamsSort // "created_at" | "mau" | "relevance"
+	Order          siteadmin.OrderDirection     // "asc" | "desc"
+	LastMonthStart time.Time                    // exact start_time value for the usage record JOIN
 }
 
 // AppStoreRow is a single row returned by ListAppsWithStats.
@@ -206,9 +206,9 @@ type ListAppsParams struct {
 	PageSize    uint64
 	AppID       string
 	OwnerSearch string
-	Plan        string                        // exact plan name filter
-	Sort        siteadmin.ListAppsParamsSort  // "created_at" (default) | "mau" | "relevance"
-	Order       siteadmin.OrderDirection // "desc" (default) | "asc"
+	Plan        string                       // exact plan name filter
+	Sort        siteadmin.ListAppsParamsSort // "created_at" (default) | "mau" | "relevance"
+	Order       siteadmin.OrderDirection     // "desc" (default) | "asc"
 }
 
 type ListAppsResult struct {

--- a/pkg/siteadmin/service/app.go
+++ b/pkg/siteadmin/service/app.go
@@ -52,7 +52,7 @@ type ListAppsStoreParams struct {
 	PlanName       string                        // optional; if set, WHERE cs.plan_name = ?
 	OwnerUserIDs   []string                      // optional; if set, WHERE ac.user_id = ANY(?)
 	Sort           siteadmin.ListAppsParamsSort  // "created_at" | "mau" | "relevance"
-	Order          siteadmin.ListAppsParamsOrder // "asc" | "desc"
+	Order          siteadmin.OrderDirection // "asc" | "desc"
 	LastMonthStart time.Time                     // exact start_time value for the usage record JOIN
 }
 
@@ -208,7 +208,7 @@ type ListAppsParams struct {
 	OwnerSearch string
 	Plan        string                        // exact plan name filter
 	Sort        siteadmin.ListAppsParamsSort  // "created_at" (default) | "mau" | "relevance"
-	Order       siteadmin.ListAppsParamsOrder // "desc" (default) | "asc"
+	Order       siteadmin.OrderDirection // "desc" (default) | "asc"
 }
 
 type ListAppsResult struct {

--- a/pkg/siteadmin/service/audit_read.go
+++ b/pkg/siteadmin/service/audit_read.go
@@ -1,0 +1,238 @@
+package service
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"errors"
+	"time"
+
+	"github.com/authgear/authgear-server/pkg/api/apierrors"
+	"github.com/authgear/authgear-server/pkg/api/siteadmin"
+	"github.com/authgear/authgear-server/pkg/lib/infra/db/auditdb"
+	portalconfig "github.com/authgear/authgear-server/pkg/portal/config"
+)
+
+const AuditLogsMaxPageSize uint64 = 100
+
+// ---- Domain types -----------------------------------------------------------
+
+type AuditLogEntry struct {
+	ID            string
+	CreatedAt     time.Time
+	ActivityType  string
+	IPAddress     string
+	UserAgent     string
+	ActorUserID   string
+	AffectedAppID string
+}
+
+type AuditLogEntryDetail struct {
+	AuditLogEntry
+	Data map[string]any
+}
+
+type ListAuditLogsParams struct {
+	Page          uint64
+	PageSize      uint64
+	AffectedAppID string
+	Order         siteadmin.OrderDirection // "asc" | "desc"; defaults to "desc"
+}
+
+type ListAuditLogsResult struct {
+	Entries    []AuditLogEntry
+	TotalCount int
+}
+
+// ---- Store ------------------------------------------------------------------
+
+type SiteAdminAuditLogStoreIface interface {
+	Count(ctx context.Context, affectedAppID string) (int, error)
+	List(ctx context.Context, affectedAppID string, order siteadmin.OrderDirection, limit, offset uint64) ([]AuditLogEntry, error)
+	Get(ctx context.Context, id string) (*AuditLogEntryDetail, error)
+}
+
+type SiteAdminAuditLogStore struct {
+	SQLBuilder     *auditdb.SQLBuilder
+	SQLExecutor    *auditdb.ReadSQLExecutor
+	AuthgearConfig *portalconfig.AuthgearConfig
+}
+
+func (s *SiteAdminAuditLogStore) scopedBuilder() *auditdb.SQLBuilderApp {
+	return s.SQLBuilder.WithAppID(s.AuthgearConfig.AppID)
+}
+
+func (s *SiteAdminAuditLogStore) Count(ctx context.Context, affectedAppID string) (int, error) {
+	sb := s.scopedBuilder()
+	q := sb.
+		Select("COUNT(*)").
+		From(sb.TableName("_audit_log")).
+		Where("activity_type LIKE ?", "site_admin.%")
+	if affectedAppID != "" {
+		q = q.Where("data->'payload'->>'app_id' = ?", affectedAppID)
+	}
+
+	row, err := s.SQLExecutor.QueryRowWith(ctx, q)
+	if err != nil {
+		return 0, err
+	}
+	var count int
+	if err := row.Scan(&count); err != nil {
+		return 0, err
+	}
+	return count, nil
+}
+
+func (s *SiteAdminAuditLogStore) List(ctx context.Context, affectedAppID string, order siteadmin.OrderDirection, limit, offset uint64) ([]AuditLogEntry, error) {
+	dir := "DESC"
+	if order == siteadmin.Asc {
+		dir = "ASC"
+	}
+
+	sb := s.scopedBuilder()
+	q := sb.
+		Select(
+			"id", "created_at", "activity_type",
+			"ip_address::text", "user_agent",
+			"data->'context'->'audit_context'->>'actor_user_id'",
+			"data->'payload'->>'app_id'",
+		).
+		From(sb.TableName("_audit_log")).
+		Where("activity_type LIKE ?", "site_admin.%").
+		OrderBy("created_at " + dir).
+		Limit(limit).
+		Offset(offset)
+	if affectedAppID != "" {
+		q = q.Where("data->'payload'->>'app_id' = ?", affectedAppID)
+	}
+
+	rows, err := s.SQLExecutor.QueryWith(ctx, q)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var entries []AuditLogEntry
+	for rows.Next() {
+		var e AuditLogEntry
+		var ipAddress, userAgent, actorUserID, affectedAppIDVal sql.NullString
+		if err := rows.Scan(&e.ID, &e.CreatedAt, &e.ActivityType,
+			&ipAddress, &userAgent, &actorUserID, &affectedAppIDVal); err != nil {
+			return nil, err
+		}
+		e.IPAddress = ipAddress.String
+		e.UserAgent = userAgent.String
+		e.ActorUserID = actorUserID.String
+		e.AffectedAppID = affectedAppIDVal.String
+		entries = append(entries, e)
+	}
+	return entries, nil
+}
+
+func (s *SiteAdminAuditLogStore) Get(ctx context.Context, id string) (*AuditLogEntryDetail, error) {
+	sb := s.scopedBuilder()
+	q := sb.
+		Select(
+			"id", "created_at", "activity_type",
+			"ip_address::text", "user_agent",
+			"data->'context'->'audit_context'->>'actor_user_id'",
+			"data->'payload'->>'app_id'",
+			"data",
+		).
+		From(sb.TableName("_audit_log")).
+		Where("id = ?", id).
+		Where("activity_type LIKE ?", "site_admin.%")
+
+	row, err := s.SQLExecutor.QueryRowWith(ctx, q)
+	if err != nil {
+		return nil, err
+	}
+
+	var detail AuditLogEntryDetail
+	var ipAddress, userAgent, actorUserID, affectedAppIDVal sql.NullString
+	var dataBytes []byte
+	if err := row.Scan(&detail.ID, &detail.CreatedAt, &detail.ActivityType,
+		&ipAddress, &userAgent, &actorUserID, &affectedAppIDVal, &dataBytes); err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return nil, apierrors.NewNotFound("audit log not found")
+		}
+		return nil, err
+	}
+	detail.IPAddress = ipAddress.String
+	detail.UserAgent = userAgent.String
+	detail.ActorUserID = actorUserID.String
+	detail.AffectedAppID = affectedAppIDVal.String
+
+	if err := json.Unmarshal(dataBytes, &detail.Data); err != nil {
+		return nil, err
+	}
+	return &detail, nil
+}
+
+// ---- Service ----------------------------------------------------------------
+
+type SiteAdminAuditReadDatabase interface {
+	ReadOnly(ctx context.Context, do func(context.Context) error) error
+}
+
+type SiteAdminAuditReadService struct {
+	AuditDatabase SiteAdminAuditReadDatabase // nil when audit DB is not configured
+	Store         SiteAdminAuditLogStoreIface
+}
+
+func (s *SiteAdminAuditReadService) ListAuditLogs(ctx context.Context, params ListAuditLogsParams) (*ListAuditLogsResult, error) {
+	if s.AuditDatabase == nil {
+		return &ListAuditLogsResult{Entries: []AuditLogEntry{}}, nil
+	}
+
+	if params.Page == 0 {
+		params.Page = 1
+	}
+	if params.PageSize == 0 || params.PageSize > AuditLogsMaxPageSize {
+		params.PageSize = AuditLogsMaxPageSize
+	}
+	if !params.Order.Valid() {
+		params.Order = siteadmin.Desc
+	}
+
+	var entries []AuditLogEntry
+	var totalCount int
+	err := s.AuditDatabase.ReadOnly(ctx, func(ctx context.Context) error {
+		var e error
+		totalCount, e = s.Store.Count(ctx, params.AffectedAppID)
+		if e != nil {
+			return e
+		}
+		if totalCount == 0 {
+			return nil
+		}
+		offset := (params.Page - 1) * params.PageSize
+		entries, e = s.Store.List(ctx, params.AffectedAppID, params.Order, params.PageSize, offset)
+		return e
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	if entries == nil {
+		entries = []AuditLogEntry{}
+	}
+	return &ListAuditLogsResult{Entries: entries, TotalCount: totalCount}, nil
+}
+
+func (s *SiteAdminAuditReadService) GetAuditLog(ctx context.Context, id string) (*AuditLogEntryDetail, error) {
+	if s.AuditDatabase == nil {
+		return nil, apierrors.NewNotFound("audit log not found")
+	}
+
+	var entry *AuditLogEntryDetail
+	err := s.AuditDatabase.ReadOnly(ctx, func(ctx context.Context) error {
+		var e error
+		entry, e = s.Store.Get(ctx, id)
+		return e
+	})
+	if err != nil {
+		return nil, err
+	}
+	return entry, nil
+}

--- a/pkg/siteadmin/service/audit_read_test.go
+++ b/pkg/siteadmin/service/audit_read_test.go
@@ -1,0 +1,219 @@
+package service
+
+import (
+	"context"
+	"sort"
+	"testing"
+	"time"
+
+	. "github.com/smartystreets/goconvey/convey"
+
+	"github.com/authgear/authgear-server/pkg/api/apierrors"
+	"github.com/authgear/authgear-server/pkg/api/siteadmin"
+)
+
+// ---- Fakes ------------------------------------------------------------------
+
+type fakeAuditReadDatabase struct{}
+
+func (f *fakeAuditReadDatabase) ReadOnly(ctx context.Context, do func(context.Context) error) error {
+	return do(ctx)
+}
+
+type fakeAuditLogStore struct {
+	rows []AuditLogEntry
+}
+
+func (f *fakeAuditLogStore) Count(_ context.Context, affectedAppID string) (int, error) {
+	return len(f.filtered(affectedAppID)), nil
+}
+
+func (f *fakeAuditLogStore) List(_ context.Context, affectedAppID string, order siteadmin.OrderDirection, limit, offset uint64) ([]AuditLogEntry, error) {
+	rows := make([]AuditLogEntry, len(f.filtered(affectedAppID)))
+	copy(rows, f.filtered(affectedAppID))
+
+	sort.SliceStable(rows, func(i, j int) bool {
+		if order == siteadmin.Asc {
+			return rows[i].CreatedAt.Before(rows[j].CreatedAt)
+		}
+		return rows[i].CreatedAt.After(rows[j].CreatedAt)
+	})
+
+	if offset >= uint64(len(rows)) {
+		return nil, nil
+	}
+	end := min(offset+limit, uint64(len(rows)))
+	return rows[offset:end], nil
+}
+
+func (f *fakeAuditLogStore) Get(_ context.Context, id string) (*AuditLogEntryDetail, error) {
+	for _, r := range f.rows {
+		if r.ID == id {
+			return &AuditLogEntryDetail{AuditLogEntry: r, Data: map[string]any{"type": "test"}}, nil
+		}
+	}
+	return nil, apierrors.NewNotFound("audit log not found")
+}
+
+func (f *fakeAuditLogStore) filtered(affectedAppID string) []AuditLogEntry {
+	if affectedAppID == "" {
+		return f.rows
+	}
+	var out []AuditLogEntry
+	for _, r := range f.rows {
+		if r.AffectedAppID == affectedAppID {
+			out = append(out, r)
+		}
+	}
+	return out
+}
+
+// ---- Tests ------------------------------------------------------------------
+
+func TestSiteAdminAuditReadService(t *testing.T) {
+	t1 := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC) // oldest
+	t2 := time.Date(2026, 2, 1, 0, 0, 0, 0, time.UTC)
+	t3 := time.Date(2026, 3, 1, 0, 0, 0, 0, time.UTC) // newest
+
+	makeService := func(store *fakeAuditLogStore) *SiteAdminAuditReadService {
+		return &SiteAdminAuditReadService{
+			AuditDatabase: &fakeAuditReadDatabase{},
+			Store:         store,
+		}
+	}
+
+	Convey("SiteAdminAuditReadService", t, func() {
+
+		Convey("ListAuditLogs: no entries returns empty", func() {
+			svc := makeService(&fakeAuditLogStore{})
+			result, err := svc.ListAuditLogs(ctxWithSession(), ListAuditLogsParams{Page: 1, PageSize: 10})
+
+			So(err, ShouldBeNil)
+			So(result.TotalCount, ShouldEqual, 0)
+			So(result.Entries, ShouldResemble, []AuditLogEntry{})
+		})
+
+		Convey("ListAuditLogs: default order=desc returns newest first", func() {
+			store := &fakeAuditLogStore{rows: []AuditLogEntry{
+				{ID: "1", CreatedAt: t1, ActivityType: "site_admin.app.plan.updated"},
+				{ID: "2", CreatedAt: t2, ActivityType: "site_admin.app.plan.updated"},
+				{ID: "3", CreatedAt: t3, ActivityType: "site_admin.app.plan.updated"},
+			}}
+			svc := makeService(store)
+			result, err := svc.ListAuditLogs(ctxWithSession(), ListAuditLogsParams{Page: 1, PageSize: 10})
+
+			So(err, ShouldBeNil)
+			So(result.TotalCount, ShouldEqual, 3)
+			So(result.Entries[0].ID, ShouldEqual, "3") // newest first
+			So(result.Entries[2].ID, ShouldEqual, "1")
+		})
+
+		Convey("ListAuditLogs: order=asc returns oldest first", func() {
+			store := &fakeAuditLogStore{rows: []AuditLogEntry{
+				{ID: "1", CreatedAt: t1, ActivityType: "site_admin.app.plan.updated"},
+				{ID: "2", CreatedAt: t2, ActivityType: "site_admin.app.plan.updated"},
+				{ID: "3", CreatedAt: t3, ActivityType: "site_admin.app.plan.updated"},
+			}}
+			svc := makeService(store)
+			result, err := svc.ListAuditLogs(ctxWithSession(), ListAuditLogsParams{
+				Page: 1, PageSize: 10, Order: siteadmin.Asc,
+			})
+
+			So(err, ShouldBeNil)
+			So(result.Entries[0].ID, ShouldEqual, "1") // oldest first
+			So(result.Entries[2].ID, ShouldEqual, "3")
+		})
+
+		Convey("ListAuditLogs: invalid order defaults to desc", func() {
+			store := &fakeAuditLogStore{rows: []AuditLogEntry{
+				{ID: "1", CreatedAt: t1, ActivityType: "site_admin.app.plan.updated"},
+				{ID: "2", CreatedAt: t3, ActivityType: "site_admin.app.plan.updated"},
+			}}
+			svc := makeService(store)
+			result, err := svc.ListAuditLogs(ctxWithSession(), ListAuditLogsParams{
+				Page: 1, PageSize: 10, Order: "invalid",
+			})
+
+			So(err, ShouldBeNil)
+			So(result.Entries[0].ID, ShouldEqual, "2") // newest first (desc default)
+		})
+
+		Convey("ListAuditLogs: AffectedAppID filter", func() {
+			store := &fakeAuditLogStore{rows: []AuditLogEntry{
+				{ID: "1", CreatedAt: t1, ActivityType: "site_admin.app.plan.updated", AffectedAppID: "app-a"},
+				{ID: "2", CreatedAt: t2, ActivityType: "site_admin.app.plan.updated", AffectedAppID: "app-b"},
+				{ID: "3", CreatedAt: t3, ActivityType: "site_admin.app.plan.updated", AffectedAppID: "app-a"},
+			}}
+			svc := makeService(store)
+			result, err := svc.ListAuditLogs(ctxWithSession(), ListAuditLogsParams{
+				Page: 1, PageSize: 10, AffectedAppID: "app-a",
+			})
+
+			So(err, ShouldBeNil)
+			So(result.TotalCount, ShouldEqual, 2)
+			So(result.Entries[0].AffectedAppID, ShouldEqual, "app-a")
+			So(result.Entries[1].AffectedAppID, ShouldEqual, "app-a")
+		})
+
+		Convey("ListAuditLogs: page 2 returns correct slice", func() {
+			store := &fakeAuditLogStore{rows: []AuditLogEntry{
+				{ID: "1", CreatedAt: t1, ActivityType: "site_admin.app.plan.updated"},
+				{ID: "2", CreatedAt: t2, ActivityType: "site_admin.app.plan.updated"},
+				{ID: "3", CreatedAt: t3, ActivityType: "site_admin.app.plan.updated"},
+			}}
+			svc := makeService(store)
+			result, err := svc.ListAuditLogs(ctxWithSession(), ListAuditLogsParams{
+				Page: 2, PageSize: 2, // page 2 of 2-per-page = 3rd entry
+			})
+
+			So(err, ShouldBeNil)
+			So(result.TotalCount, ShouldEqual, 3)
+			So(result.Entries, ShouldHaveLength, 1)
+			So(result.Entries[0].ID, ShouldEqual, "1") // oldest (3rd in desc order)
+		})
+
+		Convey("ListAuditLogs: nil AuditDatabase returns empty", func() {
+			svc := &SiteAdminAuditReadService{AuditDatabase: nil, Store: &fakeAuditLogStore{}}
+			result, err := svc.ListAuditLogs(ctxWithSession(), ListAuditLogsParams{Page: 1, PageSize: 10})
+
+			So(err, ShouldBeNil)
+			So(result.TotalCount, ShouldEqual, 0)
+			So(result.Entries, ShouldResemble, []AuditLogEntry{})
+		})
+
+		Convey("GetAuditLog: found returns entry with Data", func() {
+			store := &fakeAuditLogStore{rows: []AuditLogEntry{
+				{ID: "abc123", CreatedAt: t1, ActivityType: "site_admin.app.plan.updated",
+					ActorUserID: "user-1", AffectedAppID: "app-x"},
+			}}
+			svc := makeService(store)
+			entry, err := svc.GetAuditLog(ctxWithSession(), "abc123")
+
+			So(err, ShouldBeNil)
+			So(entry.ID, ShouldEqual, "abc123")
+			So(entry.ActorUserID, ShouldEqual, "user-1")
+			So(entry.AffectedAppID, ShouldEqual, "app-x")
+			So(entry.Data, ShouldNotBeNil)
+		})
+
+		Convey("GetAuditLog: not found returns NotFound error", func() {
+			svc := makeService(&fakeAuditLogStore{})
+			_, err := svc.GetAuditLog(ctxWithSession(), "nonexistent")
+
+			So(err, ShouldNotBeNil)
+			So(apierrors.IsAPIErrorWithCondition(err, func(e *apierrors.APIError) bool {
+				return e.Code == 404
+			}), ShouldBeTrue)
+		})
+
+		Convey("GetAuditLog: nil AuditDatabase returns NotFound", func() {
+			svc := &SiteAdminAuditReadService{AuditDatabase: nil, Store: &fakeAuditLogStore{}}
+			_, err := svc.GetAuditLog(ctxWithSession(), "abc123")
+
+			So(err, ShouldNotBeNil)
+			So(apierrors.IsAPIErrorWithCondition(err, func(e *apierrors.APIError) bool {
+				return e.Code == 404
+			}), ShouldBeTrue)
+		})
+	})
+}

--- a/pkg/siteadmin/service/deps.go
+++ b/pkg/siteadmin/service/deps.go
@@ -23,5 +23,8 @@ var DependencySet = wire.NewSet(
 	wire.Struct(new(UsageService), "*"),
 	wire.Struct(new(PlanService), "*"),
 	wire.Struct(new(SiteAdminAuditService), "*"),
+	wire.Struct(new(SiteAdminAuditLogStore), "*"),
+	wire.Bind(new(SiteAdminAuditLogStoreIface), new(*SiteAdminAuditLogStore)),
+	wire.Struct(new(SiteAdminAuditReadService), "*"),
 	NewHTTPClient,
 )

--- a/pkg/siteadmin/transport/deps.go
+++ b/pkg/siteadmin/transport/deps.go
@@ -13,5 +13,7 @@ var DependencySet = wire.NewSet(
 	wire.Struct(new(MonthlyActiveUsersUsageHandler), "*"),
 	wire.Struct(new(PlansListHandler), "*"),
 	wire.Struct(new(AppPlanChangeHandler), "*"),
+	wire.Struct(new(AuditLogsListHandler), "*"),
+	wire.Struct(new(AuditLogGetHandler), "*"),
 	wire.Struct(new(AuthzMiddleware), "*"),
 )

--- a/pkg/siteadmin/transport/handler_apps_list.go
+++ b/pkg/siteadmin/transport/handler_apps_list.go
@@ -30,7 +30,7 @@ type AppsListParams struct {
 	OwnerSearch string
 	Plan        string
 	Sort        siteadmin.ListAppsParamsSort
-	Order       siteadmin.ListAppsParamsOrder
+	Order       siteadmin.OrderDirection
 }
 
 func parseAppsListParams(r *http.Request) AppsListParams {
@@ -51,7 +51,7 @@ func parseAppsListParams(r *http.Request) AppsListParams {
 	}
 
 	sortVal := siteadmin.ListAppsParamsSort(q.Get("sort"))
-	orderVal := siteadmin.ListAppsParamsOrder(q.Get("order"))
+	orderVal := siteadmin.OrderDirection(q.Get("order"))
 
 	return AppsListParams{
 		Page:        page,

--- a/pkg/siteadmin/transport/handler_audit_log_get.go
+++ b/pkg/siteadmin/transport/handler_audit_log_get.go
@@ -10,7 +10,7 @@ import (
 )
 
 func ConfigureAuditLogGetRoute(route httproute.Route) httproute.Route {
-	return route.WithMethods("GET").
+	return route.WithMethods("OPTIONS", "GET").
 		WithPathPattern("/api/v1/audit-logs/:id")
 }
 

--- a/pkg/siteadmin/transport/handler_audit_log_get.go
+++ b/pkg/siteadmin/transport/handler_audit_log_get.go
@@ -1,8 +1,10 @@
 package transport
 
 import (
+	"context"
 	"net/http"
 
+	service "github.com/authgear/authgear-server/pkg/siteadmin/service"
 	"github.com/authgear/authgear-server/pkg/util/httproute"
 )
 
@@ -11,7 +13,12 @@ func ConfigureAuditLogGetRoute(route httproute.Route) httproute.Route {
 		WithPathPattern("/api/v1/audit-logs/:id")
 }
 
+type AuditLogGetService interface {
+	GetAuditLog(ctx context.Context, id string) (*service.AuditLogEntryDetail, error)
+}
+
 type AuditLogGetHandler struct {
+	AuditLogGet AuditLogGetService
 }
 
 func (h *AuditLogGetHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {

--- a/pkg/siteadmin/transport/handler_audit_log_get.go
+++ b/pkg/siteadmin/transport/handler_audit_log_get.go
@@ -1,0 +1,19 @@
+package transport
+
+import (
+	"net/http"
+
+	"github.com/authgear/authgear-server/pkg/util/httproute"
+)
+
+func ConfigureAuditLogGetRoute(route httproute.Route) httproute.Route {
+	return route.WithMethods("GET").
+		WithPathPattern("/api/v1/audit-logs/:id")
+}
+
+type AuditLogGetHandler struct {
+}
+
+func (h *AuditLogGetHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	http.NotFound(w, r)
+}

--- a/pkg/siteadmin/transport/handler_audit_log_get.go
+++ b/pkg/siteadmin/transport/handler_audit_log_get.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"net/http"
 
+	"github.com/authgear/authgear-server/pkg/api/siteadmin"
 	service "github.com/authgear/authgear-server/pkg/siteadmin/service"
 	"github.com/authgear/authgear-server/pkg/util/httproute"
 )
@@ -22,5 +23,25 @@ type AuditLogGetHandler struct {
 }
 
 func (h *AuditLogGetHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	http.NotFound(w, r)
+	id := httproute.GetParam(r, "id")
+
+	entry, err := h.AuditLogGet.GetAuditLog(r.Context(), id)
+	if err != nil {
+		writeError(w, r, err)
+		return
+	}
+
+	a := entryToSiteAdminAuditLog(entry.AuditLogEntry)
+	detail := siteadmin.SiteAdminAuditLogDetail{
+		ActivityType:  a.ActivityType,
+		ActorUserId:   a.ActorUserId,
+		AffectedAppId: a.AffectedAppId,
+		CreatedAt:     a.CreatedAt,
+		Id:            a.Id,
+		IpAddress:     a.IpAddress,
+		UserAgent:     a.UserAgent,
+		Data:          entry.Data,
+	}
+
+	SiteAdminAPISuccessResponse{Body: detail}.WriteTo(w)
 }

--- a/pkg/siteadmin/transport/handler_audit_logs_list.go
+++ b/pkg/siteadmin/transport/handler_audit_logs_list.go
@@ -1,8 +1,12 @@
 package transport
 
 import (
+	"context"
 	"net/http"
+	"strconv"
 
+	"github.com/authgear/authgear-server/pkg/api/siteadmin"
+	service "github.com/authgear/authgear-server/pkg/siteadmin/service"
 	"github.com/authgear/authgear-server/pkg/util/httproute"
 )
 
@@ -11,7 +15,46 @@ func ConfigureAuditLogsListRoute(route httproute.Route) httproute.Route {
 		WithPathPattern("/api/v1/audit-logs")
 }
 
+type AuditLogsListService interface {
+	ListAuditLogs(ctx context.Context, params service.ListAuditLogsParams) (*service.ListAuditLogsResult, error)
+}
+
 type AuditLogsListHandler struct {
+	AuditLogsList AuditLogsListService
+}
+
+type auditLogsListParams struct {
+	Page          uint64
+	PageSize      uint64
+	AffectedAppID string
+	Order         siteadmin.OrderDirection
+}
+
+func parseAuditLogsListParams(r *http.Request) auditLogsListParams {
+	q := r.URL.Query()
+
+	page := uint64(1)
+	if v := q.Get("page"); v != "" {
+		if n, err := strconv.ParseUint(v, 10, 64); err == nil && n >= 1 {
+			page = n
+		}
+	}
+
+	pageSize := uint64(20)
+	if v := q.Get("page_size"); v != "" {
+		if n, err := strconv.ParseUint(v, 10, 64); err == nil && n >= 1 {
+			pageSize = min(n, service.AuditLogsMaxPageSize)
+		}
+	}
+
+	order := siteadmin.OrderDirection(q.Get("order"))
+
+	return auditLogsListParams{
+		Page:          page,
+		PageSize:      pageSize,
+		AffectedAppID: q.Get("affected_app_id"),
+		Order:         order,
+	}
 }
 
 func (h *AuditLogsListHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {

--- a/pkg/siteadmin/transport/handler_audit_logs_list.go
+++ b/pkg/siteadmin/transport/handler_audit_logs_list.go
@@ -1,0 +1,19 @@
+package transport
+
+import (
+	"net/http"
+
+	"github.com/authgear/authgear-server/pkg/util/httproute"
+)
+
+func ConfigureAuditLogsListRoute(route httproute.Route) httproute.Route {
+	return route.WithMethods("OPTIONS", "GET").
+		WithPathPattern("/api/v1/audit-logs")
+}
+
+type AuditLogsListHandler struct {
+}
+
+func (h *AuditLogsListHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	http.NotFound(w, r)
+}

--- a/pkg/siteadmin/transport/handler_audit_logs_list.go
+++ b/pkg/siteadmin/transport/handler_audit_logs_list.go
@@ -57,6 +57,50 @@ func parseAuditLogsListParams(r *http.Request) auditLogsListParams {
 	}
 }
 
+func entryToSiteAdminAuditLog(e service.AuditLogEntry) siteadmin.SiteAdminAuditLog {
+	a := siteadmin.SiteAdminAuditLog{
+		Id:           e.ID,
+		CreatedAt:    e.CreatedAt,
+		ActivityType: e.ActivityType,
+	}
+	if e.IPAddress != "" {
+		a.IpAddress = &e.IPAddress
+	}
+	if e.UserAgent != "" {
+		a.UserAgent = &e.UserAgent
+	}
+	if e.ActorUserID != "" {
+		a.ActorUserId = &e.ActorUserID
+	}
+	if e.AffectedAppID != "" {
+		a.AffectedAppId = &e.AffectedAppID
+	}
+	return a
+}
+
 func (h *AuditLogsListHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	http.NotFound(w, r)
+	params := parseAuditLogsListParams(r)
+
+	result, err := h.AuditLogsList.ListAuditLogs(r.Context(), service.ListAuditLogsParams{
+		Page:          params.Page,
+		PageSize:      params.PageSize,
+		AffectedAppID: params.AffectedAppID,
+		Order:         params.Order,
+	})
+	if err != nil {
+		writeError(w, r, err)
+		return
+	}
+
+	entries := make([]siteadmin.SiteAdminAuditLog, len(result.Entries))
+	for i, e := range result.Entries {
+		entries[i] = entryToSiteAdminAuditLog(e)
+	}
+
+	SiteAdminAPISuccessResponse{Body: siteadmin.SiteAdminAuditLogsListResponse{
+		AuditLogs:  entries,
+		TotalCount: result.TotalCount,
+		Page:       params.Page,
+		PageSize:   params.PageSize,
+	}}.WriteTo(w)
 }

--- a/pkg/siteadmin/wire.go
+++ b/pkg/siteadmin/wire.go
@@ -118,6 +118,20 @@ func newMonthlyActiveUsersUsageHandler(p *deps.RequestProvider) http.Handler {
 	))
 }
 
+func newAuditLogsListHandler(p *deps.RequestProvider) http.Handler {
+	panic(wire.Build(
+		DependencySet,
+		wire.Bind(new(http.Handler), new(*transport.AuditLogsListHandler)),
+	))
+}
+
+func newAuditLogGetHandler(p *deps.RequestProvider) http.Handler {
+	panic(wire.Build(
+		DependencySet,
+		wire.Bind(new(http.Handler), new(*transport.AuditLogGetHandler)),
+	))
+}
+
 func newPlansListHandler(p *deps.RequestProvider) http.Handler {
 	panic(wire.Build(
 		DependencySet,

--- a/pkg/siteadmin/wire_gen.go
+++ b/pkg/siteadmin/wire_gen.go
@@ -585,6 +585,16 @@ func newMonthlyActiveUsersUsageHandler(p *deps.RequestProvider) http.Handler {
 	return monthlyActiveUsersUsageHandler
 }
 
+func newAuditLogsListHandler(p *deps.RequestProvider) http.Handler {
+	auditLogsListHandler := &transport.AuditLogsListHandler{}
+	return auditLogsListHandler
+}
+
+func newAuditLogGetHandler(p *deps.RequestProvider) http.Handler {
+	auditLogGetHandler := &transport.AuditLogGetHandler{}
+	return auditLogGetHandler
+}
+
 func newPlansListHandler(p *deps.RequestProvider) http.Handler {
 	rootProvider := p.RootProvider
 	pool := rootProvider.Database

--- a/pkg/siteadmin/wire_gen.go
+++ b/pkg/siteadmin/wire_gen.go
@@ -586,12 +586,52 @@ func newMonthlyActiveUsersUsageHandler(p *deps.RequestProvider) http.Handler {
 }
 
 func newAuditLogsListHandler(p *deps.RequestProvider) http.Handler {
-	auditLogsListHandler := &transport.AuditLogsListHandler{}
+	rootProvider := p.RootProvider
+	pool := rootProvider.Database
+	environmentConfig := rootProvider.EnvironmentConfig
+	databaseEnvironmentConfig := &environmentConfig.DatabaseConfig
+	auditDatabaseCredentials := deps.ProvideAuditDatabaseCredentials(environmentConfig)
+	readHandle := auditdb.NewReadHandle(pool, databaseEnvironmentConfig, auditDatabaseCredentials)
+	sqlBuilder := auditdb.NewSQLBuilder(auditDatabaseCredentials)
+	readSQLExecutor := auditdb.NewReadSQLExecutor(readHandle)
+	authgearConfig := rootProvider.AuthgearConfig
+	siteAdminAuditLogStore := &service.SiteAdminAuditLogStore{
+		SQLBuilder:     sqlBuilder,
+		SQLExecutor:    readSQLExecutor,
+		AuthgearConfig: authgearConfig,
+	}
+	siteAdminAuditReadService := &service.SiteAdminAuditReadService{
+		AuditDatabase: readHandle,
+		Store:         siteAdminAuditLogStore,
+	}
+	auditLogsListHandler := &transport.AuditLogsListHandler{
+		AuditLogsList: siteAdminAuditReadService,
+	}
 	return auditLogsListHandler
 }
 
 func newAuditLogGetHandler(p *deps.RequestProvider) http.Handler {
-	auditLogGetHandler := &transport.AuditLogGetHandler{}
+	rootProvider := p.RootProvider
+	pool := rootProvider.Database
+	environmentConfig := rootProvider.EnvironmentConfig
+	databaseEnvironmentConfig := &environmentConfig.DatabaseConfig
+	auditDatabaseCredentials := deps.ProvideAuditDatabaseCredentials(environmentConfig)
+	readHandle := auditdb.NewReadHandle(pool, databaseEnvironmentConfig, auditDatabaseCredentials)
+	sqlBuilder := auditdb.NewSQLBuilder(auditDatabaseCredentials)
+	readSQLExecutor := auditdb.NewReadSQLExecutor(readHandle)
+	authgearConfig := rootProvider.AuthgearConfig
+	siteAdminAuditLogStore := &service.SiteAdminAuditLogStore{
+		SQLBuilder:     sqlBuilder,
+		SQLExecutor:    readSQLExecutor,
+		AuthgearConfig: authgearConfig,
+	}
+	siteAdminAuditReadService := &service.SiteAdminAuditReadService{
+		AuditDatabase: readHandle,
+		Store:         siteAdminAuditLogStore,
+	}
+	auditLogGetHandler := &transport.AuditLogGetHandler{
+		AuditLogGet: siteAdminAuditReadService,
+	}
 	return auditLogGetHandler
 }
 


### PR DESCRIPTION
ref DEV-3549

Add GET `/api/v1/audit-logs` and GET `/api/v1/audit-logs/:id` endpoints to the site admin API for querying site admin audit log entries.

- Filter by affected app (affected_app_id)
- Sort direction (order=asc|desc, defaults to desc)
- Offset-based pagination (page, page_size, max 100)
- Detail endpoint returns the full raw data field


  