### PR TITLE
[Portal] Escape curly braces in plain-text translation values

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -319,3 +319,5 @@ tool (
 	golang.org/x/tools/cmd/goimports
 	golang.org/x/vuln/cmd/govulncheck
 )
+
+replace github.com/iawaknahc/gomessageformat => github.com/oursky/gomessageformat v0.0.0-20260810215310-a251ccc4eb09

--- a/go.sum
+++ b/go.sum
@@ -329,8 +329,6 @@ github.com/huandu/xstrings v1.4.0/go.mod h1:y5/lhBue+AyNmUVz9RLU9xbLR0o4KIIExikq
 github.com/ianlancetaylor/demangle v0.0.0-20200824232613-28f6c0f3b639/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
 github.com/iawaknahc/gogenwrapper v0.0.0-20250315204045-eb8ab595ac5c h1:JwJzV3LkV76E8buck8mTnQFsdtH3WtXnFRNliiXtecw=
 github.com/iawaknahc/gogenwrapper v0.0.0-20250315204045-eb8ab595ac5c/go.mod h1:Wi8UvegjqfQnzlcTGqj1BqnD6hayuDka3lw7Zdm4tHQ=
-github.com/iawaknahc/gomessageformat v0.0.0-20210428033148-c3f8592094b5 h1:i6r7zTbhSdHbhCVEJsM8W62F7MvxXfkpkwGrvfL+sFw=
-github.com/iawaknahc/gomessageformat v0.0.0-20210428033148-c3f8592094b5/go.mod h1:N6C14Rpg3pJZ9zDMbmF/zPu8LJDsmVzMAD3bc+bregI=
 github.com/iawaknahc/jsonschema v0.0.0-20250219112344-8b65018f0c9f h1:7fg9r1heGxzvbzpbRhrLg38ofAy6bP8LroR7H3buCLE=
 github.com/iawaknahc/jsonschema v0.0.0-20250219112344-8b65018f0c9f/go.mod h1:2dwQ26l1MvCcsoMMZtmUDPdaNrybnKOXi0KeletnVJc=
 github.com/iawaknahc/originmatcher v0.0.0-20240717084358-ac10088d8800 h1:oR04NBr9JKoP54k6aq4c6Vvungf3Oi3JFAN92/3K6Fg=
@@ -480,6 +478,8 @@ github.com/oschwald/geoip2-golang v1.13.0 h1:Q44/Ldc703pasJeP5V9+aFSZFmBN7DKHbNs
 github.com/oschwald/geoip2-golang v1.13.0/go.mod h1:P9zG+54KPEFOliZ29i7SeYZ/GM6tfEL+rgSn03hYuUo=
 github.com/oschwald/maxminddb-golang v1.13.0 h1:R8xBorY71s84yO06NgTmQvqvTvlS/bnYZrrWX1MElnU=
 github.com/oschwald/maxminddb-golang v1.13.0/go.mod h1:BU0z8BfFVhi1LQaonTwwGQlsHUEu9pWNdMfmq4ztm0o=
+github.com/oursky/gomessageformat v0.0.0-20260810215310-a251ccc4eb09 h1:fEqKD3q9bgaSUzaFe00NWBlLGmGXLbAJK32KqBQGK/E=
+github.com/oursky/gomessageformat v0.0.0-20260810215310-a251ccc4eb09/go.mod h1:N6C14Rpg3pJZ9zDMbmF/zPu8LJDsmVzMAD3bc+bregI=
 github.com/patrickmn/go-cache v2.1.0+incompatible h1:HRMgzkcYKYpi3C8ajMPV8OFXaaRUnok+kx1WdO15EQc=
 github.com/patrickmn/go-cache v2.1.0+incompatible/go.mod h1:3Qf8kWWT7OJRJbdiICTKqZju1ZixQ/KpMGzzAfe6+WQ=
 github.com/pelletier/go-toml/v2 v2.2.3 h1:YmeHyLY8mFWbdkNWwpr+qIL2bEqT0o95WSdkNHvL12M=

