### PR TITLE
Validate `target_step` references when saving `authgear.yaml`

### DIFF
--- a/pkg/lib/config/authentication_flow.go
+++ b/pkg/lib/config/authentication_flow.go
@@ -836,6 +836,8 @@ func (s *AuthenticationFlowSignupFlowStep) GetType() AuthenticationFlowStepType 
 	return AuthenticationFlowStepType(s.Type)
 }
 
+func (s *AuthenticationFlowSignupFlowStep) GetTargetStepName() string { return s.TargetStep }
+
 func (s *AuthenticationFlowSignupFlowStep) GetOneOf() []AuthenticationFlowObject {
 	switch s.Type {
 	case AuthenticationFlowSignupFlowStepTypeIdentify:
@@ -992,6 +994,8 @@ func (s *AuthenticationFlowLoginFlowStep) GetName() string { return s.Name }
 func (s *AuthenticationFlowLoginFlowStep) GetType() AuthenticationFlowStepType {
 	return AuthenticationFlowStepType(s.Type)
 }
+
+func (s *AuthenticationFlowLoginFlowStep) GetTargetStepName() string { return s.TargetStep }
 
 func (s *AuthenticationFlowLoginFlowStep) GetOneOf() []AuthenticationFlowObject {
 	switch s.Type {

--- a/pkg/lib/config/configsource/authentication_flow_target_step.go
+++ b/pkg/lib/config/configsource/authentication_flow_target_step.go
@@ -1,0 +1,155 @@
+package configsource
+
+import (
+	"reflect"
+	"strconv"
+
+	"github.com/authgear/authgear-server/pkg/lib/config"
+	"github.com/authgear/authgear-server/pkg/util/validation"
+)
+
+// targetStepProvider is implemented by any flow object that can carry a target_step
+// reference, at either the step level (verify, change_password) or the one_of branch
+// level (create_authenticator, authenticate).
+type targetStepProvider interface {
+	GetTargetStepName() string
+}
+
+// validateAuthenticationFlowTargetSteps checks that every target_step refers to a step
+// name that exists in the same flow.
+//
+// This runs on the write path only, so that saving a config with a dangling target_step
+// is rejected while an app whose stored config already has one keeps loading and fails
+// at runtime as before.
+//
+// Only flows that the incoming config actually changes are checked, so a dangling
+// target_step that is already stored does not block edits to unrelated parts of the
+// config.
+//
+// Only step existence is checked. Whether the target step is of a usable type
+// (AuthenticationFlowInvalidTargetStep) and whether the flow is structurally coherent
+// (AuthenticationFlowInvalidFlowConfig) are left to runtime, as both depend on intent
+// types and runtime milestone state rather than on config structure.
+//
+// Only signup, promote and login flows are walked, because target_step exists nowhere
+// else in the schema.
+func (d AuthgearYAMLDescriptor) validateAuthenticationFlowTargetSteps(validationCtx *validation.Context, original *config.AppConfig, incoming *config.AppConfig) {
+	if incoming.AuthenticationFlow == nil {
+		return
+	}
+
+	var originalFlows config.AuthenticationFlowConfig
+	if original != nil && original.AuthenticationFlow != nil {
+		originalFlows = *original.AuthenticationFlow
+	}
+
+	// PromoteFlows is intentionally of type AuthenticationFlowSignupFlow.
+	for i, flow := range incoming.AuthenticationFlow.SignupFlows {
+		if isFlowUnchanged(originalFlows.SignupFlows, flow) {
+			continue
+		}
+		validateTargetStepsInFlow(validationCtx, flow.GetSteps(), "signup_flows", i)
+	}
+	for i, flow := range incoming.AuthenticationFlow.PromoteFlows {
+		if isFlowUnchanged(originalFlows.PromoteFlows, flow) {
+			continue
+		}
+		validateTargetStepsInFlow(validationCtx, flow.GetSteps(), "promote_flows", i)
+	}
+	for i, flow := range incoming.AuthenticationFlow.LoginFlows {
+		if isFlowUnchanged(originalFlows.LoginFlows, flow) {
+			continue
+		}
+		validateTargetStepsInFlow(validationCtx, flow.GetSteps(), "login_flows", i)
+	}
+}
+
+// isFlowUnchanged reports whether incoming is identical to the flow of the same name
+// in originals. A flow with no counterpart in originals counts as changed, so a newly
+// added flow is always checked.
+//
+// A target_step is resolved within a single flow, so an untouched flow cannot have
+// acquired a dangling reference from an edit made elsewhere. Skipping it is what keeps
+// an already stored dangling reference from blocking unrelated config updates.
+func isFlowUnchanged[T interface{ GetName() string }](originals []T, incoming T) bool {
+	for _, original := range originals {
+		if original.GetName() == incoming.GetName() {
+			return reflect.DeepEqual(original, incoming)
+		}
+	}
+	return false
+}
+
+func validateTargetStepsInFlow(validationCtx *validation.Context, steps []config.AuthenticationFlowObject, flowsKey string, flowIndex int) {
+	names := make(map[string]struct{})
+	collectAuthenticationFlowStepNames(steps, names)
+	basePath := []string{"authentication_flow", flowsKey, strconv.Itoa(flowIndex), "steps"}
+	validateTargetStepRefs(validationCtx, names, steps, basePath)
+}
+
+// collectAuthenticationFlowStepNames collects every named step in the flow, including
+// steps nested inside one_of branches. authenticationflow.FindTargetStep traverses the
+// whole flow tree at runtime, so a target_step may name any step in the same flow.
+func collectAuthenticationFlowStepNames(steps []config.AuthenticationFlowObject, out map[string]struct{}) {
+	for _, stepObject := range steps {
+		step, ok := stepObject.(config.AuthenticationFlowObjectFlowStep)
+		if !ok {
+			continue
+		}
+		if name := step.GetName(); name != "" {
+			out[name] = struct{}{}
+		}
+		for _, branchObject := range step.GetOneOf() {
+			if branch, ok := branchObject.(config.AuthenticationFlowStepsObject); ok {
+				collectAuthenticationFlowStepNames(branch.GetSteps(), out)
+			}
+		}
+	}
+}
+
+func validateTargetStepRefs(validationCtx *validation.Context, names map[string]struct{}, steps []config.AuthenticationFlowObject, path []string) {
+	for i, stepObject := range steps {
+		step, ok := stepObject.(config.AuthenticationFlowObjectFlowStep)
+		if !ok {
+			continue
+		}
+		stepPath := appendPath(path, strconv.Itoa(i))
+
+		// Step-level target_step, used by verify and change_password.
+		if provider, ok := stepObject.(targetStepProvider); ok {
+			checkTargetStepRef(validationCtx, names, provider.GetTargetStepName(), appendPath(stepPath, "target_step"))
+		}
+
+		for j, branchObject := range step.GetOneOf() {
+			branchPath := appendPath(stepPath, "one_of", strconv.Itoa(j))
+
+			// Branch-level target_step, used by create_authenticator and authenticate.
+			if provider, ok := branchObject.(targetStepProvider); ok {
+				checkTargetStepRef(validationCtx, names, provider.GetTargetStepName(), appendPath(branchPath, "target_step"))
+			}
+
+			if branch, ok := branchObject.(config.AuthenticationFlowStepsObject); ok {
+				validateTargetStepRefs(validationCtx, names, branch.GetSteps(), appendPath(branchPath, "steps"))
+			}
+		}
+	}
+}
+
+func checkTargetStepRef(validationCtx *validation.Context, names map[string]struct{}, targetStep string, path []string) {
+	if targetStep == "" {
+		return
+	}
+	if _, ok := names[targetStep]; ok {
+		return
+	}
+	validationCtx.Child(path...).EmitErrorMessage("target_step does not refer to any named step in the same flow")
+}
+
+// appendPath returns a newly allocated slice so that sibling recursive calls never
+// share a backing array.
+func appendPath(path []string, segments ...string) []string {
+	out := make([]string, 0, len(path)+len(segments))
+	out = append(out, path...)
+	out = append(out, segments...)
+	return out
+}

--- a/pkg/lib/config/configsource/resources.go
+++ b/pkg/lib/config/configsource/resources.go
@@ -173,6 +173,7 @@ func (d AuthgearYAMLDescriptor) validate(ctx context.Context, original *config.A
 		return err
 	}
 	d.validateOAuthClients(validationCtx, incoming, original)
+	d.validateAuthenticationFlowTargetSteps(validationCtx, original, incoming)
 
 	return validationCtx.Error(fmt.Sprintf("invalid %v", AuthgearYAML))
 }

--- a/pkg/lib/config/configsource/resources_test.go
+++ b/pkg/lib/config/configsource/resources_test.go
@@ -1120,3 +1120,337 @@ http:
 		})
 	})
 }
