### PR TITLE
Fix access token not issued when offline_access scope is absent

### DIFF
--- a/e2e/cmd/e2e/pkg/generate_refresh_token.go
+++ b/e2e/cmd/e2e/pkg/generate_refresh_token.go
@@ -5,6 +5,8 @@ import (
 	"errors"
 	"time"
 
+	"github.com/lib/pq"
+
 	"github.com/authgear/authgear-server/pkg/api/model"
 	"github.com/authgear/authgear-server/pkg/lib/config"
 	"github.com/authgear/authgear-server/pkg/lib/config/configsource"
@@ -19,6 +21,15 @@ import (
 	"github.com/authgear/authgear-server/pkg/util/httputil"
 	"github.com/authgear/authgear-server/pkg/util/uuid"
 )
+
+// isUniqueViolation reports whether err is a Postgres unique_violation (23505).
+func isUniqueViolation(err error) bool {
+	var pqErr *pq.Error
+	if errors.As(err, &pqErr) {
+		return pqErr.Code == "23505"
+	}
+	return false
+}
 
 const refreshTokenLifetime = 30 * 24 * time.Hour
 
@@ -71,26 +82,38 @@ func (c *End2End) GenerateRefreshToken(ctx context.Context, appID, userID, clien
 		scopes := []string{oauth.ScopeOpenID, oauth.OfflineAccess, oauth.FullAccessScope}
 
 		var authz *oauth.Authorization
-		err := appProvider.AppDatabase.WithTx(ctx, func(ctx context.Context) error {
-			existing, err := authzStore.Get(ctx, userID, clientID)
-			if err != nil && !errors.Is(err, oauth.ErrAuthorizationNotFound) {
-				return err
-			}
-			if existing != nil {
-				authz = existing
-				return nil
-			}
-			authz = &oauth.Authorization{
-				ID:        uuid.New(),
-				AppID:     string(appIDCfg),
-				ClientID:  clientID,
-				UserID:    userID,
-				CreatedAt: now,
-				UpdatedAt: now,
-				Scopes:    scopes,
-			}
-			return authzStore.Create(ctx, authz)
-		})
+		getOrCreate := func() error {
+			return appProvider.AppDatabase.WithTx(ctx, func(ctx context.Context) error {
+				existing, err := authzStore.Get(ctx, userID, clientID)
+				if err != nil && !errors.Is(err, oauth.ErrAuthorizationNotFound) {
+					return err
+				}
+				if existing != nil {
+					authz = existing
+					return nil
+				}
+				authz = &oauth.Authorization{
+					ID:        uuid.New(),
+					AppID:     string(appIDCfg),
+					ClientID:  clientID,
+					UserID:    userID,
+					CreatedAt: now,
+					UpdatedAt: now,
+					Scopes:    scopes,
+				}
+				return authzStore.Create(ctx, authz)
+			})
+		}
+		err := getOrCreate()
+		if err != nil && isUniqueViolation(err) {
+			// Lost a Get-then-Create race to a concurrent call for the same
+			// (app, user, client) e.g. when e2e tests share an actor across
+			// parallel test cases. By the time Postgres reports the unique
+			// violation, the winning transaction has already committed, so a
+			// retry will find the row via Get.
+			authz = nil
+			err = getOrCreate()
+		}
 		if err != nil {
 			return err
 		}

--- a/e2e/tests/oidc/authorization_code_no_offline_access.test.yaml
+++ b/e2e/tests/oidc/authorization_code_no_offline_access.test.yaml
@@ -1,0 +1,108 @@
+name: Authorization code exchange without offline_access scope still issues an access token
+authgear.yaml:
+  override: |
+    authentication:
+      identities:
+      - login_id
+      primary_authenticators:
+      - password
+before:
+  - type: user_import
+    user_import: users.json
+steps:
+  # A public client requesting authorization_code without the offline_access
+  # scope must still receive an access token; only the refresh token is
+  # omitted. See DEV-3545.
+  - name: authorize
+    action: http_request
+    http_request_method: GET
+    http_request_url: http://{{.AppID}}.authgeare2e.localhost:4000/oauth2/authorize
+    http_request_follow_redirects: false
+    http_request_query:
+      client_id: e2e
+      redirect_uri: http://localhost:4000
+      response_type: code
+      code_challenge_method: S256
+      code_challenge: RqIZl4LIgn8KxW9QO-nTnv7pf0CnNrksx9fF-CXP2FE
+      scope: "openid https://authgear.com/scopes/full-access"
+      x_sso_enabled: "false"
+    http_output:
+      http_status: 302
+
+  - name: create_flow
+    action: create
+    input: |
+      {
+        "type": "login",
+        "name": "default",
+        "url_query": "{{ (urlParse .steps.authorize.result.http_response_headers.location).query }}"
+      }
+    output:
+      result: |
+        {
+          "action": {
+            "type": "identify"
+          }
+        }
+
+  - name: identify
+    action: input
+    input: |
+      {
+        "identification": "username",
+        "login_id": "e2e_userinfo_user"
+      }
+    output:
+      result: |
+        {
+          "action": {
+            "type": "authenticate"
+          }
+        }
+
+  - name: authenticate
+    action: input
+    input: |
+      {
+        "authentication": "primary_password",
+        "password": "password"
+      }
+    output:
+      result: |
+        {
+          "action": {
+            "type": "finished",
+            "data": {
+              "finish_redirect_uri": "[[string]]"
+            }
+          }
+        }
+
+  # This is the step that used to fail with "cannot issue access token"
+  # because the token endpoint incorrectly required offline_access to be
+  # requested before it would issue an access token.
+  - name: exchange_code
+    action: oauth_exchange_code
+    oauth_exchange_code_code_verifier: "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQ"
+    oauth_exchange_code_redirect_uri: "{{ .steps.authenticate.result.action.data.finish_redirect_uri }}"
+    output:
+      result: |
+        {
+          "id_token": {
+            "sub": "[[string]]"
+          }
+        }
+
+  # Confirm the issued access token actually works.
+  - name: userinfo
+    action: http_request
+    http_request_method: GET
+    http_request_url: http://{{.AppID}}.authgeare2e.localhost:4000/oauth2/userinfo
+    http_request_headers:
+      Authorization: "Bearer {{ .steps.exchange_code.result.access_token }}"
+    http_output:
+      http_status: 200
+      json_body: |
+        {
+          "sub": "[[string]]"
+        }

--- a/pkg/lib/oauth/handler/handler_token.go
+++ b/pkg/lib/oauth/handler/handler_token.go
@@ -1891,8 +1891,8 @@ func (h *TokenHandler) doIssueTokensForAuthorizationCode(
 				panic(fmt.Errorf("unknown session type: %v", typ))
 			}
 		}
-	} else if client.IsConfidential() {
-		// allow issuing access tokens if scopes don't contain offline_access and the client is confidential
+	} else {
+		// allow issuing access tokens if scopes don't contain offline_access
 		// fill the response with nil for not returning the refresh token
 		offlineGrant, _, err := h.issueOfflineGrant(
 			ctx,

--- a/pkg/lib/oauth/handler/handler_token_test.go
+++ b/pkg/lib/oauth/handler/handler_token_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/lestrrat-go/jwx/v2/jwt"
 	. "github.com/smartystreets/goconvey/convey"
 
+	"github.com/authgear/authgear-server/pkg/lib/authn/authenticationinfo"
 	"github.com/authgear/authgear-server/pkg/lib/config"
 	"github.com/authgear/authgear-server/pkg/lib/oauth"
 	"github.com/authgear/authgear-server/pkg/lib/oauth/handler"
@@ -25,6 +26,7 @@ import (
 	"github.com/authgear/authgear-server/pkg/lib/session/access"
 	"github.com/authgear/authgear-server/pkg/util/clock"
 	"github.com/authgear/authgear-server/pkg/util/httputil"
+	"github.com/authgear/authgear-server/pkg/util/pkce"
 )
 
 func TestTokenHandler(t *testing.T) {
@@ -47,6 +49,8 @@ func TestTokenHandler(t *testing.T) {
 		).AnyTimes()
 
 		offlineGrants := NewMockTokenHandlerOfflineGrantStore(ctrl)
+		codeGrants := NewMockTokenHandlerCodeGrantStore(ctrl)
+		uiInfoResolver := NewMockUIInfoResolver(ctrl)
 
 		authorizations := NewMockAuthorizationService(ctrl)
 		codeGrantService := NewMockTokenHandlerCodeGrantService(ctrl)
@@ -84,6 +88,8 @@ func TestTokenHandler(t *testing.T) {
 			AccessTokenEncoding:             accessTokenEncoding,
 			ClientResolver:                  clientResolver,
 			Authorizations:                  authorizations,
+			CodeGrants:                      codeGrants,
+			UIInfoResolver:                  uiInfoResolver,
 			OfflineGrants:                   offlineGrants,
 			OfflineGrantService:             offlineGrantService,
 			IDTokenIssuer:                   idTokenIssuer,
@@ -344,6 +350,111 @@ func TestTokenHandler(t *testing.T) {
 				So(err, ShouldBeNil)
 				So(body["error"], ShouldEqual, "x_rate_limited")
 				So(body["error_description"], ShouldEqual, "rate limit exceeded, please try again later.")
+			})
+		})
+
+		Convey("handle authorization_code", func() {
+			Convey("issues an access token without a refresh token when offline_access is not requested", func() {
+				req, _ := http.NewRequest("POST", "/token", nil)
+				clientResolver.ClientConfigs["app-id"] = &config.OAuthClientConfig{
+					ClientID:        "app-id",
+					ApplicationType: config.OAuthClientApplicationTypeSPA,
+					RedirectURIs: []string{
+						"https://example.com/",
+					},
+				}
+
+				verifier := pkce.GenerateS256Verifier()
+
+				authzRequest := protocol.AuthorizationRequest{
+					"client_id":             "app-id",
+					"redirect_uri":          "https://example.com/",
+					"scope":                 "some_scope",
+					"code_challenge":        verifier.Challenge(),
+					"code_challenge_method": "S256",
+				}
+				codeGrant := &oauth.CodeGrant{
+					AppID:           appID,
+					AuthorizationID: "authz-id",
+					AuthenticationInfo: authenticationinfo.T{
+						UserID: "user-id",
+					},
+					RedirectURI:          "https://example.com/",
+					AuthorizationRequest: authzRequest,
+					ExpireAt:             clock.NowUTC().Add(time.Hour),
+				}
+				codeHash := oauth.HashToken("the-code")
+				codeGrants.EXPECT().GetCodeGrant(gomock.Any(), codeHash).Return(codeGrant, nil)
+				codeGrants.EXPECT().DeleteCodeGrant(gomock.Any(), codeGrant).Return(nil)
+
+				uiInfoResolver.EXPECT().ResolveForAuthorizationEndpoint(gomock.Any(), gomock.Any(), gomock.Any()).
+					Return(&oidc.UIInfo{}, nil, nil)
+
+				authz := &oauth.Authorization{
+					ID:       "authz-id",
+					ClientID: "app-id",
+					UserID:   "user-id",
+					Scopes:   []string{"some_scope"},
+				}
+				authorizations.EXPECT().GetByID(gomock.Any(), "authz-id").Return(authz, nil)
+
+				rateLimiter.EXPECT().Allow(gomock.Any(), ratelimit.BucketSpec{
+					Name:           ratelimit.OAuthTokenPerIP,
+					RateLimitName:  ratelimit.RateLimitOAuthTokenGeneralPerIP,
+					RateLimitGroup: ratelimit.RateLimitGroupOAuthTokenGeneral,
+					Arguments:      []string{"1.2.3.4"},
+					Period:         time.Minute,
+					Burst:          120,
+					Enabled:        true,
+				}).Return(nil, nil)
+				rateLimiter.EXPECT().Allow(gomock.Any(), ratelimit.BucketSpec{
+					Name:           ratelimit.OAuthTokenPerUser,
+					RateLimitName:  ratelimit.RateLimitOAuthTokenGeneralPerUser,
+					RateLimitGroup: ratelimit.RateLimitGroupOAuthTokenGeneral,
+					Arguments:      []string{"user-id"},
+					Period:         time.Minute,
+					Burst:          60,
+					Enabled:        true,
+				}).Return(nil, nil)
+
+				issuedOfflineGrant := &oauth.OfflineGrant{
+					ID:    "offline-grant-id",
+					Attrs: *session.NewAttrs("user-id"),
+				}
+				tokenService.EXPECT().IssueOfflineGrant(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+					Return(issuedOfflineGrant, "", nil)
+
+				tokenService.EXPECT().PrepareUserAccessGrantByRefreshToken(gomock.Any(), gomock.Any()).DoAndReturn(
+					func(ctx context.Context, options handler.PrepareUserAccessGrantByRefreshTokenOptions) (*handler.PrepareUserAccessGrantByRefreshTokenResult, error) {
+						return &handler.PrepareUserAccessGrantByRefreshTokenResult{
+							// The value is unimportant.
+							PreparationResult: nil,
+						}, nil
+					})
+				accessTokenEncoding.EXPECT().MakeUserAccessTokenFromPreparationResult(gomock.Any(), gomock.Any()).DoAndReturn(func(ctx context.Context, options oauth.MakeUserAccessTokenFromPreparationOptions) (*oauth.IssueAccessGrantResult, error) {
+					return &oauth.IssueAccessGrantResult{
+						Token:     "access-token",
+						TokenType: "Bearer",
+						ExpiresIn: 300,
+					}, nil
+				})
+
+				r := protocol.TokenRequest{}
+				r["grant_type"] = []string{"authorization_code"}
+				r["client_id"] = []string{"app-id"}
+				r["code"] = []string{"the-code"}
+				r["redirect_uri"] = []string{"https://example.com/"}
+				r["code_verifier"] = []string{verifier.CodeVerifier}
+
+				ctx := context.Background()
+				res := handle(ctx, req, r)
+				So(res.Result().StatusCode, ShouldEqual, 200)
+
+				var body map[string]any
+				err := json.Unmarshal(res.Body.Bytes(), &body)
+				So(err, ShouldBeNil)
+				So(body["access_token"], ShouldEqual, "access-token")
+				So(body, ShouldNotContainKey, "refresh_token")
 			})
 		})
 


### PR DESCRIPTION
The authorization_code token exchange only issued an access token without a refresh token when the client was confidential, so public clients (e.g. SPA) requesting authorization_code without offline_access got "cannot issue access token" instead of an access token.

ref DEV-3545