### PR TITLE
[OIDC] Support client_secret_basic at the token endpoint

### DIFF
--- a/e2e/tests/oauth_idp/token_client_secret_basic.test.yaml
+++ b/e2e/tests/oauth_idp/token_client_secret_basic.test.yaml
@@ -50,7 +50,7 @@ steps:
         "id_token": "[[string]]"
       }
 ---
-name: Token endpoint rejects client credentials sent in both Authorization header and body
+name: Token endpoint prefers client credentials in the request body over an Authorization header
 before:
 - type: user_import
   user_import: users.json
@@ -87,17 +87,23 @@ steps:
   http_request_method: POST
   http_request_url: http://{{.AppID}}.authgeare2e.localhost:4000/oauth2/token
   http_request_headers:
-    Authorization: "Basic {{ printf \"%s:%s\" \"e2econfidential\" \"e2esecret\" | b64enc }}"
+    # Simulates an unrelated proxy-level Basic Auth header (e.g. protecting a
+    # staging environment), which must not conflict with client_secret_post.
+    Authorization: "Basic {{ printf \"%s:%s\" \"someproxyuser\" \"someproxypassword\" | b64enc }}"
   http_request_form_urlencoded_body:
     grant_type: authorization_code
     redirect_uri: http://localhost
-    client_secret: wrongsecretinbody
+    client_id: e2econfidential
+    client_secret: e2esecret
     code: "{{ regexFind \"[?&]code=[^&]+\" .steps.authorize.result.http_response_headers.location | trimPrefix \"?code=\" | trimPrefix \"&code=\" }}"
   http_output:
-    http_status: 400
+    http_status: 200
     json_body: |
       {
-        "error": "invalid_request"
+        "access_token": "[[string]]",
+        "token_type": "Bearer",
+        "expires_in": 1800,
+        "id_token": "[[string]]"
       }
 ---
 name: Token endpoint rejects invalid client_secret sent via HTTP Basic auth

