### PR TITLE
[Site Admin API] App Feature Config API

### DIFF
--- a/.make-lint-expect
+++ b/.make-lint-expect
@@ -5,6 +5,7 @@ pkg/api/apierrors/tags.go cannot import github.com/authgear/authgear-server/pkg/
 pkg/api/event/blocking/util.go cannot import github.com/authgear/authgear-server/pkg/util/accesscontrol
 pkg/api/event/event.go cannot import github.com/authgear/authgear-server/pkg/util/accesscontrol
 pkg/api/event/hook_response.go cannot import github.com/authgear/authgear-server/pkg/util/validation
+pkg/api/siteadmin/gen.go cannot import github.com/authgear/authgear-server/pkg/lib/config
 
 exit status 1
 pkg/lib/deps/deps_common.go cannot import github.com/authgear/authgear-server/pkg/latte/proofofphonenumberverification

--- a/.vettedpositions
+++ b/.vettedpositions
@@ -323,6 +323,11 @@
 /pkg/portal/transport/stripe_webhook_handler.go:49:9: requestcontext
 /pkg/portal/transport/system_config_handler.go:28:10: requestcontext
 /pkg/resolver/handler/resolve.go:40:9: requestcontext
+/pkg/siteadmin/transport/handler_app_feature_config_get.go:28:47: requestcontext
+/pkg/siteadmin/transport/handler_app_feature_config_preview.go:45:75: requestcontext
+/pkg/siteadmin/transport/handler_app_feature_config_preview.go:60:51: requestcontext
+/pkg/siteadmin/transport/handler_app_feature_config_update.go:47:74: requestcontext
+/pkg/siteadmin/transport/handler_app_feature_config_update.go:62:50: requestcontext
 /pkg/siteadmin/transport/handler_app_get.go:40:33: requestcontext
 /pkg/siteadmin/transport/handler_app_plan_change.go:47:65: requestcontext
 /pkg/siteadmin/transport/handler_app_plan_change.go:63:38: requestcontext

--- a/docs/api/siteadmin-api.yaml
+++ b/docs/api/siteadmin-api.yaml
@@ -202,6 +202,153 @@ paths:
         "404":
           $ref: "#/components/responses/NotFound"
 
