### PR TITLE
chore: Suppress gosec G710/G124 false positives

### DIFF
--- a/.vettedpositions
+++ b/.vettedpositions
@@ -51,9 +51,9 @@
 /pkg/auth/handler/saml/login_finish.go:104:46: requestcontext
 /pkg/auth/handler/saml/login_finish.go:114:31: requestcontext
 /pkg/auth/handler/saml/logout.go:81:9: requestcontext
-/pkg/auth/handler/saml/logout.go:613:9: requestcontext
-/pkg/auth/handler/saml/logout.go:619:46: requestcontext
-/pkg/auth/handler/saml/logout.go:622:31: requestcontext
+/pkg/auth/handler/saml/logout.go:615:9: requestcontext
+/pkg/auth/handler/saml/logout.go:621:46: requestcontext
+/pkg/auth/handler/saml/logout.go:624:31: requestcontext
 /pkg/auth/handler/webapp/account_status.go:48:27: requestcontext
 /pkg/auth/handler/webapp/app_static_assets.go:39:33: requestcontext
 /pkg/auth/handler/webapp/auth_entry_point_middleware.go:35:10: requestcontext
@@ -112,7 +112,7 @@
 /pkg/auth/handler/webapp/authflowv2/reset_password.go:173:27: requestcontext
 /pkg/auth/handler/webapp/authflowv2/reset_password_success.go:60:36: requestcontext
 /pkg/auth/handler/webapp/authflowv2/select_account.go:111:32: requestcontext
-/pkg/auth/handler/webapp/authflowv2/select_account.go:249:27: requestcontext
+/pkg/auth/handler/webapp/authflowv2/select_account.go:250:27: requestcontext
 /pkg/auth/handler/webapp/authflowv2/settings.go:89:30: requestcontext
 /pkg/auth/handler/webapp/authflowv2/settings_advanced.go:46:30: requestcontext
 /pkg/auth/handler/webapp/authflowv2/settings_biometric.go:101:30: requestcontext
@@ -244,7 +244,7 @@
 /pkg/auth/handler/webapp/sso_callback.go:65:58: requestcontext
 /pkg/auth/handler/webapp/sso_callback.go:77:44: requestcontext
 /pkg/auth/handler/webapp/sso_callback.go:92:44: requestcontext
-/pkg/auth/handler/webapp/tester.go:279:27: requestcontext
+/pkg/auth/handler/webapp/tester.go:281:27: requestcontext
 /pkg/auth/handler/webapp/turbo_response_writer.go:29:25: requestcontext
 /pkg/auth/handler/webapp/turbo_response_writer.go:34:29: requestcontext
 /pkg/auth/handler/webapp/use_passkey.go:53:27: requestcontext
@@ -280,7 +280,7 @@
 /pkg/auth/webapp_request_middleware.go:40:10: requestcontext
 /pkg/images/deps/context.go:23:10: requestcontext
 /pkg/images/deps/middleware_request.go:24:10: requestcontext
-/pkg/images/handler/get.go:94:11: requestcontext
+/pkg/images/handler/get.go:95:11: requestcontext
 /pkg/images/handler/post.go:58:9: requestcontext
 /pkg/lib/accountmanagement/rate_limit_middleware.go:36:10: requestcontext
 /pkg/lib/admin/authz/middleware.go:40:10: requestcontext
@@ -351,7 +351,7 @@
 /pkg/util/jwkutil/contextbackground.go:11:52: contextbackground
 /pkg/util/otelutil/nethttp.go:122:46: requestcontext
 /pkg/util/otelutil/nethttp.go:156:49: requestcontext
-/pkg/util/otelutil/oteldatabasesql/instrumentation.go:301:13: contextbackground
+/pkg/util/otelutil/oteldatabasesql/instrumentation.go:329:13: contextbackground
 /pkg/util/pubsub/http_handler.go:51:40: requestcontext
 /pkg/util/sentry/request.go:25:9: requestcontext
 /pkg/util/slogutil/sentry_handler.go:92:11: contextbackground

