### PR TITLE
[Portal] Render plan-gated messages as Radix callouts on migrated screens

### DIFF
--- a/portal/src/components/v2/FeatureDisabledCallout/FeatureDisabledCallout.tsx
+++ b/portal/src/components/v2/FeatureDisabledCallout/FeatureDisabledCallout.tsx
@@ -1,0 +1,34 @@
+import React from "react";
+import { Callout } from "@radix-ui/themes";
+import { InfoCircledIcon } from "@radix-ui/react-icons";
+import { FormattedMessage, Values } from "../../../intl";
+import { useFeatureDisabledMessageValues } from "../../../graphql/portal/FeatureDisabledMessageBar";
+
+export interface FeatureDisabledCalloutProps {
+  className?: string;
+  messageID: string;
+  messageValues?: Values;
+}
+
+// The v2 counterpart of FeatureDisabledMessageBar: the same
+// FeatureConfig.*.disabled message (with plan-page / contact-us links)
+// rendered as a Radix Callout, matching the info callouts used across the
+// migrated Advanced-settings screens.
+export function FeatureDisabledCallout({
+  className,
+  messageID,
+  messageValues,
+}: FeatureDisabledCalloutProps): React.ReactElement {
+  const values = useFeatureDisabledMessageValues(messageValues);
+
+  return (
+    <Callout.Root className={className} color="blue" variant="surface" size="1">
+      <Callout.Icon>
+        <InfoCircledIcon />
+      </Callout.Icon>
+      <Callout.Text>
+        <FormattedMessage id={messageID} values={values} />
+      </Callout.Text>
+    </Callout.Root>
+  );
+}

--- a/portal/src/graphql/portal/FeatureDisabledMessageBar.tsx
+++ b/portal/src/graphql/portal/FeatureDisabledMessageBar.tsx
@@ -11,33 +11,43 @@ export interface FeatureDisabledMessageBarProps extends IMessageBarProps {
   messageValues?: Values;
 }
 