--- a/portal/src/util/messageFormat.test.ts
+++ b/portal/src/util/messageFormat.test.ts
@@ -11,6 +11,48 @@ describe("escapeMessageFormatText", () => {
     expect(escapeMessageFormatText("no quotes")).toEqual("no quotes");
     expect(escapeMessageFormatText("''")).toEqual("''''");
   });
+
+  it("quotes the syntax characters", () => {
+    expect(escapeMessageFormatText("My {App}")).toEqual("My '{App}'");
+    expect(escapeMessageFormatText("{")).toEqual("'{'");
+    expect(escapeMessageFormatText("}")).toEqual("'}'");
+    expect(escapeMessageFormatText("{0} and {1}")).toEqual("'{0} and {1}'");
+  });
+
+  it("keeps adjacent syntax characters in one quoted run", () => {
+    // Quoting each character separately would produce "'{''}'", whose two
+    // inner quotes fuse into a literal apostrophe and render as "{'}".
+    expect(escapeMessageFormatText("{}")).toEqual("'{}'");
+    expect(escapeMessageFormatText("}{")).toEqual("'}{'");
+  });
+
+  it("handles apostrophes adjacent to syntax characters", () => {
+    expect(escapeMessageFormatText("{'}")).toEqual("'{''}'");
+    expect(escapeMessageFormatText("Acme '{Corp}'")).toEqual(
+      "Acme '''{Corp}'''"
+    );
+  });
+
+  it("leaves # alone, since these values are whole messages", () => {
+    expect(escapeMessageFormatText("50% off #1")).toEqual("50% off #1");
+  });
+
+  it("never emits an unterminated quoted run", () => {
+    // A stray ' would make the server reject the whole message.
+    for (const text of ["'", "''", "a'", "'a", "{'", "'}"]) {
+      const escaped = escapeMessageFormatText(text);
+      let quoted = false;
+      for (let i = 0; i < escaped.length; i++) {
+        if (escaped[i] !== "'") continue;
+        if (escaped[i + 1] === "'") {
+          i += 1;
+          continue;
+        }
+        quoted = !quoted;
+      }
+      expect(quoted).toBe(false);
+    }
+  });
 });
 
 describe("unescapeMessageFormatText", () => {
@@ -26,5 +68,38 @@ describe("unescapeMessageFormatText", () => {
     test("no quotes");
     test("''");
     test("");
+    test("My {App}");
+    test("{}");
+    test("}{");
+    test("{'}");
+    test("Acme '{Corp}'");
+    test("50% off #1");
+    test("Ünïcødé {ñ}");
+  });
+
+  it("round-trips exhaustively over the tricky characters", () => {
+    const alphabet = ["'", "{", "}", "a", "#"];
+    let cases: string[] = [""];
+    for (let n = 0; n < 5; n++) {
+      const next: string[] = [];
+      for (const prefix of cases) {
+        for (const ch of alphabet) {
+          next.push(prefix + ch);
+        }
+      }
+      for (const text of next) {
+        expect(
+          unescapeMessageFormatText(escapeMessageFormatText(text))
+        ).toEqual(text);
+      }
+      cases = next;
+    }
+  });
+
+  it("still reads values written by the previous escape", () => {
+    // Older versions doubled apostrophes but left { and } bare.
+    expect(unescapeMessageFormatText("Sam''s App")).toEqual("Sam's App");
+    expect(unescapeMessageFormatText("My {App}")).toEqual("My {App}");
+    expect(unescapeMessageFormatText("no quotes")).toEqual("no quotes");
   });
 });

