### PR TITLE
Fix FirstAuthSink not implementing event.Sink

### DIFF
--- a/pkg/lib/analytic/first_auth_sink.go
+++ b/pkg/lib/analytic/first_auth_sink.go
@@ -37,6 +37,10 @@ func (s *FirstAuthSink) ReceiveBlockingEvent(ctx context.Context, e *event.Event
 	return nil
 }
 
+func (s *FirstAuthSink) WillDeliverBlockingEvent(eventType event.Type) bool {
+	return false
+}
+
 func (s *FirstAuthSink) ReceiveNonBlockingEvent(ctx context.Context, e *event.Event) error {
 	logger := FirstAuthSinkLogger.GetLogger(ctx)
 


### PR DESCRIPTION
FirstAuthSink was missing WillDeliverBlockingEvent, which the Sink interface requires, breaking the build. It never acts on blocking events, so it always returns false, matching audit/search-reindex/ userinfo's identical no-op sinks.

ref DEV-3760