### PR TITLE
Fix feature config merge to be field-level, not whole-section

### DIFF
--- a/.claude/skills/update-feature-config/SKILL.md
+++ b/.claude/skills/update-feature-config/SKILL.md
@@ -1,0 +1,74 @@
+---
+name: update-feature-config
+description: Add or change a feature config field/section in pkg/lib/config (authgear.features.yaml). Use when adding a new feature config field, adding a new top-level section, or touching an existing section's Merge implementation.
+---
+
+# Update Feature Config
+
+Feature config (`authgear.features.yaml`) is merged across layers — code
+default ← cluster ← plan ← app override — via `FeatureConfig.Merge`
+(`pkg/lib/config/feature.go`), which reflects over every top-level field and
+dispatches to that section's own `Merge` in `pkg/lib/config/feature_*.go`.
+
+## Hard requirement: merge must be field-level, never whole-section replace
+
+Historically, most sections implemented `Merge` as a wholesale swap:
+
+```go
+// WRONG for any section with more than one leaf field
+func (c *XFeatureConfig) Merge(layer *FeatureConfig) MergeableFeatureConfig {
+	if layer.X == nil {
+		return c
+	}
+	return layer.X
+}
+```
+
+This is a real, reachable bug class, not a theoretical one: if a lower layer
+(e.g. a plan) sets field `A` and a higher layer (e.g. an app override) later
+sets a sibling field `B` — without repeating `A` — the whole-section swap
+silently resets `A` back to its code default. Plan/app documents are
+routinely partial, hand-authored YAML, so this triggers in practice, not just
+in edge cases. It was found and fixed across `identity`, `authentication`,
+`authenticator`, `ui`, `hook`, `collaborator`, `messaging.rate_limits`, and
+`test_mode` — do not reintroduce it in a new section or a new field on an
+existing section.
+
+**Every new field on an existing multi-field section, and every new
+top-level section, must merge field-level:**
+
+- Follow the reference pattern in `OAuthClientFeatureConfig.Merge`
+  (`pkg/lib/config/feature_oauth.go`): nil-safe guards first
+  (`if c == nil && layer == nil { return nil }`, `if c == nil { return layer }`,
+  `if layer == nil { return c }`), then per-field
+  `if layer.X != nil { c.X = layer.X }` for every field.
+- If a section/sub-object genuinely has only **one** field, a whole-object
+  replace at that level is fine — there's nothing else to lose. But if that
+  one field is itself an object with siblings further down, cascade the
+  field-level merge all the way down to where the real siblings are, even
+  through single-field wrapper levels. See `feature_authenticator.go`'s
+  `Authenticator → Password → Policy` cascade: `Authenticator` and `Password`
+  each have only one field, but `Policy` has three siblings that must merge
+  independently — so the cascade goes three levels deep, not stopping at the
+  first single-field level.
+- Never write `if layer.Section == nil { return c }; return layer.Section`
+  for a section with more than one leaf field, directly or transitively.
+
+## Required test coverage
+
+Every new/changed `Merge` implementation needs a case in
+`pkg/lib/config/testdata/merge_feature.yaml`: one layer sets field `A` only,
+a later layer sets a sibling field `B` only (never repeating `A`) — assert
+the final effective config has **both** `A` (from the first layer) and `B`
+(from the second), not `A` reset to its default. Pick values that are **not**
+the code default for the field being tested — otherwise a whole-section
+regression would silently produce the "right" value by accident and the test
+wouldn't catch it. See the existing `hook`/`collaborator`/`identity` cases in
+that file for the pattern.
+
+## References
+
+- `pkg/lib/config/feature.go` — top-level `FeatureConfig.Merge` dispatcher
+- `pkg/lib/config/feature_*.go` — per-section `Merge` implementations
+- `pkg/lib/config/testdata/merge_feature.yaml` — shared merge test fixture
+- `pkg/lib/config/testdata/parse_feature_tests.yaml` — schema validation test fixture

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -69,6 +69,7 @@ authgear-server/
 | Core auth logic (OAuth, OIDC, sessions, flows) | `pkg/lib/` |
 | Background jobs / workers | `cmd/authgear/background/` |
 | Config schema & validation | `pkg/lib/config/`, `cmd/authgear/config/` |