--- a/portal/src/util/messageFormat.ts
+++ b/portal/src/util/messageFormat.ts
@@ -1,11 +1,101 @@
-// ICU MessageFormat treats a single quote (') as the start of a quoted
-// literal section. A plain-text value with an odd number of quotes (e.g.
-// "O'Brien") therefore fails to parse as a message pattern. Doubling every
-// quote escapes it to a literal quote, which parses correctly.
+// These helpers convert between plain text typed by a user and an ICU
+// MessageFormat pattern, because translation.json values are parsed as
+// message patterns by the server (github.com/iawaknahc/gomessageformat).
+//
+// That library implements ApostropheMode DOUBLE_REQUIRED, which is stricter
+// than ICU's default DOUBLE_OPTIONAL:
+//
+//   - A single ' ALWAYS opens quoted literal text, whatever character
+//     follows it, so a literal apostrophe must always be written as ''.
+//   - Quoted literal text runs until the next single ', and '' inside it is
+//     a literal apostrophe that does not close the quoting.
+//   - { and } are syntax anywhere in a pattern: an unmatched { is a parse
+//     error, and {word} is silently substituted as an argument.
+//   - An unterminated quote is a parse error, so a value that ends up with
+//     a stray ' breaks the whole message.
+//
+// The escaping is done in a single left-to-right pass that tracks whether a
+// quoted run is open. Escaping apostrophes and quoting the syntax characters
+// as two independent passes does NOT work: the quote closing one run fuses
+// with an adjacent doubled apostrophe, and the parser resolves '' first.
+// For example "{}" would become "'{''}'", which renders as "{'}".
+
+// Characters that must appear inside a quoted run to be taken literally.
+//
+// # is deliberately excluded. It is only syntax inside a plural or
+// selectordinal clause, and these values are whole messages rather than
+// clause bodies, so a bare # already renders as itself. Add it here if these
+// helpers are ever reused for text embedded in a plural clause.
+const SYNTAX = "{}";
+
+/**
+ * Escape plain text so that it renders as itself when parsed as a message
+ * pattern. Apply this before writing a plain-text value to translation.json.
+ */
 export function escapeMessageFormatText(text: string): string {
-  return text.replace(/'/g, "''");
+  let out = "";
+  let quoted = false;
+  for (const ch of text) {
+    if (ch === "'") {
+      // A doubled apostrophe is a literal apostrophe whether or not a quoted
+      // run is open, and it does not change the quoting state.
+      out += "''";
+      continue;
+    }
+    if (SYNTAX.includes(ch) && !quoted) {
+      out += "'";
+      quoted = true;
+    }
+    out += ch;
+  }
+  // Once a quoted run is open it is left open, because every remaining
+  // character is literal inside it anyway. Close it at the end.
+  if (quoted) {
+    out += "'";
+  }
+  return out;
 }
 
+/**
+ * Recover the plain text that a message pattern renders as. Apply this when
+ * reading a value out of translation.json for display in an input.
+ *
+ * This resolves quoting only, so it also reads values written by earlier
+ * versions of escapeMessageFormatText, which escaped apostrophes but left
+ * { and } bare.
+ */
 export function unescapeMessageFormatText(text: string): string {
-  return text.replace(/''/g, "'");
+  let out = "";
+  let i = 0;
+  while (i < text.length) {
+    if (text[i] !== "'") {
+      out += text[i];
+      i += 1;
+      continue;
+    }
+    if (text[i + 1] === "'") {
+      out += "'";
+      i += 2;
+      continue;
+    }
+    // A lone ' opens a quoted run and contributes nothing itself.
+    i += 1;
+    while (i < text.length) {
+      if (text[i] === "'") {
+        if (text[i + 1] === "'") {
+          out += "'";
+          i += 2;
+          continue;
+        }
+        i += 1; // closing quote
+        break;
+      }
+      out += text[i];
+      i += 1;
+    }
+    // An unterminated quoted run extends to the end of the string. The server
+    // rejects such a pattern, but being lenient here shows the user something
+    // sensible rather than nothing.
+  }
+  return out;
 }


### PR DESCRIPTION
In this PR, we also fixed a bug in `gomessageformat`, so the code is now using my fork.

The changes are here:
- https://github.com/iawaknahc/gomessageformat/pull/1

ref DEV-3749