### PR TITLE
[Site Admin] Fix bugs when an app has more than one owner

### DIFF
--- a/e2e/tests/siteadmin/collaborators.test.yaml
+++ b/e2e/tests/siteadmin/collaborators.test.yaml
@@ -253,8 +253,8 @@ steps:
   audit_query: |
     SELECT
       activity_type,
-      data->'payload'->>'new_owner_user_email'      AS new_owner_email,
-      data->'payload'->>'demoted_editor_user_email' AS demoted_email
+      data->'payload'->>'new_owner_user_email' AS new_owner_email,
+      data->'payload'->'demoted_editors'       AS demoted_editors
     FROM _audit_log
     WHERE app_id = 'e2e-portal'
       AND activity_type = 'site_admin.app.collaborator.promoted'
@@ -267,7 +267,13 @@ steps:
         {
           "activity_type": "site_admin.app.collaborator.promoted",
           "new_owner_email": "editor@example.com",
-          "demoted_email": "gamma-owner@example.com"
+          "demoted_editors": [
+            {
+              "collaborator_id": "[[string]]",
+              "user_id": "[[string]]",
+              "user_email": "gamma-owner@example.com"
+            }
+          ]
         }
       ]
 

--- a/e2e/tests/siteadmin/fixture/seed_multi_owner.sql
+++ b/e2e/tests/siteadmin/fixture/seed_multi_owner.sql
@@ -1,0 +1,96 @@
+-- Regression fixture for the "an app can have more than one owner-role
+-- collaborator" bug class (dev-3757): the schema only enforces
+-- UNIQUE(app_id, user_id) on _portal_app_collaborator, nothing prevents two
+-- rows for the same app both having role='owner' if that role is ever set
+-- via a direct DB edit rather than through PromoteCollaborator. This seed
+-- reproduces that state directly so the test can verify both call sites
+-- that used to assume "at most one owner" handle it correctly:
+--   1. ListAppsWithStats (app search/list) must not duplicate the app.
+--   2. PromoteCollaborator must demote EVERY existing owner, not just one.
+-- Uses a dedicated app ID so it can't interfere with apps.test.yaml or
+-- collaborators.test.yaml.
+-- Run seed_siteadmin_actor.sql first to create user-001 and its e2e-portal membership.
+
+INSERT INTO _auth_user (
+    id, app_id, created_at, updated_at, last_login_at, login_at,
+    is_disabled, disable_reason, standard_attributes, custom_attributes,
+    is_deactivated, delete_at, is_anonymized, anonymize_at, anonymized_at,
+    last_indexed_at, require_reindex_after
+)
+VALUES
+    (
+        '00000000-0000-0000-0000-000000000101',
+        'e2e-portal',
+        NOW(), NOW(), NULL, NULL,
+        false, NULL,
+        '{"email": "multi-owner-1@example.com"}',
+        '{}',
+        false, NULL, false, NULL, NULL,
+        NOW(), NOW()
+    ),
+    (
+        '00000000-0000-0000-0000-000000000102',
+        'e2e-portal',
+        NOW(), NOW(), NULL, NULL,
+        false, NULL,
+        '{"email": "multi-owner-2@example.com"}',
+        '{}',
+        false, NULL, false, NULL, NULL,
+        NOW(), NOW()
+    ),
+    (
+        '00000000-0000-0000-0000-000000000103',
+        'e2e-portal',
+        NOW(), NOW(), NULL, NULL,
+        false, NULL,
+        '{"email": "multi-owner-editor@example.com"}',
+        '{}',
+        false, NULL, false, NULL, NULL,
+        NOW(), NOW()
+    )
+ON CONFLICT (id) DO NOTHING;
+
+INSERT INTO _portal_config_source (id, app_id, data, plan_name, created_at, updated_at)
+VALUES (
+    gen_random_uuid()::text,
+    'e2e-multiowner-app',
+    '{}',
+    'free',
+    NOW(),
+    NOW()
+)
+ON CONFLICT (app_id) DO NOTHING;
+
+-- Reset collaborators so previous runs don't leave stale rows -- this app ID
+-- is owned exclusively by this seed file and multi_owner.test.yaml.
+DELETE FROM _portal_app_collaborator WHERE app_id = 'e2e-multiowner-app';
+
+-- Two owner-role rows for the SAME app -- the invalid-but-reachable state.
+-- owner-1 is older so PromoteCollaborator's deterministic tie-break should
+-- treat it as "primary".
+INSERT INTO _portal_app_collaborator (id, app_id, user_id, created_at, updated_at, role)
+VALUES
+    (
+        gen_random_uuid()::text,
+        'e2e-multiowner-app',
+        '00000000-0000-0000-0000-000000000101',
+        NOW() - INTERVAL '1 hour',
+        NOW() - INTERVAL '1 hour',
+        'owner'
+    ),
+    (
+        gen_random_uuid()::text,
+        'e2e-multiowner-app',
+        '00000000-0000-0000-0000-000000000102',
+        NOW(),
+        NOW(),
+        'owner'
+    ),
+    (
+        gen_random_uuid()::text,
+        'e2e-multiowner-app',
+        '00000000-0000-0000-0000-000000000103',
+        NOW(),
+        NOW(),
+        'editor'
+    );