--- a/e2e/tests/oauth_idp/token_client_secret_basic.test.yaml
+++ b/e2e/tests/oauth_idp/token_client_secret_basic.test.yaml
@@ -1,0 +1,150 @@
+name: Token endpoint accepts client_secret_basic for authorization_code grant
+before:
+- type: user_import
+  user_import: users.json
+- type: create_session
+  create_session:
+    session_type: idp
+    session_id: e2e-idp-session-1
+    token: e2eidpsessiontoken1
+    select_user_id_sql: |
+      SELECT id FROM _auth_user u
+        WHERE u.app_id = '{{ .AppID }}' AND
+        u.standard_attributes ->> 'preferred_username' = 'e2e_login';
+steps:
+- name: authorize
+  action: http_request
+  http_request_method: GET
+  http_request_url: http://{{.AppID}}.authgeare2e.localhost:4000/oauth2/authorize
+  http_request_follow_redirects: false
+  http_request_session_cookie:
+    idp_session_id: e2e-idp-session-1
+    idp_session_token: e2eidpsessiontoken1
+  http_request_query:
+    client_id: e2econfidential
+    response_type: code
+    redirect_uri: http://localhost
+    scope: openid
+    prompt: none
+    state: teststate
+  http_output:
+    http_status: 303
+
+- name: token
+  action: http_request
+  http_request_method: POST
+  http_request_url: http://{{.AppID}}.authgeare2e.localhost:4000/oauth2/token
+  http_request_headers:
+    Authorization: "Basic {{ printf \"%s:%s\" \"e2econfidential\" \"e2esecret\" | b64enc }}"
+  http_request_form_urlencoded_body:
+    grant_type: authorization_code
+    redirect_uri: http://localhost
+    code: "{{ regexFind \"[?&]code=[^&]+\" .steps.authorize.result.http_response_headers.location | trimPrefix \"?code=\" | trimPrefix \"&code=\" }}"
+  http_output:
+    http_status: 200
+    json_body: |
+      {
+        "access_token": "[[string]]",
+        "token_type": "Bearer",
+        "expires_in": 1800,
+        "id_token": "[[string]]"
+      }
+---
+name: Token endpoint rejects client credentials sent in both Authorization header and body
+before:
+- type: user_import
+  user_import: users.json
+- type: create_session
+  create_session:
+    session_type: idp
+    session_id: e2e-idp-session-1
+    token: e2eidpsessiontoken1
+    select_user_id_sql: |
+      SELECT id FROM _auth_user u
+        WHERE u.app_id = '{{ .AppID }}' AND
+        u.standard_attributes ->> 'preferred_username' = 'e2e_login';
+steps:
+- name: authorize
+  action: http_request
+  http_request_method: GET
+  http_request_url: http://{{.AppID}}.authgeare2e.localhost:4000/oauth2/authorize
+  http_request_follow_redirects: false
+  http_request_session_cookie:
+    idp_session_id: e2e-idp-session-1
+    idp_session_token: e2eidpsessiontoken1
+  http_request_query:
+    client_id: e2econfidential
+    response_type: code
+    redirect_uri: http://localhost
+    scope: openid
+    prompt: none
+    state: teststate
+  http_output:
+    http_status: 303
+
+- name: token
+  action: http_request
+  http_request_method: POST
+  http_request_url: http://{{.AppID}}.authgeare2e.localhost:4000/oauth2/token
+  http_request_headers:
+    Authorization: "Basic {{ printf \"%s:%s\" \"e2econfidential\" \"e2esecret\" | b64enc }}"
+  http_request_form_urlencoded_body:
+    grant_type: authorization_code
+    redirect_uri: http://localhost
+    client_secret: wrongsecretinbody
+    code: "{{ regexFind \"[?&]code=[^&]+\" .steps.authorize.result.http_response_headers.location | trimPrefix \"?code=\" | trimPrefix \"&code=\" }}"
+  http_output:
+    http_status: 400
+    json_body: |
+      {
+        "error": "invalid_request"
+      }
+---
+name: Token endpoint rejects invalid client_secret sent via HTTP Basic auth
+before:
+- type: user_import
+  user_import: users.json
+- type: create_session
+  create_session:
+    session_type: idp
+    session_id: e2e-idp-session-1
+    token: e2eidpsessiontoken1
+    select_user_id_sql: |
+      SELECT id FROM _auth_user u
+        WHERE u.app_id = '{{ .AppID }}' AND
+        u.standard_attributes ->> 'preferred_username' = 'e2e_login';
+steps:
+- name: authorize
+  action: http_request
+  http_request_method: GET
+  http_request_url: http://{{.AppID}}.authgeare2e.localhost:4000/oauth2/authorize
+  http_request_follow_redirects: false
+  http_request_session_cookie:
+    idp_session_id: e2e-idp-session-1
+    idp_session_token: e2eidpsessiontoken1
+  http_request_query:
+    client_id: e2econfidential
+    response_type: code
+    redirect_uri: http://localhost
+    scope: openid
+    prompt: none
+    state: teststate
+  http_output:
+    http_status: 303
+
+- name: token
+  action: http_request
+  http_request_method: POST
+  http_request_url: http://{{.AppID}}.authgeare2e.localhost:4000/oauth2/token
+  http_request_headers:
+    Authorization: "Basic {{ printf \"%s:%s\" \"e2econfidential\" \"wrongsecret\" | b64enc }}"
+  http_request_form_urlencoded_body:
+    grant_type: authorization_code
+    redirect_uri: http://localhost
+    code: "{{ regexFind \"[?&]code=[^&]+\" .steps.authorize.result.http_response_headers.location | trimPrefix \"?code=\" | trimPrefix \"&code=\" }}"
+  http_output:
+    http_status: 400
+    json_body: |
+      {
+        "error": "invalid_request"
+      }

--- a/pkg/lib/oauth/handler/handler_token.go
+++ b/pkg/lib/oauth/handler/handler_token.go
@@ -261,26 +261,27 @@ func (h *TokenHandler) Handle(ctx context.Context, rw http.ResponseWriter, req *
 		return resultErr
 	}
 
