### PR TITLE
Fix usage.limits override lost through deprecated-migration re-marshal

### DIFF
--- a/pkg/lib/config/feature_test.go
+++ b/pkg/lib/config/feature_test.go
@@ -335,6 +335,50 @@ collaborator:
 			Action: model.UsageLimitActionBlock,
 		}})
 	})
+
+	Convey("an explicit empty usage.limits.sms override survives Migrate's deprecated messaging.sms_usage fallback", t, func() {
+		// Migrate (feature.go) runs on the merge fold's re-parsed result and
+		// only backfills a limit from the deprecated messaging.sms_usage
+		// field when featureUsageLimits(SMS) is nil -- i.e. when it can't
+		// tell "explicitly cleared" apart from "never configured". If the
+		// explicit empty override doesn't survive the marshal/re-parse
+		// round trip (the omitempty bug this package's Merge fix
+		// addresses), Migrate wrongly treats it as unset and re-injects a
+		// limit derived from the deprecated field, clobbering the override.
+		ctx := context.Background()
+
+		planYAML := []byte(`
+messaging:
+  sms_usage:
+    enabled: true
+    quota: 50
+    period: month
+`)
+		appYAML := []byte(`
+usage:
+  limits:
+    sms: []
+`)
+
+		planCfg, err := config.ParseFeatureConfigWithoutDefaults(ctx, planYAML)
+		So(err, ShouldBeNil)
+		appCfg, err := config.ParseFeatureConfigWithoutDefaults(ctx, appYAML)
+		So(err, ShouldBeNil)
+
+		mergedConfig := &config.FeatureConfig{}
+		mergedConfig = mergedConfig.Merge(planCfg)
+		mergedConfig = mergedConfig.Merge(appCfg)
+
+		mergedYAML, err := yaml.Marshal(mergedConfig)
+		So(err, ShouldBeNil)
+
+		effective, err := config.ParseFeatureConfig(ctx, mergedYAML)
+		So(err, ShouldBeNil)
+
+		So(effective.Usage, ShouldNotBeNil)
+		So(effective.Usage.Limits, ShouldNotBeNil)
+		So(effective.Usage.Limits.SMS, ShouldResemble, []config.FeatureUsageLimitConfig{})
+	})
 }
 
 // These single-field sections have `false` as their real, correct default

--- a/pkg/lib/config/feature_test.go
+++ b/pkg/lib/config/feature_test.go
@@ -255,6 +255,86 @@ collaborator:
 		So(effective.UI.PhoneInput, ShouldNotBeNil)
 		So(effective.UI.PhoneInput.AllowList, ShouldResemble, []string{"US", "GB"})
 	})
