### PR TITLE
Fix onboarding wizard and survey selection controls

### DIFF
--- a/portal/src/components/v2/ColorPickerField/ColorPickerField.module.css
+++ b/portal/src/components/v2/ColorPickerField/ColorPickerField.module.css
@@ -4,6 +4,9 @@
   border-radius: var(--radius-2);
 }
 
-.colorPickerField__pickerButton {
-  @apply top-0 left-0 right-0 bottom-0 absolute bg-transparent;
+.colorPickerField__pickerInput {
+  @apply absolute top-0 left-0 h-full w-full cursor-pointer opacity-0;
+  padding: 0;
+  margin: 0;
+  border: none;
 }

--- a/portal/src/components/v2/ColorPickerField/ColorPickerField.tsx
+++ b/portal/src/components/v2/ColorPickerField/ColorPickerField.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useRef, useState, useEffect } from "react";
+import React, { useCallback, useState, useEffect } from "react";
 import { TextField as RadixTextField } from "@radix-ui/themes";
 import { TextField } from "../TextField/TextField";
 
@@ -108,13 +108,6 @@ function ColorPicker({
   onValueChange?: (value: ColorHex) => void;
   onOpen?: () => void;
 }) {
-  const inputRef = useRef<HTMLInputElement>(null);
-
-  const openPicker = useCallback(() => {
-    onOpen?.();
-    inputRef.current?.click();
-  }, [onOpen]);
-
   const handleColorInputChange = useCallback(
     (e: React.ChangeEvent<HTMLInputElement>) => {
       const el = e.currentTarget;
@@ -123,20 +116,24 @@ function ColorPicker({
     [onValueChange]
   );
 
+  const handleClick = useCallback(() => {
+    onOpen?.();
+  }, [onOpen]);
+
   return (
     <div
       className={styles.colorPickerField__pickerContainer}
       style={{ backgroundColor: value }}
     >
-      <button
-        type="button"
-        className={styles.colorPickerField__pickerButton}
-        onClick={openPicker}
-      />
+      {/* The input itself covers the swatch so the user's click lands
+          directly on it. Safari only opens the native color panel for an
+          input with a real rendered box; programmatically clicking a
+          zero-size input does nothing there. */}
       <input
-        ref={inputRef}
         type="color"
-        className="h-0 w-0 appearance-none border-none"
+        value={value}
+        className={styles.colorPickerField__pickerInput}
+        onClick={handleClick}
         onChange={handleColorInputChange}
       />
     </div>

--- a/portal/src/components/v2/IconRadioCards/IconRadioCards.tsx
+++ b/portal/src/components/v2/IconRadioCards/IconRadioCards.tsx
@@ -1,6 +1,10 @@
 import cn from "classnames";
-import { RadioCards as RadixRadioCards, Text } from "@radix-ui/themes";
-import React, { useCallback, useMemo } from "react";
+import {
+  CheckboxCards as RadixCheckboxCards,
+  RadioCards as RadixRadioCards,
+  Text,
+} from "@radix-ui/themes";
+import React, { useCallback } from "react";
 import styles from "./IconRadioCards.module.css";
 import { Tooltip } from "../Tooltip/Tooltip";
 
@@ -65,38 +69,54 @@ export function MultiSelectIconRadioCards<T extends string>({
   values,
   onValuesChange,
   options,
-  ...rootProps
+  size,
+  itemMinWidth = 160,
+  itemFillSpaces = false,
+  numberOfColumns,
 }: MultiSelectIconRadioCardsProps<T>): React.ReactElement {
-  const checkedValuesSet = useMemo(() => new Set(values), [values]);
-
-  const onToggleCallbacks = useMemo(() => {
-    return options.map((option) => {
-      const fn = () => {
-        const newValues = new Set(checkedValuesSet);
-        if (!checkedValuesSet.has(option.value)) {
-          newValues.add(option.value);
-        } else {
-          newValues.delete(option.value);
-        }
-        onValuesChange(Array.from(newValues));
-      };
-      return fn;
-    });
-  }, [checkedValuesSet, onValuesChange, options]);
+  // A radio group can only ever hold one value, so the multi-select variant
+  // is backed by CheckboxCards; its Root is controlled by the whole value
+  // list, which also keeps a forced-on disabled item rendered as checked.
+  const handleValueChange = useCallback(
+    (newValues: string[]) => {
+      onValuesChange(newValues as T[]);
+    },
+    [onValuesChange]
+  );
 
   return (
-    <Root {...rootProps}>
-      {options.map((option, idx) => {
+    <RadixCheckboxCards.Root
+      className={cn(styles.iconRadioCards__root)}
+      size={size}
+      variant="surface"
+      color="indigo"
+      value={values}
+      onValueChange={handleValueChange}
+      columns={`repeat(${gridColumnRepeat(
+        numberOfColumns
+      )}, minmax(${itemMinWidth}px, ${itemMaxSize(itemFillSpaces)}))`}
+    >
+      {options.map((option) => {
         return (
-          <OptionItem
+          <Tooltip
             key={option.value}
-            option={option}
-            checked={checkedValuesSet.has(option.value)}
-            onToggle={onToggleCallbacks[idx]}
-          />
+            content={option.tooltip}
+            disabled={option.tooltip == null}
+          >
+            {/* We need this extra div because Tooltip and RadixCheckboxCards.Item both write to data-state attribute causing bugs */}
+            <div className={styles.iconRadioCards__itemWrapper}>
+              <RadixCheckboxCards.Item
+                className={styles.iconRadioCards__item}
+                value={option.value}
+                disabled={option.disabled}
+              >
+                <OptionItemContent option={option} />
+              </RadixCheckboxCards.Item>
+            </div>
+          </Tooltip>
         );
       })}
-    </Root>
+    </RadixCheckboxCards.Root>
   );
 }
 
@@ -138,12 +158,8 @@ function Root({
 
 function OptionItem<T extends string>({
   option,
-  checked,
-  onToggle,
 }: {
   option: IconRadioCardOption<T>;
-  checked?: boolean;
-  onToggle?: () => void;
 }) {
   return (
     <Tooltip content={option.tooltip} disabled={option.tooltip == null}>
@@ -154,43 +170,49 @@ function OptionItem<T extends string>({
           key={option.value}
           value={option.value}
           disabled={option.disabled}
-          checked={checked}
-          onClick={onToggle}
         >
-          <div
-            className={cn(
-              styles.iconRadioCards__itemContainer,
-              option.subtitle == null &&
-                styles["iconRadioCards__itemContainer--center"]
-            )}
-          >
-            <div className={styles.iconRadioCards__iconContainer}>
-              {option.icon}
-            </div>
-            <div className={styles.iconRadioCards__itemTextContainer}>
-              <Text
-                as="p"
-                size={"2"}
-                weight={"medium"}
-                className={styles.iconRadioCards__itemTextTitle}
-              >
-                {option.title}
-              </Text>
-              {option.subtitle ? (
-                <Text
-                  as="p"
-                  size={"2"}
-                  weight={"regular"}
-                  className={styles.iconRadioCards__itemTextSubtitle}
-                >
-                  {option.subtitle}
-                </Text>
-              ) : null}
-            </div>
-          </div>
+          <OptionItemContent option={option} />
         </RadixRadioCards.Item>
       </div>
     </Tooltip>
+  );
+}
+
+function OptionItemContent<T extends string>({
+  option,
+}: {
+  option: IconRadioCardOption<T>;
+}) {
+  return (
+    <div
+      className={cn(
+        styles.iconRadioCards__itemContainer,
+        option.subtitle == null &&
+          styles["iconRadioCards__itemContainer--center"]
+      )}
+    >
+      <div className={styles.iconRadioCards__iconContainer}>{option.icon}</div>
+      <div className={styles.iconRadioCards__itemTextContainer}>
+        <Text
+          as="p"
+          size={"2"}
+          weight={"medium"}
+          className={styles.iconRadioCards__itemTextTitle}
+        >
+          {option.title}
+        </Text>
+        {option.subtitle ? (
+          <Text
+            as="p"
+            size={"2"}
+            weight={"regular"}
+            className={styles.iconRadioCards__itemTextSubtitle}
+          >
+            {option.subtitle}
+          </Text>
+        ) : null}
+      </div>
+    </div>
   );
 }
 

--- a/portal/src/components/v2/RadioCards/RadioCards.tsx
+++ b/portal/src/components/v2/RadioCards/RadioCards.tsx
@@ -63,7 +63,10 @@ export function RadioCards<T extends string>({
       color="indigo"
       highContrast={highContrast}
       columns={gridColumns(numberOfColumns, itemMinWidth, itemFillSpaces)}
-      value={value ?? undefined}
+      // "" (never undefined) keeps the Root controlled from the first render,
+      // so a null selection renders as nothing checked instead of leaving the
+      // group uncontrolled. Matches IconRadioCards.
+      value={value ?? ""}
       onValueChange={handleValueChange}
     >
       {options.map((option) => {

--- a/portal/src/components/v2/RadioCards/RadioCards.tsx
+++ b/portal/src/components/v2/RadioCards/RadioCards.tsx
@@ -1,6 +1,10 @@
 import cn from "classnames";
-import { RadioCards as RadixRadioCards, Text } from "@radix-ui/themes";
-import React, { useMemo } from "react";
+import {
+  CheckboxCards as RadixCheckboxCards,
+  RadioCards as RadixRadioCards,
+  Text,
+} from "@radix-ui/themes";
+import React, { useCallback } from "react";
 import styles from "./RadioCards.module.css";
 
 export interface RadioCardOption<T extends string> {
@@ -30,33 +34,50 @@ export function RadioCards<T extends string>({
   value,
   onValueChange,
   options,
-  ...rootProps
+  darkMode,
+  size,
+  highContrast,
+  itemMinWidth,
+  itemFillSpaces,
+  numberOfColumns,
 }: RadioCardsProps<T>): React.ReactElement {
-  const onToggleCallbacks = useMemo(() => {
-    return options.map((option) => {
-      const fn = () => {
-        if (value === option.value) {
-          return;
-        }
-        onValueChange(option.value);
-      };
-      return fn;
-    });
-  }, [onValueChange, options, value]);
+  // RadixRadioCards.Item derives its checked visual solely from
+  // Root's value === Item's value; a `checked` prop on the Item is ignored.
+  // The Root must therefore be controlled for the form state to drive the
+  // selection (e.g. restoring a persisted selection on mount).
+  const handleValueChange = useCallback(
+    (newValue: string) => {
+      if (newValue === value) {
+        return;
+      }
+      onValueChange(newValue as T);
+    },
+    [onValueChange, value]
+  );
 
   return (
-    <Root {...rootProps}>
-      {options.map((option, idx) => {
+    <RadixRadioCards.Root
+      className={cn(styles.radioCards__root, darkMode ? "dark" : null)}
+      size={size}
+      variant="surface"
+      color="indigo"
+      highContrast={highContrast}
+      columns={gridColumns(numberOfColumns, itemMinWidth, itemFillSpaces)}
+      value={value ?? undefined}
+      onValueChange={handleValueChange}
+    >
+      {options.map((option) => {
         return (
-          <OptionItem
+          <RadixRadioCards.Item
             key={option.value}
-            option={option}
-            checked={value === option.value}
-            onToggle={onToggleCallbacks[idx]}
-          />
+            value={option.value}
+            disabled={option.disabled}
+          >
+            <OptionItemContent option={option} />
+          </RadixRadioCards.Item>
         );
       })}
-    </Root>
+    </RadixRadioCards.Root>
   );
 }
 
@@ -70,127 +91,83 @@ export function MultiSelectRadioCards<T extends string>({
   values,
   onValuesChange,
   options,
-  ...rootProps
-}: MultiSelectRadioCardsProps<T>): React.ReactElement {
-  const checkedValuesSet = useMemo(() => new Set(values), [values]);
-
-  const onToggleCallbacks = useMemo(() => {
-    return options.map((option) => {
-      const fn = () => {
-        const newValues = new Set(checkedValuesSet);
-        if (!checkedValuesSet.has(option.value)) {
-          newValues.add(option.value);
-        } else {
-          newValues.delete(option.value);
-        }
-        onValuesChange(Array.from(newValues));
-      };
-      return fn;
-    });
-  }, [checkedValuesSet, onValuesChange, options]);
-
-  return (
-    <Root {...rootProps}>
-      {options.map((option, idx) => {
-        return (
-          <OptionItem
-            key={option.value}
-            option={option}
-            checked={checkedValuesSet.has(option.value)}
-            onToggle={onToggleCallbacks[idx]}
-          />
-        );
-      })}
-    </Root>
-  );
-}
-
-interface RootProps {
-  darkMode?: boolean;
-  highContrast?: boolean;
-  size: "1" | "2" | "3";
-  itemMinWidth?: number;
-  itemFillSpaces?: boolean;
-  numberOfColumns?: number;
-  children?: React.ReactNode;
-}
-
-function Root({
   darkMode,
   size,
   highContrast,
-  itemMinWidth = 160,
-  itemFillSpaces = false,
+  itemMinWidth,
+  itemFillSpaces,
   numberOfColumns,
-  children,
-}: RootProps) {
+}: MultiSelectRadioCardsProps<T>): React.ReactElement {
+  // A radio group can only ever hold one value, so multi-select must be
+  // backed by CheckboxCards; its Root is controlled by the whole value list.
+  const handleValueChange = useCallback(
+    (newValues: string[]) => {
+      onValuesChange(newValues as T[]);
+    },
+    [onValuesChange]
+  );
+
   return (
-    <RadixRadioCards.Root
+    <RadixCheckboxCards.Root
       className={cn(styles.radioCards__root, darkMode ? "dark" : null)}
       size={size}
       variant="surface"
       color="indigo"
       highContrast={highContrast}
-      columns={`repeat(${gridColumnRepeat(
-        numberOfColumns
-      )}, minmax(${itemMinWidth}px, ${itemMaxSize(itemFillSpaces)}))`}
+      columns={gridColumns(numberOfColumns, itemMinWidth, itemFillSpaces)}
+      value={values}
+      onValueChange={handleValueChange}
     >
-      {children}
-    </RadixRadioCards.Root>
+      {options.map((option) => {
+        return (
+          <RadixCheckboxCards.Item
+            key={option.value}
+            value={option.value}
+            disabled={option.disabled}
+          >
+            <OptionItemContent option={option} />
+          </RadixCheckboxCards.Item>
+        );
+      })}
+    </RadixCheckboxCards.Root>
   );
 }
 
-function OptionItem<T extends string>({
+function OptionItemContent<T extends string>({
   option,
-  checked,
-  onToggle,
 }: {
   option: RadioCardOption<T>;
-  checked?: boolean;
-  onToggle?: () => void;
 }) {
   return (
-    <RadixRadioCards.Item
-      key={option.value}
-      value={option.value}
-      disabled={option.disabled}
-      checked={checked}
-      onClick={onToggle}
-    >
-      <div className={styles.radioCards__itemTextContainer}>
+    <div className={styles.radioCards__itemTextContainer}>
+      <Text
+        as="p"
+        size={"2"}
+        weight={"medium"}
+        className={styles.radioCards__itemTextTitle}
+      >
+        {option.title}
+      </Text>
+      {option.subtitle ? (
         <Text
           as="p"
           size={"2"}
-          weight={"medium"}
-          className={styles.radioCards__itemTextTitle}
+          weight={"regular"}
+          className={styles.radioCards__itemTextSubtitle}
         >
-          {option.title}
+          {option.subtitle}
         </Text>
-        {option.subtitle ? (
-          <Text
-            as="p"
-            size={"2"}
-            weight={"regular"}
-            className={styles.radioCards__itemTextSubtitle}
-          >
-            {option.subtitle}
-          </Text>
-        ) : null}
-      </div>
-    </RadixRadioCards.Item>
+      ) : null}
+    </div>
   );
 }
 
-function itemMaxSize(itemFillSpaces: boolean) {
-  if (itemFillSpaces) {
-    return "1fr";
-  }
-  return "max-content";
-}
-
-function gridColumnRepeat(numberOfColumns: number | undefined) {
-  if (numberOfColumns == null) {
-    return "auto-fit";
-  }
-  return `${numberOfColumns}`;
+function gridColumns(
+  numberOfColumns: number | undefined,
+  itemMinWidth: number = 160,
+  itemFillSpaces: boolean = false
+) {
+  const repeat = numberOfColumns == null ? "auto-fit" : `${numberOfColumns}`;
+  const maxSize = itemFillSpaces ? "1fr" : "max-content";
+  return `repeat(${repeat}, minmax(${itemMinWidth}px, ${maxSize}))`;
 }


### PR DESCRIPTION
Fixes three QA-reported onboarding bugs sharing two root causes.

## DEV-3752 — No color picker shown when clicking the button color box (Safari)

Safari only opens the native color panel for an `input[type=color]` with a real rendered box; the previous implementation programmatically clicked a zero-size hidden input, which silently no-ops in WebKit. The input itself now covers the swatch (`opacity: 0`) so the user's click lands directly on it, and it is controlled so the panel opens at the current color instead of black.

<img width="1130" height="825" alt="SCR-20260731-rjso" src="https://github.com/user-attachments/assets/5b57563a-4369-42e1-8179-fe4e88d6cadc" />


## DEV-3750 / DEV-3751 — Multi-select cards display only the last click

`MultiSelectRadioCards` (survey step 4) and `MultiSelectIconRadioCards` (project wizard step 2) were built on Radix `RadioCards.Root` — a radio group that can hold at most one value. Form state accumulated selections correctly, but the cards displayed only the last click (and nothing after a remount), so:

- the survey's "(Multiple)" question appeared single-select, and the "Describe your reason" textarea seemed to show at random (it tracked the invisible state);
- wizard step 2's Passwordless / Input Password buttons didn't toggle visibly, and the "select at least one authentication method" error could show while an option looked selected.

Both variants are now backed by Radix `CheckboxCards` controlled by the whole value list, which also gives users a visible checkbox affordance and renders the forced **Input Password** card as checked-and-disabled while **Username** is on. The single-select `RadioCards` Root is now controlled too, so a persisted answer displays when returning to a step.

Verified in-browser: multi-select toggling, Username ⇒ forced Input Password, social-only hides the auth-method section (Next enabled), deselect-all shows the error with Next disabled, and the survey textarea shows iff Other is selected. Full portal CI suite passes (typecheck / eslint / stylelint / prettier / test / gentype / build).

ref DEV-3752, DEV-3750, DEV-3751

<img width="685" height="881" alt="SCR-20260731-rjqh" src="https://github.com/user-attachments/assets/ce8d3ac0-4309-44c5-a952-9bc45d64af29" />
<img width="1059" height="940" alt="SCR-20260731-rjmb" src="https://github.com/user-attachments/assets/c021e4ac-fc5b-48d5-8860-1fec9eef2169" />