-	if username, password, ok := req.BasicAuth(); ok {
-		// RFC 6749 section 2.3: The client MUST NOT use more than one
-		// authentication method in each request.
-		if r.ClientID() != "" || r.ClientSecret() != "" {
-			return errorResult(protocol.NewError("invalid_request", "client authentication must not be presented in both the Authorization header and the request body"))
-		}
+	// Prefer client authentication in the request body over the Authorization
+	// header: an Authorization header may come from an unrelated proxy (e.g.
+	// one protecting a staging environment with HTTP Basic auth) rather than
+	// the client itself, so it must not take precedence over, or conflict
+	// with, credentials the client actually placed in the body.
+	if r.ClientID() == "" && r.ClientSecret() == "" {
+		if username, password, ok := req.BasicAuth(); ok {
+			// RFC 6749 Appendix B: client_id and client_secret are encoded with
+			// application/x-www-form-urlencoded before being used in HTTP Basic auth.
+			clientID, err := url.QueryUnescape(username)
+			if err != nil {
+				return errorResult(protocol.NewError("invalid_request", "invalid client_id in Authorization header"))
+			}
+			clientSecret, err := url.QueryUnescape(password)
+			if err != nil {
+				return errorResult(protocol.NewError("invalid_request", "invalid client_secret in Authorization header"))
+			}
 
-		// RFC 6749 Appendix B: client_id and client_secret are encoded with
-		// application/x-www-form-urlencoded before being used in HTTP Basic auth.
-		clientID, err := url.QueryUnescape(username)
-		if err != nil {
-			return errorResult(protocol.NewError("invalid_request", "invalid client_id in Authorization header"))
+			r["client_id"] = []string{clientID}
+			r["client_secret"] = []string{clientSecret}
 		}
-		clientSecret, err := url.QueryUnescape(password)
-		if err != nil {
-			return errorResult(protocol.NewError("invalid_request", "invalid client_secret in Authorization header"))
-		}
-
-		r["client_id"] = []string{clientID}
-		r["client_secret"] = []string{clientSecret}
 	}
 
 	ipRateLimitBucket := NewBucketSpecOAuthTokenPerIP(string(h.RemoteIP))

--- a/pkg/lib/oauth/handler/handler_token.go
+++ b/pkg/lib/oauth/handler/handler_token.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"log/slog"
 	"net/http"
+	"net/url"
 	"reflect"
 	"slices"
 	"strings"
@@ -258,6 +259,28 @@ func (h *TokenHandler) Handle(ctx context.Context, rw http.ResponseWriter, req *
 			resultErr.InternalError = true
 		}
 		return resultErr
+	}
+
+	if username, password, ok := req.BasicAuth(); ok {
+		// RFC 6749 section 2.3: The client MUST NOT use more than one
+		// authentication method in each request.
+		if r.ClientID() != "" || r.ClientSecret() != "" {
+			return errorResult(protocol.NewError("invalid_request", "client authentication must not be presented in both the Authorization header and the request body"))
+		}
+
+		// RFC 6749 Appendix B: client_id and client_secret are encoded with
+		// application/x-www-form-urlencoded before being used in HTTP Basic auth.
+		clientID, err := url.QueryUnescape(username)
+		if err != nil {
+			return errorResult(protocol.NewError("invalid_request", "invalid client_id in Authorization header"))
+		}
+		clientSecret, err := url.QueryUnescape(password)
+		if err != nil {
+			return errorResult(protocol.NewError("invalid_request", "invalid client_secret in Authorization header"))
+		}
+
+		r["client_id"] = []string{clientID}
+		r["client_secret"] = []string{clientSecret}
 	}
 
 	ipRateLimitBucket := NewBucketSpecOAuthTokenPerIP(string(h.RemoteIP))

--- a/pkg/lib/oauth/handler/handler_token_test.go
+++ b/pkg/lib/oauth/handler/handler_token_test.go
@@ -919,22 +919,40 @@ func TestTokenHandler(t *testing.T) {
 				So(body["access_token"], ShouldEqual, accessToken)
 			})
 