+
+	Convey("an explicit empty usage.limits.sms override survives the merge fold's marshal-and-reparse round trip", t, func() {
+		ctx := context.Background()
+
+		planYAML := []byte(`
+usage:
+  limits:
+    sms:
+      - quota: 100
+        period: day
+        action: block
+`)
+		appYAML := []byte(`
+usage:
+  limits:
+    sms: []
+`)
+
+		planCfg, err := config.ParseFeatureConfigWithoutDefaults(ctx, planYAML)
+		So(err, ShouldBeNil)
+		appCfg, err := config.ParseFeatureConfigWithoutDefaults(ctx, appYAML)
+		So(err, ShouldBeNil)
+
+		mergedConfig := &config.FeatureConfig{}
+		mergedConfig = mergedConfig.Merge(planCfg)
+		mergedConfig = mergedConfig.Merge(appCfg)
+
+		mergedYAML, err := yaml.Marshal(mergedConfig)
+		So(err, ShouldBeNil)
+
+		effective, err := config.ParseFeatureConfig(ctx, mergedYAML)
+		So(err, ShouldBeNil)
+
+		So(effective.Usage, ShouldNotBeNil)
+		So(effective.Usage.Limits, ShouldNotBeNil)
+		So(effective.Usage.Limits.SMS, ShouldResemble, []config.FeatureUsageLimitConfig{})
+	})
+
+	Convey("an app override that doesn't touch usage.limits.sms inherits the plan's list", t, func() {
+		ctx := context.Background()
+
+		planYAML := []byte(`
+usage:
+  limits:
+    sms:
+      - quota: 100
+        period: day
+        action: block
+`)
+		// The app layer is present and non-empty, but never mentions
+		// usage.limits.sms -- this is the "not set" case, distinct from
+		// the explicit-empty case above, and must inherit the plan's list.
+		appYAML := []byte(`
+collaborator:
+  maximum: 5
+`)
+
+		planCfg, err := config.ParseFeatureConfigWithoutDefaults(ctx, planYAML)
+		So(err, ShouldBeNil)
+		appCfg, err := config.ParseFeatureConfigWithoutDefaults(ctx, appYAML)
+		So(err, ShouldBeNil)
+
+		mergedConfig := &config.FeatureConfig{}
+		mergedConfig = mergedConfig.Merge(planCfg)
+		mergedConfig = mergedConfig.Merge(appCfg)
+
+		mergedYAML, err := yaml.Marshal(mergedConfig)
+		So(err, ShouldBeNil)
+
+		effective, err := config.ParseFeatureConfig(ctx, mergedYAML)
+		So(err, ShouldBeNil)
+
+		So(effective.Usage, ShouldNotBeNil)
+		So(effective.Usage.Limits, ShouldNotBeNil)
+		So(effective.Usage.Limits.SMS, ShouldResemble, []config.FeatureUsageLimitConfig{{
+			Quota:  100,
+			Period: model.UsageLimitPeriodDay,
+			Action: model.UsageLimitActionBlock,
+		}})
+	})
 }
 
 // These single-field sections have `false` as their real, correct default

--- a/pkg/lib/config/feature_usage.go
+++ b/pkg/lib/config/feature_usage.go
@@ -72,12 +72,20 @@ var _ = FeatureConfigSchema.Add("FeatureUsageLimitsConfig", `
 `)
 
 type FeatureUsageLimitsConfig struct {
-	UserExport     []FeatureUsageLimitConfig         `json:"user_export,omitempty"`
-	UserImport     []FeatureUsageLimitConfig         `json:"user_import,omitempty"`
-	Email          []FeatureUsageLimitConfig         `json:"email,omitempty"`
-	Whatsapp       []FeatureUsageLimitConfig         `json:"whatsapp,omitempty"`
-	SMS            []FeatureUsageLimitConfig         `json:"sms,omitempty"`
-	OAuthClientDCR []StandingFeatureUsageLimitConfig `json:"oauth_client_dcr,omitempty"`
+	// omitzero, not omitempty: nil (unset, inherit from a lower layer) and
+	// an explicit empty slice (override to "no limits") are semantically
+	// distinct here — omitempty would drop both cases the same way,
+	// silently reverting an explicit override back to inherited on the
+	// merge-fold's marshal/re-parse round trip (see
+	// viewEffectiveResource in configsource/resources.go). omitzero only
+	// omits the true zero value (nil), preserving an explicit []
+	// through that round trip.
+	UserExport     []FeatureUsageLimitConfig         `json:"user_export,omitzero"`
+	UserImport     []FeatureUsageLimitConfig         `json:"user_import,omitzero"`
+	Email          []FeatureUsageLimitConfig         `json:"email,omitzero"`
+	Whatsapp       []FeatureUsageLimitConfig         `json:"whatsapp,omitzero"`
+	SMS            []FeatureUsageLimitConfig         `json:"sms,omitzero"`
+	OAuthClientDCR []StandingFeatureUsageLimitConfig `json:"oauth_client_dcr,omitzero"`
 }
 
 func (c *FeatureUsageLimitsConfig) Limits(name model.UsageName) []FeatureUsageLimitConfig {


### PR DESCRIPTION
An app-level `usage.limits.<name>: []` override (meant to clear an inherited quota) was silently discarded when a deprecated field like `messaging.sms_usage` was also enabled, the merge-fold's marshal/re-parse round trip dropped the empty slice due to `omitempty`, so `Migrate()` couldn't tell "explicitly cleared" from "never configured" and re-injected the legacy limit. Switches the tags to `omitzero` (matching the existing `phone_input.allowlist` fix) and adds a regression test covering the exact scenario.

ref DEV-3811