+// useFeatureDisabledMessageValues provides the standard rich-text values
+// (plan-page link, contact-us link, bold) for FeatureConfig.*.disabled
+// messages. Shared by the Fluent message bar below and the v2
+// FeatureDisabledCallout.
+export function useFeatureDisabledMessageValues(
+  messageValues?: Values
+): Values {
+  const { appID } = useParams() as { appID: string };
+
+  return useMemo(() => {
+    const planPagePath = `/project/${appID}/billing`;
+    const contactUsHref =
+      "https://www.authgear.com/schedule-demo?utm_source=portal&utm_medium=link&utm_campaign=additional_order";
+    return {
+      planPagePath,
+      contactUsHref,
+
+      b: (chunks: React.ReactNode) => <b>{chunks}</b>,
+
+      ReactRouterLink: (chunks: React.ReactNode) => (
+        <ReactRouterLink to={planPagePath} target="_blank">
+          {chunks}
+        </ReactRouterLink>
+      ),
+
+      ExternalLink: (chunks: React.ReactNode) => (
+        <ExternalLink href={contactUsHref}>{chunks}</ExternalLink>
+      ),
+      ...messageValues,
+    };
+  }, [appID, messageValues]);
+}
+
 const FeatureDisabledMessageBar: React.VFC<FeatureDisabledMessageBarProps> =
   function FeatureDisabledMessageBar(props: FeatureDisabledMessageBarProps) {
     const { messageID, messageValues, ...rest } = props;
-    const { appID } = useParams() as { appID: string };
-
-    const values = useMemo(() => {
-      const planPagePath = `/project/${appID}/billing`;
-      const contactUsHref =
-        "https://www.authgear.com/schedule-demo?utm_source=portal&utm_medium=link&utm_campaign=additional_order";
-      return {
-        planPagePath,
-        contactUsHref,
-        // eslint-disable-next-line react/no-unstable-nested-components
-        b: (chunks: React.ReactNode) => <b>{chunks}</b>,
-        // eslint-disable-next-line react/no-unstable-nested-components
-        ReactRouterLink: (chunks: React.ReactNode) => (
-          <ReactRouterLink to={planPagePath} target="_blank">
-            {chunks}
-          </ReactRouterLink>
-        ),
-        // eslint-disable-next-line react/no-unstable-nested-components
-        ExternalLink: (chunks: React.ReactNode) => (
-          <ExternalLink href={contactUsHref}>{chunks}</ExternalLink>
-        ),
-        ...messageValues,
-      };
-    }, [appID, messageValues]);
+    const values = useFeatureDisabledMessageValues(messageValues);
 
     return (
       <BlueMessageBar {...rest}>

--- a/portal/src/graphql/portal/SMSProviderConfigurationScreen.tsx
+++ b/portal/src/graphql/portal/SMSProviderConfigurationScreen.tsx
@@ -56,7 +56,7 @@ import { genRandomHexadecimalString } from "../../util/random";
 import { useAppAndSecretConfigQuery } from "./query/appAndSecretConfigQuery";
 import { useSendTestSMSMutation } from "./mutations/sendTestSMS";
 import { useCheckDenoHookMutation } from "./mutations/checkDenoHook";
-import FeatureDisabledMessageBar from "./FeatureDisabledMessageBar";
+import { FeatureDisabledCallout } from "../../components/v2/FeatureDisabledCallout/FeatureDisabledCallout";
 import { ErrorParseRule, makeLocalErrorParseRule } from "../../error/parse";
 import { APIError, LocalError } from "../../error/error";
 import { ConfirmationDialog } from "../../components/v2/ConfirmationDialog/ConfirmationDialog";
@@ -1126,7 +1126,7 @@ function SMSProviderConfigurationContent(props: {
           </Text>
         </div>
         {isCustomSMSProviderDisabled ? (
-          <FeatureDisabledMessageBar
+          <FeatureDisabledCallout
             className={styles.widget}
             messageID="FeatureConfig.custom-sms-provider.disabled"
           />

--- a/portal/src/graphql/portal/SMTPConfigurationScreen.tsx
+++ b/portal/src/graphql/portal/SMTPConfigurationScreen.tsx
@@ -39,7 +39,7 @@ import { useLocationEffect } from "../../hook/useLocationEffect";
 import { useAppSecretVisitToken } from "./mutations/generateAppSecretVisitTokenMutation";
 import { useAppAndSecretConfigQuery } from "./query/appAndSecretConfigQuery";
 import { useAppFeatureConfigQuery } from "./query/appFeatureConfigQuery";
-import FeatureDisabledMessageBar from "./FeatureDisabledMessageBar";
+import { FeatureDisabledCallout } from "../../components/v2/FeatureDisabledCallout/FeatureDisabledCallout";
 import { ErrorParseRule, ErrorParseRuleResult } from "../../error/parse";
 import { APIError, APISMTPTestFailedError } from "../../error/error";
 import { useSystemConfig } from "../../context/SystemConfigContext";
@@ -613,7 +613,7 @@ const SMTPConfigurationScreenContent: React.VFC<SMTPConfigurationScreenContentPr
           </Text>
         </div>
         {isCustomSMTPDisabled ? (
-          <FeatureDisabledMessageBar
+          <FeatureDisabledCallout
             className={styles.widget}
             messageID="FeatureConfig.custom-smtp.disabled"
           />

--- a/portal/src/radix-theme-overrides.css
+++ b/portal/src/radix-theme-overrides.css
@@ -22,3 +22,9 @@
 .rt-BaseDialogOverlay {
   z-index: 10000;
 }
+
+/* Links inside callouts (upgrade-plan, external references) need more weight
+   to stand out from the surrounding message text. */
+.rt-CalloutRoot a {
+  font-weight: var(--font-weight-medium);
+}


### PR DESCRIPTION
## Summary

Follow-up to #5771. On staging, projects with gated plans still showed the old FluentUI `FeatureDisabledMessageBar` on the migrated Custom SMS Gateway / Custom Email Provider screens — it clashed with the Radix design and was invisible in local dev (no plan restrictions), so the migration missed it.

- Extract the shared plan-page / contact-us rich-text values into `useFeatureDisabledMessageValues`.
- Add a v2 `FeatureDisabledCallout` (Radix `Callout`, blue surface + info icon), matching the info callout on Account Deletion.
- Use it on `SMSProviderConfigurationScreen` and `SMTPConfigurationScreen`. Non-migrated screens keep the Fluent bar.

Verified locally by putting a project on a plan with `custom_smtp_disabled` / `custom_sms_provider_disabled` — callout renders in the Radix style and the Upgrade link still routes to Billing.

ref DEV-2234


Before

<img width="985" height="369" alt="SCR-20260723-jsbf" src="https://github.com/user-attachments/assets/57242b12-aae4-4b13-8d68-5df53a95b5a5" />


After

<img width="920" height="340" alt="image" src="https://github.com/user-attachments/assets/54700608-cc05-460f-b213-6d52cd83ce3d" />


