### PR TITLE
chore: Bump gomessageformat to upstream, drop the fork replace

### DIFF
--- a/custombuild/go.mod
+++ b/custombuild/go.mod
@@ -111,7 +111,7 @@ require (
 	github.com/hashicorp/go-multierror v1.1.1 // indirect
 	github.com/hashicorp/golang-lru v1.0.2 // indirect
 	github.com/huandu/xstrings v1.4.0 // indirect
-	github.com/iawaknahc/gomessageformat v0.0.0-20210428033148-c3f8592094b5 // indirect
+	github.com/iawaknahc/gomessageformat v0.0.0-20260812135726-04797505aebe // indirect
 	github.com/iawaknahc/jsonschema v0.0.0-20250219112344-8b65018f0c9f // indirect
 	github.com/iawaknahc/originmatcher v0.0.0-20240717084358-ac10088d8800 // indirect
 	github.com/imdario/mergo v0.3.16 // indirect

--- a/custombuild/go.sum
+++ b/custombuild/go.sum
@@ -278,8 +278,8 @@ github.com/hashicorp/golang-lru v1.0.2 h1:dV3g9Z/unq5DpblPpw+Oqcv4dU/1omnb4Ok8iP
 github.com/hashicorp/golang-lru v1.0.2/go.mod h1:iADmTwqILo4mZ8BN3D2Q6+9jd8WM5uGBxy+E8yxSoD4=
 github.com/huandu/xstrings v1.4.0 h1:D17IlohoQq4UcpqD7fDk80P7l+lwAmlFaBHgOipl2FU=
 github.com/huandu/xstrings v1.4.0/go.mod h1:y5/lhBue+AyNmUVz9RLU9xbLR0o4KIIExikq4ovT0aE=
-github.com/iawaknahc/gomessageformat v0.0.0-20210428033148-c3f8592094b5 h1:i6r7zTbhSdHbhCVEJsM8W62F7MvxXfkpkwGrvfL+sFw=
-github.com/iawaknahc/gomessageformat v0.0.0-20210428033148-c3f8592094b5/go.mod h1:N6C14Rpg3pJZ9zDMbmF/zPu8LJDsmVzMAD3bc+bregI=
+github.com/iawaknahc/gomessageformat v0.0.0-20260812135726-04797505aebe h1:mIQgGnsnjKnEFxn/b5wc9PPirq5bj4cS6g++kUpUPlw=
+github.com/iawaknahc/gomessageformat v0.0.0-20260812135726-04797505aebe/go.mod h1:N6C14Rpg3pJZ9zDMbmF/zPu8LJDsmVzMAD3bc+bregI=
 github.com/iawaknahc/jsonschema v0.0.0-20250219112344-8b65018f0c9f h1:7fg9r1heGxzvbzpbRhrLg38ofAy6bP8LroR7H3buCLE=
 github.com/iawaknahc/jsonschema v0.0.0-20250219112344-8b65018f0c9f/go.mod h1:2dwQ26l1MvCcsoMMZtmUDPdaNrybnKOXi0KeletnVJc=
 github.com/iawaknahc/originmatcher v0.0.0-20240717084358-ac10088d8800 h1:oR04NBr9JKoP54k6aq4c6Vvungf3Oi3JFAN92/3K6Fg=

--- a/e2e/go.mod
+++ b/e2e/go.mod
@@ -112,7 +112,7 @@ require (
 	github.com/hashicorp/go-multierror v1.1.1 // indirect
 	github.com/hashicorp/golang-lru v1.0.2 // indirect
 	github.com/huandu/xstrings v1.4.0 // indirect
-	github.com/iawaknahc/gomessageformat v0.0.0-20210428033148-c3f8592094b5 // indirect
+	github.com/iawaknahc/gomessageformat v0.0.0-20260812135726-04797505aebe // indirect
 	github.com/iawaknahc/jsonschema v0.0.0-20250219112344-8b65018f0c9f // indirect
 	github.com/iawaknahc/originmatcher v0.0.0-20240717084358-ac10088d8800 // indirect
 	github.com/imdario/mergo v0.3.16 // indirect

--- a/e2e/go.sum
+++ b/e2e/go.sum
@@ -273,8 +273,8 @@ github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpO
 github.com/huandu/xstrings v1.4.0 h1:D17IlohoQq4UcpqD7fDk80P7l+lwAmlFaBHgOipl2FU=
 github.com/huandu/xstrings v1.4.0/go.mod h1:y5/lhBue+AyNmUVz9RLU9xbLR0o4KIIExikq4ovT0aE=
 github.com/ianlancetaylor/demangle v0.0.0-20200824232613-28f6c0f3b639/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
-github.com/iawaknahc/gomessageformat v0.0.0-20210428033148-c3f8592094b5 h1:i6r7zTbhSdHbhCVEJsM8W62F7MvxXfkpkwGrvfL+sFw=
-github.com/iawaknahc/gomessageformat v0.0.0-20210428033148-c3f8592094b5/go.mod h1:N6C14Rpg3pJZ9zDMbmF/zPu8LJDsmVzMAD3bc+bregI=
+github.com/iawaknahc/gomessageformat v0.0.0-20260812135726-04797505aebe h1:mIQgGnsnjKnEFxn/b5wc9PPirq5bj4cS6g++kUpUPlw=
+github.com/iawaknahc/gomessageformat v0.0.0-20260812135726-04797505aebe/go.mod h1:N6C14Rpg3pJZ9zDMbmF/zPu8LJDsmVzMAD3bc+bregI=
 github.com/iawaknahc/jsonschema v0.0.0-20250219112344-8b65018f0c9f h1:7fg9r1heGxzvbzpbRhrLg38ofAy6bP8LroR7H3buCLE=
 github.com/iawaknahc/jsonschema v0.0.0-20250219112344-8b65018f0c9f/go.mod h1:2dwQ26l1MvCcsoMMZtmUDPdaNrybnKOXi0KeletnVJc=
 github.com/iawaknahc/originmatcher v0.0.0-20240717084358-ac10088d8800 h1:oR04NBr9JKoP54k6aq4c6Vvungf3Oi3JFAN92/3K6Fg=

--- a/go.mod
+++ b/go.mod
@@ -20,7 +20,7 @@ require (
 	github.com/google/uuid v1.6.0
 	github.com/google/wire v0.5.0
 	github.com/graphql-go/graphql v0.8.1
-	github.com/iawaknahc/gomessageformat v0.0.0-20210428033148-c3f8592094b5
+	github.com/iawaknahc/gomessageformat v0.0.0-20260812135726-04797505aebe
 	github.com/iawaknahc/jsonschema v0.0.0-20250219112344-8b65018f0c9f
 	github.com/iawaknahc/originmatcher v0.0.0-20240717084358-ac10088d8800
 	github.com/joho/godotenv v1.5.1
@@ -319,5 +319,3 @@ tool (
 	golang.org/x/tools/cmd/goimports
 	golang.org/x/vuln/cmd/govulncheck
 )
-
-replace github.com/iawaknahc/gomessageformat => github.com/oursky/gomessageformat v0.0.0-20260810215310-a251ccc4eb09

--- a/go.sum
+++ b/go.sum
@@ -329,6 +329,8 @@ github.com/huandu/xstrings v1.4.0/go.mod h1:y5/lhBue+AyNmUVz9RLU9xbLR0o4KIIExikq
 github.com/ianlancetaylor/demangle v0.0.0-20200824232613-28f6c0f3b639/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
 github.com/iawaknahc/gogenwrapper v0.0.0-20250315204045-eb8ab595ac5c h1:JwJzV3LkV76E8buck8mTnQFsdtH3WtXnFRNliiXtecw=
 github.com/iawaknahc/gogenwrapper v0.0.0-20250315204045-eb8ab595ac5c/go.mod h1:Wi8UvegjqfQnzlcTGqj1BqnD6hayuDka3lw7Zdm4tHQ=
+github.com/iawaknahc/gomessageformat v0.0.0-20260812135726-04797505aebe h1:mIQgGnsnjKnEFxn/b5wc9PPirq5bj4cS6g++kUpUPlw=
+github.com/iawaknahc/gomessageformat v0.0.0-20260812135726-04797505aebe/go.mod h1:N6C14Rpg3pJZ9zDMbmF/zPu8LJDsmVzMAD3bc+bregI=
 github.com/iawaknahc/jsonschema v0.0.0-20250219112344-8b65018f0c9f h1:7fg9r1heGxzvbzpbRhrLg38ofAy6bP8LroR7H3buCLE=
 github.com/iawaknahc/jsonschema v0.0.0-20250219112344-8b65018f0c9f/go.mod h1:2dwQ26l1MvCcsoMMZtmUDPdaNrybnKOXi0KeletnVJc=
 github.com/iawaknahc/originmatcher v0.0.0-20240717084358-ac10088d8800 h1:oR04NBr9JKoP54k6aq4c6Vvungf3Oi3JFAN92/3K6Fg=
@@ -478,8 +480,6 @@ github.com/oschwald/geoip2-golang v1.13.0 h1:Q44/Ldc703pasJeP5V9+aFSZFmBN7DKHbNs
 github.com/oschwald/geoip2-golang v1.13.0/go.mod h1:P9zG+54KPEFOliZ29i7SeYZ/GM6tfEL+rgSn03hYuUo=
 github.com/oschwald/maxminddb-golang v1.13.0 h1:R8xBorY71s84yO06NgTmQvqvTvlS/bnYZrrWX1MElnU=
 github.com/oschwald/maxminddb-golang v1.13.0/go.mod h1:BU0z8BfFVhi1LQaonTwwGQlsHUEu9pWNdMfmq4ztm0o=
-github.com/oursky/gomessageformat v0.0.0-20260810215310-a251ccc4eb09 h1:fEqKD3q9bgaSUzaFe00NWBlLGmGXLbAJK32KqBQGK/E=
-github.com/oursky/gomessageformat v0.0.0-20260810215310-a251ccc4eb09/go.mod h1:N6C14Rpg3pJZ9zDMbmF/zPu8LJDsmVzMAD3bc+bregI=
 github.com/patrickmn/go-cache v2.1.0+incompatible h1:HRMgzkcYKYpi3C8ajMPV8OFXaaRUnok+kx1WdO15EQc=
 github.com/patrickmn/go-cache v2.1.0+incompatible/go.mod h1:3Qf8kWWT7OJRJbdiICTKqZju1ZixQ/KpMGzzAfe6+WQ=
 github.com/pelletier/go-toml/v2 v2.2.3 h1:YmeHyLY8mFWbdkNWwpr+qIL2bEqT0o95WSdkNHvL12M=


### PR DESCRIPTION
The double-apostrophe fix previously pulled in via the oursky/gomessageformat fork has been merged upstream into iawaknahc/gomessageformat. Point go.mod, custombuild/go.mod, and e2e/go.mod directly at the upstream commit and remove the replace directive, since replace directives do not propagate across module boundaries and custombuild/e2e need the fix independently.

ref DEV-3749
