### PR TITLE
[Portal] Show save progress in the Change framework dialog

### DIFF
--- a/portal/src/graphql/portal/EditOAuthClientFormFrameworkQuickStart.tsx
+++ b/portal/src/graphql/portal/EditOAuthClientFormFrameworkQuickStart.tsx
@@ -20,6 +20,7 @@ import { Context, FormattedMessage } from "../../intl";
 import ExternalLink from "../../ExternalLink";
 import PrimaryButton from "../../PrimaryButton";
 import DefaultButton from "../../DefaultButton";
+import ButtonWithLoading from "../../ButtonWithLoading";
 import { AppSecretConfigFormModel } from "../../hook/useAppSecretConfigForm";
 import {
   findFramework,
@@ -109,19 +110,22 @@ export function EditOAuthClientFormFrameworkQuickStart<
 
   const applyFramework = useCallback(
     async (newFrameworkId: Framework) => {
+      const newState = produce(form.state, (draft) => {
+        draft.clients = draft.clients.map((c) =>
+          c.client_id === client.client_id
+            ? { ...c, x_framework: newFrameworkId }
+            : c
+        );
+        if (draft.editedClient?.client_id === client.client_id) {
+          draft.editedClient.x_framework = newFrameworkId;
+        }
+      });
       setApplying(true);
       try {
-        const newState = produce(form.state, (draft) => {
-          draft.clients = draft.clients.map((c) =>
-            c.client_id === client.client_id
-              ? { ...c, x_framework: newFrameworkId }
-              : c
-          );
-          if (draft.editedClient?.client_id === client.client_id) {
-            draft.editedClient.x_framework = newFrameworkId;
-          }
-        });
-        form.setState(() => newState);
+        // Do not touch the form state before the save: saveWithState reloads
+        // the config on success, so the content behind the dialog updates at
+        // the same moment the dialog dismisses. Updating the state upfront
+        // made the dialog look hung while the request was still in flight.
         await form.saveWithState(newState);
         setDialogVisible(false);
       } finally {
@@ -402,12 +406,11 @@ function ChangeFrameworkDialog(props: ChangeFrameworkDialogProps) {
         />
       </div>
       <DialogFooter>
-        <PrimaryButton
+        <ButtonWithLoading
           onClick={onApplyClick}
           disabled={!canApply}
-          text={
-            <FormattedMessage id="EditOAuthClientFormFrameworkQuickStart.change-dialog.apply" />
-          }
+          loading={applying}
+          labelId="EditOAuthClientFormFrameworkQuickStart.change-dialog.apply"
         />
         <DefaultButton
           onClick={onDismiss}


### PR DESCRIPTION
## Summary

On the application Quick Start tab, pressing **Apply** in the Change framework dialog updated the form state *before* awaiting the save, so the content behind the dialog changed immediately while the dialog sat open with no progress indicator until the GraphQL round-trip completed — reading as a hang (a few seconds on staging).

## Changes

- `applyFramework` no longer touches the form state up front: it saves first (`saveWithState` reloads the config on success, so the background data updates exactly when the call completes), then dismisses the dialog at the same moment.
- The Apply button is now a `ButtonWithLoading` showing a spinner while the save is in flight; Cancel stays disabled and the dialog blocking during that window, matching the rest of the portal's save affordances.

## Verification

- Portal `typecheck`, `eslint`, and `prettier` pass.
- Verified manually in the local dev portal: Apply shows a spinner; the framework display and dialog dismissal update together when the save completes.

Before
<img width="2151" height="2435" alt="SCR-20260821-nduv" src="https://github.com/user-attachments/assets/2b296088-0f24-4b84-8772-b6747a5487c5" />

After
<img width="2677" height="2202" alt="SCR-20260821-nivu" src="https://github.com/user-attachments/assets/354a5cfe-2683-493a-8148-0521d53de995" />


ref DEV-2392