### PR TITLE
chore: Update kin-openapi to v0.145.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -166,7 +166,7 @@ require (
 	github.com/envoyproxy/go-control-plane/envoy v1.37.0 // indirect
 	github.com/envoyproxy/protoc-gen-validate v1.3.3 // indirect
 	github.com/erikgeiser/coninput v0.0.0-20211004153227-1c3628e74d0f // indirect
-	github.com/getkin/kin-openapi v0.142.0 // indirect
+	github.com/getkin/kin-openapi v0.145.0 // indirect
 	github.com/go-ini/ini v1.67.0 // indirect
 	github.com/go-jose/go-jose/v4 v4.1.4 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -188,8 +188,8 @@ github.com/fsnotify/fsnotify v1.9.0 h1:2Ml+OJNzbYCTzsxtv8vKSFD9PbJjmhYF14k/jKC7S
 github.com/fsnotify/fsnotify v1.9.0/go.mod h1:8jBTzvmWwFyi3Pb8djgCCO5IBqzKJ/Jwo8TRcHyHii0=
 github.com/fxamacker/cbor/v2 v2.9.0 h1:NpKPmjDBgUfBms6tr6JZkTHtfFGcMKsw3eGcmD/sapM=
 github.com/fxamacker/cbor/v2 v2.9.0/go.mod h1:vM4b+DJCtHn+zz7h3FFp/hDAI9WNWCsZj23V5ytsSxQ=
-github.com/getkin/kin-openapi v0.142.0 h1:izj0vBdFprMhitfzaX8sTqztsEQyvwhssBoB6n8NO7w=
-github.com/getkin/kin-openapi v0.142.0/go.mod h1:3BH9M9XDe/y9M5DSvEocVYAYq1w0qrhJHjC/vZi0AaY=
+github.com/getkin/kin-openapi v0.145.0 h1:htBX+Q7SevVaCUqymFegUKzH2WCbewl9tsmyn2FMGWY=
+github.com/getkin/kin-openapi v0.145.0/go.mod h1:3BH9M9XDe/y9M5DSvEocVYAYq1w0qrhJHjC/vZi0AaY=
 github.com/getsentry/sentry-go v0.35.0 h1:+FJNlnjJsZMG3g0/rmmP7GiKjQoUF5EXfEtBwtPtkzY=
 github.com/getsentry/sentry-go v0.35.0/go.mod h1:C55omcY9ChRQIUcVcGcs+Zdy4ZpQGvNJ7JYHIoSWOtE=
 github.com/getsentry/sentry-go/slog v0.35.0 h1:pmaBLpH0z+p9M59ur1ULhhVHZWVRn0w19LrdKmIBgHs=


### PR DESCRIPTION
Bump the indirect dependency github.com/getkin/kin-openapi from v0.142.0 to v0.145.0 to clear two advisories, both patched in v0.144.0:

- GHSA-r277-6w6q-xmqw (CRITICAL, CWE-287): ValidationHandler.Load() silently substitutes NoopAuthenticationFunc for a nil AuthenticationFunc, making every OpenAPI security requirement fail open. https://github.com/getkin/kin-openapi/security/advisories/GHSA-r277-6w6q-xmqw
- GHSA-jpcw-4wr7-c3vq (MODERATE, CWE-476): unauthenticated nil-pointer panic in openapi3filter when validating a request against a content parameter whose media type declares no schema. https://github.com/getkin/kin-openapi/security/advisories/GHSA-jpcw-4wr7-c3vq

Neither was exploitable here. Both live in openapi3filter, which this repo never imports; kin-openapi is pulled in only by oapi-codegen/v2 v2.8.0 as a code generator for pkg/api/siteadmin/gen.go, and that config generates models only. The package never reaches a shipped binary. The bump closes the Dependabot alerts rather than fixing a live exposure.

oapi-codegen v2.8.0 is already the latest release and still requires v0.142.0, so the bump is applied directly via MVS rather than by upgrading the parent.

Verified: the oapi-codegen binary builds against v0.145.0 and `go generate ./pkg/api/siteadmin/...` reproduces gen.go byte-identically.