+| Feature config (`authgear.features.yaml`) | `pkg/lib/config/feature_*.go` — **merge must be field-level, see `update-feature-config` skill** |
 | E2E tests | `e2e/tests/` |
 
 ## Documentation map
@@ -134,6 +135,7 @@ Use existing repo skills instead of one-off instructions when they fit:
 - `review-pr` — **mandatory before marking any code change complete** (see Verification below), also usable on demand for "review this PR/branch"
 - `update-portal-ui` — **use this before adding or editing any portal UI page** (link components, i18n inline links, FluentUI Text pitfalls, hardcoded/untranslated text)
 - `update-email-templates` — **use this before editing any email template, translation string, or email subject line** (`*.gotemplate`, `messages/translation.json`, `translation.json` subjects)
+- `update-feature-config` — **use this before adding or changing any `pkg/lib/config/feature_*.go` field or `Merge` implementation** (field-level merge is a hard requirement, plus required test coverage in `merge_feature.yaml`)
 - `write-e2e-test` — **includes patterns for testing feature variants and actual functionality. Use this before writing, editing, or running e2e tests** (see "Common Patterns" section)
 - Repo-local skills for Go tests, Portal GraphQL operations, Go version updates, important-module updates, and vetted-position updates
 

--- a/pkg/lib/config/feature_authentication.go
+++ b/pkg/lib/config/feature_authentication.go
@@ -20,7 +20,15 @@ func (c *AuthenticationFeatureConfig) Merge(layer *FeatureConfig) MergeableFeatu
 	if layer.Authentication == nil {
 		return c
 	}
