### PR TITLE
Fix font preload to only include woff2, not eot/ttf/woff

### DIFF
--- a/authui/vite.config.ts
+++ b/authui/vite.config.ts
@@ -5,7 +5,7 @@ import crypto from "crypto";
 import path from "path";
 import fs from "fs/promises";
 
-const fontFileExtensions = [".eot", ".otf", ".ttf", "woff", ".woff2"];
+const fontFileExtensions = [".woff2"];
 
 const templateBase = "../resources/authgear/templates/en/web/";
 const templateNameByAssetName: Record<string, string> = {


### PR DESCRIPTION
Every browser capable of rel=preload also supports woff2 and selects it first from each @font-face src list, so preloading eot/ttf/woff alongside it only forces an extra, guaranteed-unused download on every cold login/signup page load (~2.4 MB for tabler-icons, material-symbols, and Twemoji combined). Fallback formats stay available via the existing @font-face src chains; they're just no longer force-fetched upfront.

ref DEV-3718
Fix #5812