--- a/e2e/tests/siteadmin/multi_owner.test.yaml
+++ b/e2e/tests/siteadmin/multi_owner.test.yaml
@@ -1,0 +1,177 @@
+name: Site Admin - App with more than one owner (dev-3757 regression)
+app_id: e2e-portal
+authgear.yaml:
+  override: |
+    http:
+      public_origin: "http://localhost:4000"
+before:
+- type: custom_sql
+  custom_sql:
+    path: fixture/seed_siteadmin_actor.sql
+- type: custom_sql
+  custom_sql:
+    path: fixture/seed_multi_owner.sql
+
+steps:
+# ── Authentication ─────────────────────────────────────────────────────────
+- name: generate_token
+  action: generate_refresh_token
+  generate_refresh_token_user_id: "00000000-0000-0000-0000-000000000001"
+  generate_refresh_token_client_id: e2e
+
+- name: get_access_token
+  action: http_request
+  http_request_method: POST
+  http_request_url: http://localhost:4000/oauth2/token
+  http_request_form_urlencoded_body:
+    grant_type: refresh_token
+    refresh_token: "{{ .steps.generate_token.result.refresh_token }}"
+    client_id: e2e
+  http_output:
+    http_status: 200
+    json_body: |
+      {
+        "access_token": "[[string]]"
+      }
+
+# ── Bug 1: an app with 2 owner-role collaborators must not be duplicated ──
+# in the list/search results, and total_count must not be inflated.
+- name: list filtered to the multi-owner app
+  action: http_request
+  http_request_method: GET
+  http_request_url: http://127.0.0.1:4003/api/v1/apps
+  http_request_headers:
+    Authorization: "Bearer {{ .steps.get_access_token.result.http_json_body.access_token }}"
+  http_request_query:
+    app_id: "e2e-multiowner-app"
+  http_output:
+    http_status: 200
+    json_body: |
+      {
+        "apps": [
+          {
+            "id": "e2e-multiowner-app",
+            "owner_email": "[[string]]",
+            "plan": "free",
+            "created_at": "[[string]]",
+            "last_month_mau": "[[number]]"
+          }
+        ],
+        "total_count": 1,
+        "page": 1,
+        "page_size": "[[number]]",
+        "collaborator_search_truncated": false
+      }
+
+# ── Bug 2: promoting a collaborator must demote EVERY existing owner ───────
+# (not just one, leaving a stale second owner behind).
+- name: get_editor_collab
+  action: query
+  query: |
+    SELECT id FROM _portal_app_collaborator
+    WHERE app_id = 'e2e-multiowner-app'
+    AND user_id = '00000000-0000-0000-0000-000000000103'
+  query_output:
+    rows: |
+      [{"id": "[[string]]"}]
+
+- name: promote editor to owner
+  action: http_request
+  http_request_method: POST
+  http_request_url: http://127.0.0.1:4003/api/v1/apps/e2e-multiowner-app/collaborators/{{ index (index .steps.get_editor_collab.result.rows 0) "id" }}/promote
+  http_request_headers:
+    Authorization: "Bearer {{ .steps.get_access_token.result.http_json_body.access_token }}"
+  http_output:
+    http_status: 200
+    json_body: |
+      {
+        "id": "[[string]]",
+        "app_id": "e2e-multiowner-app",
+        "user_id": "00000000-0000-0000-0000-000000000103",
+        "user_email": "multi-owner-editor@example.com",
+        "role": "owner",
+        "created_at": "[[string]]"
+      }
+
+- name: audit_promote_collaborator
+  action: audit_query
+  audit_query: |
+    SELECT
+      activity_type,
+      data->'payload'->>'new_owner_user_email'      AS new_owner_email,
+      data->'payload'->>'demoted_editor_user_email' AS demoted_email,
+      data->'payload'->'demoted_editors'             AS demoted_editors
+    FROM _audit_log
+    WHERE app_id = 'e2e-portal'
+      AND activity_type = 'site_admin.app.collaborator.promoted'
+      AND data->'payload'->>'app_id' = 'e2e-multiowner-app'
+    ORDER BY created_at DESC
+    LIMIT 1
+  audit_query_output:
+    rows: |
+      [
+        {
+          "activity_type": "site_admin.app.collaborator.promoted",
+          "new_owner_email": "multi-owner-editor@example.com",
+          "demoted_email": "multi-owner-1@example.com",
+          "demoted_editors": [
+            {
+              "collaborator_id": "[[string]]",
+              "user_id": "00000000-0000-0000-0000-000000000101",
+              "user_email": "multi-owner-1@example.com"
+            },
+            {
+              "collaborator_id": "[[string]]",
+              "user_id": "00000000-0000-0000-0000-000000000102",
+              "user_email": "multi-owner-2@example.com"
+            }
+          ]
+        }
+      ]
+
+# After promotion, exactly ONE owner remains (the newly promoted
+# collaborator) and BOTH pre-existing owners were demoted to editor -- not
+# just the one PromoteCollaborator happened to pick first.
+- name: verify exactly one owner remains, both previous owners demoted
+  action: query
+  query: |
+    SELECT user_id, role FROM _portal_app_collaborator
+    WHERE app_id = 'e2e-multiowner-app'
+    ORDER BY user_id
+  query_output:
+    rows: |
+      [
+        {"user_id": "00000000-0000-0000-0000-000000000101", "role": "editor"},
+        {"user_id": "00000000-0000-0000-0000-000000000102", "role": "editor"},
+        {"user_id": "00000000-0000-0000-0000-000000000103", "role": "owner"}
+      ]
+
+# The list/search fix from Bug 1 still holds after the promote -- re-check
+# it now that the app is back to exactly one owner, as a sanity check that
+# the earlier duplication wasn't coincidentally masked by fixture ordering.
+- name: list filtered to the multi-owner app after promote
+  action: http_request
+  http_request_method: GET
+  http_request_url: http://127.0.0.1:4003/api/v1/apps
+  http_request_headers:
+    Authorization: "Bearer {{ .steps.get_access_token.result.http_json_body.access_token }}"
+  http_request_query:
+    app_id: "e2e-multiowner-app"
+  http_output:
+    http_status: 200
+    json_body: |
+      {
+        "apps": [
+          {
+            "id": "e2e-multiowner-app",
+            "owner_email": "multi-owner-editor@example.com",
+            "plan": "free",
+            "created_at": "[[string]]",
+            "last_month_mau": "[[number]]"
+          }
+        ],
+        "total_count": 1,
+        "page": 1,
+        "page_size": "[[number]]",
+        "collaborator_search_truncated": false
+      }