--- a/pkg/auth/handler/saml/logout.go
+++ b/pkg/auth/handler/saml/logout.go
@@ -202,6 +202,8 @@ func (h *LogoutHandler) doLogoutRemainingSPs(
 		return
 	} else if result.sloSession.Entry.PostLogoutRedirectURI != "" {
 		// This is not a logout triggered by SP, redirect to post logout url
+		// #nosec G710 -- PostLogoutRedirectURI is only ever populated from webapp.ResolvePostLogoutRedirectURI,
+		// which allow-lists it against the OAuth client's registered PostLogoutRedirectURIs or enforces same-origin.
 		http.Redirect(rw, r, result.sloSession.Entry.PostLogoutRedirectURI, http.StatusFound)
 		return
 	} else {

--- a/pkg/auth/handler/webapp/auth_entry_point_middleware.go
+++ b/pkg/auth/handler/webapp/auth_entry_point_middleware.go
@@ -50,6 +50,7 @@ func (m *AuthEntryPointMiddleware) Handle(next http.Handler) http.Handler {
 			defaultRedirectURI := webapp.DerivePostLoginRedirectURIFromRequest(r, m.OAuthClientResolver, m.UIConfig)
 			redirectURI := webapp.GetRedirectURI(r, bool(m.TrustProxy), defaultRedirectURI)
 
+			// #nosec G710 -- webapp.GetRedirectURI enforces same-origin via httputil.parseRedirectURI, or falls back to defaultRedirectURI.
 			http.Redirect(w, r, redirectURI, http.StatusFound)
 		} else if userID == nil && !fromAuthzEndpoint && directAccessDisabled {
 			logger := AuthEntryPointMiddlewareLogger.GetLogger(ctx)

--- a/pkg/auth/handler/webapp/authflowv2/select_account.go
+++ b/pkg/auth/handler/webapp/authflowv2/select_account.go
@@ -197,6 +197,7 @@ func (h *AuthflowV2SelectAccountHandler) ServeHTTP(w http.ResponseWriter, r *htt
 			redirectURI = h.UIInfoResolver.SetAuthenticationInfoInQuery(redirectURI, entry)
 		}
 
+		// #nosec G710 -- redirectURI is either webSession.RedirectURI (set from an allow-listed/same-origin redirect_uri when the web session was created) or webapp.DerivePostLoginRedirectURIFromRequest, which allow-lists against the OAuth client's registered RedirectURIs.
 		http.Redirect(w, r, redirectURI, http.StatusFound)
 		return nil
 	}
@@ -316,5 +317,6 @@ func (h *AuthflowV2SelectAccountHandler) ServeHTTP(w http.ResponseWriter, r *htt
 func (h *AuthflowV2SelectAccountHandler) continueFlow(w http.ResponseWriter, r *http.Request, path string) {
 	// preserve query only when continuing the login flow
 	u := webapp.MakeRelativeURL(path, webapp.PreserveQuery(r.URL.Query()))
+	// #nosec G710 -- webapp.MakeRelativeURL only ever sets Path and RawQuery, never Scheme/Host, so u is always relative to the current origin.
 	http.Redirect(w, r, u.String(), http.StatusFound)
 }

--- a/pkg/auth/handler/webapp/authflowv2/signup.go
+++ b/pkg/auth/handler/webapp/authflowv2/signup.go
@@ -23,6 +23,7 @@ func (h *AuthflowV2SignupHandler) ServeHTTP(w http.ResponseWriter, r *http.Reque
 	if h.AuthenticationConfig.PublicSignupDisabled {
 		path := "/login"
 		u := webapp.MakeRelativeURL(path, webapp.PreserveQuery(r.URL.Query()))
+		// #nosec G710 -- webapp.MakeRelativeURL only ever sets Path and RawQuery, never Scheme/Host, so u is always relative to the current origin.
 		http.Redirect(w, r, u.String(), http.StatusFound)
 		return
 	}

--- a/pkg/auth/handler/webapp/logout.go
+++ b/pkg/auth/handler/webapp/logout.go
@@ -120,6 +120,7 @@ func (h *LogoutHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		}
 
 		// If no saml service provider is pending logout
+		// #nosec G710 -- redirectURI comes from webapp.GetRedirectURI, which enforces same-origin, or webapp.ResolvePostLogoutRedirectURI, which allow-lists against the OAuth client's registered PostLogoutRedirectURIs.
 		http.Redirect(w, r, redirectURI, http.StatusFound)
 		return nil
 

--- a/pkg/auth/handler/webapp/noproject_sso_callback.go
+++ b/pkg/auth/handler/webapp/noproject_sso_callback.go
@@ -68,5 +68,6 @@ func (h *NoProjectSSOCallbackHandler) ServeHTTP(w http.ResponseWriter, r *http.R
 	redirectURL.RawQuery = r.URL.RawQuery
 
 	// Use 307 so that method and body is kept
+	// #nosec G710 -- redirectURL's scheme/host come from the app's server-configured PublicOrigin (resolved via the validated state token), not user input; only RawQuery is copied from the request.
 	http.Redirect(w, r, redirectURL.String(), http.StatusTemporaryRedirect)
 }

--- a/pkg/auth/handler/webapp/oauth_entrypoint.go
+++ b/pkg/auth/handler/webapp/oauth_entrypoint.go
@@ -28,5 +28,6 @@ func (h *OAuthEntrypointHandler) ServeHTTP(w http.ResponseWriter, r *http.Reques
 		h.Endpoints.SelectAccountEndpointURL().Path,
 		webapp.PreserveQuery(r.URL.Query()),
 	)
+	// #nosec G710 -- webapp.MakeRelativeURL only ever sets Path and RawQuery, never Scheme/Host, so u is always relative to the current origin.
 	http.Redirect(w, r, u.String(), http.StatusFound)
 }

--- a/pkg/auth/handler/webapp/tester.go
+++ b/pkg/auth/handler/webapp/tester.go
@@ -145,6 +145,7 @@ func (h *TesterHandler) triggerAuth(ctx context.Context, token string, w http.Re
 
 	redirectTo := h.OauthEndpointsProvider.AuthorizeEndpointURL()
 	redirectTo.RawQuery = q.Encode()
+	// #nosec G710 -- redirectTo's scheme/host come from the server-configured AuthorizeEndpointURL; only the query string (built from fixed keys above) is set.
 	http.Redirect(w, r, redirectTo.String(), http.StatusFound)
 
 	return nil
@@ -245,6 +246,7 @@ func (h *TesterHandler) doCodeExchange(ctx context.Context, code string, stateb6
 
 	redirectTo := h.TesterEndpointsProvider.TesterURL()
 	redirectTo.RawQuery = q.Encode()
+	// #nosec G710 -- redirectTo's scheme/host come from the server-configured TesterURL; only the query string (built from fixed keys above) is set.
 	http.Redirect(w, r, redirectTo.String(), http.StatusFound)
 
 	return nil

--- a/pkg/auth/webapp/public_origin_middleware.go
+++ b/pkg/auth/webapp/public_origin_middleware.go
@@ -42,6 +42,7 @@ func (m *PublicOriginMiddleware) Handle(next http.Handler) http.Handler {
 		newURL.Host = publicOrigin.Host
 
 		logger.Debug(ctx, "redirect to the configured public origin", slog.String("new_url", newURL.String()))
+		// #nosec G710 -- newURL.Scheme and newURL.Host are set from the server-configured PublicOrigin, not user input.
 		http.Redirect(w, r, newURL.String(), http.StatusTemporaryRedirect)
 	})
 }

--- a/pkg/images/handler/get.go
+++ b/pkg/images/handler/get.go
@@ -75,6 +75,7 @@ func (h *GetHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			u := *r.URL
 			u.Scheme = string(h.HTTPProto)
 			u.Host = string(h.ImagesCDNHost)
+			// #nosec G710 -- u.Scheme and u.Host are set from the server-configured ImagesCDNHost, not user input.
 			http.Redirect(w, r, u.String(), http.StatusFound)
 			return
 		}

--- a/pkg/util/httputil/cookie.go
+++ b/pkg/util/httputil/cookie.go
@@ -108,6 +108,7 @@ func (f *CookieManager) GetCookie(r *http.Request, def *CookieDef) (*http.Cookie
 
 // ValueCookie generates a cookie that when set, the cookie is set to the specified value.
 func (f *CookieManager) ValueCookie(def *CookieDef, value string) *http.Cookie {
+	// #nosec G124 -- Secure and SameSite are set below via field assignment, since they depend on f.secure().
 	cookie := &http.Cookie{
 		Name:     f.CookieName(def),
 		Path:     def.Path,
@@ -133,6 +134,7 @@ func (f *CookieManager) ValueCookie(def *CookieDef, value string) *http.Cookie {
 // ClearCookie generates a cookie that when set, the cookie is clear.
 func (f *CookieManager) ClearCookie(def *CookieDef) *http.Cookie {
 	emptyValue := ""
+	// #nosec G124 -- ValueCookie already sets Secure, HttpOnly, and SameSite on the returned cookie.
 	cookie := f.ValueCookie(def, emptyValue)
 
 	// Suppress the MaxAge attribute written by ValueCookie


### PR DESCRIPTION
The golangci-lint bump to v2.11.3 (08c0cfb3b6) pulled in a newer gosec that added G710 (open redirect via taint analysis) and G124 (cookie missing Secure/HttpOnly/SameSite) checks not present in the previously pinned v2.5.0. Audited every flagged site: redirects are same-origin enforced, allow-listed against registered client URIs, or point at a server-configured host; cookie attributes are set via field assignment right after the literal gosec inspects. Added #nosec justification comments and synced .vettedpositions for the resulting line shifts.