-			Convey("rejects client_secret present in both the Authorization header and the request body", func() {
+			Convey("prefers client_secret in the request body over Authorization header", func() {
+				// e.g. a reverse proxy protecting a staging environment with its
+				// own HTTP Basic auth, unrelated to OAuth client authentication.
+				expectClientCredentialsRateLimits()
+				clientResourceScopeService.EXPECT().GetClientResourceByURI(gomock.Any(), clientID, resourceURI).Return(resource, nil)
+				clientResourceScopeService.EXPECT().GetClientResourceScopes(gomock.Any(), clientID, resourceID).Return(allowedScopes, nil)
+
+				accessToken := "access-token-body-preferred"
+				tokenService.EXPECT().IssueClientCredentialsAccessToken(gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(
+					func(ctx context.Context, opts handler.ClientCredentialsAccessTokenOptions, resp protocol.TokenResponse) error {
+						resp.AccessToken(accessToken)
+						resp.TokenType("Bearer")
+						resp.ExpiresIn(3600)
+						resp.Scope("read")
+						return nil
+					},
+				)
+
 				req, _ := http.NewRequest("POST", "/token", nil)
-				req.SetBasicAuth(clientID, "supersecret")
+				req.SetBasicAuth("proxy-user", "proxy-password")
 				r := protocol.TokenRequest{
 					"grant_type":    []string{"client_credentials"},
+					"client_id":     []string{clientID},
 					"resource":      []string{resourceURI},
 					"client_secret": []string{"supersecret"},
 				}
 				ctx := context.Background()
 				resp := handle(ctx, req, r)
 
-				So(resp.Result().StatusCode, ShouldEqual, 400)
+				So(resp.Result().StatusCode, ShouldEqual, 200)
 				var body map[string]any
 				err := json.Unmarshal(resp.Body.Bytes(), &body)
 				So(err, ShouldBeNil)
-				So(body["error"], ShouldEqual, "invalid_request")
+				So(body["access_token"], ShouldEqual, accessToken)
 			})
 
 			Convey("rejects an invalid client_secret sent via the Authorization header", func() {

--- a/pkg/lib/oauth/handler/handler_token_test.go
+++ b/pkg/lib/oauth/handler/handler_token_test.go
@@ -823,5 +823,138 @@ func TestTokenHandler(t *testing.T) {
 				So(body["error_description"], ShouldEqual, "resource URI must not be a prefixed by authgear endpoint")
 			})
 		})
+
+		Convey("client authentication via HTTP Basic auth (client_secret_basic)", func() {
+			clientID := "basic-auth-client"
+			resourceURI := "https://api.example.com/resource"
+			resourceID := "resource-id-1"
+			allowedScopes := []*resourcescope.Scope{
+				{ID: "scope-id-1", ResourceID: resourceID, Scope: "read"},
+			}
+			clientResolver.ClientConfigs[clientID] = &config.OAuthClientConfig{
+				ClientID:            clientID,
+				ApplicationType:     config.OAuthClientApplicationTypeConfidential,
+				AccessTokenLifetime: config.DurationSeconds(3600),
+				IssueJWTAccessToken: true,
+			}
+
+			key, err := jwk.FromRaw([]byte("supersecret"))
+			if err != nil {
+				t.Fatalf("failed to create jwk: %v", err)
+			}
+			keySet := jwk.NewSet()
+			_ = keySet.AddKey(key)
+			h.OAuthClientCredentials = &config.OAuthClientCredentials{
+				Items: []config.OAuthClientCredentialsItem{
+					{
+						ClientID:                     clientID,
+						OAuthClientCredentialsKeySet: config.OAuthClientCredentialsKeySet{Set: keySet},
+					},
+				},
+			}
+
+			resource := &resourcescope.Resource{
+				ID:          resourceID,
+				ResourceURI: resourceURI,
+			}
+
+			expectClientCredentialsRateLimits := func() {
+				rateLimiter.EXPECT().Allow(gomock.Any(), ratelimit.BucketSpec{
+					Name:           ratelimit.OAuthTokenPerIP,
+					RateLimitName:  ratelimit.RateLimitOAuthTokenGeneralPerIP,
+					RateLimitGroup: ratelimit.RateLimitGroupOAuthTokenGeneral,
+					Arguments:      []string{"1.2.3.4"},
+					Period:         time.Minute,
+					Burst:          120,
+					Enabled:        true,
+				}).Return(nil, nil)
+				rateLimiter.EXPECT().Allow(gomock.Any(), ratelimit.BucketSpec{
+					Name:           ratelimit.OAuthTokenClientCredentialsPerClient,
+					RateLimitName:  ratelimit.RateLimitOAuthTokenClientCredentialsPerClient,
+					RateLimitGroup: ratelimit.RateLimitGroupOAuthTokenClientCredentials,
+					Arguments:      []string{clientID},
+					Period:         time.Minute,
+					Burst:          5,
+					Enabled:        true,
+				}).Return(nil, nil)
+				rateLimiter.EXPECT().Allow(gomock.Any(), ratelimit.BucketSpec{
+					Name:           ratelimit.OAuthTokenClientCredentialsPerProject,
+					RateLimitName:  ratelimit.RateLimitOAuthTokenClientCredentialsPerProject,
+					RateLimitGroup: ratelimit.RateLimitGroupOAuthTokenClientCredentials,
+					Period:         time.Minute,
+					Burst:          20,
+					Enabled:        true,
+				}).Return(nil, nil)
+			}
+
+			Convey("success: client_id and client_secret are taken from the Authorization header", func() {
+				expectClientCredentialsRateLimits()
+				clientResourceScopeService.EXPECT().GetClientResourceByURI(gomock.Any(), clientID, resourceURI).Return(resource, nil)
+				clientResourceScopeService.EXPECT().GetClientResourceScopes(gomock.Any(), clientID, resourceID).Return(allowedScopes, nil)
+
+				accessToken := "access-token-basic-auth"
+				tokenService.EXPECT().IssueClientCredentialsAccessToken(gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(
+					func(ctx context.Context, opts handler.ClientCredentialsAccessTokenOptions, resp protocol.TokenResponse) error {
+						resp.AccessToken(accessToken)
+						resp.TokenType("Bearer")
+						resp.ExpiresIn(3600)
+						resp.Scope("read")
+						return nil
+					},
+				)
+
+				req, _ := http.NewRequest("POST", "/token", nil)
+				req.SetBasicAuth(clientID, "supersecret")
+				r := protocol.TokenRequest{
+					"grant_type": []string{"client_credentials"},
+					"resource":   []string{resourceURI},
+				}
+				ctx := context.Background()
+				resp := handle(ctx, req, r)
+
+				So(resp.Result().StatusCode, ShouldEqual, 200)
+				var body map[string]any
+				err := json.Unmarshal(resp.Body.Bytes(), &body)
+				So(err, ShouldBeNil)
+				So(body["access_token"], ShouldEqual, accessToken)
+			})
+
+			Convey("rejects client_secret present in both the Authorization header and the request body", func() {
+				req, _ := http.NewRequest("POST", "/token", nil)
+				req.SetBasicAuth(clientID, "supersecret")
+				r := protocol.TokenRequest{
+					"grant_type":    []string{"client_credentials"},
+					"resource":      []string{resourceURI},
+					"client_secret": []string{"supersecret"},
+				}
+				ctx := context.Background()
+				resp := handle(ctx, req, r)
+
+				So(resp.Result().StatusCode, ShouldEqual, 400)
+				var body map[string]any
+				err := json.Unmarshal(resp.Body.Bytes(), &body)
+				So(err, ShouldBeNil)
+				So(body["error"], ShouldEqual, "invalid_request")
+			})
+
+			Convey("rejects an invalid client_secret sent via the Authorization header", func() {
+				expectClientCredentialsRateLimits()
+
+				req, _ := http.NewRequest("POST", "/token", nil)
+				req.SetBasicAuth(clientID, "wrongsecret")
+				r := protocol.TokenRequest{
+					"grant_type": []string{"client_credentials"},
+					"resource":   []string{resourceURI},
+				}
+				ctx := context.Background()
+				resp := handle(ctx, req, r)
+
+				So(resp.Result().StatusCode, ShouldEqual, 400)
+				var body map[string]any
+				err := json.Unmarshal(resp.Body.Bytes(), &body)
+				So(err, ShouldBeNil)
+				So(body["error"], ShouldEqual, "invalid_request")
+			})
+		})
 	})
 }