--- a/e2e/tests/siteadmin/multi_owner.test.yaml
+++ b/e2e/tests/siteadmin/multi_owner.test.yaml
@@ -98,9 +98,8 @@ steps:
   audit_query: |
     SELECT
       activity_type,
-      data->'payload'->>'new_owner_user_email'      AS new_owner_email,
-      data->'payload'->>'demoted_editor_user_email' AS demoted_email,
-      data->'payload'->'demoted_editors'             AS demoted_editors
+      data->'payload'->>'new_owner_user_email' AS new_owner_email,
+      data->'payload'->'demoted_editors'       AS demoted_editors
     FROM _audit_log
     WHERE app_id = 'e2e-portal'
       AND activity_type = 'site_admin.app.collaborator.promoted'
@@ -113,7 +112,6 @@ steps:
         {
           "activity_type": "site_admin.app.collaborator.promoted",
           "new_owner_email": "multi-owner-editor@example.com",
-          "demoted_email": "multi-owner-1@example.com",
           "demoted_editors": [
             {
               "collaborator_id": "[[string]]",

--- a/pkg/siteadmin/auditlog/app_collaborator_promoted.go
+++ b/pkg/siteadmin/auditlog/app_collaborator_promoted.go
@@ -11,10 +11,28 @@ type AppCollaboratorPromotedPayload struct {
 	NewOwnerCollaboratorID string `json:"new_owner_collaborator_id"`
 	NewOwnerUserID         string `json:"new_owner_user_id"`
 	NewOwnerUserEmail      string `json:"new_owner_user_email"`
-	// DemotedEditor* fields are omitted when the app had no previous owner.
-	DemotedEditorCollaboratorID string `json:"demoted_editor_collaborator_id,omitempty"`
-	DemotedEditorUserID         string `json:"demoted_editor_user_id,omitempty"`
-	DemotedEditorUserEmail      string `json:"demoted_editor_user_email,omitempty"`
+	// Deprecated_* fields: this event type already ships in production, so
+	// these are kept for older consumers/historical entries (same JSON keys
+	// as before -- only the Go names change), but new code should read
+	// DemotedEditors instead -- these three only ever describe the single
+	// (oldest) demoted owner, silently dropping any others. Omitted when
+	// the app had no previous owner.
+	Deprecated_DemotedEditorCollaboratorID string `json:"demoted_editor_collaborator_id,omitempty"`
+	Deprecated_DemotedEditorUserID         string `json:"demoted_editor_user_id,omitempty"`
+	Deprecated_DemotedEditorUserEmail      string `json:"demoted_editor_user_email,omitempty"`
+	// DemotedEditors lists every collaborator demoted by this promotion, in
+	// the same order as the deprecated fields above (oldest first) --
+	// normally at most one, but the schema has no constraint preventing an
+	// app from having more than one owner-role collaborator before this
+	// promotion (e.g. a direct DB edit can create that state), and none of
+	// them should be silently dropped from the audit trail.
+	DemotedEditors []DemotedEditor `json:"demoted_editors,omitempty"`
+}
+
+type DemotedEditor struct {
+	CollaboratorID string `json:"collaborator_id"`
+	UserID         string `json:"user_id"`
+	UserEmail      string `json:"user_email"`
 }
 
 func (e *AppCollaboratorPromotedPayload) NonBlockingEventType() event.Type {

--- a/pkg/siteadmin/auditlog/app_collaborator_promoted.go
+++ b/pkg/siteadmin/auditlog/app_collaborator_promoted.go
@@ -11,17 +11,7 @@ type AppCollaboratorPromotedPayload struct {
 	NewOwnerCollaboratorID string `json:"new_owner_collaborator_id"`
 	NewOwnerUserID         string `json:"new_owner_user_id"`
 	NewOwnerUserEmail      string `json:"new_owner_user_email"`
-	// Deprecated_* fields: this event type already ships in production, so
-	// these are kept for older consumers/historical entries (same JSON keys
-	// as before -- only the Go names change), but new code should read
-	// DemotedEditors instead -- these three only ever describe the single
-	// (oldest) demoted owner, silently dropping any others. Omitted when
-	// the app had no previous owner.
-	Deprecated_DemotedEditorCollaboratorID string `json:"demoted_editor_collaborator_id,omitempty"`
-	Deprecated_DemotedEditorUserID         string `json:"demoted_editor_user_id,omitempty"`
-	Deprecated_DemotedEditorUserEmail      string `json:"demoted_editor_user_email,omitempty"`
-	// DemotedEditors lists every collaborator demoted by this promotion, in
-	// the same order as the deprecated fields above (oldest first) --
+	// DemotedEditors lists every collaborator demoted by this promotion --
 	// normally at most one, but the schema has no constraint preventing an
 	// app from having more than one owner-role collaborator before this
 	// promotion (e.g. a direct DB edit can create that state), and none of

--- a/pkg/siteadmin/service/app.go
+++ b/pkg/siteadmin/service/app.go
@@ -77,10 +77,16 @@ type AppOwnerStore struct {
 var ErrOwnerNotFound = errors.New("app owner not found")
 
 func (s *AppOwnerStore) GetOwnerByAppID(ctx context.Context, appID string) (string, error) {
+	// ORDER BY makes the pick deterministic: the schema has no constraint
+	// preventing more than one collaborator row from having role="owner"
+	// (a direct DB edit can create this state), so without an explicit
+	// order, which row "wins" here would be arbitrary and could change
+	// between calls. Oldest row first, id as a tie-break.
 	q := s.SQLBuilder.
 		Select("user_id").
 		From(s.SQLBuilder.TableName("_portal_app_collaborator")).
 		Where("app_id = ? AND role = ?", appID, "owner").
+		OrderBy("created_at ASC, id ASC").
 		Limit(1)
 
 	scanner, err := s.SQLExecutor.QueryRowWith(ctx, q)
@@ -124,11 +130,14 @@ func (s *AppOwnerStore) ListAppsWithStats(ctx context.Context, params ListAppsSt
 		return q
 	}
 
-	// Count query — no usage record join needed.
+	// Count query — no usage record join needed. No owner join either: none
+	// of withFilters' WHERE clauses reference an "ac" alias, so joining the
+	// collaborator table here would only risk inflating COUNT(*) if an app
+	// has more than one owner-role collaborator (see the page query below),
+	// with no corresponding benefit.
 	countQ := withFilters(
 		s.SQLBuilder.Select("COUNT(*)").
-			From(configTable + " cs").
-			LeftJoin(collaboratorTable + " ac ON ac.app_id = cs.app_id AND ac.role = 'owner'"),
+			From(configTable + " cs"),
 	)
 	scanner, err := s.SQLExecutor.QueryRowWith(ctx, countQ)
 	if err != nil {
@@ -181,7 +190,15 @@ func (s *AppOwnerStore) ListAppsWithStats(ctx context.Context, params ListAppsSt
 			"COALESCE(ur.count, 0) AS last_month_mau",
 		).
 			From(configTable+" cs").
-			LeftJoin(collaboratorTable+" ac ON ac.app_id = cs.app_id AND ac.role = 'owner'").
+			// LATERAL ... LIMIT 1, not a plain equi-join: the schema has no
+			// constraint preventing more than one collaborator row from
+			// having role="owner" for the same app (a direct DB edit can
+			// create this state). A plain "ac.app_id = cs.app_id AND
+			// ac.role = 'owner'" join would then fan out to one output row
+			// per matching owner, duplicating that app in the results.
+			// ORDER BY makes the pick deterministic (oldest row first),
+			// matching GetOwnerByAppID above.
+			LeftJoin("LATERAL (SELECT user_id FROM "+collaboratorTable+" WHERE app_id = cs.app_id AND role = 'owner' ORDER BY created_at ASC, id ASC LIMIT 1) ac ON true").
 			LeftJoin(
 				usageTable+" ur ON ur.app_id = cs.app_id AND ur.name = ? AND ur.period = ? AND ur.start_time = ?",
 				usage.RecordNameActiveUser, periodical.Monthly, params.LastMonthStart,

--- a/pkg/siteadmin/service/collaborator.go
+++ b/pkg/siteadmin/service/collaborator.go
@@ -255,9 +255,6 @@ func existingOwnersSorted(all []*model.Collaborator) []*model.Collaborator {
 }
 
 // promotedCollaboratorPayload builds the audit payload for a promotion.
-// demotedOwners[0] (if any) also fills the deprecated singular
-// DemotedEditor* fields, for older consumers/historical entries -- new code
-// should read DemotedEditors, which lists all of them.
 func promotedCollaboratorPayload(appID string, promoted *model.Collaborator, demotedOwners []*model.Collaborator, emailMap map[string]string) *siteadminauditlog.AppCollaboratorPromotedPayload {
 	payload := &siteadminauditlog.AppCollaboratorPromotedPayload{
 		AppID:                  appID,
@@ -265,13 +262,6 @@ func promotedCollaboratorPayload(appID string, promoted *model.Collaborator, dem
 		NewOwnerUserID:         promoted.UserID,
 		NewOwnerUserEmail:      emailMap[promoted.UserID],
 	}
-	if len(demotedOwners) == 0 {
-		return payload
-	}
-	primary := demotedOwners[0]
-	payload.Deprecated_DemotedEditorCollaboratorID = primary.ID
-	payload.Deprecated_DemotedEditorUserID = primary.UserID
-	payload.Deprecated_DemotedEditorUserEmail = emailMap[primary.UserID]
 	for _, owner := range demotedOwners {
 		payload.DemotedEditors = append(payload.DemotedEditors, siteadminauditlog.DemotedEditor{
 			CollaboratorID: owner.ID,

--- a/pkg/siteadmin/service/collaborator.go
+++ b/pkg/siteadmin/service/collaborator.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"errors"
+	"sort"
 
 	sq "github.com/Masterminds/squirrel"
 	"github.com/lib/pq"
@@ -232,9 +233,58 @@ func (s *CollaboratorService) AddCollaborator(ctx context.Context, appID string,
 	}, nil
 }
 
+// existingOwnersSorted returns every owner-role collaborator in all,
+// deterministically ordered (oldest first, id as a tie-break --
+// ListCollaborators has no ORDER BY of its own). Normally at most one, but
+// the schema has no constraint preventing more: nothing stops a direct DB
+// edit from setting a second collaborator's role to "owner".
+func existingOwnersSorted(all []*model.Collaborator) []*model.Collaborator {
+	var owners []*model.Collaborator
+	for _, c := range all {
+		if c.Role == model.CollaboratorRoleOwner {
+			owners = append(owners, c)
+		}
+	}
+	sort.Slice(owners, func(i, j int) bool {
+		if !owners[i].CreatedAt.Equal(owners[j].CreatedAt) {
+			return owners[i].CreatedAt.Before(owners[j].CreatedAt)
+		}
+		return owners[i].ID < owners[j].ID
+	})
+	return owners
+}
+
+// promotedCollaboratorPayload builds the audit payload for a promotion.
+// demotedOwners[0] (if any) also fills the deprecated singular
+// DemotedEditor* fields, for older consumers/historical entries -- new code
+// should read DemotedEditors, which lists all of them.
+func promotedCollaboratorPayload(appID string, promoted *model.Collaborator, demotedOwners []*model.Collaborator, emailMap map[string]string) *siteadminauditlog.AppCollaboratorPromotedPayload {
+	payload := &siteadminauditlog.AppCollaboratorPromotedPayload{
+		AppID:                  appID,
+		NewOwnerCollaboratorID: promoted.ID,
+		NewOwnerUserID:         promoted.UserID,
+		NewOwnerUserEmail:      emailMap[promoted.UserID],
+	}
+	if len(demotedOwners) == 0 {
+		return payload
+	}
+	primary := demotedOwners[0]
+	payload.Deprecated_DemotedEditorCollaboratorID = primary.ID
+	payload.Deprecated_DemotedEditorUserID = primary.UserID
+	payload.Deprecated_DemotedEditorUserEmail = emailMap[primary.UserID]
+	for _, owner := range demotedOwners {
+		payload.DemotedEditors = append(payload.DemotedEditors, siteadminauditlog.DemotedEditor{
+			CollaboratorID: owner.ID,
+			UserID:         owner.UserID,
+			UserEmail:      emailMap[owner.UserID],
+		})
+	}
+	return payload
+}
+
 func (s *CollaboratorService) PromoteCollaborator(ctx context.Context, appID string, collaboratorID string) (*siteadmin.Collaborator, error) {
 	var promoted *model.Collaborator
-	var demotedOwner *model.Collaborator // nil if the app had no previous owner
+	var demotedOwners []*model.Collaborator // empty if the app had no previous owner
 	err := s.GlobalDatabase.WithTx(ctx, func(ctx context.Context) error {
 		target, err := s.Store.GetCollaborator(ctx, collaboratorID)
 		if err != nil {
@@ -251,27 +301,24 @@ func (s *CollaboratorService) PromoteCollaborator(ctx context.Context, appID str
 		if err != nil {
 			return err
 		}
-		var currentOwner *model.Collaborator
-		for _, c := range all {
-			if c.Role == model.CollaboratorRoleOwner {
-				currentOwner = c
-				break
-			}
-		}
+		// Demote every existing owner-role collaborator, not just the first
+		// one found: demoting only one would leave the app with MORE owners
+		// after "promoting" than before (see existingOwnersSorted).
+		owners := existingOwnersSorted(all)
 
 		target.Role = model.CollaboratorRoleOwner
 		if err := s.Store.UpdateCollaborator(ctx, target); err != nil {
 			return err
 		}
-		if currentOwner != nil {
-			currentOwner.Role = model.CollaboratorRoleEditor
-			if err := s.Store.UpdateCollaborator(ctx, currentOwner); err != nil {
+		for _, owner := range owners {
+			owner.Role = model.CollaboratorRoleEditor
+			if err := s.Store.UpdateCollaborator(ctx, owner); err != nil {
 				return err
 			}
 		}
 
 		promoted = target
-		demotedOwner = currentOwner
+		demotedOwners = owners
 		return nil
 	})
 	if err != nil {
@@ -279,8 +326,8 @@ func (s *CollaboratorService) PromoteCollaborator(ctx context.Context, appID str
 	}
 
 	userIDsToResolve := []string{promoted.UserID}
-	if demotedOwner != nil {
-		userIDsToResolve = append(userIDsToResolve, demotedOwner.UserID)
+	for _, owner := range demotedOwners {
+		userIDsToResolve = append(userIDsToResolve, owner.UserID)
 	}
 	emailMap, err := s.AdminAPI.ResolveUserEmails(ctx, userIDsToResolve)
 	if err != nil {
@@ -288,17 +335,7 @@ func (s *CollaboratorService) PromoteCollaborator(ctx context.Context, appID str
 	}
 
 	if s.AuditService != nil {
-		payload := &siteadminauditlog.AppCollaboratorPromotedPayload{
-			AppID:                  appID,
-			NewOwnerCollaboratorID: promoted.ID,
-			NewOwnerUserID:         promoted.UserID,
-			NewOwnerUserEmail:      emailMap[promoted.UserID],
-		}
-		if demotedOwner != nil {
-			payload.DemotedEditorCollaboratorID = demotedOwner.ID
-			payload.DemotedEditorUserID = demotedOwner.UserID
-			payload.DemotedEditorUserEmail = emailMap[demotedOwner.UserID]
-		}
+		payload := promotedCollaboratorPayload(appID, promoted, demotedOwners, emailMap)
 		if err := s.AuditService.LogEvent(ctx, appID, payload); err != nil {
 			AuditServiceLogger.GetLogger(ctx).WithError(err).Error(ctx, "failed to emit site admin audit log")
 		}

--- a/pkg/siteadmin/service/collaborator_test.go
+++ b/pkg/siteadmin/service/collaborator_test.go
@@ -461,9 +461,10 @@ func TestCollaboratorService(t *testing.T) {
 			So(payload.NewOwnerCollaboratorID, ShouldEqual, "editor-1")
 			So(payload.NewOwnerUserID, ShouldEqual, "user-editor")
 			So(payload.NewOwnerUserEmail, ShouldEqual, "editor@example.com")
-			So(payload.Deprecated_DemotedEditorCollaboratorID, ShouldEqual, "owner-1")
-			So(payload.Deprecated_DemotedEditorUserID, ShouldEqual, "user-owner")
-			So(payload.Deprecated_DemotedEditorUserEmail, ShouldEqual, "owner@example.com")
+			So(payload.DemotedEditors, ShouldHaveLength, 1)
+			So(payload.DemotedEditors[0].CollaboratorID, ShouldEqual, "owner-1")
+			So(payload.DemotedEditors[0].UserID, ShouldEqual, "user-owner")
+			So(payload.DemotedEditors[0].UserEmail, ShouldEqual, "owner@example.com")
 		})
 
 		Convey("PromoteCollaborator records every demoted owner in DemotedEditors", func() {
@@ -498,11 +499,6 @@ func TestCollaboratorService(t *testing.T) {
 			So(audit.logged, ShouldHaveLength, 1)
 			payload, ok := audit.logged[0].(*siteadminauditlog.AppCollaboratorPromotedPayload)
 			So(ok, ShouldBeTrue)
-			// Deprecated singular fields still name the oldest owner, for
-			// older consumers/historical entries.
-			So(payload.Deprecated_DemotedEditorCollaboratorID, ShouldEqual, "owner-1")
-			So(payload.Deprecated_DemotedEditorUserID, ShouldEqual, "user-owner-1")
-			So(payload.Deprecated_DemotedEditorUserEmail, ShouldEqual, "owner1@example.com")
 			// DemotedEditors lists every demoted owner -- neither is silently
 			// dropped from the audit trail.
 			So(payload.DemotedEditors, ShouldHaveLength, 2)
@@ -544,8 +540,7 @@ func TestCollaboratorService(t *testing.T) {
 			payload, ok := audit.logged[0].(*siteadminauditlog.AppCollaboratorPromotedPayload)
 			So(ok, ShouldBeTrue)
 			So(payload.NewOwnerCollaboratorID, ShouldEqual, "editor-1")
-			So(payload.Deprecated_DemotedEditorCollaboratorID, ShouldEqual, "")
-			So(payload.Deprecated_DemotedEditorUserID, ShouldEqual, "")
+			So(payload.DemotedEditors, ShouldBeEmpty)
 		})
 	})
 }

--- a/pkg/siteadmin/service/collaborator_test.go
+++ b/pkg/siteadmin/service/collaborator_test.go
@@ -269,6 +269,50 @@ func TestCollaboratorService(t *testing.T) {
 			So(store.updated[1].Role, ShouldEqual, portalmodel.CollaboratorRoleEditor)
 		})
 
+		Convey("PromoteCollaborator demotes every existing owner, not just one, when the app has more than one (e.g. from a direct DB edit)", func() {
+			db := &fakeCollaboratorDatabase{}
+			store := &fakeCollaboratorStore{
+				listed: []*portalmodel.Collaborator{
+					{ID: "owner-2", AppID: "app-1", UserID: "user-owner-2", CreatedAt: now.Add(time.Hour), Role: portalmodel.CollaboratorRoleOwner},
+					{ID: "owner-1", AppID: "app-1", UserID: "user-owner-1", CreatedAt: now, Role: portalmodel.CollaboratorRoleOwner},
+					{ID: "editor-1", AppID: "app-1", UserID: "user-editor", CreatedAt: now, Role: portalmodel.CollaboratorRoleEditor},
+				},
+				existingByID: map[string]*portalmodel.Collaborator{
+					"editor-1": {ID: "editor-1", AppID: "app-1", UserID: "user-editor", CreatedAt: now, Role: portalmodel.CollaboratorRoleEditor},
+				},
+			}
+			svr := adminAPIServer(getNodesResponse(
+				map[string]any{"id": relay.ToGlobalID("User", "user-editor"), "standardAttributes": map[string]any{"email": "editor@example.com"}},
+				map[string]any{"id": relay.ToGlobalID("User", "user-owner-1"), "standardAttributes": map[string]any{"email": "owner1@example.com"}},
+				map[string]any{"id": relay.ToGlobalID("User", "user-owner-2"), "standardAttributes": map[string]any{"email": "owner2@example.com"}},
+			))
+			defer svr.Close()
+
+			svc := &CollaboratorService{
+				GlobalDatabase: db,
+				Store:          store,
+				AdminAPI:       makeAdminAPI(svr),
+			}
+
+			result, err := svc.PromoteCollaborator(ctxWithCollaboratorSession(), "app-1", "editor-1")
+
+			So(err, ShouldBeNil)
+			So(result.Role, ShouldEqual, siteadmin.Owner)
+			// The newly promoted collaborator, plus BOTH pre-existing owners
+			// demoted -- not just the one the old first-match-wins logic
+			// would have picked.
+			So(store.updated, ShouldHaveLength, 3)
+			So(store.updated[0].ID, ShouldEqual, "editor-1")
+			So(store.updated[0].Role, ShouldEqual, portalmodel.CollaboratorRoleOwner)
+			// Oldest owner (owner-1, created at `now`) demoted before the
+			// newer one (owner-2, created an hour later) -- deterministic
+			// order, not whatever ListCollaborators happened to return.
+			So(store.updated[1].ID, ShouldEqual, "owner-1")
+			So(store.updated[1].Role, ShouldEqual, portalmodel.CollaboratorRoleEditor)
+			So(store.updated[2].ID, ShouldEqual, "owner-2")
+			So(store.updated[2].Role, ShouldEqual, portalmodel.CollaboratorRoleEditor)
+		})
+
 		Convey("PromoteCollaborator returns not found when collaboratorID is missing", func() {
 			db := &fakeCollaboratorDatabase{}
 			store := &fakeCollaboratorStore{
@@ -417,9 +461,57 @@ func TestCollaboratorService(t *testing.T) {
 			So(payload.NewOwnerCollaboratorID, ShouldEqual, "editor-1")
 			So(payload.NewOwnerUserID, ShouldEqual, "user-editor")
 			So(payload.NewOwnerUserEmail, ShouldEqual, "editor@example.com")
-			So(payload.DemotedEditorCollaboratorID, ShouldEqual, "owner-1")
-			So(payload.DemotedEditorUserID, ShouldEqual, "user-owner")
-			So(payload.DemotedEditorUserEmail, ShouldEqual, "owner@example.com")
+			So(payload.Deprecated_DemotedEditorCollaboratorID, ShouldEqual, "owner-1")
+			So(payload.Deprecated_DemotedEditorUserID, ShouldEqual, "user-owner")
+			So(payload.Deprecated_DemotedEditorUserEmail, ShouldEqual, "owner@example.com")
+		})
+
+		Convey("PromoteCollaborator records every demoted owner in DemotedEditors", func() {
+			db := &fakeCollaboratorDatabase{}
+			store := &fakeCollaboratorStore{
+				listed: []*portalmodel.Collaborator{
+					{ID: "owner-2", AppID: "app-1", UserID: "user-owner-2", CreatedAt: now.Add(time.Hour), Role: portalmodel.CollaboratorRoleOwner},
+					{ID: "owner-1", AppID: "app-1", UserID: "user-owner-1", CreatedAt: now, Role: portalmodel.CollaboratorRoleOwner},
+					{ID: "editor-1", AppID: "app-1", UserID: "user-editor", CreatedAt: now, Role: portalmodel.CollaboratorRoleEditor},
+				},
+				existingByID: map[string]*portalmodel.Collaborator{
+					"editor-1": {ID: "editor-1", AppID: "app-1", UserID: "user-editor", CreatedAt: now, Role: portalmodel.CollaboratorRoleEditor},
+				},
+			}
+			svr := adminAPIServer(getNodesResponse(
+				map[string]any{"id": relay.ToGlobalID("User", "user-editor"), "standardAttributes": map[string]any{"email": "editor@example.com"}},
+				map[string]any{"id": relay.ToGlobalID("User", "user-owner-1"), "standardAttributes": map[string]any{"email": "owner1@example.com"}},
+				map[string]any{"id": relay.ToGlobalID("User", "user-owner-2"), "standardAttributes": map[string]any{"email": "owner2@example.com"}},
+			))
+			defer svr.Close()
+
+			audit := &fakeAuditService{}
+			svc := &CollaboratorService{
+				GlobalDatabase: db,
+				Store:          store,
+				AdminAPI:       makeAdminAPI(svr),
+				AuditService:   audit,
+			}
+
+			_, err := svc.PromoteCollaborator(ctxWithCollaboratorSession(), "app-1", "editor-1")
+			So(err, ShouldBeNil)
+			So(audit.logged, ShouldHaveLength, 1)
+			payload, ok := audit.logged[0].(*siteadminauditlog.AppCollaboratorPromotedPayload)
+			So(ok, ShouldBeTrue)
+			// Deprecated singular fields still name the oldest owner, for
+			// older consumers/historical entries.
+			So(payload.Deprecated_DemotedEditorCollaboratorID, ShouldEqual, "owner-1")
+			So(payload.Deprecated_DemotedEditorUserID, ShouldEqual, "user-owner-1")
+			So(payload.Deprecated_DemotedEditorUserEmail, ShouldEqual, "owner1@example.com")
+			// DemotedEditors lists every demoted owner -- neither is silently
+			// dropped from the audit trail.
+			So(payload.DemotedEditors, ShouldHaveLength, 2)
+			So(payload.DemotedEditors[0].CollaboratorID, ShouldEqual, "owner-1")
+			So(payload.DemotedEditors[0].UserID, ShouldEqual, "user-owner-1")
+			So(payload.DemotedEditors[0].UserEmail, ShouldEqual, "owner1@example.com")
+			So(payload.DemotedEditors[1].CollaboratorID, ShouldEqual, "owner-2")
+			So(payload.DemotedEditors[1].UserID, ShouldEqual, "user-owner-2")
+			So(payload.DemotedEditors[1].UserEmail, ShouldEqual, "owner2@example.com")
 		})
 
 		Convey("PromoteCollaborator emits audit log without demoted fields when no previous owner", func() {
@@ -452,8 +544,8 @@ func TestCollaboratorService(t *testing.T) {
 			payload, ok := audit.logged[0].(*siteadminauditlog.AppCollaboratorPromotedPayload)
 			So(ok, ShouldBeTrue)
 			So(payload.NewOwnerCollaboratorID, ShouldEqual, "editor-1")
-			So(payload.DemotedEditorCollaboratorID, ShouldEqual, "")
-			So(payload.DemotedEditorUserID, ShouldEqual, "")
+			So(payload.Deprecated_DemotedEditorCollaboratorID, ShouldEqual, "")
+			So(payload.Deprecated_DemotedEditorUserID, ShouldEqual, "")
 		})
 	})
 }


### PR DESCRIPTION
An app can have more than one owner via a direct DB edit, which duplicated apps in search/list and left extra owners undemoted on promote. Fixes both, adds e2e regression test.

ref DEV-3757