+  /api/v1/apps/{app_id}/feature-config:
+    get:
+      operationId: getAppFeatureConfig
+      summary: Get the feature config layers of an app
+      description: >
+        Returns three layers of the app's feature config, all fully populated
+        with server defaults so the client never has to reason about what is
+        "unset": the effective **plan** config (defaults ← plan, i.e. what the
+        app would get with no app-specific override — display this as the
+        read-only "Plan" column/panel), the app-specific override YAML
+        document as stored (verbatim, sparse — only the fields this app
+        overrides), and the effective config for the app as it actually runs
+        today (defaults ← plan ← app override). The server merges every
+        section field-by-field (see `pkg/lib/config/feature_*.go` — every
+        section's `Merge` is field-level, so setting one field never resets an
+        unrelated sibling field back to a default); clients MUST NOT
+        reimplement this merge — always use `effective_plan_feature_config`
+        and `effective_app_feature_config` from this response for display, and the
+        preview endpoint for live feedback while editing.
+      parameters:
+        - name: app_id
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          description: The feature config layers of the app
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/AppFeatureConfigResponse"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          $ref: "#/components/responses/NotFound"
+
+    put:
+      operationId: updateAppFeatureConfig
+      summary: Replace the app-specific feature config override
+      description: >
+        Replaces the entire app-specific feature config override with the
+        given YAML document. This is a full replacement, not a patch: any
+        field previously overridden but omitted from the new document reverts
+        to inheriting from the plan. The document is stored verbatim,
+        preserving comments and key order. Pass an empty string (or a
+        whitespace-only string) to clear all app-specific overrides. The
+        document is validated against the feature config JSON schema before
+        being stored; on failure, responds 400 with reason `ValidationFailed`
+        and `info.causes` populated per
+        [ValidationErrorCause](#/components/schemas/ValidationErrorCause) —
+        each cause's `location` is an RFC 6901 JSON pointer into the submitted
+        document (e.g. `/identity/oauth/providers/apple/disabled`), letting the
+        client map every failure directly to the corresponding row in a table
+        view without any custom error-parsing logic. The plan config itself is
+        never modified by this endpoint. A site admin audit log entry
+        (`site_admin.app.feature_config.updated`) is recorded.
+      parameters:
+        - name: app_id
+          in: path
+          required: true
+          schema:
+            type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/UpdateAppFeatureConfigRequest"
+      responses:
+        "200":
+          description: >
+            The feature config layers after the update, including the newly
+            computed effective config.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/AppFeatureConfigResponse"
+        "400":
+          description: >
+            Invalid request. When `reason` is `ValidationFailed`,
+            `info.causes` is an array of ValidationErrorCause objects, one per
+            failing field — see the `ValidationErrorCause` schema and the
+            description above for the exact shape and an example.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorEnvelope"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          $ref: "#/components/responses/NotFound"
+
+  /api/v1/apps/{app_id}/feature-config/preview:
+    post:
+      operationId: previewAppFeatureConfig
+      summary: Preview the effective feature config for a candidate override
+      description: >
+        Computes the effective feature config that would result from the given
+        app-specific override, without persisting anything. Merging uses the
+        app's current plan and the exact same server-side merge as the GET and
+        PUT endpoints. This is the mechanism that keeps merge logic out of the
+        client entirely: call this endpoint (debounced) on every edit to
+        refresh a live "Effective" view — never compute it from
+        `effective_plan_feature_config` and the edited YAML locally. The
+        candidate override is validated against the feature config JSON
+        schema exactly as PUT does; validation failures use the same 400
+        `ValidationFailed` / `info.causes` shape described on PUT, so the same
+        client-side error-highlighting code handles both endpoints.
+      parameters:
+        - name: app_id
+          in: path
+          required: true
+          schema:
+            type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/PreviewAppFeatureConfigRequest"
+      responses:
+        "200":
+          description: >
+            The feature config layers as they would be if the candidate
+            override were saved. Nothing is persisted.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/AppFeatureConfigResponse"
+        "400":
+          description: >
+            Invalid request. When `reason` is `ValidationFailed`,
+            `info.causes` is an array of ValidationErrorCause objects, one per
+            failing field — see the `ValidationErrorCause` schema and the
+            description on PUT for the exact shape and an example.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorEnvelope"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          $ref: "#/components/responses/NotFound"
+
   /api/v1/apps/{app_id}/usage/messaging:
     get:
       operationId: getAppMessagingUsage
@@ -507,7 +654,13 @@ components:
           description: Opaque ID for correlating errors in logs
         info:
           type: object
-          description: Additional structured details about the error
+          description: >
+            Additional structured details about the error. Shape depends on
+            `reason`. Notably, for `reason: ValidationFailed` (JSON-schema
+            validation failures — this is the server-wide convention, not
+            specific to any one endpoint), `info.causes` is an array of
+            [ValidationErrorCause](#/components/schemas/ValidationErrorCause)
+            objects, one per failing field.
           additionalProperties: true
 
     MessagingUsage:
@@ -804,3 +957,137 @@ components:
                 Raw audit log data — the full event JSON stored in the
                 _audit_log.data column, including context and payload.
               additionalProperties: true
+
+    ValidationErrorCause:
+      description: >
+        One JSON-schema validation failure. Matches the server's
+        `validation.Error` struct (`pkg/util/validation/error.go`) — this is
+        the server-wide shape for every `ValidationFailed` error in this API,
+        not something specific to feature config. Emitted as one entry per
+        failing leaf value; a client can group/sort by `location` to render
+        multiple errors against the same document.
+      type: object
+      required:
+        - location
+        - kind
+      properties:
+        location:
+          type: string
+          description: >
+            RFC 6901 JSON pointer to the failing value in the submitted
+            document, e.g. `/identity/oauth/providers/apple/disabled` or
+            `/oauth/client/maximum`. Empty string means the failure applies to
+            the document root. Clients use this to look up the corresponding
+            field in a declarative field registry and highlight that row.
+        kind:
+          type: string
+          description: >
+            The JSON schema keyword that failed, e.g. `type`, `required`,
+            `enum`, `minimum`, `additionalProperties`. Use `details` and/or a
+            generic per-kind message for display; do not assume every kind
+            listed here is exhaustive — new keywords can appear as the schema
+            evolves.
+        details:
+          type: object
+          description: >
+            Keyword-specific detail payload, e.g. `{"actual": "string",
+            "expected": "boolean"}` for a `type` failure, or `{"missing":
+            ["client_id"]}` for a `required` failure. Shape varies by `kind`;
+            treat as opaque beyond displaying it or using known keys
+            defensively.
+          additionalProperties: true
+
+    FeatureConfig:
+      x-go-type: config.FeatureConfig
+      x-go-type-import:
+        name: config
+        path: github.com/authgear/authgear-server/pkg/lib/config
+      description: >
+        An Authgear feature config object (the JSON form of
+        authgear.features.yaml). The authoritative schema is the server's
+        feature config JSON schema (FeatureConfigSchema in
+        pkg/lib/config); it is not duplicated here. Top-level sections
+        include identity, authentication, authenticator, custom_domain, ui,
+        oauth, hook, audit_log, google_tag_manager, rate_limits, messaging,
+        usage, collaborator, admin_api, test_mode, and fraud_protection. Every
+        section merges field-by-field across layers (code defaults ← cluster
+        ← plan ← app override) — an app-specific override only ever affects
+        the exact fields it sets; every other field simply inherits from the
+        plan.
+      type: object
+      additionalProperties: true
+
+    AppFeatureConfigResponse:
+      type: object
+      required:
+        - plan_name
+        - effective_plan_feature_config
+        - app_feature_config_yaml
+        - effective_app_feature_config
+      properties:
+        plan_name:
+          type: string
+          description: The plan the app is currently on.
+        effective_plan_feature_config:
+          allOf:
+            - $ref: "#/components/schemas/FeatureConfig"
+          description: >
+            The **effective** feature config of the plan alone — server
+            defaults merged with the plan's config, fully populated. This is
+            what the app would get if it had no app-specific override at all;
+            display this as the read-only "Plan" column/panel. It is
+            deliberately not the raw/sparse plan document: since merge is
+            field-level everywhere, the effective value is always well-defined
+            and there is no ambiguity between "the plan set this" and "this is
+            a code default" for the client to worry about — every value shown
+            here is simply what the app would actually run with under this
+            plan.
+        app_feature_config_yaml:
+          type: string
+          description: >
+            The stored app-specific override YAML document, verbatim —
+            including comments and key order. Empty string when the app has
+            no override. Sparse: only fields explicitly overridden for this
+            app are present. Clients parse this to render structured views
+            (e.g. a table); any field absent from this document simply
+            inherits from `effective_plan_feature_config`.
+        effective_app_feature_config:
+          allOf:
+            - $ref: "#/components/schemas/FeatureConfig"
+          description: >
+            The effective feature config computed by the server by merging
+            defaults ← plan ← app override, fully populated. This is what the
+            app actually runs with; use it for the "Effective" display. Always
+            re-fetch this (via GET after save, or via the preview endpoint
+            while editing) rather than deriving it from
+            `effective_plan_feature_config` and `app_feature_config_yaml`
+            locally.
+
+    UpdateAppFeatureConfigRequest:
+      type: object
+      required:
+        - app_feature_config_yaml
+      properties:
+        app_feature_config_yaml:
+          type: string
+          description: >
+            The new app-specific feature config override as a YAML document.
+            Replaces the existing override entirely and is stored verbatim,
+            preserving comments and key order. Pass an empty string (or a
+            whitespace-only string) to clear all overrides. Validated against
+            the feature config JSON schema; see the `ValidationErrorCause`
+            schema for the shape of validation failures. Since YAML is a
+            superset of JSON, automation may pass a JSON document here.
+
+    PreviewAppFeatureConfigRequest:
+      type: object
+      required:
+        - app_feature_config_yaml
+      properties:
+        app_feature_config_yaml:
+          type: string
+          description: >
+            The candidate app-specific feature config override as a YAML
+            document. Not persisted. Validated against the feature config
+            JSON schema exactly as PUT does; see the `ValidationErrorCause`
+            schema for the shape of validation failures.

--- a/docs/plans/siteadmin-api/09-feature-config-api.md
+++ b/docs/plans/siteadmin-api/09-feature-config-api.md
@@ -1,0 +1,929 @@
+# 09 — App Feature Config API
+
+## Goal / Scope
+
+Implement the three endpoints specified in `docs/api/siteadmin-api.yaml`:
+
+| Endpoint | operationId | Method |
+|---|---|---|
+| `/api/v1/apps/{app_id}/feature-config` | `getAppFeatureConfig` | GET |
+| `/api/v1/apps/{app_id}/feature-config` | `updateAppFeatureConfig` | PUT |
+| `/api/v1/apps/{app_id}/feature-config/preview` | `previewAppFeatureConfig` | POST |
+
+Nothing under `pkg/siteadmin/` currently references feature config — there is
+no handler stub, no generated types yet. This plan covers spec-to-code
+generation, handler scaffolding, and full implementation in one pass (Stages
+2, 3, and 5 of `new-siteadmin-api` combined — the spec is already written and
+reviewed, so Stage 1 is done), plus DI wiring, unit tests, and e2e coverage.
+
+**Baseline assumption**: feature config merge is field-level for every
+section — setting one field never resets a sibling field. See
+`pkg/lib/config/feature_*.go` for the `Merge` implementations. This plan's
+test fixtures (§"Test plan") use `collaborator` and `oauth.client` simply as
+two structurally different examples (a two-field section and a
+four-mixed-type-field section), not to contrast merge strategies.
+
+One new service (`FeatureConfigService`), one new audit payload
+(`site_admin.app.feature_config.updated`), three new transport handlers. No
+new exported symbols needed from `pkg/lib/config/configsource`.
+
+---
+
+## Merge computation (shared by GET / PUT / POST)
+
+New private helpers in `pkg/siteadmin/service/feature_config.go`, used by all
+three public methods. No new exported symbols are added to
+`pkg/lib/config/configsource` — everything needed is already exported.
+
+Layer stack to fold, matching `dbApp.doLoad`
+(`pkg/lib/config/configsource/database.go:469-470`):
+**`BaseResources ⟵ plan ⟵ app`**, not just `[plan, app]`. `FeatureConfigService`
+gets a new `BaseResources deps.AppBaseResources` field (already provided by
+`deps.DependencySet`, no new wiring needed — see "DI wiring" below).
+`deps.AppBaseResources` is a distinct named type over `*resource.Manager`,
+not an alias, so convert with `(*resource.Manager)(s.BaseResources)` before
+calling `.Overlay`.
+
+```go
+func featureConfigOverrideKey() string {
+    return filepathutil.EscapePath(configsource.AuthgearFeatureYAML)
+}
+
+// computeLayers folds BaseResources, the plan named planName, and a
+// candidate app-override document (nil/empty overrideYAML = no override)
+// exactly the way dbApp.doLoad computes an app's effective feature config —
+// same layer stack, same order, same FS-construction helpers. No merge
+// logic is reimplemented.
+func (s *FeatureConfigService) computeLayers(
+    ctx context.Context,
+    planName string,
+    overrideYAML []byte,
+) (planEffective *config.FeatureConfig, effective *config.FeatureConfig, err error) {
+    p, err := s.PlanStore.GetPlan(ctx, planName)
+    if err != nil && !errors.Is(err, plan.ErrPlanNotFound) {
+        return nil, nil, err
+    }
+    // On ErrPlanNotFound, p stays nil. MakePlanFSFromPlan(nil) produces an
+    // empty plan layer — the same tolerance dbApp.doLoad has for an app
+    // referencing a missing plan.
+
+    planFs, err := configsource.MakePlanFSFromPlan(p)
+    if err != nil {
+        return nil, nil, err
+    }
+
+    appData := map[string][]byte{}
+    if len(overrideYAML) > 0 {
+        appData[featureConfigOverrideKey()] = overrideYAML
+    }
+    appFs, err := configsource.MakeAppFSFromDatabaseSource(&configsource.DatabaseSource{Data: appData})
+    if err != nil {
+        return nil, nil, err
+    }
+
+    base := (*resource.Manager)(s.BaseResources)
+    planEffective, err = readEffectiveFeatureConfig(ctx, base.Overlay(planFs))
+    if err != nil {
+        return nil, nil, err
+    }
+    effective, err = readEffectiveFeatureConfig(ctx, base.Overlay(planFs).Overlay(appFs))
+    if err != nil {
+        return nil, nil, err
+    }
+    return planEffective, effective, nil
+}
+
+// readEffectiveFeatureConfig mirrors configsource.LoadConfig's feature config
+// resolution (pkg/lib/config/configsource/loader.go:31): read the
+// FeatureConfig resource from the given manager, falling back to server
+// defaults when no layer has an authgear.features.yaml file.
+func readEffectiveFeatureConfig(ctx context.Context, mgr *resource.Manager) (*config.FeatureConfig, error) {
+    result, err := mgr.Read(ctx, configsource.FeatureConfig, resource.EffectiveResource{})
+    if errors.Is(err, resource.ErrResourceNotFound) {
+        return config.NewEffectiveDefaultFeatureConfig(), nil
+    }
+    if err != nil {
+        return nil, err
+    }
+    return result.(*config.FeatureConfig), nil
+}
+```
+
+`plan.Plan.RawFeatureConfig` is a parsed `*config.FeatureConfig`
+(`plan/store.go:147`), sparse, no defaults — `MakePlanFSFromPlan` re-marshals
+it to YAML, matching `dbApp.doLoad`'s round-trip.
+
+---
+
+## Validation error contract
+
+Existing server-wide convention, not new for this endpoint: a JSON Schema
+validation failure returns `*validation.AggregatedError`
+(`pkg/util/validation/error.go`), which `pkg/api/apierrors`'s `asAPIError`
+automatically converts into a 400 response with `info.causes` — an array of
+`{location, kind, details}`, `location` being an RFC 6901 JSON pointer to the
+failing field. This is the `ValidationErrorCause` OpenAPI schema. No new
+conversion code is written for this endpoint.
+
+Specific to this plan:
+
+1. **This service never calls `config.ParseFeatureConfigWithoutDefaults`
+   directly on the raw submitted document.** It's called twice, both times
+   inside `viewEffectiveResource` (`pkg/lib/config/configsource/resources.go:694-716`),
+   which `computeLayers`/`readEffectiveFeatureConfig` invoke via
+   `Manager.Read`: once per layer while folding (the submitted override is
+   one of those layers), and once more on the fully merged YAML.
+2. `UpdateAppFeatureConfig`/`PreviewAppFeatureConfig` must return whatever
+   error `computeLayers` produces **unmodified** (or `%w`-wrapped —
+   `errors.As` still unwraps it). **Do not** catch and rebuild it; that would
+   silently drop `causes`/`location`.
+3. **One hand-built exception**: the multi-document-YAML guard (see
+   "Validation" below) returns `apierrors.ValidationFailed.New("...")`
+   directly — same `reason: ValidationFailed`, but **no `causes`**, since the
+   failure is about the whole document, not one field. Tests must cover both
+   shapes (with `causes`, and without).
+
+---
+
+## Validation (PUT and POST share this)
+
+Schema validation of the submitted document is **not** a standalone
+pre-check. This service only pre-checks what JSON schema can't express —
+emptiness, multi-document-YAML — and leaves `computeLayers` (next, see
+"Runtime flow") as the single source of truth for schema validity, including
+of the submitted document itself.
+
+```go
+// parseAppFeatureConfigOverride handles the two things that must be checked
+// before a candidate override can even be considered for merging. Returns
+// (nil, nil) when raw is empty or whitespace-only, meaning "clear the
+// override" — this is the one case callers must treat specially (not an
+// error, and not "store an empty file"). Does NOT run schema validation —
+// that happens inside computeLayers (see "Runtime flow"), which validates
+// this data as one of the layers it merges, plus the merged result.
+func parseAppFeatureConfigOverride(raw string) ([]byte, error) {
+    if strings.TrimSpace(raw) == "" {
+        return nil, nil
+    }
+
+    data := []byte(raw)
+
+    n, err := countYAMLDocuments(data)
+    if err != nil {
+        return nil, err
+    }
+    if n > 1 {
+        return nil, apierrors.ValidationFailed.New("app_feature_config_yaml must contain at most one YAML document")
+    }
+
+    return data, nil
+}
+
+// countYAMLDocuments counts YAML documents separated by "---". Malformed
+// YAML is not an error here — countYAMLDocuments returns whatever count it
+// reached and nil; computeLayers (via ParseFeatureConfigWithoutDefaults)
+// produces the canonical validation error for malformed input.
+func countYAMLDocuments(data []byte) (int, error) {
+    dec := goyaml.NewDecoder(bytes.NewReader(data))
+    count := 0
+    for {
+        var doc any
+        if err := dec.Decode(&doc); err != nil {
+            if errors.Is(err, io.EOF) {
+                return count, nil
+            }
+            return count, nil
+        }
+        count++
+    }
+}
+```
+
+`goyaml` is `gopkg.in/yaml.v3` (already an indirect dependency per `go.mod`;
+this makes it direct). Used only for document counting — parsing the config
+itself still goes through `config.ParseFeatureConfigWithoutDefaults` inside
+`computeLayers` (`sigs.k8s.io/yaml` + the real JSON schema), so the
+`causes`/`location` contract above is unaffected. Multi-document input never
+reaches that point: `sigs.k8s.io/yaml.YAMLToJSON` silently keeps only the
+first document rather than erroring, so this guard must run first.
+
+---
+
+## Runtime flow
+
+### `GetAppFeatureConfig(ctx, appID string) (*AppFeatureConfigResult, error)`
+
+1. `s.GlobalDatabase.ReadOnly(ctx, func(ctx) error { ... })`
+2. Inside: `dbs, e := s.ConfigSourceStore.GetDatabaseSourceByAppID(ctx, appID)`.
+   `errors.Is(e, configsource.ErrAppNotFound)` → return
+   `apierrors.NotFound.WithReason("AppNotFound").New("app not found")` (same
+   pattern as `PlanService.ChangeAppPlan`, `pkg/siteadmin/service/plan.go:84`).
+3. `overrideYAML := dbs.Data[featureConfigOverrideKey()]` (nil if absent — `""`
+   when stringified, matching the spec).
+4. `planEffective, effective, e := s.computeLayers(ctx, dbs.PlanName, overrideYAML)`.
+5. Outside the transaction: build
+   `&AppFeatureConfigResult{PlanName: dbs.PlanName, EffectivePlanFeatureConfig:
+   planEffective, AppFeatureConfigYAML: string(overrideYAML), EffectiveAppFeatureConfig:
+   effective}`.
+
+### `UpdateAppFeatureConfig(ctx, appID string, rawYAML string) (*AppFeatureConfigResult, error)`
+
+Validate-via-merge happens **before** writing, so an invalid override is
+never persisted even transiently (and so a failed write attempt is never
+even issued):
+
+1. `overrideBytes, err := parseAppFeatureConfigOverride(rawYAML)` — **outside**
+   any DB transaction; only the empty/whitespace-clear case and the
+   multi-document guard, no schema validation yet (see "Validation").
+2. `s.GlobalDatabase.WithTx(ctx, func(ctx) error { ... })`
+3. Inside:
+   a. `dbs, e := s.ConfigSourceStore.GetDatabaseSourceByAppID(ctx, appID)` →
+      404 `AppNotFound` on `configsource.ErrAppNotFound`, same as GET.
+   b. `key := featureConfigOverrideKey()`; `oldYAML := string(dbs.Data[key])`.
+   c. **`planEffective, effective, e := s.computeLayers(ctx, dbs.PlanName, overrideBytes)`
+      — this is the actual schema validation** (see "Validation error
+      contract"). Return `e` as-is on failure (400 `ValidationFailed` /
+      `causes`); nothing below this line runs, and the transaction rolls
+      back.
+   d. If `dbs.Data == nil`, initialize `dbs.Data = map[string][]byte{}` (the
+      real DB rows always unmarshal to a non-nil map from the `NOT NULL`
+      jsonb column, but this is a defensive guard against assigning to a nil
+      map panicking).
+   e. If `overrideBytes == nil` (parsed as "clear"): `delete(dbs.Data, key)`.
+      Else: `dbs.Data[key] = overrideBytes`.
+   f. `dbs.UpdatedAt = s.Clock.NowUTC()`.
+   g. `s.ConfigSourceStore.UpdateDatabaseSource(ctx, dbs)` — the plain SQL
+      `UPDATE` that fires the `notify_config_source_change` trigger;
+      propagation needs no other action.
+4. Outside the transaction, if `s.AuditService != nil`: emit
+   `*siteadminauditlog.AppFeatureConfigUpdatedPayload{AppID: appID, OldAppFeatureConfigYAML:
+   oldYAML, NewAppFeatureConfigYAML: string(overrideBytes)}` via
+   `s.AuditService.LogEvent(ctx, appID, payload)`. Log-and-continue on error
+   (never fail the mutation because audit logging failed) — same pattern as
+   `PlanService.ChangeAppPlan`.
+5. Return `&AppFeatureConfigResult{...}` using `planEffective`/`effective`
+   from step 3c (already computed, no need to recompute) and `overrideBytes`
+   instead of the pre-write `overrideYAML`.
+
+### `PreviewAppFeatureConfig(ctx, appID string, rawYAML string) (*AppFeatureConfigResult, error)`
+
+1. `overrideBytes, err := parseAppFeatureConfigOverride(rawYAML)` — same as
+   PUT step 1.
+2. `s.GlobalDatabase.ReadOnly(ctx, func(ctx) error { ... })`
+3. Inside: `dbs, e := s.ConfigSourceStore.GetDatabaseSourceByAppID(ctx, appID)`
+   → 404 `AppNotFound` on `configsource.ErrAppNotFound`, same as GET.
+   `planEffective, effective, e := s.computeLayers(ctx, dbs.PlanName, overrideBytes)`
+   — same validation, same error shape as PUT step 3c. Return `e` as-is on
+   failure.
+4. **No write.** Return `&AppFeatureConfigResult{PlanName: dbs.PlanName,
+   EffectivePlanFeatureConfig: planEffective, AppFeatureConfigYAML:
+   string(overrideBytes), EffectiveAppFeatureConfig: effective}`.
+
+---
+
+## Service layer — file-level plan
+
+### New file: `pkg/siteadmin/service/feature_config.go`
+
+```go
+package service
+
+import (
+    "bytes"
+    "context"
+    "errors"
+    "io"
+    "strings"
+
+    goyaml "gopkg.in/yaml.v3"
+
+    "github.com/authgear/authgear-server/pkg/api/apierrors"
+    "github.com/authgear/authgear-server/pkg/api/event"
+    "github.com/authgear/authgear-server/pkg/lib/config"
+    "github.com/authgear/authgear-server/pkg/lib/config/configsource"
+    "github.com/authgear/authgear-server/pkg/lib/config/plan"
+    "github.com/authgear/authgear-server/pkg/portal/deps"
+    siteadminauditlog "github.com/authgear/authgear-server/pkg/siteadmin/auditlog"
+    "github.com/authgear/authgear-server/pkg/util/clock"
+    "github.com/authgear/authgear-server/pkg/util/filepathutil"
+    "github.com/authgear/authgear-server/pkg/util/resource"
+)
+
+// ---- Narrow interfaces -------------------------------------------------------
+
+type FeatureConfigServiceGlobalDatabase interface {
+    WithTx(ctx context.Context, do func(ctx context.Context) error) error
+    ReadOnly(ctx context.Context, do func(ctx context.Context) error) error
+}
+
+type FeatureConfigServicePlanStore interface {
+    GetPlan(ctx context.Context, name string) (*plan.Plan, error)
+}
+
+type FeatureConfigServiceConfigSourceStore interface {
+    GetDatabaseSourceByAppID(ctx context.Context, appID string) (*configsource.DatabaseSource, error)
+    UpdateDatabaseSource(ctx context.Context, dbs *configsource.DatabaseSource) error
+}
+
+type FeatureConfigServiceAuditService interface {
+    LogEvent(ctx context.Context, appID string, payload event.NonBlockingPayload) error
+}
+
+// ---- Domain types -------------------------------------------------------------
+
+// AppFeatureConfigResult is the internal computation result — pointer-typed
+// because config.FeatureConfig sections are pointer fields throughout
+// pkg/lib/config. Transport dereferences EffectivePlanFeatureConfig /
+// EffectiveAppFeatureConfig into the (value-typed, generated) wire schema.
+type AppFeatureConfigResult struct {
+    PlanName                   string
+    EffectivePlanFeatureConfig *config.FeatureConfig
+    AppFeatureConfigYAML       string
+    EffectiveAppFeatureConfig     *config.FeatureConfig
+}
+
+// ---- FeatureConfigService -------------------------------------------------------
+
+type FeatureConfigService struct {
+    GlobalDatabase    FeatureConfigServiceGlobalDatabase
+    PlanStore         FeatureConfigServicePlanStore
+    ConfigSourceStore FeatureConfigServiceConfigSourceStore
+    AuditService      FeatureConfigServiceAuditService
+    BaseResources     deps.AppBaseResources // already provided by deps.DependencySet, no new wiring
+    Clock             clock.Clock
+}
+
+func (s *FeatureConfigService) GetAppFeatureConfig(ctx context.Context, appID string) (*AppFeatureConfigResult, error) {
+    // ... (see "Runtime flow" above)
+}
+
+func (s *FeatureConfigService) UpdateAppFeatureConfig(ctx context.Context, appID string, rawYAML string) (*AppFeatureConfigResult, error) {
+    // ... (see "Runtime flow" above)
+}
+
+func (s *FeatureConfigService) PreviewAppFeatureConfig(ctx context.Context, appID string, rawYAML string) (*AppFeatureConfigResult, error) {
+    // ... (see "Runtime flow" above)
+}
+
+// ---- Merge computation (see "Merge computation" section above for full bodies) --
+
+func featureConfigOverrideKey() string { /* ... */ }
+func (s *FeatureConfigService) computeLayers(ctx context.Context, planName string, overrideYAML []byte) (*config.FeatureConfig, *config.FeatureConfig, error) { /* ... */ }
+func readEffectiveFeatureConfig(ctx context.Context, fs []resource.Fs) (*config.FeatureConfig, error) { /* ... */ }
+
+// ---- Validation (see "Validation" section above for full bodies) ---------------
+
+func parseAppFeatureConfigOverride(raw string) ([]byte, error) { /* ... */ }
+func countYAMLDocuments(data []byte) (int, error) { /* ... */ }
+```
+
+(The plan repeats the full bodies from the sections above rather than eliding
+them in the actual implementation — this file listing is grouped by concern
+for readability, not to be copy-pasted with the elisions left in.)
+
+### New file: `pkg/siteadmin/auditlog/app_feature_config_updated.go`
+
+Copy `app_plan_updated.go` verbatim (same `event.NonBlockingPayload` method
+set: `NonBlockingEventType`, `UserID` → `""`, `GetTriggeredBy` →
+`event.TriggeredBySiteAdmin`, `FillContext` → no-op, `ForHook` → `false`,
+`ForAudit` → `true`, `RequireReindexUserIDs`/`DeletedUserIDs` → `nil`), only
+changing:
+
+```go
+const AppFeatureConfigUpdated event.Type = "site_admin.app.feature_config.updated"
+
+type AppFeatureConfigUpdatedPayload struct {
+    AppID                   string `json:"app_id"`
+    OldAppFeatureConfigYAML string `json:"old_app_feature_config_yaml"`
+    NewAppFeatureConfigYAML string `json:"new_app_feature_config_yaml"`
+}
+```
+
+Storing full old/new YAML documents (not a diff): documents are small (a few
+dozen fields at most) and contain no end-user PII, only per-app operational
+settings.
+
+### `pkg/siteadmin/service/deps.go`
+
+Add:
+```go
+wire.Struct(new(FeatureConfigService), "*"),
+```
+
+---
+
+## Transport layer — file-level plan
+
+Three new handler files, all following the existing
+`handler_app_plan_change.go`-style shape. GET has no request body; PUT and
+POST are structurally identical (envelope-validate → call service → same
+response builder) and differ only in the columns below.
+
+### New file: `pkg/siteadmin/transport/handler_app_feature_config_get.go`
+
+```go
+package transport
+
+import (
+    "context"
+    "net/http"
+
+    "github.com/authgear/authgear-server/pkg/api/siteadmin"
+    "github.com/authgear/authgear-server/pkg/siteadmin/service"
+    "github.com/authgear/authgear-server/pkg/util/httproute"
+)
+
+func ConfigureAppFeatureConfigGetRoute(route httproute.Route) httproute.Route {
+    return route.WithMethods("OPTIONS", "GET").
+        WithPathPattern("/api/v1/apps/:appID/feature-config")
+}
+
+type AppFeatureConfigGetService interface {
+    GetAppFeatureConfig(ctx context.Context, appID string) (*service.AppFeatureConfigResult, error)
+}
+
+type AppFeatureConfigGetHandler struct {
+    Service AppFeatureConfigGetService
+}
+
+func (h *AppFeatureConfigGetHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+    appID := httproute.GetParam(r, "appID")
+
+    result, err := h.Service.GetAppFeatureConfig(r.Context(), appID)
+    if err != nil {
+        writeError(w, r, err)
+        return
+    }
+
+    SiteAdminAPISuccessResponse{Body: featureConfigResultToResponse(result)}.WriteTo(w)
+}
+
+// featureConfigResultToResponse is shared by the get/update/preview handlers
+// (defined here since this is the first of the three files registered).
+func featureConfigResultToResponse(result *service.AppFeatureConfigResult) siteadmin.AppFeatureConfigResponse {
+    return siteadmin.AppFeatureConfigResponse{
+        PlanName:                   result.PlanName,
+        EffectivePlanFeatureConfig: *result.EffectivePlanFeatureConfig,
+        AppFeatureConfigYaml:       result.AppFeatureConfigYAML,
+        EffectiveAppFeatureConfig:     *result.EffectiveAppFeatureConfig,
+    }
+}
+```
+
+### New files: `handler_app_feature_config_update.go` (PUT) and `handler_app_feature_config_preview.go` (POST)
+
+Canonical shape (shown once — both files are this same template, substitute
+the column values below):
+
+```go
+package transport
+
+import (
+    "context"
+    "encoding/json"
+    "net/http"
+
+    "github.com/authgear/authgear-server/pkg/api/siteadmin"
+    "github.com/authgear/authgear-server/pkg/siteadmin/service"
+    "github.com/authgear/authgear-server/pkg/util/httproute"
+    "github.com/authgear/authgear-server/pkg/util/validation"
+)
+
+func Configure<Route>(route httproute.Route) httproute.Route {
+    return route.WithMethods(<methods>).
+        WithPathPattern(<path>)
+}
+
+var <RequestSchema> = validation.NewSimpleSchema(`
+{
+    "type": "object",
+    "properties": { "app_feature_config_yaml": { "type": "string" } },
+    "required": ["app_feature_config_yaml"]
+}
+`)
+
+type <Service> interface {
+    <Method>(ctx context.Context, appID string, rawYAML string) (*service.AppFeatureConfigResult, error)
+}
+
+type <Handler> struct {
+    Service <Service>
+}
+
+type <Params> struct {
+    AppID string
+    siteadmin.<RequestType>
+}
+
+func parse<Params>(r *http.Request) (<Params>, error) {
+    var body siteadmin.<RequestType>
+    if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+        return <Params>{}, err
+    }
+    if err := <RequestSchema>.Validator().ValidateValue(r.Context(), body); err != nil {
+        return <Params>{}, err
+    }
+    return <Params>{AppID: httproute.GetParam(r, "appID"), <RequestType>: body}, nil
+}
+
+func (h *<Handler>) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+    params, err := parse<Params>(r)
+    if err != nil {
+        writeError(w, r, err)
+        return
+    }
+    result, err := h.Service.<Method>(r.Context(), params.AppID, params.AppFeatureConfigYaml)
+    if err != nil {
+        writeError(w, r, err)
+        return
+    }
+    SiteAdminAPISuccessResponse{Body: featureConfigResultToResponse(result)}.WriteTo(w)
+}
+```
+
+| Placeholder | PUT (`handler_app_feature_config_update.go`) | POST (`handler_app_feature_config_preview.go`) |
+|---|---|---|
+| `<Route>`/file symbol prefix | `AppFeatureConfigUpdateRoute` | `AppFeatureConfigPreviewRoute` |
+| `<methods>` | `"PUT"` (GET already registered `OPTIONS` for this shared path — see routes.go) | `"OPTIONS", "POST"` (separate path, declares its own) |
+| `<path>` | `/api/v1/apps/:appID/feature-config` | `/api/v1/apps/:appID/feature-config/preview` |
+| `<RequestSchema>` | `AppFeatureConfigUpdateRequestSchema` | `AppFeatureConfigPreviewRequestSchema` |
+| `<Service>`/`<Method>` | `AppFeatureConfigUpdateService` / `UpdateAppFeatureConfig` | `AppFeatureConfigPreviewService` / `PreviewAppFeatureConfig` |
+| `<Handler>` | `AppFeatureConfigUpdateHandler` | `AppFeatureConfigPreviewHandler` |
+| `<Params>` | `AppFeatureConfigUpdateParams` | `AppFeatureConfigPreviewParams` |
+| `<RequestType>` | `siteadmin.UpdateAppFeatureConfigRequest` | `siteadmin.PreviewAppFeatureConfigRequest` |
+
+`<RequestSchema>` only validates the request envelope shape
+(`app_feature_config_yaml` is a present string) — it is **not** where the
+feature-config document itself gets validated. That happens inside
+`s.computeLayers` (via `parseAppFeatureConfigOverride` for the
+empty/multi-document checks, then `viewEffectiveResource` for schema
+validation during the merge), which is what produces the `causes`/`location`
+errors described above.
+
+`configsource.ErrAppNotFound` is mapped to 404 **inside the service** for all
+three methods (matching `PlanService.ChangeAppPlan`'s convention), so no
+transport-layer `errors.Is(err, configsource.ErrAppNotFound)` branch is
+needed here.
+
+### `pkg/siteadmin/transport/deps.go`
+
+Add:
+```go
+wire.Struct(new(AppFeatureConfigGetHandler), "*"),
+wire.Struct(new(AppFeatureConfigUpdateHandler), "*"),
+wire.Struct(new(AppFeatureConfigPreviewHandler), "*"),
+```
+
+---
+
+## DI wiring — file-level plan
+
+### `pkg/siteadmin/deps.go`
+
+Add, in the "siteadmin service layer" section (alongside the existing
+`PlanService*` bindings):
+
+```go
+// FeatureConfigService bindings
+wire.Bind(new(siteadminservice.FeatureConfigServiceGlobalDatabase), new(*globaldb.Handle)),
+wire.Bind(new(siteadminservice.FeatureConfigServicePlanStore), new(*plan.Store)),
+wire.Bind(new(siteadminservice.FeatureConfigServiceConfigSourceStore), new(*configsource.Store)),
+wire.Bind(new(siteadminservice.FeatureConfigServiceAuditService), new(*siteadminservice.SiteAdminAuditService)),
+
+// transport bindings
+wire.Bind(new(transport.AppFeatureConfigGetService), new(*siteadminservice.FeatureConfigService)),
+wire.Bind(new(transport.AppFeatureConfigUpdateService), new(*siteadminservice.FeatureConfigService)),
+wire.Bind(new(transport.AppFeatureConfigPreviewService), new(*siteadminservice.FeatureConfigService)),
+```
+
+`*globaldb.Handle`, `*plan.Store`, `*configsource.Store`, and
+`*siteadminservice.SiteAdminAuditService` are all already constructed
+elsewhere in this same `DependencySet` (used by `PlanService`); no new
+concrete providers are needed, only the additional `wire.Bind` lines above.
+
+`FeatureConfigService.BaseResources` needs **no wiring change at all**:
+its field type is `deps.AppBaseResources`, already provided by
+`deps.DependencySet` (imported at `pkg/siteadmin/deps.go:45`) — wire resolves
+`wire.Struct(new(FeatureConfigService), "*")` fields by type, so this one is
+satisfied automatically alongside the explicit binds above.
+
+### `pkg/siteadmin/wire.go`
+
+Add three injectors, one per handler, same template as every existing
+injector in this file:
+
+```go
+func newAppFeatureConfig<X>Handler(p *deps.RequestProvider) http.Handler {
+    panic(wire.Build(
+        DependencySet,
+        wire.Bind(new(http.Handler), new(*transport.AppFeatureConfig<X>Handler)),
+    ))
+}
+```
+
+`<X>` ∈ `{Get, Update, Preview}`.
+
+### `pkg/siteadmin/routes.go`
+
+Add, after `ConfigureAppPlanChangeRoute` (GET registered before PUT so GET's
+route owns the shared path's `OPTIONS` registration):
+
+```go
+router.Add(transport.ConfigureAppFeatureConfigGetRoute(route), p.Handler(newAppFeatureConfigGetHandler))
+router.Add(transport.ConfigureAppFeatureConfigUpdateRoute(route), p.Handler(newAppFeatureConfigUpdateHandler))
+router.Add(transport.ConfigureAppFeatureConfigPreviewRoute(route), p.Handler(newAppFeatureConfigPreviewHandler))
+```
+
+### Spec-to-code generation
+
+`pkg/api/siteadmin/gen.go` has not been regenerated yet for this feature —
+`make generate` (Stage 2 of `new-siteadmin-api`) must run before any handler
+code referencing the new generated types will compile. Verify after
+generation that:
+
+- `pkg/api/siteadmin/gen.go` contains a `FeatureConfig` type alias to
+  `config.FeatureConfig`, matching the existing `APIError` alias pattern.
+- `AppFeatureConfigResponse`'s `EffectivePlanFeatureConfig` /
+  `EffectiveAppFeatureConfig` fields generate as **value** types (`FeatureConfig`,
+  not `*FeatureConfig`).
+- `ValidationErrorCause` generates as a plain struct with `Location`,
+  `Keyword`, `Details` fields (or equivalent per the generator's naming
+  convention) — it isn't referenced directly by any Go code in this plan (the
+  `causes` array is built generically by `pkg/api/apierrors`), it exists
+  purely for API-consumer documentation.
+
+If `x-go-type` codegen for `FeatureConfig` doesn't produce a clean alias,
+adjust the **spec** (not the generated file).
+
+After the spec regeneration and the `deps.go`/`wire.go` changes above:
+```bash
+make generate
+go generate ./pkg/siteadmin/...
+go mod tidy   # adds gopkg.in/yaml.v3 as a direct dependency
+go build ./pkg/siteadmin/...
+go build ./cmd/portal/...
+```
+
+`wire_gen.go` and `pkg/api/siteadmin/gen.go` must never be hand-edited — only
+regenerated by the commands above.
+
+---
+
+## Test plan
+
+### Unit tests — `pkg/siteadmin/service/feature_config_test.go` (new, package
+`service`, Convey BDD style — matches `plan_test.go`, `collaborator_test.go`)
+
+Reuse `fakeDatabase{}` from `app_test.go` (already provides `WithTx`/`ReadOnly`
+no-ops) and `fakeAuditService{}` from `plan_test.go`.
+
+New fakes needed:
+
+```go
+type fakeFeatureConfigPlanStore struct {
+    plans map[string]*plan.Plan
+}
+
+func (f *fakeFeatureConfigPlanStore) GetPlan(_ context.Context, name string) (*plan.Plan, error) {
+    if p, ok := f.plans[name]; ok {
+        return p, nil
+    }
+    return nil, plan.ErrPlanNotFound
+}
+
+type fakeFeatureConfigConfigSourceStore struct {
+    sources map[string]*configsource.DatabaseSource
+    updated *configsource.DatabaseSource
+}
+
+func (f *fakeFeatureConfigConfigSourceStore) GetDatabaseSourceByAppID(_ context.Context, appID string) (*configsource.DatabaseSource, error) {
+    if s, ok := f.sources[appID]; ok {
+        cp := *s
+        cp.Data = maps.Clone(s.Data) // deep-enough copy so mutation in the service doesn't corrupt the fixture between test cases
+        return &cp, nil
+    }
+    return nil, configsource.ErrAppNotFound
+}
+
+func (f *fakeFeatureConfigConfigSourceStore) UpdateDatabaseSource(_ context.Context, dbs *configsource.DatabaseSource) error {
+    f.updated = dbs
+    return nil
+}
+```
+
+Two field-level fixtures, chosen for structural variety:
+
+- **`collaborator`** (two independent `*int` fields, `pkg/lib/config/feature_collaborator.go`).
+  Plan sets `maximum = 3`; override sets only `soft_maximum = 1` → effective
+  `maximum` stays **3** (inherited from the plan), `soft_maximum` is `1`.
+- **`oauth.client`** (four independent fields of mixed `*int`/`*bool` type,
+  `pkg/lib/config/feature_oauth.go`). Plan sets `maximum = 10`; override sets
+  only `custom_ui_enabled = true` → effective `maximum` stays **10**,
+  `custom_ui_enabled` is `true`.
+
+**Test cases:**
+
+| Method | Case | Assertion |
+|---|---|---|
+| `GetAppFeatureConfig` | app has no override | `AppFeatureConfigYAML == ""`, `EffectiveAppFeatureConfig` equals plan-only fold |
+| `GetAppFeatureConfig` | app has an override with a comment | `AppFeatureConfigYAML` matches the stored bytes **verbatim, including the comment** (not re-serialized) |
+| `GetAppFeatureConfig` | `collaborator` fixture | effective `maximum` inherited from plan, `soft_maximum` from override |
+| `GetAppFeatureConfig` | `oauth.client` fixture | effective `maximum` inherited from plan, `custom_ui_enabled` from override |
+| `GetAppFeatureConfig` | app references a plan that does not exist (`plan.ErrPlanNotFound`) | no error; `EffectivePlanFeatureConfig` equals server defaults |
+| `GetAppFeatureConfig` | app does not exist | `apierrors.NotFound` with condition `Kind.Name == apierrors.NotFound` |
+| `UpdateAppFeatureConfig` | valid YAML | stored bytes in `csStore.updated.Data[key]` match input exactly (byte-for-byte, including comments/key order); response reflects new effective config |
+| `UpdateAppFeatureConfig` | empty string clears an existing override | `csStore.updated.Data` no longer contains the key (not present at all, not an empty-string value) |
+| `UpdateAppFeatureConfig` | whitespace-only string (`"  \n\t"`) clears | same as above |
+| `UpdateAppFeatureConfig` | invalid YAML — unknown top-level key (schema `additionalProperties: false` violation) | `errors.As(err, &aggErr)` where `aggErr` is `*validation.AggregatedError`; `aggErr.Errors[0].Location` is the JSON pointer to the offending key (verify the actual value the schema validator produces rather than assuming); `csStore.updated` stays nil |
+| `UpdateAppFeatureConfig` | invalid YAML — field-level type error, e.g. `oauth: {client: {maximum: "not-a-number"}}` | `errors.As(err, &aggErr)`; `aggErr.Errors[0].Location == "/oauth/client/maximum"`, `aggErr.Errors[0].Keyword == "type"`; `csStore.updated` stays nil. **This is the test that pins the JSON-pointer contract** — if the schema validator's location format ever changes, this test catches it before the frontend does. |
+| `UpdateAppFeatureConfig` | multi-document YAML (`"a: 1\n---\nb: 2\n"`) | `apierrors.IsAPIErrorWithCondition` with `Kind.Name == apierrors.Invalid` and `Kind.Reason == "ValidationFailed"`; error does **not** satisfy `errors.As(err, &aggErr)` (no `causes` present); `csStore.updated` stays nil |
+| `UpdateAppFeatureConfig` | app does not exist | `apierrors.NotFound`; `csStore.updated` stays nil |
+| `UpdateAppFeatureConfig` | emits audit log with old and new YAML | `fakeAuditService.logged[0]` is `*siteadminauditlog.AppFeatureConfigUpdatedPayload` with correct `AppID`/`OldAppFeatureConfigYAML`/`NewAppFeatureConfigYAML` |
+| `UpdateAppFeatureConfig` | audit failure does not affect mutation result | `AuditService` nil → still succeeds |
+| `PreviewAppFeatureConfig` | valid candidate | response matches what PUT would have produced, but `csStore.updated` stays nil (nothing persisted) |
+| `PreviewAppFeatureConfig` | invalid candidate (field-level type error) | same `Location`/`Keyword` assertions as PUT's field-level-type-error case; `csStore.updated` stays nil |
+| `PreviewAppFeatureConfig` | app does not exist | `apierrors.NotFound` |
+| `countYAMLDocuments` | 0 docs (empty input) | `0, nil` |
+| `countYAMLDocuments` | 1 doc | `1, nil` |
+| `countYAMLDocuments` | 2 docs separated by `---` | `2, nil` |
+
+### e2e — `e2e/tests/siteadmin/feature_config.test.yaml` (new)
+
+Follows the structure of `plans.test.yaml` exactly (same `generate_token` /
+`get_access_token` steps, same `http://127.0.0.1:4003` base URL). Uses a
+**dedicated** plan and app (not `e2e-siteadmin-app-alpha/beta/gamma`, which
+`apps.test.yaml`/`plans.test.yaml` depend on staying in known states) to
+avoid cross-test interference.
+
+New fixture file `e2e/tests/siteadmin/fixture/seed_feature_config.sql`:
+```sql
+-- Dedicated plan + app for feature config e2e tests, isolated from the
+-- apps/plans/collaborators fixtures so this test can freely mutate the
+-- app's feature config override without affecting other suites.
+INSERT INTO _portal_plan (id, name, feature_config, created_at, updated_at)
+VALUES (
+    gen_random_uuid()::text,
+    'e2e-feature-config-plan',
+    '{"collaborator": {"maximum": 3}, "oauth": {"client": {"maximum": 10}}}',
+    NOW(), NOW()
+)
+ON CONFLICT (name) DO NOTHING;
+
+INSERT INTO _portal_config_source (id, app_id, data, plan_name, created_at, updated_at)
+VALUES (
+    gen_random_uuid()::text,
+    'e2e-siteadmin-app-feature-config',
+    '{}',
+    'e2e-feature-config-plan',
+    NOW(), NOW()
+)
+ON CONFLICT (app_id) DO NOTHING;
+```
+
+`before:` block adds this fixture after the shared actor/apps seeds (same
+`before:` shape as `plans.test.yaml`).
+
+Steps (all against `http://127.0.0.1:4003/api/v1/apps/e2e-siteadmin-app-feature-config/feature-config...`):
+
+1. `get_initial` — GET, expect 200, `plan_name: "e2e-feature-config-plan"`,
+   `app_feature_config_yaml: ""`, `effective_plan_feature_config.collaborator.maximum:
+   3`, `effective_app_feature_config.collaborator.maximum: 3` (no override yet).
+2. `preview_candidate` — POST `/preview` with body
+   `{"app_feature_config_yaml": "collaborator:\n  soft_maximum: 1\n"}`, expect
+   200, `effective_app_feature_config.collaborator.maximum: 3` (inherited from
+   the plan) and `effective_app_feature_config.collaborator.soft_maximum: 1`.
+   Assert via `query` that `_portal_config_source.data` for this app is still
+   `{}` (nothing persisted by preview).
+3. `preview_invalid_returns_causes_with_location` — POST `/preview` with body
+   `{"app_feature_config_yaml": "oauth:\n  client:\n    maximum: \"not-a-number\"\n"}`,
+   expect 400, `error.reason: "ValidationFailed"`,
+   `error.info.causes[0].location: "/oauth/client/maximum"`,
+   `error.info.causes[0].kind: "type"`. This is the e2e-level pin of the
+   JSON-pointer contract — it must be exercised over the real HTTP/JSON wire,
+   not just asserted in Go unit tests.
+4. `update_override` — PUT with the same body as step 2, expect 200, same
+   `effective_app_feature_config` shape as the preview response.
+5. `verify_override_stored` — plain SQL `query` action:
+   `SELECT data->>'YXV0aGdlYXIuZmVhdHVyZXMueWFtbA==' AS override FROM
+   _portal_config_source WHERE app_id = 'e2e-siteadmin-app-feature-config'`
+   (the exact base64 key is computed at plan-writing time from
+   `filepathutil.EscapePath("authgear.features.yaml")` — the implementer must
+   verify the exact encoding `EscapePath` produces and substitute it here;
+   `filepathutil.EscapePath` is `pkg/util/filepathutil/escape.go:11`), asserts
+   the stored value equals the submitted YAML byte-for-byte.
+6. `audit_update` — `audit_query` action (same shape as `plans.test.yaml`'s
+   `audit_change_plan` step), asserting one row with `activity_type =
+   'site_admin.app.feature_config.updated'`,
+   `data->'payload'->>'app_id' = 'e2e-siteadmin-app-feature-config'`, and
+   `data->'payload'->>'new_app_feature_config_yaml'` containing the submitted
+   text.
+7. `clear_override` — PUT with `{"app_feature_config_yaml": ""}`, expect 200,
+   `app_feature_config_yaml: ""` in the response.
+8. `verify_override_cleared` — SQL `query` asserting the override key is
+   **absent** from `_portal_config_source.data` for this app (not merely an
+   empty string) — e.g. `SELECT data ? '<key>' AS has_key FROM
+   _portal_config_source WHERE app_id = '...'` expecting `has_key: false`
+   (Postgres jsonb `?` containment operator).
+9. `update_invalid_yaml_returns_400_no_causes` — PUT with
+   `{"app_feature_config_yaml": "a: 1\n---\nb: 2\n"}` (multi-document), expect
+   400, `error.reason: "ValidationFailed"`; do not assert `causes` is present
+   here, since it deliberately isn't (the negative case for the hand-built
+   exception in the validation error contract).
+10. `update_non_existent_app_returns_404` — PUT to
+    `.../apps/non-existent-app/feature-config`, expect 404.
+11. `get_non_existent_app_returns_404` — GET on the same non-existent app,
+    expect 404.
+12. `preview_non_existent_app_returns_404` — POST `/preview` on the same
+    non-existent app, expect 404.
+
+---
+
+## Fixed behavioral decisions
+
+- Whitespace-only is defined as `strings.TrimSpace(raw) == ""` (covers empty
+  string, spaces, tabs, newlines). Treated identically to the empty string:
+  clears the override (deletes the map key), never stores a whitespace-only
+  file.
+- Multi-document YAML is rejected with 400 `ValidationFailed` in
+  `parseAppFeatureConfigOverride`, before `computeLayers` ever runs, using a
+  document count via `gopkg.in/yaml.v3`, because
+  `sigs.k8s.io/yaml.YAMLToJSON` silently keeps only the first document
+  otherwise. This is the **one** validation failure in this endpoint that
+  does not carry `info.causes`.
+- Every other validation failure (schema violations inside the document, or
+  in the merged result) surfaces from **`computeLayers`**, which is the only
+  place `config.ParseFeatureConfigWithoutDefaults` is called for this
+  endpoint (via `viewEffectiveResource`, twice: once per layer during the
+  fold, once more on the merged YAML). It produces `info.causes` with RFC
+  6901 `location` pointers automatically via the existing
+  `pkg/api/apierrors` conversion — **no new error-formatting code is written
+  for this endpoint, and there is no separate standalone pre-validation
+  step.**
+- For `UpdateAppFeatureConfig`, `computeLayers` runs inside the transaction,
+  after fetching `dbs` but before any mutation — an invalid override is
+  rejected (and the transaction rolled back) before `dbs.Data` is touched or
+  `UpdateDatabaseSource` is called.
+- `configsource.ErrAppNotFound` is mapped to 404 inside `FeatureConfigService`
+  (not in transport), for all three methods, for consistency with
+  `PlanService.ChangeAppPlan` and because `UpdateAppFeatureConfig` must do
+  this mapping inside its transaction regardless.
+- `plan.ErrPlanNotFound` is tolerated (empty plan layer) in all three
+  methods, never surfaced as an error to the caller.
+- Audit payload carries the full old and new YAML documents, not a diff —
+  both are always small.
+- `dbs.UpdatedAt` is still bumped on every successful PUT even though it is
+  not the propagation mechanism — kept for consistency with `ChangeAppPlan`
+  and because `_portal_config_source` rows are otherwise inspected by admins
+  expecting `updated_at` to reflect the latest write.
+- No optimistic locking / `expected_updated_at` — matches the rest of the
+  Site Admin API.
+- No cross-validation of the new feature config against the app's current
+  `authgear.yaml` — matches existing plan-change behavior.
+- No new per-endpoint request body size limit — already generically capped
+  at 1 MiB by `newBodyLimitMiddleware` in `pkg/siteadmin/routes.go`'s
+  `rootChain`.
+- No enum update needed anywhere for the new
+  `site_admin.app.feature_config.updated` activity type: the audit read path
+  filters `WHERE activity_type LIKE 'site_admin.%'` (prefix, not
+  allow-list); the Admin API GraphQL `AuditLogActivityType` enum never
+  included `site_admin.*` values.
+
+---
+
+## Implementation order
+
+1. OpenAPI spec regeneration: `make generate` (produces `pkg/api/siteadmin/gen.go`
+   with the new types — the spec itself, `docs/api/siteadmin-api.yaml`, is
+   already written and is not part of this implementation plan's scope to
+   change further unless generation surfaces a problem).
+2. Service layer: `pkg/siteadmin/service/feature_config.go` +
+   `pkg/siteadmin/service/feature_config_test.go` + `pkg/siteadmin/service/deps.go`.
+   Fully testable in isolation with fakes; no transport or DI changes needed
+   yet.
+3. Audit payload: `pkg/siteadmin/auditlog/app_feature_config_updated.go`
+   (small, no dependencies on the rest).
+4. Transport handler scaffolding: the three new handler files, with full
+   `ServeHTTP` bodies.
+5. DI wiring: `pkg/siteadmin/deps.go`, `pkg/siteadmin/wire.go`,
+   `pkg/siteadmin/routes.go`, `pkg/siteadmin/transport/deps.go`, then
+   `go generate ./pkg/siteadmin/...` to produce `wire_gen.go`.
+6. `.vettedpositions` update for the new `r.Context()` call sites in the three
+   new handler files.
+7. e2e test + fixture.
+
+---
+
+## Atomic commit plan
+
+| # | Commit message | Files | Verification |
+|---|---|---|---|
+| 1 | `[Site Admin API] Generate models for app feature config` | `pkg/api/siteadmin/gen.go` (regenerated, not hand-edited) | `go build ./pkg/api/siteadmin/...` · `make fmt` |
+| 2 | `[Site Admin API] Add FeatureConfigService` | `pkg/siteadmin/service/feature_config.go`, `pkg/siteadmin/service/feature_config_test.go`, `pkg/siteadmin/service/deps.go`, `go.mod`/`go.sum` (yaml.v3 becomes direct) | `go test ./pkg/siteadmin/service/...` · `make fmt` |
+| 3 | `[Site Admin API] Add site_admin.app.feature_config.updated audit payload` | `pkg/siteadmin/auditlog/app_feature_config_updated.go` | `go build ./pkg/siteadmin/...` · `make fmt` |
+| 4 | `[Site Admin API] Add app feature config handlers` | `pkg/siteadmin/transport/handler_app_feature_config_get.go`, `handler_app_feature_config_update.go`, `handler_app_feature_config_preview.go`, `pkg/siteadmin/transport/deps.go` | `go build ./pkg/siteadmin/...` · `make fmt` |
+| 5 | `[Site Admin API] Wire app feature config handlers` | `pkg/siteadmin/deps.go`, `pkg/siteadmin/wire.go`, `pkg/siteadmin/routes.go`, `pkg/siteadmin/wire_gen.go` (regenerated, not hand-edited) | `go generate ./pkg/siteadmin/...` · `go build ./pkg/siteadmin/... ./cmd/portal/...` · `make fmt` |
+| 6 | `[Site Admin API] Add app feature config e2e tests` | `e2e/tests/siteadmin/feature_config.test.yaml`, `e2e/tests/siteadmin/fixture/seed_feature_config.sql` | `make -C e2e run` (or the targeted subset per `write-e2e-test`) |
+| 7 | final: `.vettedpositions` + `make check-tidy` output, folded into commit 4 or its own trailing commit per the `new-siteadmin-api` skill's final-gate rule | `.vettedpositions`, any files `make check-tidy` reformats/regenerates | `go run ./devtools/goanalysis ./cmd/... ./pkg/...` · `make sort-vettedpositions` · `go run ./devtools/goanalysis ./cmd/... ./pkg/...` (must be clean) · `make check-tidy` (run once, last) |
+
+Each commit builds and tests cleanly on its own before moving to the next,
+per the `new-siteadmin-api` skill's commit-sequence rule.

--- a/e2e/tests/siteadmin/feature_config.test.yaml
+++ b/e2e/tests/siteadmin/feature_config.test.yaml
@@ -1,0 +1,262 @@
+name: Site Admin - App Feature Config
+app_id: e2e-portal
+authgear.yaml:
+  override: |
+    http:
+      public_origin: "http://localhost:4000"
+before:
+- type: custom_sql
+  custom_sql:
+    path: fixture/seed_siteadmin_actor.sql
+- type: custom_sql
+  custom_sql:
+    path: fixture/seed_feature_config.sql
+
+steps:
+# ── Authentication ─────────────────────────────────────────────────────────
+- name: generate_token
+  action: generate_refresh_token
+  generate_refresh_token_user_id: "00000000-0000-0000-0000-000000000001"
+  generate_refresh_token_client_id: e2e
+
+- name: get_access_token
+  action: http_request
+  http_request_method: POST
+  http_request_url: http://localhost:4000/oauth2/token
+  http_request_form_urlencoded_body:
+    grant_type: refresh_token
+    refresh_token: "{{ .steps.generate_token.result.refresh_token }}"
+    client_id: e2e
+  http_output:
+    http_status: 200
+    json_body: |
+      {
+        "access_token": "[[string]]"
+      }
+
+# ── Get initial feature config (no override yet) ─────────────────────────────
+- name: get_initial
+  action: http_request
+  http_request_method: GET
+  http_request_url: http://127.0.0.1:4003/api/v1/apps/e2e-feature-config-app/feature-config
+  http_request_headers:
+    Authorization: "Bearer {{ .steps.get_access_token.result.http_json_body.access_token }}"
+  http_output:
+    http_status: 200
+    json_body: |
+      {
+        "plan_name": "e2e-feature-config-plan",
+        "app_feature_config_yaml": "",
+        "effective_plan_feature_config": {
+          "collaborator": {
+            "maximum": 3
+          }
+        },
+        "effective_app_feature_config": {
+          "collaborator": {
+            "maximum": 3
+          }
+        }
+      }
+
+# ── Preview a candidate override — nothing persisted ──────────────────────────
+- name: preview_candidate
+  action: http_request
+  http_request_method: POST
+  http_request_url: http://127.0.0.1:4003/api/v1/apps/e2e-feature-config-app/feature-config/preview
+  http_request_headers:
+    Authorization: "Bearer {{ .steps.get_access_token.result.http_json_body.access_token }}"
+    Content-Type: application/json
+  http_request_body: |
+    {"app_feature_config_yaml": "collaborator:\n  soft_maximum: 1\n"}
+  http_output:
+    http_status: 200
+    json_body: |
+      {
+        "plan_name": "e2e-feature-config-plan",
+        "effective_app_feature_config": {
+          "collaborator": {
+            "maximum": 3,
+            "soft_maximum": 1
+          }
+        }
+      }
+
+- name: verify_preview_persisted_nothing
+  action: query
+  query: |
+    SELECT data::text AS data FROM _portal_config_source
+    WHERE app_id = 'e2e-feature-config-app'
+  query_output:
+    rows: |
+      [{"data": "{}"}]
+
+# ── Preview an invalid candidate — 400 with field-addressable causes ─────────
+- name: preview_invalid_returns_causes_with_location
+  action: http_request
+  http_request_method: POST
+  http_request_url: http://127.0.0.1:4003/api/v1/apps/e2e-feature-config-app/feature-config/preview
+  http_request_headers:
+    Authorization: "Bearer {{ .steps.get_access_token.result.http_json_body.access_token }}"
+    Content-Type: application/json
+  http_request_body: |
+    {"app_feature_config_yaml": "oauth:\n  client:\n    maximum: \"not-a-number\"\n"}
+  http_output:
+    http_status: 400
+    json_body: |
+      {
+        "error": {
+          "name": "Invalid",
+          "reason": "ValidationFailed",
+          "code": 400,
+          "info": {
+            "causes": [
+              {
+                "location": "/oauth/client/maximum",
+                "kind": "type"
+              }
+            ]
+          }
+        }
+      }
+
+# ── Save the override via PUT ────────────────────────────────────────────────
+- name: update_override
+  action: http_request
+  http_request_method: PUT
+  http_request_url: http://127.0.0.1:4003/api/v1/apps/e2e-feature-config-app/feature-config
+  http_request_headers:
+    Authorization: "Bearer {{ .steps.get_access_token.result.http_json_body.access_token }}"
+    Content-Type: application/json
+  http_request_body: |
+    {"app_feature_config_yaml": "collaborator:\n  soft_maximum: 1\n"}
+  http_output:
+    http_status: 200
+    json_body: |
+      {
+        "plan_name": "e2e-feature-config-plan",
+        "app_feature_config_yaml": "collaborator:\n  soft_maximum: 1\n",
+        "effective_app_feature_config": {
+          "collaborator": {
+            "maximum": 3,
+            "soft_maximum": 1
+          }
+        }
+      }
+
+- name: verify_override_stored
+  action: query
+  query: |
+    SELECT convert_from(decode(data->>'authgear.features.yaml', 'base64'), 'UTF8') AS override
+    FROM _portal_config_source
+    WHERE app_id = 'e2e-feature-config-app'
+  query_output:
+    rows: |
+      [{"override": "collaborator:\n  soft_maximum: 1\n"}]
+
+- name: audit_update
+  action: audit_query
+  audit_query: |
+    SELECT
+      activity_type,
+      data->'payload'->>'app_id' AS app_id,
+      data->'payload'->>'new_app_feature_config_yaml' AS new_yaml
+    FROM _audit_log
+    WHERE app_id = 'e2e-portal'
+      AND activity_type = 'site_admin.app.feature_config.updated'
+      AND data->'payload'->>'app_id' = 'e2e-feature-config-app'
+    ORDER BY created_at DESC
+    LIMIT 1
+  audit_query_output:
+    rows: |
+      [
+        {
+          "activity_type": "site_admin.app.feature_config.updated",
+          "app_id": "e2e-feature-config-app",
+          "new_yaml": "collaborator:\n  soft_maximum: 1\n"
+        }
+      ]
+
+# ── Clear the override ───────────────────────────────────────────────────────
+- name: clear_override
+  action: http_request
+  http_request_method: PUT
+  http_request_url: http://127.0.0.1:4003/api/v1/apps/e2e-feature-config-app/feature-config
+  http_request_headers:
+    Authorization: "Bearer {{ .steps.get_access_token.result.http_json_body.access_token }}"
+    Content-Type: application/json
+  http_request_body: |
+    {"app_feature_config_yaml": ""}
+  http_output:
+    http_status: 200
+    json_body: |
+      {
+        "plan_name": "e2e-feature-config-plan",
+        "app_feature_config_yaml": ""
+      }
+
+- name: verify_override_cleared
+  action: query
+  query: |
+    SELECT data ? 'authgear.features.yaml' AS has_key
+    FROM _portal_config_source
+    WHERE app_id = 'e2e-feature-config-app'
+  query_output:
+    rows: |
+      [{"has_key": false}]
+
+# ── Multi-document YAML is rejected without causes ──────────────────────────
+- name: update_invalid_yaml_returns_400_no_causes
+  action: http_request
+  http_request_method: PUT
+  http_request_url: http://127.0.0.1:4003/api/v1/apps/e2e-feature-config-app/feature-config
+  http_request_headers:
+    Authorization: "Bearer {{ .steps.get_access_token.result.http_json_body.access_token }}"
+    Content-Type: application/json
+  http_request_body: |
+    {"app_feature_config_yaml": "a: 1\n---\nb: 2\n"}
+  http_output:
+    http_status: 400
+    json_body: |
+      {
+        "error": {
+          "name": "Invalid",
+          "reason": "ValidationFailed",
+          "code": 400,
+          "info": "[[never]]"
+        }
+      }
+
+# ── Non-existent app returns 404 on all three endpoints ──────────────────────
+- name: update_non_existent_app_returns_404
+  action: http_request
+  http_request_method: PUT
+  http_request_url: http://127.0.0.1:4003/api/v1/apps/non-existent-app/feature-config
+  http_request_headers:
+    Authorization: "Bearer {{ .steps.get_access_token.result.http_json_body.access_token }}"
+    Content-Type: application/json
+  http_request_body: |
+    {"app_feature_config_yaml": "collaborator:\n  soft_maximum: 1\n"}
+  http_output:
+    http_status: 404
+
+- name: get_non_existent_app_returns_404
+  action: http_request
+  http_request_method: GET
+  http_request_url: http://127.0.0.1:4003/api/v1/apps/non-existent-app/feature-config
+  http_request_headers:
+    Authorization: "Bearer {{ .steps.get_access_token.result.http_json_body.access_token }}"
+  http_output:
+    http_status: 404
+
+- name: preview_non_existent_app_returns_404
+  action: http_request
+  http_request_method: POST
+  http_request_url: http://127.0.0.1:4003/api/v1/apps/non-existent-app/feature-config/preview
+  http_request_headers:
+    Authorization: "Bearer {{ .steps.get_access_token.result.http_json_body.access_token }}"
+    Content-Type: application/json
+  http_request_body: |
+    {"app_feature_config_yaml": "collaborator:\n  soft_maximum: 1\n"}
+  http_output:
+    http_status: 404

--- a/e2e/tests/siteadmin/fixture/seed_feature_config.sql
+++ b/e2e/tests/siteadmin/fixture/seed_feature_config.sql
@@ -1,0 +1,21 @@
+-- Dedicated plan + app for feature config e2e tests, isolated from the
+-- apps/plans/collaborators fixtures so this test can freely mutate the
+-- app's feature config override without affecting other suites.
+INSERT INTO _portal_plan (id, name, feature_config, created_at, updated_at)
+VALUES (
+    gen_random_uuid()::text,
+    'e2e-feature-config-plan',
+    '{"collaborator": {"maximum": 3}, "oauth": {"client": {"maximum": 10}}}',
+    NOW(), NOW()
+)
+ON CONFLICT (name) DO NOTHING;
+
+INSERT INTO _portal_config_source (id, app_id, data, plan_name, created_at, updated_at)
+VALUES (
+    gen_random_uuid()::text,
+    'e2e-feature-config-app',
+    '{}',
+    'e2e-feature-config-plan',
+    NOW(), NOW()
+)
+ON CONFLICT (app_id) DO NOTHING;

--- a/go.mod
+++ b/go.mod
@@ -74,7 +74,7 @@ require (
 	github.com/yudai/gojsondiff v1.0.0
 	go.uber.org/automaxprocs v1.6.0
 	golang.org/x/exp v0.0.0-20260218203240-3dfff04db8fa // indirect
-	gopkg.in/yaml.v3 v3.0.1 // indirect
+	gopkg.in/yaml.v3 v3.0.1
 )
 
 require (

--- a/pkg/api/siteadmin/gen.go
+++ b/pkg/api/siteadmin/gen.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	apierrors "github.com/authgear/authgear-server/pkg/api/apierrors"
+	config "github.com/authgear/authgear-server/pkg/lib/config"
 )
 
 // Defines values for CollaboratorRole.
@@ -114,6 +115,21 @@ type AppDetail struct {
 	UserCount int `json:"user_count"`
 }
 
+// AppFeatureConfigResponse defines model for AppFeatureConfigResponse.
+type AppFeatureConfigResponse struct {
+	// AppFeatureConfigYaml The stored app-specific override YAML document, verbatim — including comments and key order. Empty string when the app has no override. Sparse: only fields explicitly overridden for this app are present. Clients parse this to render structured views (e.g. a table); any field absent from this document simply inherits from `effective_plan_feature_config`.
+	AppFeatureConfigYaml string `json:"app_feature_config_yaml"`
+
+	// EffectiveAppFeatureConfig The effective feature config computed by the server by merging defaults ← plan ← app override, fully populated. This is what the app actually runs with; use it for the "Effective" display. Always re-fetch this (via GET after save, or via the preview endpoint while editing) rather than deriving it from `effective_plan_feature_config` and `app_feature_config_yaml` locally.
+	EffectiveAppFeatureConfig FeatureConfig `json:"effective_app_feature_config"`
+
+	// EffectivePlanFeatureConfig The **effective** feature config of the plan alone — server defaults merged with the plan's config, fully populated. This is what the app would get if it had no app-specific override at all; display this as the read-only "Plan" column/panel. It is deliberately not the raw/sparse plan document: since merge is field-level everywhere, the effective value is always well-defined and there is no ambiguity between "the plan set this" and "this is a code default" for the client to worry about — every value shown here is simply what the app would actually run with under this plan.
+	EffectivePlanFeatureConfig FeatureConfig `json:"effective_plan_feature_config"`
+
+	// PlanName The plan the app is currently on.
+	PlanName string `json:"plan_name"`
+}
+
 // AppsListResponse defines model for AppsListResponse.
 type AppsListResponse struct {
 	Apps []App `json:"apps"`
@@ -172,6 +188,9 @@ type ErrorEnvelope struct {
 	Error APIError `json:"error"`
 }
 
+// FeatureConfig An Authgear feature config object (the JSON form of authgear.features.yaml). The authoritative schema is the server's feature config JSON schema (FeatureConfigSchema in pkg/lib/config); it is not duplicated here. Top-level sections include identity, authentication, authenticator, custom_domain, ui, oauth, hook, audit_log, google_tag_manager, rate_limits, messaging, usage, collaborator, admin_api, test_mode, and fraud_protection. Every section merges field-by-field across layers (code defaults ← cluster ← plan ← app override) — an app-specific override only ever affects the exact fields it sets; every other field simply inherits from the plan.
+type FeatureConfig = config.FeatureConfig
+
 // MessagingUsage defines model for MessagingUsage.
 type MessagingUsage struct {
 	// EndDate End of the date range, inclusive. Format YYYY-MM-DD.
@@ -218,6 +237,12 @@ type Plan struct {
 // PlansListResponse defines model for PlansListResponse.
 type PlansListResponse struct {
 	Plans []Plan `json:"plans"`
+}
+
+// PreviewAppFeatureConfigRequest defines model for PreviewAppFeatureConfigRequest.
+type PreviewAppFeatureConfigRequest struct {
+	// AppFeatureConfigYaml The candidate app-specific feature config override as a YAML document. Not persisted. Validated against the feature config JSON schema exactly as PUT does; see the `ValidationErrorCause` schema for the shape of validation failures.
+	AppFeatureConfigYaml string `json:"app_feature_config_yaml"`
 }
 
 // SiteAdminAuditLog defines model for SiteAdminAuditLog.
@@ -283,6 +308,12 @@ type SiteAdminAuditLogsListResponse struct {
 
 	// TotalCount Total number of entries matching the query.
 	TotalCount int `json:"total_count"`
+}
+
+// UpdateAppFeatureConfigRequest defines model for UpdateAppFeatureConfigRequest.
+type UpdateAppFeatureConfigRequest struct {
+	// AppFeatureConfigYaml The new app-specific feature config override as a YAML document. Replaces the existing override entirely and is stored verbatim, preserving comments and key order. Pass an empty string (or a whitespace-only string) to clear all overrides. Validated against the feature config JSON schema; see the `ValidationErrorCause` schema for the shape of validation failures. Since YAML is a superset of JSON, automation may pass a JSON document here.
+	AppFeatureConfigYaml string `json:"app_feature_config_yaml"`
 }
 
 // BadRequest Error response envelope matching the api.Response struct.
@@ -362,6 +393,12 @@ type ListAuditLogsParams struct {
 
 // AddAppCollaboratorJSONRequestBody defines body for AddAppCollaborator for application/json ContentType.
 type AddAppCollaboratorJSONRequestBody = AddCollaboratorRequest
+
+// UpdateAppFeatureConfigJSONRequestBody defines body for UpdateAppFeatureConfig for application/json ContentType.
+type UpdateAppFeatureConfigJSONRequestBody = UpdateAppFeatureConfigRequest
+
+// PreviewAppFeatureConfigJSONRequestBody defines body for PreviewAppFeatureConfig for application/json ContentType.
+type PreviewAppFeatureConfigJSONRequestBody = PreviewAppFeatureConfigRequest
 
 // ChangeAppPlanJSONRequestBody defines body for ChangeAppPlan for application/json ContentType.
 type ChangeAppPlanJSONRequestBody = ChangeAppPlanRequest

--- a/pkg/siteadmin/auditlog/app_feature_config_updated.go
+++ b/pkg/siteadmin/auditlog/app_feature_config_updated.go
@@ -1,0 +1,45 @@
+package auditlog
+
+import (
+	"github.com/authgear/authgear-server/pkg/api/event"
+)
+
+const AppFeatureConfigUpdated event.Type = "site_admin.app.feature_config.updated"
+
+type AppFeatureConfigUpdatedPayload struct {
+	AppID                   string `json:"app_id"`
+	OldAppFeatureConfigYAML string `json:"old_app_feature_config_yaml"`
+	NewAppFeatureConfigYAML string `json:"new_app_feature_config_yaml"`
+}
+
+func (e *AppFeatureConfigUpdatedPayload) NonBlockingEventType() event.Type {
+	return AppFeatureConfigUpdated
+}
+
+func (e *AppFeatureConfigUpdatedPayload) UserID() string {
+	return ""
+}
+
+func (e *AppFeatureConfigUpdatedPayload) GetTriggeredBy() event.TriggeredByType {
+	return event.TriggeredBySiteAdmin
+}
+
+func (e *AppFeatureConfigUpdatedPayload) FillContext(_ *event.Context) {}
+
+func (e *AppFeatureConfigUpdatedPayload) ForHook() bool {
+	return false
+}
+
+func (e *AppFeatureConfigUpdatedPayload) ForAudit() bool {
+	return true
+}
+
+func (e *AppFeatureConfigUpdatedPayload) RequireReindexUserIDs() []string {
+	return nil
+}
+
+func (e *AppFeatureConfigUpdatedPayload) DeletedUserIDs() []string {
+	return nil
+}
+
+var _ event.NonBlockingPayload = &AppFeatureConfigUpdatedPayload{}

--- a/pkg/siteadmin/deps.go
+++ b/pkg/siteadmin/deps.go
@@ -104,6 +104,12 @@ var DependencySet = wire.NewSet(
 	wire.Bind(new(siteadminservice.PlanServiceAuditService), new(*siteadminservice.SiteAdminAuditService)),
 	wire.Bind(new(siteadminservice.CollaboratorServiceAuditService), new(*siteadminservice.SiteAdminAuditService)),
 
+	// FeatureConfigService bindings
+	wire.Bind(new(siteadminservice.FeatureConfigServiceGlobalDatabase), new(*globaldb.Handle)),
+	wire.Bind(new(siteadminservice.FeatureConfigServicePlanStore), new(*plan.Store)),
+	wire.Bind(new(siteadminservice.FeatureConfigServiceConfigSourceStore), new(*configsource.Store)),
+	wire.Bind(new(siteadminservice.FeatureConfigServiceAuditService), new(*siteadminservice.SiteAdminAuditService)),
+
 	// transport bindings
 	wire.Bind(new(transport.AppsListService), new(*siteadminservice.AppService)),
 	wire.Bind(new(transport.AppGetService), new(*siteadminservice.AppService)),
@@ -115,6 +121,9 @@ var DependencySet = wire.NewSet(
 	wire.Bind(new(transport.PlansListService), new(*siteadminservice.PlanService)),
 	wire.Bind(new(transport.AppPlanChangeService), new(*siteadminservice.PlanService)),
 	wire.Bind(new(transport.CollaboratorPromoteService), new(*siteadminservice.CollaboratorService)),
+	wire.Bind(new(transport.AppFeatureConfigGetService), new(*siteadminservice.FeatureConfigService)),
+	wire.Bind(new(transport.AppFeatureConfigUpdateService), new(*siteadminservice.FeatureConfigService)),
+	wire.Bind(new(transport.AppFeatureConfigPreviewService), new(*siteadminservice.FeatureConfigService)),
 
 	// audit log read service transport bindings
 	wire.Bind(new(transport.AuditLogsListService), new(*siteadminservice.SiteAdminAuditReadService)),

--- a/pkg/siteadmin/routes.go
+++ b/pkg/siteadmin/routes.go
@@ -49,6 +49,9 @@ func NewRouter(p *deps.RootProvider) http.Handler {
 	router.Add(transport.ConfigureMonthlyActiveUsersUsageRoute(route), p.Handler(newMonthlyActiveUsersUsageHandler))
 	router.Add(transport.ConfigurePlansListRoute(route), p.Handler(newPlansListHandler))
 	router.Add(transport.ConfigureAppPlanChangeRoute(route), p.Handler(newAppPlanChangeHandler))
+	router.Add(transport.ConfigureAppFeatureConfigGetRoute(route), p.Handler(newAppFeatureConfigGetHandler))
+	router.Add(transport.ConfigureAppFeatureConfigUpdateRoute(route), p.Handler(newAppFeatureConfigUpdateHandler))
+	router.Add(transport.ConfigureAppFeatureConfigPreviewRoute(route), p.Handler(newAppFeatureConfigPreviewHandler))
 	router.Add(transport.ConfigureAuditLogsListRoute(route), p.Handler(newAuditLogsListHandler))
 	router.Add(transport.ConfigureAuditLogGetRoute(route), p.Handler(newAuditLogGetHandler))
 

--- a/pkg/siteadmin/service/deps.go
+++ b/pkg/siteadmin/service/deps.go
@@ -22,6 +22,7 @@ var DependencySet = wire.NewSet(
 	wire.Struct(new(CollaboratorService), "*"),
 	wire.Struct(new(UsageService), "*"),
 	wire.Struct(new(PlanService), "*"),
+	wire.Struct(new(FeatureConfigService), "*"),
 	wire.Struct(new(SiteAdminAuditService), "*"),
 	wire.Struct(new(SiteAdminAuditLogStore), "*"),
 	wire.Bind(new(SiteAdminAuditLogStoreIface), new(*SiteAdminAuditLogStore)),

--- a/pkg/siteadmin/service/feature_config.go
+++ b/pkg/siteadmin/service/feature_config.go
@@ -265,7 +265,16 @@ func readEffectiveFeatureConfig(ctx context.Context, mgr *resource.Manager) (*co
 // override" — this is the one case callers must treat specially (not an
 // error, and not "store an empty file"). Does NOT run schema validation —
 // that happens inside computeLayers, which validates this data as one of the
-// layers it merges, plus the merged result.
+// layers it merges, plus the merged result. It DOES reject YAML that fails
+// to even parse syntactically, for the same reason as the multi-document
+// check below: computeLayers's underlying error for a syntax failure
+// (configsource.AuthgearFeatureYAMLDescriptor.viewEffectiveResource's
+// "malformed feature config: %w") is a plain wrapped error, not a
+// *validation.AggregatedError, so pkg/api/apierrors's asAPIError can't
+// recognize it as ValidationFailed — it falls through to an unclassified
+// 500 UnexpectedError instead. A syntax error is a whole-document problem
+// like the multi-document case, not a per-field one, so it gets the same
+// hand-built ValidationFailed treatment (no causes).
 func parseAppFeatureConfigOverride(raw string) ([]byte, error) {
 	if strings.TrimSpace(raw) == "" {
 		return nil, nil
@@ -275,7 +284,7 @@ func parseAppFeatureConfigOverride(raw string) ([]byte, error) {
 
 	n, err := countYAMLDocuments(data)
 	if err != nil {
-		return nil, err
+		return nil, apierrors.ValidationFailed.New("app_feature_config_yaml is not valid YAML: " + err.Error())
 	}
 	if n > 1 {
 		return nil, apierrors.ValidationFailed.New("app_feature_config_yaml must contain at most one YAML document")
@@ -284,10 +293,9 @@ func parseAppFeatureConfigOverride(raw string) ([]byte, error) {
 	return data, nil
 }
 
-// countYAMLDocuments counts YAML documents separated by "---". Malformed
-// YAML is not an error here — countYAMLDocuments returns whatever count it
-// reached and nil; computeLayers (via ParseFeatureConfigWithoutDefaults)
-// produces the canonical validation error for malformed input.
+// countYAMLDocuments counts YAML documents separated by "---". A genuine
+// syntax error is returned to the caller (see parseAppFeatureConfigOverride
+// above) — only a clean end-of-input is treated as "done counting".
 func countYAMLDocuments(data []byte) (int, error) {
 	dec := goyaml.NewDecoder(bytes.NewReader(data))
 	count := 0
@@ -297,7 +305,7 @@ func countYAMLDocuments(data []byte) (int, error) {
 			if errors.Is(err, io.EOF) {
 				return count, nil
 			}
-			return count, nil
+			return count, err
 		}
 		count++
 	}

--- a/pkg/siteadmin/service/feature_config.go
+++ b/pkg/siteadmin/service/feature_config.go
@@ -1,0 +1,304 @@
+package service
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"io"
+	"strings"
+
+	goyaml "gopkg.in/yaml.v3"
+
+	"github.com/authgear/authgear-server/pkg/api/apierrors"
+	"github.com/authgear/authgear-server/pkg/api/event"
+	"github.com/authgear/authgear-server/pkg/lib/config"
+	"github.com/authgear/authgear-server/pkg/lib/config/configsource"
+	"github.com/authgear/authgear-server/pkg/lib/config/plan"
+	"github.com/authgear/authgear-server/pkg/portal/deps"
+	siteadminauditlog "github.com/authgear/authgear-server/pkg/siteadmin/auditlog"
+	"github.com/authgear/authgear-server/pkg/util/clock"
+	"github.com/authgear/authgear-server/pkg/util/filepathutil"
+	"github.com/authgear/authgear-server/pkg/util/resource"
+)
+
+// ---- Narrow interfaces -------------------------------------------------------
+
+type FeatureConfigServiceGlobalDatabase interface {
+	WithTx(ctx context.Context, do func(ctx context.Context) error) error
+	ReadOnly(ctx context.Context, do func(ctx context.Context) error) error
+}
+
+type FeatureConfigServicePlanStore interface {
+	GetPlan(ctx context.Context, name string) (*plan.Plan, error)
+}
+
+type FeatureConfigServiceConfigSourceStore interface {
+	GetDatabaseSourceByAppID(ctx context.Context, appID string) (*configsource.DatabaseSource, error)
+	UpdateDatabaseSource(ctx context.Context, dbs *configsource.DatabaseSource) error
+}
+
+type FeatureConfigServiceAuditService interface {
+	LogEvent(ctx context.Context, appID string, payload event.NonBlockingPayload) error
+}
+
+// ---- Domain types -------------------------------------------------------------
+
+// AppFeatureConfigResult is the internal computation result — pointer-typed
+// because config.FeatureConfig sections are pointer fields throughout
+// pkg/lib/config. Transport dereferences EffectivePlanFeatureConfig /
+// EffectiveAppFeatureConfig into the (value-typed, generated) wire schema.
+type AppFeatureConfigResult struct {
+	PlanName                   string
+	EffectivePlanFeatureConfig *config.FeatureConfig
+	AppFeatureConfigYAML       string
+	EffectiveAppFeatureConfig  *config.FeatureConfig
+}
+
+// ---- FeatureConfigService -------------------------------------------------------
+
+type FeatureConfigService struct {
+	GlobalDatabase    FeatureConfigServiceGlobalDatabase
+	PlanStore         FeatureConfigServicePlanStore
+	ConfigSourceStore FeatureConfigServiceConfigSourceStore
+	AuditService      FeatureConfigServiceAuditService
+	BaseResources     deps.AppBaseResources
+	Clock             clock.Clock
+}
+
+func (s *FeatureConfigService) GetAppFeatureConfig(ctx context.Context, appID string) (*AppFeatureConfigResult, error) {
+	var planName string
+	var overrideYAML []byte
+	var planEffective *config.FeatureConfig
+	var effective *config.FeatureConfig
+	err := s.GlobalDatabase.ReadOnly(ctx, func(ctx context.Context) error {
+		dbs, e := s.ConfigSourceStore.GetDatabaseSourceByAppID(ctx, appID)
+		if errors.Is(e, configsource.ErrAppNotFound) {
+			return apierrors.NotFound.WithReason("AppNotFound").New("app not found")
+		}
+		if e != nil {
+			return e
+		}
+		planName = dbs.PlanName
+		overrideYAML = dbs.Data[featureConfigOverrideKey()]
+
+		planEffective, effective, e = s.computeLayers(ctx, planName, overrideYAML)
+		return e
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return &AppFeatureConfigResult{
+		PlanName:                   planName,
+		EffectivePlanFeatureConfig: planEffective,
+		AppFeatureConfigYAML:       string(overrideYAML),
+		EffectiveAppFeatureConfig:  effective,
+	}, nil
+}
+
+func (s *FeatureConfigService) UpdateAppFeatureConfig(ctx context.Context, appID string, rawYAML string) (*AppFeatureConfigResult, error) {
+	overrideBytes, err := parseAppFeatureConfigOverride(rawYAML)
+	if err != nil {
+		return nil, err
+	}
+
+	var planName string
+	var oldYAML string
+	var planEffective *config.FeatureConfig
+	var effective *config.FeatureConfig
+	err = s.GlobalDatabase.WithTx(ctx, func(ctx context.Context) error {
+		dbs, e := s.ConfigSourceStore.GetDatabaseSourceByAppID(ctx, appID)
+		if errors.Is(e, configsource.ErrAppNotFound) {
+			return apierrors.NotFound.WithReason("AppNotFound").New("app not found")
+		}
+		if e != nil {
+			return e
+		}
+		planName = dbs.PlanName
+
+		key := featureConfigOverrideKey()
+		oldYAML = string(dbs.Data[key])
+
+		planEffective, effective, e = s.computeLayers(ctx, dbs.PlanName, overrideBytes)
+		if e != nil {
+			return e
+		}
+
+		if dbs.Data == nil {
+			dbs.Data = map[string][]byte{}
+		}
+		if overrideBytes == nil {
+			delete(dbs.Data, key)
+		} else {
+			dbs.Data[key] = overrideBytes
+		}
+		dbs.UpdatedAt = s.Clock.NowUTC()
+
+		return s.ConfigSourceStore.UpdateDatabaseSource(ctx, dbs)
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	if s.AuditService != nil {
+		if e := s.AuditService.LogEvent(ctx, appID, &siteadminauditlog.AppFeatureConfigUpdatedPayload{
+			AppID:                   appID,
+			OldAppFeatureConfigYAML: oldYAML,
+			NewAppFeatureConfigYAML: string(overrideBytes),
+		}); e != nil {
+			AuditServiceLogger.GetLogger(ctx).WithError(e).Error(ctx, "failed to emit site admin audit log")
+		}
+	}
+
+	return &AppFeatureConfigResult{
+		PlanName:                   planName,
+		EffectivePlanFeatureConfig: planEffective,
+		AppFeatureConfigYAML:       string(overrideBytes),
+		EffectiveAppFeatureConfig:  effective,
+	}, nil
+}
+
+func (s *FeatureConfigService) PreviewAppFeatureConfig(ctx context.Context, appID string, rawYAML string) (*AppFeatureConfigResult, error) {
+	overrideBytes, err := parseAppFeatureConfigOverride(rawYAML)
+	if err != nil {
+		return nil, err
+	}
+
+	var planName string
+	var planEffective *config.FeatureConfig
+	var effective *config.FeatureConfig
+	err = s.GlobalDatabase.ReadOnly(ctx, func(ctx context.Context) error {
+		dbs, e := s.ConfigSourceStore.GetDatabaseSourceByAppID(ctx, appID)
+		if errors.Is(e, configsource.ErrAppNotFound) {
+			return apierrors.NotFound.WithReason("AppNotFound").New("app not found")
+		}
+		if e != nil {
+			return e
+		}
+		planName = dbs.PlanName
+
+		planEffective, effective, e = s.computeLayers(ctx, dbs.PlanName, overrideBytes)
+		return e
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return &AppFeatureConfigResult{
+		PlanName:                   planName,
+		EffectivePlanFeatureConfig: planEffective,
+		AppFeatureConfigYAML:       string(overrideBytes),
+		EffectiveAppFeatureConfig:  effective,
+	}, nil
+}
+
+// ---- Merge computation --------------------------------------------------------
+
+func featureConfigOverrideKey() string {
+	return filepathutil.EscapePath(configsource.AuthgearFeatureYAML)
+}
+
+// computeLayers folds BaseResources, the plan named planName, and a
+// candidate app-override document (nil/empty overrideYAML = no override)
+// exactly the way dbApp.doLoad computes an app's effective feature config —
+// same layer stack, same order, same FS-construction helpers. No merge
+// logic is reimplemented.
+func (s *FeatureConfigService) computeLayers(
+	ctx context.Context,
+	planName string,
+	overrideYAML []byte,
+) (planEffective *config.FeatureConfig, effective *config.FeatureConfig, err error) {
+	p, err := s.PlanStore.GetPlan(ctx, planName)
+	if err != nil && !errors.Is(err, plan.ErrPlanNotFound) {
+		return nil, nil, err
+	}
+	// On ErrPlanNotFound, p stays nil. MakePlanFSFromPlan(nil) produces an
+	// empty plan layer — the same tolerance dbApp.doLoad has for an app
+	// referencing a missing plan.
+
+	planFs, err := configsource.MakePlanFSFromPlan(p)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	appData := map[string][]byte{}
+	if len(overrideYAML) > 0 {
+		appData[featureConfigOverrideKey()] = overrideYAML
+	}
+	appFs, err := configsource.MakeAppFSFromDatabaseSource(&configsource.DatabaseSource{Data: appData})
+	if err != nil {
+		return nil, nil, err
+	}
+
+	base := (*resource.Manager)(s.BaseResources)
+	planEffective, err = readEffectiveFeatureConfig(ctx, base.Overlay(planFs))
+	if err != nil {
+		return nil, nil, err
+	}
+	effective, err = readEffectiveFeatureConfig(ctx, base.Overlay(planFs).Overlay(appFs))
+	if err != nil {
+		return nil, nil, err
+	}
+	return planEffective, effective, nil
+}
+
+// readEffectiveFeatureConfig mirrors configsource.LoadConfig's feature config
+// resolution: read the FeatureConfig resource from the given manager,
+// falling back to server defaults when no layer has an authgear.features.yaml
+// file.
+func readEffectiveFeatureConfig(ctx context.Context, mgr *resource.Manager) (*config.FeatureConfig, error) {
+	result, err := mgr.Read(ctx, configsource.FeatureConfig, resource.EffectiveResource{})
+	if errors.Is(err, resource.ErrResourceNotFound) {
+		return config.NewEffectiveDefaultFeatureConfig(), nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	return result.(*config.FeatureConfig), nil
+}
+
+// ---- Validation (PUT and POST share this) --------------------------------------
+
+// parseAppFeatureConfigOverride handles the two things that must be checked
+// before a candidate override can even be considered for merging. Returns
+// (nil, nil) when raw is empty or whitespace-only, meaning "clear the
+// override" — this is the one case callers must treat specially (not an
+// error, and not "store an empty file"). Does NOT run schema validation —
+// that happens inside computeLayers, which validates this data as one of the
+// layers it merges, plus the merged result.
+func parseAppFeatureConfigOverride(raw string) ([]byte, error) {
+	if strings.TrimSpace(raw) == "" {
+		return nil, nil
+	}
+
+	data := []byte(raw)
+
+	n, err := countYAMLDocuments(data)
+	if err != nil {
+		return nil, err
+	}
+	if n > 1 {
+		return nil, apierrors.ValidationFailed.New("app_feature_config_yaml must contain at most one YAML document")
+	}
+
+	return data, nil
+}
+
+// countYAMLDocuments counts YAML documents separated by "---". Malformed
+// YAML is not an error here — countYAMLDocuments returns whatever count it
+// reached and nil; computeLayers (via ParseFeatureConfigWithoutDefaults)
+// produces the canonical validation error for malformed input.
+func countYAMLDocuments(data []byte) (int, error) {
+	dec := goyaml.NewDecoder(bytes.NewReader(data))
+	count := 0
+	for {
+		var doc any
+		if err := dec.Decode(&doc); err != nil {
+			if errors.Is(err, io.EOF) {
+				return count, nil
+			}
+			return count, nil
+		}
+		count++
+	}
+}

--- a/pkg/siteadmin/service/feature_config_test.go
+++ b/pkg/siteadmin/service/feature_config_test.go
@@ -278,6 +278,29 @@ func TestFeatureConfigService_UpdateAppFeatureConfig(t *testing.T) {
 			So(csStore.updated, ShouldBeNil)
 		})
 
+		Convey("YAML that fails to parse syntactically is rejected as ValidationFailed, not an unclassified 500", func() {
+			svc := makeService(csStore)
+
+			// A genuine syntax error (unindented scalar breaking mapping
+			// syntax), not a schema violation -- this must never reach
+			// computeLayers, whose underlying "malformed feature config"
+			// error from configsource.viewEffectiveResource is a plain
+			// wrapped error, not a *validation.AggregatedError, so
+			// pkg/api/apierrors's asAPIError can't classify it and falls
+			// through to UnexpectedError/500 (the bug this test pins).
+			_, err := svc.UpdateAppFeatureConfig(context.Background(), "app1", "oauth:\n  client\n    maximum: 5\n")
+			So(err, ShouldNotBeNil)
+			So(apierrors.IsAPIErrorWithCondition(err, func(e *apierrors.APIError) bool {
+				return e.Kind.Name == apierrors.Invalid && e.Kind.Reason == "ValidationFailed"
+			}), ShouldBeTrue)
+			So(apierrors.IsAPIErrorWithCondition(err, func(e *apierrors.APIError) bool {
+				return e.Code >= 500
+			}), ShouldBeFalse)
+			var aggErr *validation.AggregatedError
+			So(errors.As(err, &aggErr), ShouldBeFalse)
+			So(csStore.updated, ShouldBeNil)
+		})
+
 		Convey("app does not exist", func() {
 			svc := makeService(csStore)
 

--- a/pkg/siteadmin/service/feature_config_test.go
+++ b/pkg/siteadmin/service/feature_config_test.go
@@ -1,0 +1,403 @@
+package service
+
+import (
+	"context"
+	"errors"
+	"maps"
+	"testing"
+	"time"
+
+	. "github.com/smartystreets/goconvey/convey"
+
+	"github.com/authgear/authgear-server/pkg/api/apierrors"
+	"github.com/authgear/authgear-server/pkg/lib/config"
+	"github.com/authgear/authgear-server/pkg/lib/config/configsource"
+	"github.com/authgear/authgear-server/pkg/lib/config/plan"
+	"github.com/authgear/authgear-server/pkg/portal/deps"
+	siteadminauditlog "github.com/authgear/authgear-server/pkg/siteadmin/auditlog"
+	"github.com/authgear/authgear-server/pkg/util/clock"
+	"github.com/authgear/authgear-server/pkg/util/resource"
+	"github.com/authgear/authgear-server/pkg/util/validation"
+)
+
+// ---- Fakes -------------------------------------------------------------------
+
+type fakeFeatureConfigPlanStore struct {
+	plans map[string]*plan.Plan
+}
+
+func (f *fakeFeatureConfigPlanStore) GetPlan(_ context.Context, name string) (*plan.Plan, error) {
+	if p, ok := f.plans[name]; ok {
+		return p, nil
+	}
+	return nil, plan.ErrPlanNotFound
+}
+
+type fakeFeatureConfigConfigSourceStore struct {
+	sources map[string]*configsource.DatabaseSource
+	updated *configsource.DatabaseSource
+}
+
+func (f *fakeFeatureConfigConfigSourceStore) GetDatabaseSourceByAppID(_ context.Context, appID string) (*configsource.DatabaseSource, error) {
+	if s, ok := f.sources[appID]; ok {
+		cp := *s
+		cp.Data = maps.Clone(s.Data) // deep-enough copy so mutation in the service doesn't corrupt the fixture between test cases
+		return &cp, nil
+	}
+	return nil, configsource.ErrAppNotFound
+}
+
+func (f *fakeFeatureConfigConfigSourceStore) UpdateDatabaseSource(_ context.Context, dbs *configsource.DatabaseSource) error {
+	f.updated = dbs
+	return nil
+}
+
+// ---- Test helpers --------------------------------------------------------------
+
+func emptyBaseResources() deps.AppBaseResources {
+	return deps.AppBaseResources(resource.NewManager(resource.DefaultRegistry, nil))
+}
+
+// ---- Tests -------------------------------------------------------------------
+
+func TestFeatureConfigService_GetAppFeatureConfig(t *testing.T) {
+	updatedAt := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
+
+	makeService := func(planStore *fakeFeatureConfigPlanStore, csStore *fakeFeatureConfigConfigSourceStore) *FeatureConfigService {
+		return &FeatureConfigService{
+			GlobalDatabase:    fakeDatabase{},
+			PlanStore:         planStore,
+			ConfigSourceStore: csStore,
+			BaseResources:     emptyBaseResources(),
+			Clock:             clock.NewMockClockAtTime(updatedAt),
+		}
+	}
+
+	Convey("GetAppFeatureConfig", t, func() {
+		planStore := &fakeFeatureConfigPlanStore{
+			plans: map[string]*plan.Plan{
+				"test-plan": {
+					Name: "test-plan",
+					RawFeatureConfig: &config.FeatureConfig{
+						Collaborator: &config.CollaboratorFeatureConfig{Maximum: new(3)},
+						OAuth: &config.OAuthFeatureConfig{
+							Client: &config.OAuthClientFeatureConfig{Maximum: new(10)},
+						},
+					},
+				},
+			},
+		}
+
+		Convey("app has no override", func() {
+			csStore := &fakeFeatureConfigConfigSourceStore{
+				sources: map[string]*configsource.DatabaseSource{
+					"app1": {AppID: "app1", PlanName: "test-plan", Data: map[string][]byte{}},
+				},
+			}
+			svc := makeService(planStore, csStore)
+
+			result, err := svc.GetAppFeatureConfig(context.Background(), "app1")
+			So(err, ShouldBeNil)
+			So(result.AppFeatureConfigYAML, ShouldEqual, "")
+			So(*result.EffectiveAppFeatureConfig.Collaborator.Maximum, ShouldEqual, 3)
+			So(result.EffectiveAppFeatureConfig, ShouldResemble, result.EffectivePlanFeatureConfig)
+		})
+
+		Convey("app has an override with a comment", func() {
+			overrideYAML := "# a comment\ncollaborator:\n  soft_maximum: 1\n"
+			csStore := &fakeFeatureConfigConfigSourceStore{
+				sources: map[string]*configsource.DatabaseSource{
+					"app1": {AppID: "app1", PlanName: "test-plan", Data: map[string][]byte{
+						featureConfigOverrideKey(): []byte(overrideYAML),
+					}},
+				},
+			}
+			svc := makeService(planStore, csStore)
+
+			result, err := svc.GetAppFeatureConfig(context.Background(), "app1")
+			So(err, ShouldBeNil)
+			So(result.AppFeatureConfigYAML, ShouldEqual, overrideYAML)
+		})
+
+		Convey("collaborator fixture: effective maximum inherited from plan, soft_maximum from override", func() {
+			csStore := &fakeFeatureConfigConfigSourceStore{
+				sources: map[string]*configsource.DatabaseSource{
+					"app1": {AppID: "app1", PlanName: "test-plan", Data: map[string][]byte{
+						featureConfigOverrideKey(): []byte("collaborator:\n  soft_maximum: 1\n"),
+					}},
+				},
+			}
+			svc := makeService(planStore, csStore)
+
+			result, err := svc.GetAppFeatureConfig(context.Background(), "app1")
+			So(err, ShouldBeNil)
+			So(*result.EffectiveAppFeatureConfig.Collaborator.Maximum, ShouldEqual, 3)
+			So(*result.EffectiveAppFeatureConfig.Collaborator.SoftMaximum, ShouldEqual, 1)
+		})
+
+		Convey("oauth.client fixture: effective maximum inherited from plan, custom_ui_enabled from override", func() {
+			csStore := &fakeFeatureConfigConfigSourceStore{
+				sources: map[string]*configsource.DatabaseSource{
+					"app1": {AppID: "app1", PlanName: "test-plan", Data: map[string][]byte{
+						featureConfigOverrideKey(): []byte("oauth:\n  client:\n    custom_ui_enabled: true\n"),
+					}},
+				},
+			}
+			svc := makeService(planStore, csStore)
+
+			result, err := svc.GetAppFeatureConfig(context.Background(), "app1")
+			So(err, ShouldBeNil)
+			So(*result.EffectiveAppFeatureConfig.OAuth.Client.Maximum, ShouldEqual, 10)
+			So(*result.EffectiveAppFeatureConfig.OAuth.Client.CustomUIEnabled, ShouldBeTrue)
+		})
+
+		Convey("app references a plan that does not exist", func() {
+			csStore := &fakeFeatureConfigConfigSourceStore{
+				sources: map[string]*configsource.DatabaseSource{
+					"app1": {AppID: "app1", PlanName: "nonexistent-plan", Data: map[string][]byte{}},
+				},
+			}
+			svc := makeService(planStore, csStore)
+
+			result, err := svc.GetAppFeatureConfig(context.Background(), "app1")
+			So(err, ShouldBeNil)
+			So(result.EffectivePlanFeatureConfig, ShouldResemble, config.NewEffectiveDefaultFeatureConfig())
+		})
+
+		Convey("app does not exist", func() {
+			csStore := &fakeFeatureConfigConfigSourceStore{sources: map[string]*configsource.DatabaseSource{}}
+			svc := makeService(planStore, csStore)
+
+			_, err := svc.GetAppFeatureConfig(context.Background(), "missing-app")
+			So(err, ShouldNotBeNil)
+			So(apierrors.IsAPIErrorWithCondition(err, func(e *apierrors.APIError) bool {
+				return e.Kind.Name == apierrors.NotFound
+			}), ShouldBeTrue)
+		})
+	})
+}
+
+func TestFeatureConfigService_UpdateAppFeatureConfig(t *testing.T) {
+	updatedAt := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
+
+	planStore := &fakeFeatureConfigPlanStore{
+		plans: map[string]*plan.Plan{
+			"test-plan": {
+				Name: "test-plan",
+				RawFeatureConfig: &config.FeatureConfig{
+					Collaborator: &config.CollaboratorFeatureConfig{Maximum: new(3)},
+				},
+			},
+		},
+	}
+
+	makeService := func(csStore *fakeFeatureConfigConfigSourceStore) *FeatureConfigService {
+		return &FeatureConfigService{
+			GlobalDatabase:    fakeDatabase{},
+			PlanStore:         planStore,
+			ConfigSourceStore: csStore,
+			BaseResources:     emptyBaseResources(),
+			Clock:             clock.NewMockClockAtTime(updatedAt),
+		}
+	}
+
+	Convey("UpdateAppFeatureConfig", t, func() {
+		csStore := &fakeFeatureConfigConfigSourceStore{
+			sources: map[string]*configsource.DatabaseSource{
+				"app1": {AppID: "app1", PlanName: "test-plan", Data: map[string][]byte{
+					featureConfigOverrideKey(): []byte("collaborator:\n  soft_maximum: 1\n"),
+				}},
+			},
+		}
+
+		Convey("valid YAML is stored byte-for-byte", func() {
+			svc := makeService(csStore)
+			newYAML := "# comment\ncollaborator:\n  soft_maximum: 2\n"
+
+			result, err := svc.UpdateAppFeatureConfig(context.Background(), "app1", newYAML)
+			So(err, ShouldBeNil)
+			So(csStore.updated, ShouldNotBeNil)
+			So(string(csStore.updated.Data[featureConfigOverrideKey()]), ShouldEqual, newYAML)
+			So(*result.EffectiveAppFeatureConfig.Collaborator.SoftMaximum, ShouldEqual, 2)
+			So(*result.EffectiveAppFeatureConfig.Collaborator.Maximum, ShouldEqual, 3)
+		})
+
+		Convey("empty string clears an existing override", func() {
+			svc := makeService(csStore)
+
+			_, err := svc.UpdateAppFeatureConfig(context.Background(), "app1", "")
+			So(err, ShouldBeNil)
+			So(csStore.updated, ShouldNotBeNil)
+			_, ok := csStore.updated.Data[featureConfigOverrideKey()]
+			So(ok, ShouldBeFalse)
+		})
+
+		Convey("whitespace-only string clears an existing override", func() {
+			svc := makeService(csStore)
+
+			_, err := svc.UpdateAppFeatureConfig(context.Background(), "app1", "  \n\t")
+			So(err, ShouldBeNil)
+			So(csStore.updated, ShouldNotBeNil)
+			_, ok := csStore.updated.Data[featureConfigOverrideKey()]
+			So(ok, ShouldBeFalse)
+		})
+
+		Convey("invalid YAML - unknown top-level key", func() {
+			svc := makeService(csStore)
+
+			_, err := svc.UpdateAppFeatureConfig(context.Background(), "app1", "nonexistent_top_level_key: 1\n")
+			So(err, ShouldNotBeNil)
+			var aggErr *validation.AggregatedError
+			So(errors.As(err, &aggErr), ShouldBeTrue)
+			So(aggErr.Errors[0].Location, ShouldEqual, "/nonexistent_top_level_key")
+			So(csStore.updated, ShouldBeNil)
+		})
+
+		Convey("invalid YAML - field-level type error", func() {
+			svc := makeService(csStore)
+
+			_, err := svc.UpdateAppFeatureConfig(context.Background(), "app1", "oauth:\n  client:\n    maximum: \"not-a-number\"\n")
+			So(err, ShouldNotBeNil)
+			var aggErr *validation.AggregatedError
+			So(errors.As(err, &aggErr), ShouldBeTrue)
+			So(aggErr.Errors[0].Location, ShouldEqual, "/oauth/client/maximum")
+			So(aggErr.Errors[0].Keyword, ShouldEqual, "type")
+			So(csStore.updated, ShouldBeNil)
+		})
+
+		Convey("multi-document YAML is rejected without causes", func() {
+			svc := makeService(csStore)
+
+			_, err := svc.UpdateAppFeatureConfig(context.Background(), "app1", "a: 1\n---\nb: 2\n")
+			So(err, ShouldNotBeNil)
+			So(apierrors.IsAPIErrorWithCondition(err, func(e *apierrors.APIError) bool {
+				return e.Kind.Name == apierrors.Invalid && e.Kind.Reason == "ValidationFailed"
+			}), ShouldBeTrue)
+			var aggErr *validation.AggregatedError
+			So(errors.As(err, &aggErr), ShouldBeFalse)
+			So(csStore.updated, ShouldBeNil)
+		})
+
+		Convey("app does not exist", func() {
+			svc := makeService(csStore)
+
+			_, err := svc.UpdateAppFeatureConfig(context.Background(), "missing-app", "collaborator:\n  soft_maximum: 1\n")
+			So(err, ShouldNotBeNil)
+			So(apierrors.IsAPIErrorWithCondition(err, func(e *apierrors.APIError) bool {
+				return e.Kind.Name == apierrors.NotFound
+			}), ShouldBeTrue)
+			So(csStore.updated, ShouldBeNil)
+		})
+
+		Convey("emits audit log with old and new YAML", func() {
+			svc := makeService(csStore)
+			audit := &fakeAuditService{}
+			svc.AuditService = audit
+
+			newYAML := "collaborator:\n  soft_maximum: 2\n"
+			_, err := svc.UpdateAppFeatureConfig(context.Background(), "app1", newYAML)
+			So(err, ShouldBeNil)
+			So(audit.logged, ShouldHaveLength, 1)
+			payload, ok := audit.logged[0].(*siteadminauditlog.AppFeatureConfigUpdatedPayload)
+			So(ok, ShouldBeTrue)
+			So(payload.AppID, ShouldEqual, "app1")
+			So(payload.OldAppFeatureConfigYAML, ShouldEqual, "collaborator:\n  soft_maximum: 1\n")
+			So(payload.NewAppFeatureConfigYAML, ShouldEqual, newYAML)
+		})
+
+		Convey("audit failure does not affect mutation result", func() {
+			svc := makeService(csStore)
+			// AuditService is nil — mutation must still succeed.
+			result, err := svc.UpdateAppFeatureConfig(context.Background(), "app1", "collaborator:\n  soft_maximum: 2\n")
+			So(err, ShouldBeNil)
+			So(*result.EffectiveAppFeatureConfig.Collaborator.SoftMaximum, ShouldEqual, 2)
+		})
+	})
+}
+
+func TestFeatureConfigService_PreviewAppFeatureConfig(t *testing.T) {
+	updatedAt := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
+
+	planStore := &fakeFeatureConfigPlanStore{
+		plans: map[string]*plan.Plan{
+			"test-plan": {
+				Name: "test-plan",
+				RawFeatureConfig: &config.FeatureConfig{
+					Collaborator: &config.CollaboratorFeatureConfig{Maximum: new(3)},
+				},
+			},
+		},
+	}
+
+	makeService := func(csStore *fakeFeatureConfigConfigSourceStore) *FeatureConfigService {
+		return &FeatureConfigService{
+			GlobalDatabase:    fakeDatabase{},
+			PlanStore:         planStore,
+			ConfigSourceStore: csStore,
+			BaseResources:     emptyBaseResources(),
+			Clock:             clock.NewMockClockAtTime(updatedAt),
+		}
+	}
+
+	Convey("PreviewAppFeatureConfig", t, func() {
+		csStore := &fakeFeatureConfigConfigSourceStore{
+			sources: map[string]*configsource.DatabaseSource{
+				"app1": {AppID: "app1", PlanName: "test-plan", Data: map[string][]byte{}},
+			},
+		}
+
+		Convey("valid candidate matches what PUT would produce, nothing persisted", func() {
+			svc := makeService(csStore)
+
+			result, err := svc.PreviewAppFeatureConfig(context.Background(), "app1", "collaborator:\n  soft_maximum: 1\n")
+			So(err, ShouldBeNil)
+			So(*result.EffectiveAppFeatureConfig.Collaborator.SoftMaximum, ShouldEqual, 1)
+			So(*result.EffectiveAppFeatureConfig.Collaborator.Maximum, ShouldEqual, 3)
+			So(csStore.updated, ShouldBeNil)
+		})
+
+		Convey("invalid candidate - field-level type error", func() {
+			svc := makeService(csStore)
+
+			_, err := svc.PreviewAppFeatureConfig(context.Background(), "app1", "oauth:\n  client:\n    maximum: \"not-a-number\"\n")
+			So(err, ShouldNotBeNil)
+			var aggErr *validation.AggregatedError
+			So(errors.As(err, &aggErr), ShouldBeTrue)
+			So(aggErr.Errors[0].Location, ShouldEqual, "/oauth/client/maximum")
+			So(aggErr.Errors[0].Keyword, ShouldEqual, "type")
+			So(csStore.updated, ShouldBeNil)
+		})
+
+		Convey("app does not exist", func() {
+			svc := makeService(csStore)
+
+			_, err := svc.PreviewAppFeatureConfig(context.Background(), "missing-app", "collaborator:\n  soft_maximum: 1\n")
+			So(err, ShouldNotBeNil)
+			So(apierrors.IsAPIErrorWithCondition(err, func(e *apierrors.APIError) bool {
+				return e.Kind.Name == apierrors.NotFound
+			}), ShouldBeTrue)
+		})
+	})
+}
+
+func TestCountYAMLDocuments(t *testing.T) {
+	Convey("countYAMLDocuments", t, func() {
+		Convey("0 docs (empty input)", func() {
+			n, err := countYAMLDocuments([]byte(""))
+			So(err, ShouldBeNil)
+			So(n, ShouldEqual, 0)
+		})
+
+		Convey("1 doc", func() {
+			n, err := countYAMLDocuments([]byte("a: 1\n"))
+			So(err, ShouldBeNil)
+			So(n, ShouldEqual, 1)
+		})
+
+		Convey("2 docs separated by ---", func() {
+			n, err := countYAMLDocuments([]byte("a: 1\n---\nb: 2\n"))
+			So(err, ShouldBeNil)
+			So(n, ShouldEqual, 2)
+		})
+	})
+}

--- a/pkg/siteadmin/transport/deps.go
+++ b/pkg/siteadmin/transport/deps.go
@@ -15,5 +15,8 @@ var DependencySet = wire.NewSet(
 	wire.Struct(new(AppPlanChangeHandler), "*"),
 	wire.Struct(new(AuditLogsListHandler), "*"),
 	wire.Struct(new(AuditLogGetHandler), "*"),
+	wire.Struct(new(AppFeatureConfigGetHandler), "*"),
+	wire.Struct(new(AppFeatureConfigUpdateHandler), "*"),
+	wire.Struct(new(AppFeatureConfigPreviewHandler), "*"),
 	wire.Struct(new(AuthzMiddleware), "*"),
 )

--- a/pkg/siteadmin/transport/handler_app_feature_config_get.go
+++ b/pkg/siteadmin/transport/handler_app_feature_config_get.go
@@ -1,0 +1,46 @@
+package transport
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/authgear/authgear-server/pkg/api/siteadmin"
+	"github.com/authgear/authgear-server/pkg/siteadmin/service"
+	"github.com/authgear/authgear-server/pkg/util/httproute"
+)
+
+func ConfigureAppFeatureConfigGetRoute(route httproute.Route) httproute.Route {
+	return route.WithMethods("OPTIONS", "GET").
+		WithPathPattern("/api/v1/apps/:appID/feature-config")
+}
+
+type AppFeatureConfigGetService interface {
+	GetAppFeatureConfig(ctx context.Context, appID string) (*service.AppFeatureConfigResult, error)
+}
+
+type AppFeatureConfigGetHandler struct {
+	Service AppFeatureConfigGetService
+}
+
+func (h *AppFeatureConfigGetHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	appID := httproute.GetParam(r, "appID")
+
+	result, err := h.Service.GetAppFeatureConfig(r.Context(), appID)
+	if err != nil {
+		writeError(w, r, err)
+		return
+	}
+
+	SiteAdminAPISuccessResponse{Body: featureConfigResultToResponse(result)}.WriteTo(w)
+}
+
+// featureConfigResultToResponse is shared by the get/update/preview handlers
+// (defined here since this is the first of the three files registered).
+func featureConfigResultToResponse(result *service.AppFeatureConfigResult) siteadmin.AppFeatureConfigResponse {
+	return siteadmin.AppFeatureConfigResponse{
+		PlanName:                   result.PlanName,
+		EffectivePlanFeatureConfig: *result.EffectivePlanFeatureConfig,
+		AppFeatureConfigYaml:       result.AppFeatureConfigYAML,
+		EffectiveAppFeatureConfig:  *result.EffectiveAppFeatureConfig,
+	}
+}

--- a/pkg/siteadmin/transport/handler_app_feature_config_preview.go
+++ b/pkg/siteadmin/transport/handler_app_feature_config_preview.go
@@ -1,0 +1,66 @@
+package transport
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+
+	"github.com/authgear/authgear-server/pkg/api/siteadmin"
+	"github.com/authgear/authgear-server/pkg/siteadmin/service"
+	"github.com/authgear/authgear-server/pkg/util/httproute"
+	"github.com/authgear/authgear-server/pkg/util/validation"
+)
+
+func ConfigureAppFeatureConfigPreviewRoute(route httproute.Route) httproute.Route {
+	return route.WithMethods("OPTIONS", "POST").
+		WithPathPattern("/api/v1/apps/:appID/feature-config/preview")
+}
+
+var AppFeatureConfigPreviewRequestSchema = validation.NewSimpleSchema(`
+{
+    "type": "object",
+    "properties": { "app_feature_config_yaml": { "type": "string" } },
+    "required": ["app_feature_config_yaml"]
+}
+`)
+
+type AppFeatureConfigPreviewService interface {
+	PreviewAppFeatureConfig(ctx context.Context, appID string, rawYAML string) (*service.AppFeatureConfigResult, error)
+}
+
+type AppFeatureConfigPreviewHandler struct {
+	Service AppFeatureConfigPreviewService
+}
+
+type AppFeatureConfigPreviewParams struct {
+	AppID string
+	siteadmin.PreviewAppFeatureConfigRequest
+}
+
+func parseAppFeatureConfigPreviewParams(r *http.Request) (AppFeatureConfigPreviewParams, error) {
+	var body siteadmin.PreviewAppFeatureConfigRequest
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		return AppFeatureConfigPreviewParams{}, err
+	}
+	if err := AppFeatureConfigPreviewRequestSchema.Validator().ValidateValue(r.Context(), body); err != nil {
+		return AppFeatureConfigPreviewParams{}, err
+	}
+	return AppFeatureConfigPreviewParams{
+		AppID:                          httproute.GetParam(r, "appID"),
+		PreviewAppFeatureConfigRequest: body,
+	}, nil
+}
+
+func (h *AppFeatureConfigPreviewHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	params, err := parseAppFeatureConfigPreviewParams(r)
+	if err != nil {
+		writeError(w, r, err)
+		return
+	}
+	result, err := h.Service.PreviewAppFeatureConfig(r.Context(), params.AppID, params.AppFeatureConfigYaml)
+	if err != nil {
+		writeError(w, r, err)
+		return
+	}
+	SiteAdminAPISuccessResponse{Body: featureConfigResultToResponse(result)}.WriteTo(w)
+}

--- a/pkg/siteadmin/transport/handler_app_feature_config_update.go
+++ b/pkg/siteadmin/transport/handler_app_feature_config_update.go
@@ -1,0 +1,68 @@
+package transport
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+
+	"github.com/authgear/authgear-server/pkg/api/siteadmin"
+	"github.com/authgear/authgear-server/pkg/siteadmin/service"
+	"github.com/authgear/authgear-server/pkg/util/httproute"
+	"github.com/authgear/authgear-server/pkg/util/validation"
+)
+
+func ConfigureAppFeatureConfigUpdateRoute(route httproute.Route) httproute.Route {
+	// The OPTIONS request for this shared path is handled by
+	// ConfigureAppFeatureConfigGetRoute.
+	return route.WithMethods("PUT").
+		WithPathPattern("/api/v1/apps/:appID/feature-config")
+}
+
+var AppFeatureConfigUpdateRequestSchema = validation.NewSimpleSchema(`
+{
+    "type": "object",
+    "properties": { "app_feature_config_yaml": { "type": "string" } },
+    "required": ["app_feature_config_yaml"]
+}
+`)
+
+type AppFeatureConfigUpdateService interface {
+	UpdateAppFeatureConfig(ctx context.Context, appID string, rawYAML string) (*service.AppFeatureConfigResult, error)
+}
+
+type AppFeatureConfigUpdateHandler struct {
+	Service AppFeatureConfigUpdateService
+}
+
+type AppFeatureConfigUpdateParams struct {
+	AppID string
+	siteadmin.UpdateAppFeatureConfigRequest
+}
+
+func parseAppFeatureConfigUpdateParams(r *http.Request) (AppFeatureConfigUpdateParams, error) {
+	var body siteadmin.UpdateAppFeatureConfigRequest
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		return AppFeatureConfigUpdateParams{}, err
+	}
+	if err := AppFeatureConfigUpdateRequestSchema.Validator().ValidateValue(r.Context(), body); err != nil {
+		return AppFeatureConfigUpdateParams{}, err
+	}
+	return AppFeatureConfigUpdateParams{
+		AppID:                         httproute.GetParam(r, "appID"),
+		UpdateAppFeatureConfigRequest: body,
+	}, nil
+}
+
+func (h *AppFeatureConfigUpdateHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	params, err := parseAppFeatureConfigUpdateParams(r)
+	if err != nil {
+		writeError(w, r, err)
+		return
+	}
+	result, err := h.Service.UpdateAppFeatureConfig(r.Context(), params.AppID, params.AppFeatureConfigYaml)
+	if err != nil {
+		writeError(w, r, err)
+		return
+	}
+	SiteAdminAPISuccessResponse{Body: featureConfigResultToResponse(result)}.WriteTo(w)
+}

--- a/pkg/siteadmin/wire.go
+++ b/pkg/siteadmin/wire.go
@@ -146,6 +146,27 @@ func newAppPlanChangeHandler(p *deps.RequestProvider) http.Handler {
 	))
 }
 
+func newAppFeatureConfigGetHandler(p *deps.RequestProvider) http.Handler {
+	panic(wire.Build(
+		DependencySet,
+		wire.Bind(new(http.Handler), new(*transport.AppFeatureConfigGetHandler)),
+	))
+}
+
+func newAppFeatureConfigUpdateHandler(p *deps.RequestProvider) http.Handler {
+	panic(wire.Build(
+		DependencySet,
+		wire.Bind(new(http.Handler), new(*transport.AppFeatureConfigUpdateHandler)),
+	))
+}
+
+func newAppFeatureConfigPreviewHandler(p *deps.RequestProvider) http.Handler {
+	panic(wire.Build(
+		DependencySet,
+		wire.Bind(new(http.Handler), new(*transport.AppFeatureConfigPreviewHandler)),
+	))
+}
+
 func newSessionInfoMiddleware(p *deps.RequestProvider) httproute.Middleware {
 	panic(wire.Build(
 		DependencySet,

--- a/pkg/siteadmin/wire_gen.go
+++ b/pkg/siteadmin/wire_gen.go
@@ -811,6 +811,186 @@ func newAppPlanChangeHandler(p *deps.RequestProvider) http.Handler {
 	return appPlanChangeHandler
 }
 
+func newAppFeatureConfigGetHandler(p *deps.RequestProvider) http.Handler {
+	rootProvider := p.RootProvider
+	pool := rootProvider.Database
+	environmentConfig := rootProvider.EnvironmentConfig
+	globalDatabaseCredentialsEnvironmentConfig := &environmentConfig.GlobalDatabase
+	databaseEnvironmentConfig := &environmentConfig.DatabaseConfig
+	handle := newSiteadminGlobalHandle(pool, globalDatabaseCredentialsEnvironmentConfig, databaseEnvironmentConfig)
+	sqlBuilder := globaldb.NewSQLBuilder(globalDatabaseCredentialsEnvironmentConfig)
+	sqlExecutor := globaldb.NewSQLExecutor(handle)
+	clockClock := _wireSystemClockValue
+	store := &plan.Store{
+		SQLBuilder:  sqlBuilder,
+		SQLExecutor: sqlExecutor,
+		Clock:       clockClock,
+	}
+	configsourceStore := &configsource.Store{
+		SQLBuilder:  sqlBuilder,
+		SQLExecutor: sqlExecutor,
+	}
+	auditDatabaseCredentials := deps.ProvideAuditDatabaseCredentials(environmentConfig)
+	writeHandle := auditdb.NewWriteHandle(pool, databaseEnvironmentConfig, auditDatabaseCredentials)
+	auditdbSQLBuilder := auditdb.NewSQLBuilder(auditDatabaseCredentials)
+	writeSQLExecutor := auditdb.NewWriteSQLExecutor(writeHandle)
+	authgearConfig := rootProvider.AuthgearConfig
+	request := p.Request
+	trustProxy := environmentConfig.TrustProxy
+	remoteIP := deps.ProvideRemoteIP(request, trustProxy)
+	userAgentString := deps.ProvideUserAgentString(request)
+	httpProto := deps.ProvideHTTPProto(request, trustProxy)
+	httpHost := deps.ProvideHTTPHost(request, trustProxy)
+	httpRequestURL := deps.ProvideRequestURL(request, httpProto, httpHost)
+	siteAdminAuditService := &service.SiteAdminAuditService{
+		AuditDatabase:     writeHandle,
+		SQLBuilder:        auditdbSQLBuilder,
+		WriteSQLExecutor:  writeSQLExecutor,
+		Clock:             clockClock,
+		AuthgearConfig:    authgearConfig,
+		RemoteIP:          remoteIP,
+		UserAgentString:   userAgentString,
+		HTTPRequestURL:    httpRequestURL,
+		Request:           request,
+		GlobalDatabase:    handle,
+		GlobalSQLBuilder:  sqlBuilder,
+		GlobalSQLExecutor: sqlExecutor,
+	}
+	appBaseResources := deps.ProvideAppBaseResources(rootProvider)
+	featureConfigService := &service.FeatureConfigService{
+		GlobalDatabase:    handle,
+		PlanStore:         store,
+		ConfigSourceStore: configsourceStore,
+		AuditService:      siteAdminAuditService,
+		BaseResources:     appBaseResources,
+		Clock:             clockClock,
+	}
+	appFeatureConfigGetHandler := &transport.AppFeatureConfigGetHandler{
+		Service: featureConfigService,
+	}
+	return appFeatureConfigGetHandler
+}
+
+func newAppFeatureConfigUpdateHandler(p *deps.RequestProvider) http.Handler {
+	rootProvider := p.RootProvider
+	pool := rootProvider.Database
+	environmentConfig := rootProvider.EnvironmentConfig
+	globalDatabaseCredentialsEnvironmentConfig := &environmentConfig.GlobalDatabase
+	databaseEnvironmentConfig := &environmentConfig.DatabaseConfig
+	handle := newSiteadminGlobalHandle(pool, globalDatabaseCredentialsEnvironmentConfig, databaseEnvironmentConfig)
+	sqlBuilder := globaldb.NewSQLBuilder(globalDatabaseCredentialsEnvironmentConfig)
+	sqlExecutor := globaldb.NewSQLExecutor(handle)
+	clockClock := _wireSystemClockValue
+	store := &plan.Store{
+		SQLBuilder:  sqlBuilder,
+		SQLExecutor: sqlExecutor,
+		Clock:       clockClock,
+	}
+	configsourceStore := &configsource.Store{
+		SQLBuilder:  sqlBuilder,
+		SQLExecutor: sqlExecutor,
+	}
+	auditDatabaseCredentials := deps.ProvideAuditDatabaseCredentials(environmentConfig)
+	writeHandle := auditdb.NewWriteHandle(pool, databaseEnvironmentConfig, auditDatabaseCredentials)
+	auditdbSQLBuilder := auditdb.NewSQLBuilder(auditDatabaseCredentials)
+	writeSQLExecutor := auditdb.NewWriteSQLExecutor(writeHandle)
+	authgearConfig := rootProvider.AuthgearConfig
+	request := p.Request
+	trustProxy := environmentConfig.TrustProxy
+	remoteIP := deps.ProvideRemoteIP(request, trustProxy)
+	userAgentString := deps.ProvideUserAgentString(request)
+	httpProto := deps.ProvideHTTPProto(request, trustProxy)
+	httpHost := deps.ProvideHTTPHost(request, trustProxy)
+	httpRequestURL := deps.ProvideRequestURL(request, httpProto, httpHost)
+	siteAdminAuditService := &service.SiteAdminAuditService{
+		AuditDatabase:     writeHandle,
+		SQLBuilder:        auditdbSQLBuilder,
+		WriteSQLExecutor:  writeSQLExecutor,
+		Clock:             clockClock,
+		AuthgearConfig:    authgearConfig,
+		RemoteIP:          remoteIP,
+		UserAgentString:   userAgentString,
+		HTTPRequestURL:    httpRequestURL,
+		Request:           request,
+		GlobalDatabase:    handle,
+		GlobalSQLBuilder:  sqlBuilder,
+		GlobalSQLExecutor: sqlExecutor,
+	}
+	appBaseResources := deps.ProvideAppBaseResources(rootProvider)
+	featureConfigService := &service.FeatureConfigService{
+		GlobalDatabase:    handle,
+		PlanStore:         store,
+		ConfigSourceStore: configsourceStore,
+		AuditService:      siteAdminAuditService,
+		BaseResources:     appBaseResources,
+		Clock:             clockClock,
+	}
+	appFeatureConfigUpdateHandler := &transport.AppFeatureConfigUpdateHandler{
+		Service: featureConfigService,
+	}
+	return appFeatureConfigUpdateHandler
+}
+
+func newAppFeatureConfigPreviewHandler(p *deps.RequestProvider) http.Handler {
+	rootProvider := p.RootProvider
+	pool := rootProvider.Database
+	environmentConfig := rootProvider.EnvironmentConfig
+	globalDatabaseCredentialsEnvironmentConfig := &environmentConfig.GlobalDatabase
+	databaseEnvironmentConfig := &environmentConfig.DatabaseConfig
+	handle := newSiteadminGlobalHandle(pool, globalDatabaseCredentialsEnvironmentConfig, databaseEnvironmentConfig)
+	sqlBuilder := globaldb.NewSQLBuilder(globalDatabaseCredentialsEnvironmentConfig)
+	sqlExecutor := globaldb.NewSQLExecutor(handle)
+	clockClock := _wireSystemClockValue
+	store := &plan.Store{
+		SQLBuilder:  sqlBuilder,
+		SQLExecutor: sqlExecutor,
+		Clock:       clockClock,
+	}
+	configsourceStore := &configsource.Store{
+		SQLBuilder:  sqlBuilder,
+		SQLExecutor: sqlExecutor,
+	}
+	auditDatabaseCredentials := deps.ProvideAuditDatabaseCredentials(environmentConfig)
+	writeHandle := auditdb.NewWriteHandle(pool, databaseEnvironmentConfig, auditDatabaseCredentials)
+	auditdbSQLBuilder := auditdb.NewSQLBuilder(auditDatabaseCredentials)
+	writeSQLExecutor := auditdb.NewWriteSQLExecutor(writeHandle)
+	authgearConfig := rootProvider.AuthgearConfig
+	request := p.Request
+	trustProxy := environmentConfig.TrustProxy
+	remoteIP := deps.ProvideRemoteIP(request, trustProxy)
+	userAgentString := deps.ProvideUserAgentString(request)
+	httpProto := deps.ProvideHTTPProto(request, trustProxy)
+	httpHost := deps.ProvideHTTPHost(request, trustProxy)
+	httpRequestURL := deps.ProvideRequestURL(request, httpProto, httpHost)
+	siteAdminAuditService := &service.SiteAdminAuditService{
+		AuditDatabase:     writeHandle,
+		SQLBuilder:        auditdbSQLBuilder,
+		WriteSQLExecutor:  writeSQLExecutor,
+		Clock:             clockClock,
+		AuthgearConfig:    authgearConfig,
+		RemoteIP:          remoteIP,
+		UserAgentString:   userAgentString,
+		HTTPRequestURL:    httpRequestURL,
+		Request:           request,
+		GlobalDatabase:    handle,
+		GlobalSQLBuilder:  sqlBuilder,
+		GlobalSQLExecutor: sqlExecutor,
+	}
+	appBaseResources := deps.ProvideAppBaseResources(rootProvider)
+	featureConfigService := &service.FeatureConfigService{
+		GlobalDatabase:    handle,
+		PlanStore:         store,
+		ConfigSourceStore: configsourceStore,
+		AuditService:      siteAdminAuditService,
+		BaseResources:     appBaseResources,
+		Clock:             clockClock,
+	}
+	appFeatureConfigPreviewHandler := &transport.AppFeatureConfigPreviewHandler{
+		Service: featureConfigService,
+	}
+	return appFeatureConfigPreviewHandler
+}
+
 func newSessionInfoMiddleware(p *deps.RequestProvider) httproute.Middleware {
 	rootProvider := p.RootProvider
 	authgearConfig := rootProvider.AuthgearConfig


### PR DESCRIPTION
- Add GET/PUT/preview endpoints for site admins to view and edit an app's feature config override, reusing the production merge stack (BaseResources ⟵ plan ⟵ app) so validation and the effective config can never drift from what the app actually runs.

ref DEV-3687