--- a/pkg/lib/oauth/metadata.go
+++ b/pkg/lib/oauth/metadata.go
@@ -17,9 +17,8 @@ func (p *MetadataProvider) PopulateMetadata(meta map[string]any) {
 	meta["grant_types_supported"] = []string{"authorization_code", "refresh_token", "client_credentials"}
 	meta["code_challenge_methods_supported"] = []string{pkce.CodeChallengeMethodS256}
 	meta["revocation_endpoint"] = p.Endpoints.RevokeEndpointURL().String()
-	// The default is client_secret_basic if this key is omitted.
 	// See https://openid.net/specs/openid-connect-discovery-1_0.html#:~:text=passed%20by%20reference.-,token_endpoint_auth_methods_supported,-OPTIONAL.%20JSON%20array
 	// See https://openid.net/specs/openid-connect-core-1_0.html#ClientAuthentication:~:text=The%20Client%20does%20not%20authenticate%20itself%20at%20the%20Token%20Endpoint
-	meta["token_endpoint_auth_methods_supported"] = []string{"none", "client_secret_post"}
+	meta["token_endpoint_auth_methods_supported"] = []string{"none", "client_secret_post", "client_secret_basic"}
 	meta["dpop_signing_alg_values_supported"] = dpop.SupportedAlgorithms
 }


### PR DESCRIPTION
Extract client_id/client_secret from an HTTP Basic Authorization header in TokenHandler.Handle, alongside the existing client_secret_post support, and advertise it in token_endpoint_auth_methods_supported.

ref DEV-3728