+
+func TestAuthgearYAMLTargetStep(t *testing.T) {
+	Convey("AuthgearYAML target_step", t, func() {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		domainService := NewMockDomainService(ctrl)
+		domainService.EXPECT().ListDomains(gomock.Any(), "test").Return([]*apimodel.Domain{}, nil).AnyTimes()
+
+		path := "authgear.yaml"
+		featureConfig := config.NewEffectiveDefaultFeatureConfig()
+		ctx := context.Background()
+		ctx = context.WithValue(ctx, ContextKeyFeatureConfig, featureConfig)
+		ctx = context.WithValue(ctx, ContextKeyAppHostSuffixes, &config.AppHostSuffixes{})
+		ctx = context.WithValue(ctx, ContextKeyDomainService, domainService)
+		app := resource.LeveledAferoFs{FsLevel: resource.FsLevelApp}
+		descriptor := &AuthgearYAMLDescriptor{}
+
+		const original = `id: test
+http:
+  public_origin: http://test
+`
+
+		update := func(incoming string) error {
+			_, err := descriptor.UpdateResource(
+				ctx,
+				nil,
+				&resource.ResourceFile{
+					Location: resource.Location{
+						Fs:   app,
+						Path: path,
+					},
+					Data: []byte(original),
+				},
+				[]byte(incoming),
+			)
+			return err
+		}
+
+		Convey("signup verify target_step must exist", func() {
+			err := update(`id: test
+http:
+  public_origin: http://test
+authentication_flow:
+  signup_flows:
+  - name: default
+    steps:
+    - type: identify
+      name: identify_email
+      one_of:
+      - identification: email
+    - type: verify
+      target_step: nonexistent
+`)
+			So(err, ShouldBeError, `invalid authgear.yaml:
+/authentication_flow/signup_flows/0/steps/1/target_step: target_step does not refer to any named step in the same flow`)
+		})
+
+		Convey("signup create_authenticator branch target_step must exist", func() {
+			err := update(`id: test
+http:
+  public_origin: http://test
+authentication_flow:
+  signup_flows:
+  - name: default
+    steps:
+    - type: identify
+      name: identify_email
+      one_of:
+      - identification: email
+    - type: create_authenticator
+      one_of:
+      - authentication: primary_oob_otp_email
+        target_step: nonexistent
+`)
+			So(err, ShouldBeError, `invalid authgear.yaml:
+/authentication_flow/signup_flows/0/steps/1/one_of/0/target_step: target_step does not refer to any named step in the same flow`)
+		})
+
+		Convey("promote verify target_step must exist", func() {
+			err := update(`id: test
+http:
+  public_origin: http://test
+authentication_flow:
+  promote_flows:
+  - name: default
+    steps:
+    - type: identify
+      name: identify_email
+      one_of:
+      - identification: email
+    - type: verify
+      target_step: nonexistent
+`)
+			So(err, ShouldBeError, `invalid authgear.yaml:
+/authentication_flow/promote_flows/0/steps/1/target_step: target_step does not refer to any named step in the same flow`)
+		})
+
+		Convey("login change_password target_step must exist", func() {
+			err := update(`id: test
+http:
+  public_origin: http://test
+authentication_flow:
+  login_flows:
+  - name: default
+    steps:
+    - type: identify
+      name: identify_email
+      one_of:
+      - identification: email
+    - type: change_password
+      target_step: nonexistent
+`)
+			So(err, ShouldBeError, `invalid authgear.yaml:
+/authentication_flow/login_flows/0/steps/1/target_step: target_step does not refer to any named step in the same flow`)
+		})
+
+		Convey("login authenticate branch target_step must exist", func() {
+			err := update(`id: test
+http:
+  public_origin: http://test
+authentication_flow:
+  login_flows:
+  - name: default
+    steps:
+    - type: identify
+      name: identify_email
+      one_of:
+      - identification: email
+    - type: authenticate
+      one_of:
+      - authentication: primary_oob_otp_email
+        target_step: nonexistent
+`)
+			So(err, ShouldBeError, `invalid authgear.yaml:
+/authentication_flow/login_flows/0/steps/1/one_of/0/target_step: target_step does not refer to any named step in the same flow`)
+		})
+
+		Convey("target_step referring to an existing step is accepted", func() {
+			err := update(`id: test
+http:
+  public_origin: http://test
+authentication_flow:
+  signup_flows:
+  - name: default
+    steps:
+    - type: identify
+      name: identify_email
+      one_of:
+      - identification: email
+    - type: verify
+      target_step: identify_email
+`)
+			So(err, ShouldBeNil)
+		})
+
+		Convey("target_step referring to a step nested in one_of is accepted", func() {
+			err := update(`id: test
+http:
+  public_origin: http://test
+authentication_flow:
+  signup_flows:
+  - name: default
+    steps:
+    - type: identify
+      one_of:
+      - identification: email
+        steps:
+        - type: identify
+          name: nested_identify
+          one_of:
+          - identification: email
+        - type: verify
+          target_step: nested_identify
+`)
+			So(err, ShouldBeNil)
+		})
+	})
+}
+
+func TestAuthgearYAMLTargetStepUnchangedFlows(t *testing.T) {
+	Convey("AuthgearYAML target_step only checks changed flows", t, func() {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		domainService := NewMockDomainService(ctrl)
+		domainService.EXPECT().ListDomains(gomock.Any(), "test").Return([]*apimodel.Domain{}, nil).AnyTimes()
+
+		path := "authgear.yaml"
+		featureConfig := config.NewEffectiveDefaultFeatureConfig()
+		ctx := context.Background()
+		ctx = context.WithValue(ctx, ContextKeyFeatureConfig, featureConfig)
+		ctx = context.WithValue(ctx, ContextKeyAppHostSuffixes, &config.AppHostSuffixes{})
+		ctx = context.WithValue(ctx, ContextKeyDomainService, domainService)
+		app := resource.LeveledAferoFs{FsLevel: resource.FsLevelApp}
+		descriptor := &AuthgearYAMLDescriptor{}
+
+		// Already stored, and already carrying a dangling target_step.
+		const originalWithDangling = `id: test
+http:
+  public_origin: http://test
+authentication_flow:
+  signup_flows:
+  - name: default
+    steps:
+    - type: identify
+      name: identify_email
+      one_of:
+      - identification: email
+    - type: verify
+      target_step: nonexistent
+`
+
+		update := func(original string, incoming string) error {
+			_, err := descriptor.UpdateResource(
+				ctx,
+				nil,
+				&resource.ResourceFile{
+					Location: resource.Location{
+						Fs:   app,
+						Path: path,
+					},
+					Data: []byte(original),
+				},
+				[]byte(incoming),
+			)
+			return err
+		}
+
+		Convey("editing an unrelated part of the config is not blocked", func() {
+			err := update(originalWithDangling, `id: test
+http:
+  public_origin: http://test
+authentication_flow:
+  signup_flows:
+  - name: default
+    steps:
+    - type: identify
+      name: identify_email
+      one_of:
+      - identification: email
+    - type: verify
+      target_step: nonexistent
+ui:
+  default_client_uri: http://example.com
+`)
+			So(err, ShouldBeNil)
+		})
+
+		Convey("editing a different flow is not blocked", func() {
+			err := update(originalWithDangling, `id: test
+http:
+  public_origin: http://test
+authentication_flow:
+  signup_flows:
+  - name: default
+    steps:
+    - type: identify
+      name: identify_email
+      one_of:
+      - identification: email
+    - type: verify
+      target_step: nonexistent
+  login_flows:
+  - name: default
+    steps:
+    - type: identify
+      one_of:
+      - identification: email
+`)
+			So(err, ShouldBeNil)
+		})
+
+		Convey("editing the offending flow is blocked", func() {
+			err := update(originalWithDangling, `id: test
+http:
+  public_origin: http://test
+authentication_flow:
+  signup_flows:
+  - name: default
+    steps:
+    - type: identify
+      name: identify_email
+      one_of:
+      - identification: email
+    - type: verify
+      target_step: nonexistent
+    - type: view_recovery_code
+`)
+			So(err, ShouldBeError, `invalid authgear.yaml:
+/authentication_flow/signup_flows/0/steps/1/target_step: target_step does not refer to any named step in the same flow`)
+		})
+
+		Convey("introducing a new dangling target_step is blocked", func() {
+			err := update(`id: test
+http:
+  public_origin: http://test
+`, `id: test
+http:
+  public_origin: http://test
+authentication_flow:
+  signup_flows:
+  - name: default
+    steps:
+    - type: identify
+      name: identify_email
+      one_of:
+      - identification: email
+    - type: verify
+      target_step: nonexistent
+`)
+			So(err, ShouldBeError, `invalid authgear.yaml:
+/authentication_flow/signup_flows/0/steps/1/target_step: target_step does not refer to any named step in the same flow`)
+		})
+
+		Convey("fixing the offending flow is accepted", func() {
+			err := update(originalWithDangling, `id: test
+http:
+  public_origin: http://test
+authentication_flow:
+  signup_flows:
+  - name: default
+    steps:
+    - type: identify
+      name: identify_email
+      one_of:
+      - identification: email
+    - type: verify
+      target_step: identify_email
+`)
+			So(err, ShouldBeNil)
+		})
+	})
+}


### PR DESCRIPTION
Validation will be performed when saving, so existing apps will not be affected

ref DEV-3759

after:

- #5866 