-	return layer.Authentication
+
+	merged := c
+	if merged == nil {
+		merged = &AuthenticationFeatureConfig{}
+	}
+
+	merged.SecondaryAuthenticators = merged.SecondaryAuthenticators.Merge(layer.Authentication.SecondaryAuthenticators)
+
+	return merged
 }
 
 var _ = FeatureConfigSchema.Add("AuthenticatorsFeatureConfig", `
@@ -35,6 +43,22 @@ var _ = FeatureConfigSchema.Add("AuthenticatorsFeatureConfig", `
 
 type AuthenticatorsFeatureConfig struct {
 	OOBOTPSMS *AuthenticatorOOBOTBSMSFeatureConfig `json:"oob_otp_sms,omitempty"`
+}
+
+func (c *AuthenticatorsFeatureConfig) Merge(layer *AuthenticatorsFeatureConfig) *AuthenticatorsFeatureConfig {
+	if c == nil && layer == nil {
+		return nil
+	}
+	if c == nil {
+		return layer
+	}
+	if layer == nil {
+		return c
+	}
+	if layer.OOBOTPSMS != nil {
+		c.OOBOTPSMS = layer.OOBOTPSMS
+	}
+	return c
 }
 
 var _ = FeatureConfigSchema.Add("AuthenticatorOOBOTBSMSFeatureConfig", `

--- a/pkg/lib/config/feature_authenticator.go
+++ b/pkg/lib/config/feature_authenticator.go
@@ -20,7 +20,15 @@ func (c *AuthenticatorFeatureConfig) Merge(layer *FeatureConfig) MergeableFeatur
 	if layer.Authenticator == nil {
 		return c
 	}
-	return layer.Authenticator
+
+	merged := c
+	if merged == nil {
+		merged = &AuthenticatorFeatureConfig{}
+	}
+
+	merged.Password = merged.Password.Merge(layer.Authenticator.Password)
+
+	return merged
 }
 
 var _ = FeatureConfigSchema.Add("AuthenticatorPasswordFeatureConfig", `
@@ -35,6 +43,20 @@ var _ = FeatureConfigSchema.Add("AuthenticatorPasswordFeatureConfig", `
 
 type AuthenticatorPasswordFeatureConfig struct {
 	Policy *PasswordPolicyFeatureConfig `json:"policy,omitempty"`
+}
+
+func (c *AuthenticatorPasswordFeatureConfig) Merge(layer *AuthenticatorPasswordFeatureConfig) *AuthenticatorPasswordFeatureConfig {
+	if c == nil && layer == nil {
+		return nil
+	}
+	if c == nil {
+		return layer
+	}
+	if layer == nil {
+		return c
+	}
+	c.Policy = c.Policy.Merge(layer.Policy)
+	return c
 }
 
 var _ = FeatureConfigSchema.Add("PasswordPolicyFeatureConfig", `
@@ -53,6 +75,28 @@ type PasswordPolicyFeatureConfig struct {
 	MinimumGuessableLevel *PasswordPolicyItemFeatureConfig `json:"minimum_guessable_level,omitempty"`
 	ExcludedKeywords      *PasswordPolicyItemFeatureConfig `json:"excluded_keywords,omitempty"`
 	History               *PasswordPolicyItemFeatureConfig `json:"history,omitempty"`
+}
+
+func (c *PasswordPolicyFeatureConfig) Merge(layer *PasswordPolicyFeatureConfig) *PasswordPolicyFeatureConfig {
+	if c == nil && layer == nil {
+		return nil
+	}
+	if c == nil {
+		return layer
+	}
+	if layer == nil {
+		return c
+	}
+	if layer.MinimumGuessableLevel != nil {
+		c.MinimumGuessableLevel = layer.MinimumGuessableLevel
+	}
+	if layer.ExcludedKeywords != nil {
+		c.ExcludedKeywords = layer.ExcludedKeywords
+	}
+	if layer.History != nil {
+		c.History = layer.History
+	}
+	return c
 }
 
 var _ = FeatureConfigSchema.Add("PasswordPolicyItemFeatureConfig", `

--- a/pkg/lib/config/feature_collaborator.go
+++ b/pkg/lib/config/feature_collaborator.go
@@ -22,5 +22,18 @@ func (c *CollaboratorFeatureConfig) Merge(layer *FeatureConfig) MergeableFeature
 	if layer.Collaborator == nil {
 		return c
 	}
-	return layer.Collaborator
+
+	merged := c
+	if merged == nil {
+		merged = &CollaboratorFeatureConfig{}
+	}
+
+	if layer.Collaborator.Maximum != nil {
+		merged.Maximum = layer.Collaborator.Maximum
+	}
+	if layer.Collaborator.SoftMaximum != nil {
+		merged.SoftMaximum = layer.Collaborator.SoftMaximum
+	}
+
+	return merged
 }

--- a/pkg/lib/config/feature_hook.go
+++ b/pkg/lib/config/feature_hook.go
@@ -22,7 +22,16 @@ func (c *HookFeatureConfig) Merge(layer *FeatureConfig) MergeableFeatureConfig {
 	if layer.Hook == nil {
 		return c
 	}
-	return layer.Hook
+
+	merged := c
+	if merged == nil {
+		merged = &HookFeatureConfig{}
+	}
+
+	merged.BlockingHandler = merged.BlockingHandler.Merge(layer.Hook.BlockingHandler)
+	merged.NonBlockingHandler = merged.NonBlockingHandler.Merge(layer.Hook.NonBlockingHandler)
+
+	return merged
 }
 
 var _ = FeatureConfigSchema.Add("BlockingHandlerFeatureConfig", `
@@ -45,6 +54,22 @@ func (c *BlockingHandlerFeatureConfig) SetDefaults() {
 	}
 }
 
+func (c *BlockingHandlerFeatureConfig) Merge(layer *BlockingHandlerFeatureConfig) *BlockingHandlerFeatureConfig {
+	if c == nil && layer == nil {
+		return nil
+	}
+	if c == nil {
+		return layer
+	}
+	if layer == nil {
+		return c
+	}
+	if layer.Maximum != nil {
+		c.Maximum = layer.Maximum
+	}
+	return c
+}
+
 var _ = FeatureConfigSchema.Add("NonBlockingHandlerFeatureConfig", `
 {
 	"type": "object",
@@ -63,4 +88,20 @@ func (c *NonBlockingHandlerFeatureConfig) SetDefaults() {
 	if c.Maximum == nil {
 		c.Maximum = new(99)
 	}
+}
+
+func (c *NonBlockingHandlerFeatureConfig) Merge(layer *NonBlockingHandlerFeatureConfig) *NonBlockingHandlerFeatureConfig {
+	if c == nil && layer == nil {
+		return nil
+	}
+	if c == nil {
+		return layer
+	}
+	if layer == nil {
+		return c
+	}
+	if layer.Maximum != nil {
+		c.Maximum = layer.Maximum
+	}
+	return c
 }

--- a/pkg/lib/config/feature_identity.go
+++ b/pkg/lib/config/feature_identity.go
@@ -30,7 +30,21 @@ func (c *IdentityFeatureConfig) Merge(layer *FeatureConfig) MergeableFeatureConf
 	if layer.Identity == nil {
 		return c
 	}
-	return layer.Identity
+
+	merged := c
+	if merged == nil {
+		merged = &IdentityFeatureConfig{}
+	}
+
+	if layer.Identity.LoginID != nil {
+		merged.LoginID = layer.Identity.LoginID
+	}
+	merged.OAuth = merged.OAuth.Merge(layer.Identity.OAuth)
+	if layer.Identity.Biometric != nil {
+		merged.Biometric = layer.Identity.Biometric
+	}
+
+	return merged
 }
 
 var _ = FeatureConfigSchema.Add("LoginIDFeatureConfig", `
@@ -97,6 +111,23 @@ func (c *OAuthSSOFeatureConfig) SetDefaults() {
 	}
 }
 
+func (c *OAuthSSOFeatureConfig) Merge(layer *OAuthSSOFeatureConfig) *OAuthSSOFeatureConfig {
+	if c == nil && layer == nil {
+		return nil
+	}
+	if c == nil {
+		return layer
+	}
+	if layer == nil {
+		return c
+	}
+	if layer.MaximumProviders != nil {
+		c.MaximumProviders = layer.MaximumProviders
+	}
+	c.Providers = c.Providers.Merge(layer.Providers)
+	return c
+}
+
 var _ = FeatureConfigSchema.Add("OAuthSSOProvidersFeatureConfig", `
 {
 	"type": "object",
@@ -125,6 +156,46 @@ type OAuthSSOProvidersFeatureConfig struct {
 	ADFS       *OAuthSSOProviderFeatureConfig `json:"adfs,omitempty"`
 	Apple      *OAuthSSOProviderFeatureConfig `json:"apple,omitempty"`
 	Wechat     *OAuthSSOProviderFeatureConfig `json:"wechat,omitempty"`
+}
+
+func (c *OAuthSSOProvidersFeatureConfig) Merge(layer *OAuthSSOProvidersFeatureConfig) *OAuthSSOProvidersFeatureConfig {
+	if c == nil && layer == nil {
+		return nil
+	}
+	if c == nil {
+		return layer
+	}
+	if layer == nil {
+		return c
+	}
+	if layer.Google != nil {
+		c.Google = layer.Google
+	}
+	if layer.Facebook != nil {
+		c.Facebook = layer.Facebook
+	}
+	if layer.Github != nil {
+		c.Github = layer.Github
+	}
+	if layer.LinkedIn != nil {
+		c.LinkedIn = layer.LinkedIn
+	}
+	if layer.Azureadv2 != nil {
+		c.Azureadv2 = layer.Azureadv2
+	}
+	if layer.Azureadb2c != nil {
+		c.Azureadb2c = layer.Azureadb2c
+	}
+	if layer.ADFS != nil {
+		c.ADFS = layer.ADFS
+	}
+	if layer.Apple != nil {
+		c.Apple = layer.Apple
+	}
+	if layer.Wechat != nil {
+		c.Wechat = layer.Wechat
+	}
+	return c
 }
 
 func (c *OAuthSSOProvidersFeatureConfig) IsDisabled(cfg oauthrelyingparty.ProviderConfig) bool {

--- a/pkg/lib/config/feature_messaging.go
+++ b/pkg/lib/config/feature_messaging.go
@@ -44,9 +44,7 @@ func (c *MessagingFeatureConfig) Merge(layer *FeatureConfig) MergeableFeatureCon
 	if merged == nil {
 		merged = &MessagingFeatureConfig{}
 	}
-	if layer.Messaging.RateLimits != nil {
-		merged.RateLimits = layer.Messaging.RateLimits
-	}
+	merged.RateLimits = merged.RateLimits.Merge(layer.Messaging.RateLimits)
 	if layer.Messaging.SMSUsage != nil {
 		merged.SMSUsage = layer.Messaging.SMSUsage
 	}
@@ -131,6 +129,37 @@ type MessagingRateLimitsFeatureConfig struct {
 	Email          *RateLimitConfig `json:"email,omitempty"`
 	EmailPerIP     *RateLimitConfig `json:"email_per_ip,omitempty"`
 	EmailPerTarget *RateLimitConfig `json:"email_per_target,omitempty"`
+}
+
+func (c *MessagingRateLimitsFeatureConfig) Merge(layer *MessagingRateLimitsFeatureConfig) *MessagingRateLimitsFeatureConfig {
+	if c == nil && layer == nil {
+		return nil
+	}
+	if c == nil {
+		return layer
+	}
+	if layer == nil {
+		return c
+	}
+	if layer.SMS != nil {
+		c.SMS = layer.SMS
+	}
+	if layer.SMSPerIP != nil {
+		c.SMSPerIP = layer.SMSPerIP
+	}
+	if layer.SMSPerTarget != nil {
+		c.SMSPerTarget = layer.SMSPerTarget
+	}
+	if layer.Email != nil {
+		c.Email = layer.Email
+	}
+	if layer.EmailPerIP != nil {
+		c.EmailPerIP = layer.EmailPerIP
+	}
+	if layer.EmailPerTarget != nil {
+		c.EmailPerTarget = layer.EmailPerTarget
+	}
+	return c
 }
 
 func (c *MessagingRateLimitsFeatureConfig) SetDefaults() {

--- a/pkg/lib/config/feature_test_mode.go
+++ b/pkg/lib/config/feature_test_mode.go
@@ -81,7 +81,29 @@ func (c *TestModeFeatureConfig) Merge(layer *FeatureConfig) MergeableFeatureConf
 	if layer.TestMode == nil {
 		return c
 	}
-	return layer.TestMode
+
+	merged := c
+	if merged == nil {
+		merged = &TestModeFeatureConfig{}
+	}
+
+	if layer.TestMode.FixedOOBOTP != nil {
+		merged.FixedOOBOTP = layer.TestMode.FixedOOBOTP
+	}
+	if layer.TestMode.DeterministicLinkOTP != nil {
+		merged.DeterministicLinkOTP = layer.TestMode.DeterministicLinkOTP
+	}
+	if layer.TestMode.SMS != nil {
+		merged.SMS = layer.TestMode.SMS
+	}
+	if layer.TestMode.Whatsapp != nil {
+		merged.Whatsapp = layer.TestMode.Whatsapp
+	}
+	if layer.TestMode.Email != nil {
+		merged.Email = layer.TestMode.Email
+	}
+
+	return merged
 }
 
 type TestModeFixedOOBOTPFeatureConfig struct {

--- a/pkg/lib/config/feature_ui.go
+++ b/pkg/lib/config/feature_ui.go
@@ -24,7 +24,20 @@ func (c *UIFeatureConfig) Merge(layer *FeatureConfig) MergeableFeatureConfig {
 	if layer.UI == nil {
 		return c
 	}
-	return layer.UI
+
+	merged := c
+	if merged == nil {
+		merged = &UIFeatureConfig{}
+	}
+
+	if layer.UI.WhiteLabeling != nil {
+		merged.WhiteLabeling = layer.UI.WhiteLabeling
+	}
+	if layer.UI.PhoneInput != nil {
+		merged.PhoneInput = layer.UI.PhoneInput
+	}
+
+	return merged
 }
 
 var _ = FeatureConfigSchema.Add("WhiteLabelingFeatureConfig", `

--- a/pkg/lib/config/testdata/merge_feature.yaml
+++ b/pkg/lib/config/testdata/merge_feature.yaml
@@ -69,7 +69,42 @@ configs:
         allowlist:
           - US
           - CA
+  - identity:
+      oauth:
+        providers:
+          apple:
+            disabled: true
+  - identity:
+      oauth:
+        maximum_providers: 150
+  - identity:
+      oauth:
+        providers:
+          wechat:
+            disabled: true
+  - identity:
+      login_id:
+        types:
+          phone:
+            disabled: true
+  - identity:
+      biometric:
+        disabled: true
 result:
+  identity:
+    login_id:
+      types:
+        phone:
+          disabled: true
+    oauth:
+      maximum_providers: 150
+      providers:
+        apple:
+          disabled: true
+        wechat:
+          disabled: true
+    biometric:
+      disabled: true
   hook:
     blocking_handler:
       maximum: 5

--- a/pkg/lib/config/testdata/merge_feature.yaml
+++ b/pkg/lib/config/testdata/merge_feature.yaml
@@ -64,6 +64,11 @@ configs:
   - hook:
       non_blocking_handler:
         maximum: 7
+  - ui:
+      phone_input:
+        allowlist:
+          - US
+          - CA
 result:
   hook:
     blocking_handler:
@@ -83,6 +88,10 @@ result:
   ui:
     white_labeling:
       disabled: true
+    phone_input:
+      allowlist:
+        - US
+        - CA
   custom_domain:
     disabled: true
   oauth:

--- a/pkg/lib/config/testdata/merge_feature.yaml
+++ b/pkg/lib/config/testdata/merge_feature.yaml
@@ -90,7 +90,24 @@ configs:
   - identity:
       biometric:
         disabled: true
+  - authenticator:
+      password:
+        policy:
+          history:
+            disabled: true
+  - authenticator:
+      password:
+        policy:
+          minimum_guessable_level:
+            disabled: true
 result:
+  authenticator:
+    password:
+      policy:
+        history:
+          disabled: true
+        minimum_guessable_level:
+          disabled: true
   identity:
     login_id:
       types:

--- a/pkg/lib/config/testdata/merge_feature.yaml
+++ b/pkg/lib/config/testdata/merge_feature.yaml
@@ -114,7 +114,20 @@ configs:
           enabled: true
           period: 1h
           burst: 9
+  - test_mode:
+      fixed_oob_otp:
+        enabled: true
+        code: "123456"
+  - test_mode:
+      sms:
+        suppressed: true
 result:
+  test_mode:
+    fixed_oob_otp:
+      enabled: true
+      code: "123456"
+    sms:
+      suppressed: true
   authenticator:
     password:
       policy:

--- a/pkg/lib/config/testdata/merge_feature.yaml
+++ b/pkg/lib/config/testdata/merge_feature.yaml
@@ -102,6 +102,18 @@ configs:
             disabled: true
   - collaborator:
       soft_maximum: 40
+  - messaging:
+      rate_limits:
+        sms:
+          enabled: true
+          period: 30s
+          burst: 3
+  - messaging:
+      rate_limits:
+        email:
+          enabled: true
+          period: 1h
+          burst: 9
 result:
   authenticator:
     password:
@@ -158,6 +170,15 @@ result:
     maximum: 3
     soft_maximum: 40
   messaging:
+    rate_limits:
+      sms:
+        enabled: true
+        period: 30s
+        burst: 3
+      email:
+        enabled: true
+        period: 1h
+        burst: 9
     whatsapp_usage_count_disabled: true
     custom_sms_provider_disabled: true
     sms_usage:

--- a/pkg/lib/config/testdata/merge_feature.yaml
+++ b/pkg/lib/config/testdata/merge_feature.yaml
@@ -58,7 +58,18 @@ configs:
         quota: 2
   - admin_api:
       create_session_enabled: true
+  - hook:
+      blocking_handler:
+        maximum: 5
+  - hook:
+      non_blocking_handler:
+        maximum: 7
 result:
+  hook:
+    blocking_handler:
+      maximum: 5
+    non_blocking_handler:
+      maximum: 7
   admin_api:
     create_session_enabled: true
     user_import_usage:

--- a/pkg/lib/config/testdata/merge_feature.yaml
+++ b/pkg/lib/config/testdata/merge_feature.yaml
@@ -100,6 +100,8 @@ configs:
         policy:
           minimum_guessable_level:
             disabled: true
+  - collaborator:
+      soft_maximum: 40
 result:
   authenticator:
     password:
@@ -154,7 +156,7 @@ result:
       app2app_enabled: false
   collaborator:
     maximum: 3
-    soft_maximum: 30
+    soft_maximum: 40
   messaging:
     whatsapp_usage_count_disabled: true
     custom_sms_provider_disabled: true


### PR DESCRIPTION
ref DEV-3738

Summary:

| # | Section | Merge behavior | Notes |
|---|---|---|---|
| 1 | `identity` | ✅ Field-level | 3-level cascade: `login_id`/`oauth`/`biometric` independent; within `oauth`: `maximum_providers`/`providers` independent; within `providers`: all 9 providers independent |
| 2 | `authentication` | ✅ Field-level | Cascades to `secondary_authenticators`'s one field (`oob_otp_sms`) — moot today (only one leaf), proactive fix |
| 3 | `authenticator` | ✅ Field-level | Cascades through `password` → `policy` to the 3 independent gates (`minimum_guessable_level`/`excluded_keywords`/`history`) |
| 4 | `custom_domain` | Whole-section replace | **Fine** — single field (`disabled`), nothing to clobber |
| 5 | `ui` | ✅ Field-level | `white_labeling`/`phone_input` independent |
| 6 | `oauth` | ✅ Field-level (already correct) | Cascades to `client`'s 4 independent fields — this was the reference pattern used for all the fixes above |
| 7 | `hook` | ✅ Field-level | `blocking_handler.maximum`/`non_blocking_handler.maximum` independent |
| 8 | `audit_log` | Whole-section replace | **Fine** — single field (`retrieval_days`) |
| 9 | `google_tag_manager` | Whole-section replace | **Fine** — single field (`disabled`) |
| 10 | `rate_limits` (top-level) | Whole-section replace | **Fine** — single field (`disabled`) |
| 11 | `messaging` | ✅ Field-level (already correct) + fixed nested gap | Top-level fields (`rate_limits`/`sms_usage`/etc.) independent; **and now** `rate_limits`'s 6 channels (`sms`/`sms_per_ip`/`sms_per_target`/`email`/`email_per_ip`/`email_per_target`) are independent too |
| 12 | `usage` | ✅ Field-level (already correct) | `hooks` appends across layers (deliberately, unique); `limits` merges per usage-name (`sms`/`email`/`whatsapp`/`user_import`/`user_export`) independently |
| 13 | `collaborator` | ✅ Field-level | `maximum`/`soft_maximum` independent |
| 14 | `web3` | ⚠️ **Never merges at all** | No `Merge` method, no `MergeableFeatureConfig` assertion — any layer's `web3.nft.maximum` is silently ignored, always resolves to hardcoded default `3`. Different bug class from "whole-section replace"; left as-is since deprecated |
| 15 | `admin_api` | ✅ Field-level (already correct) | `create_session_enabled`/`user_import_usage`/`user_export_usage` independent |
| 16 | `test_mode` | ✅ Field-level | All 5 gates (`fixed_oob_otp`/`deterministic_link_otp`/`sms.suppressed`/`email.suppressed`/`whatsapp.suppressed`) independent |
| 17 | `fraud_protection` | Whole-section replace | **Fine** — single field (`is_modifiable`) |