### PR TITLE
[Portal] Sort project list and present it as a scrollable table

### DIFF
--- a/pkg/portal/graphql/query.go
+++ b/pkg/portal/graphql/query.go
@@ -40,7 +40,7 @@ var query = graphql.NewObject(graphql.ObjectConfig{
 			},
 		},
 		"appList": &graphql.Field{
-			Description: "The list of apps accessible to the current viewer",
+			Description: "The list of apps accessible to the current viewer, sorted by app ID in ascending order",
 			Type: graphql.NewList(graphql.NewNonNull(graphql.NewObject(graphql.ObjectConfig{
 				Name: "AppListItem",
 				Fields: graphql.Fields{

--- a/pkg/portal/service/app.go
+++ b/pkg/portal/service/app.go
@@ -10,6 +10,8 @@ import (
 	"net/url"
 	"path"
 	"regexp"
+	"slices"
+	"strings"
 	"time"
 
 	"github.com/lib/pq"
@@ -177,7 +179,18 @@ func (s *AppService) GetAppList(ctx context.Context, userID string) ([]*model.Ap
 			PublicOrigin: app.Context.Config.AppConfig.HTTP.PublicOrigin,
 		})
 	}
+	sortAppListItems(appList)
 	return appList, nil
+}
+
+// sortAppListItems orders the list by app ID in ascending byte order, so every
+// client shows projects in the same predictable order regardless of which
+// config source produced the IDs. App IDs are lowercase letters, digits and
+// hyphens, so byte order is alphabetical order.
+func sortAppListItems(items []*model.AppListItem) {
+	slices.SortFunc(items, func(a, b *model.AppListItem) int {
+		return strings.Compare(a.AppID, b.AppID)
+	})
 }
 
 // GetProjectQuota acquires connection.

--- a/pkg/portal/service/app_test.go
+++ b/pkg/portal/service/app_test.go
@@ -7,6 +7,7 @@ import (
 	. "github.com/smartystreets/goconvey/convey"
 
 	runtimeresource "github.com/authgear/authgear-server"
+	"github.com/authgear/authgear-server/pkg/portal/model"
 	portalresource "github.com/authgear/authgear-server/pkg/portal/resource"
 	"github.com/authgear/authgear-server/pkg/util/resource"
 )
@@ -72,6 +73,57 @@ func TestValidateAppID(t *testing.T) {
 		Convey("some examples of valid app ID", func() {
 			So(service.validateAppID(ctx, "myapp"), ShouldBeNil)
 			So(service.validateAppID(ctx, "this-app"), ShouldBeNil)
+		})
+	})
+}
+
+func TestSortAppListItems(t *testing.T) {
+	Convey("sortAppListItems", t, func() {
+		appIDs := func(items []*model.AppListItem) []string {
+			out := make([]string, len(items))
+			for i, item := range items {
+				out[i] = item.AppID
+			}
+			return out
+		}
+
+		Convey("orders items by app ID in ascending byte order", func() {
+			items := []*model.AppListItem{
+				{AppID: "zebra-4d3c2b", PublicOrigin: "https://zebra-4d3c2b.example.com"},
+				{AppID: "apple-10", PublicOrigin: "https://apple-10.example.com"},
+				{AppID: "mango-9f8e7d", PublicOrigin: "https://mango-9f8e7d.example.com"},
+				{AppID: "apple-2", PublicOrigin: "https://apple-2.example.com"},
+			}
+
+			sortAppListItems(items)
+
+			So(appIDs(items), ShouldResemble, []string{
+				"apple-10",
+				"apple-2",
+				"mango-9f8e7d",
+				"zebra-4d3c2b",
+			})
+			// Each item keeps its own origin; only the order changes.
+			So(items[0].PublicOrigin, ShouldEqual, "https://apple-10.example.com")
+		})
+
+		Convey("leaves an already sorted list unchanged", func() {
+			items := []*model.AppListItem{
+				{AppID: "a-project"},
+				{AppID: "b-project"},
+			}
+
+			sortAppListItems(items)
+
+			So(appIDs(items), ShouldResemble, []string{"a-project", "b-project"})
+		})
+
+		Convey("accepts an empty or nil list", func() {
+			empty := []*model.AppListItem{}
+			sortAppListItems(empty)
+			So(empty, ShouldBeEmpty)
+
+			So(func() { sortAppListItems(nil) }, ShouldNotPanic)
 		})
 	})
 }

--- a/portal/src/ScreenHeader.tsx
+++ b/portal/src/ScreenHeader.tsx
@@ -72,7 +72,10 @@ const MobileViewHeaderIconSection: React.VFC<
           the dark/colored variant meant for a light background. */}
       <Logo
         inverted={true}
-        containerClassName={logoStyles.logo__containerHeader}
+        containerClassName={cn(
+          logoStyles.logo__containerHeader,
+          logoStyles.logo__containerHeaderMobile
+        )}
       />
     </Link>
   );

--- a/portal/src/components/common/Logo.module.css
+++ b/portal/src/components/common/Logo.module.css
@@ -15,3 +15,10 @@
   padding-left: 16px;
   padding-right: 0.5rem;
 }
+
+/* Mobile header without a hamburger: the header already pads 16px on the
+   left (the hamburger's slot), so the logo must not add its own or it lands
+   at 32px, misaligned with the 16px content edge below it. */
+.logo__container.logo__containerHeaderMobile {
+  padding-left: 0;
+}

--- a/portal/src/components/header/ProjectSelector.tsx
+++ b/portal/src/components/header/ProjectSelector.tsx
@@ -46,13 +46,9 @@ const ProjectSelector: React.VFC<ProjectSelectorProps> =
       });
     }, [apps, isAuthgearOnce, authgearAppID]);
 
-    const sortedApps = useMemo(() => {
-      return [...filteredApps].sort((a, b) => a.appID.localeCompare(b.appID));
-    }, [filteredApps]);
-
     const otherApps = useMemo(() => {
-      return sortedApps.filter((app) => app.appID !== displayAppID);
-    }, [sortedApps, displayAppID]);
+      return filteredApps.filter((app) => app.appID !== displayAppID);
+    }, [filteredApps, displayAppID]);
 
     const createButtonDisabled =
       isProjectQuotaReached(viewer ?? null) || isAuthgearOnce;

--- a/portal/src/graphql/portal/AppsScreen.module.css
+++ b/portal/src/graphql/portal/AppsScreen.module.css
@@ -2,7 +2,23 @@
   display: flex;
   flex-direction: column;
   height: 100vh;
+  /* The panel is fixed-height on mobile too, so prefer the dynamic viewport
+     unit where available: on iOS Safari 100vh includes the area behind the
+     browser toolbar and would hide the bottom of the list. Older browsers
+     ignore this line and keep the 100vh above. */
+  /* stylelint-disable-next-line plugin/no-unsupported-browser-features */
+  height: 100dvh;
   width: 100vw;
+}
+
+/* Unlike ScreenLayoutScrollView, this stays a fixed-height container on
+   mobile too, so the panel can fill the viewport under the header and scroll
+   its rows internally on every width. */
+.content {
+  flex: 1 0 0;
+  min-width: 0;
+  min-height: 0;
+  overflow: auto;
 }
 
 .body {
@@ -10,12 +26,41 @@
   max-width: 720px;
   margin: 0 auto;
   padding: 24px 20px 40px;
+  box-sizing: border-box;
+  /* Fill the container so the panel can cap its height and scroll the rows
+     inside itself. */
+  height: 100%;
   display: flex;
   flex-direction: column;
-  row-gap: 20px;
+
+  /* On mobile the panel goes edge to edge under the header. */
+  @apply mobile:max-w-none mobile:p-0;
+}
+
+/* The title, toolbar and rows share one bordered panel; the rows are divided
+   by hairlines inside it, like the other v2 list tables. The panel is a
+   column that shrinks to the available height, and only .list scrolls, so the
+   title, toolbar and border stay put however long the list is. */
+.panel {
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+  border: 1px solid var(--gray-a6);
+  border-radius: var(--radius-3);
+  background-color: var(--color-panel-solid);
+
+  /* Full width and full height on mobile; the header already draws the
+     hairline above it, so the panel needs no border of its own. */
+  @apply mobile:flex-1 mobile:border-0 mobile:rounded-none;
+}
+
+.panelTitle {
+  flex: none;
+  padding: 20px 16px 0;
 }
 
 .toolbar {
+  flex: none;
   display: flex;
   flex-direction: row;
   /* The v2 TextField reserves an error/hint row below the input, making its
@@ -24,6 +69,8 @@
      reserved space. */
   align-items: flex-start;
   gap: 12px;
+  padding: 16px 16px 12px;
+  border-bottom: 1px solid var(--gray-a6);
 }
 
 .search {
@@ -31,43 +78,62 @@
   min-width: 0;
 }
 
+.quota {
+  flex: none;
+  padding: 12px 16px;
+}
+
 .list {
   display: flex;
   flex-direction: column;
-  row-gap: 12px;
+  flex: 1 1 auto;
+  min-height: 0;
+  overflow-y: auto;
+  /* Clip scrolled rows (and their hover background) to the panel's rounded
+     bottom corners. */
+  border-bottom-left-radius: calc(var(--radius-3) - 1px);
+  border-bottom-right-radius: calc(var(--radius-3) - 1px);
+
+  @apply mobile:rounded-none;
 }
 
-.card {
-  display: flex;
-  flex-direction: column;
-  row-gap: 4px;
-  padding: 16px;
-  border: 1px solid var(--gray-a5);
-  border-radius: var(--radius-3);
-  background-color: var(--color-panel-solid);
+/* When the quota callout sits between the toolbar and the rows, restore the
+   hairline above the first row. */
+.quota + .list {
+  border-top: 1px solid var(--gray-a6);
+}
+
+.row {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
+  column-gap: 16px;
+  align-items: baseline;
+  padding: 14px 16px;
   text-decoration: none;
-  transition: border-color 0.15s ease, background-color 0.15s ease;
+  transition: background-color 0.15s ease;
 }
 
-.card:hover {
-  border-color: var(--accent-8);
-  background-color: var(--accent-a2);
+.row + .row {
+  border-top: 1px solid var(--gray-a6);
 }
 
-.cardAppID {
+.row:hover {
+  background-color: var(--gray-a2);
+}
+
+.rowAppID {
   color: var(--gray-12);
   /* Deprecated but safari does not support "overflow-wrap: break-word;" */
   /* stylelint-disable-next-line declaration-property-value-keyword-no-deprecated */
   word-break: break-word;
 }
 
-.cardAppName {
+.rowOrigin {
   color: var(--gray-a11);
-  /* stylelint-disable-next-line declaration-property-value-keyword-no-deprecated */
-  word-break: break-word;
+  text-align: right;
 }
 
 .emptyText {
-  padding: 24px 0;
+  padding: 24px 16px;
   text-align: center;
 }

--- a/portal/src/graphql/portal/AppsScreen.tsx
+++ b/portal/src/graphql/portal/AppsScreen.tsx
@@ -11,7 +11,6 @@ import { Callout } from "../../components/v2/Callout/Callout";
 import ShowError from "../../ShowError";
 import ShowLoading from "../../ShowLoading";
 import ScreenHeader from "../../ScreenHeader";
-import ScreenLayoutScrollView from "../../ScreenLayoutScrollView";
 import ExternalLink from "../../ExternalLink";
 import { useAppListQuery } from "./query/appListQuery";
 import { useViewerQuery } from "./query/viewerQuery";
@@ -23,14 +22,14 @@ import { toTypedID } from "../../util/graphql";
 import { useSystemConfig } from "../../context/SystemConfigContext";
 import { shouldShowSurvey } from "../../util/survey";
 
-interface AppCardData {
-  appName: string;
+interface AppRowData {
   appID: string;
+  publicOrigin: string;
   url: string;
 }
 
-const AppCard: React.VFC<AppCardData> = function AppCard(props: AppCardData) {
-  const { appName, appID, url } = props;
+const AppRow: React.VFC<AppRowData> = function AppRow(props: AppRowData) {
+  const { appID, publicOrigin, url } = props;
   const capture = useCapture();
   const onClick = useCallback(() => {
     capture(
@@ -45,12 +44,12 @@ const AppCard: React.VFC<AppCardData> = function AppCard(props: AppCardData) {
   }, [appID, capture]);
 
   return (
-    <Link to={url} className={styles.card} onClick={onClick}>
-      <Text as="p" size="3" weight="bold" className={styles.cardAppID}>
+    <Link to={url} className={styles.row} onClick={onClick}>
+      <Text as="p" size="2" weight="medium" className={styles.rowAppID}>
         {appID}
       </Text>
-      <Text as="p" size="2" className={styles.cardAppName}>
-        {appName}
+      <Text as="p" size="2" truncate={true} className={styles.rowOrigin}>
+        {publicOrigin}
       </Text>
     </Link>
   );
@@ -69,25 +68,131 @@ function ProjectQuotaMessageBar(
     return null;
   }
   return (
-    <Callout
-      type="info"
-      showCloseButton={false}
-      text={
-        <FormattedMessage
-          id="AppsScreen.project-quota-reached"
-          values={{
-            // eslint-disable-next-line react/no-unstable-nested-components
-            externalLink: (chunks: React.ReactNode) => (
-              <ExternalLink href="https://go.authgear.com/portal-support">
-                {chunks}
-              </ExternalLink>
-            ),
-          }}
-        />
-      }
-    />
+    <div className={styles.quota}>
+      <Callout
+        type="info"
+        showCloseButton={false}
+        text={
+          <FormattedMessage
+            id="AppsScreen.project-quota-reached"
+            values={{
+              // eslint-disable-next-line react/no-unstable-nested-components
+              externalLink: (chunks: React.ReactNode) => (
+                <ExternalLink href="https://go.authgear.com/portal-support">
+                  {chunks}
+                </ExternalLink>
+              ),
+            }}
+          />
+        }
+      />
+    </div>
   );
 }
+
+interface AppListPanelProps {
+  apps: AppListItem[];
+  viewer: Viewer;
+  isAuthgearOnce: boolean;
+  onCreateClick: (e: React.MouseEvent<HTMLButtonElement>) => void;
+}
+
+// AppListPanel is the presentational part of the projects page: the bordered
+// panel holding the title, the sticky search/create toolbar and the rows. It
+// does no data fetching of its own.
+const AppListPanel: React.VFC<AppListPanelProps> = function AppListPanel(
+  props: AppListPanelProps
+) {
+  const { apps, viewer, isAuthgearOnce, onCreateClick } = props;
+  const { renderToString } = React.useContext(Context);
+  const projectQuotaReached = isProjectQuotaReached(viewer);
+  const createButtonDisabled = projectQuotaReached || isAuthgearOnce;
+
+  const [searchKeyword, setSearchKeyword] = useState("");
+
+  const appRowsData: AppRowData[] = useMemo(() => {
+    // The API returns projects in no particular order; sort them A-Z by ID,
+    // which is the leading column of each row.
+    return [...apps]
+      .sort((a, b) => a.appID.localeCompare(b.appID))
+      .map((app) => {
+        const appID = app.appID;
+        const typedID = toTypedID("App", appID);
+        const relPath = "/project/" + encodeURIComponent(typedID);
+        return {
+          appID,
+          publicOrigin: app.publicOrigin,
+          url: relPath,
+        };
+      });
+  }, [apps]);
+
+  const filteredAppRowsData = useMemo(() => {
+    const keyword = searchKeyword.trim().toLowerCase();
+    if (keyword === "") {
+      return appRowsData;
+    }
+    return appRowsData.filter(
+      (a) =>
+        a.appID.toLowerCase().includes(keyword) ||
+        a.publicOrigin.toLowerCase().includes(keyword)
+    );
+  }, [appRowsData, searchKeyword]);
+
+  const onChangeSearchKeyword = useCallback(
+    (e: React.ChangeEvent<HTMLInputElement>) => {
+      setSearchKeyword(e.currentTarget.value);
+    },
+    []
+  );
+
+  return (
+    <section className={styles.body}>
+      <div className={styles.panel}>
+        <Heading as="h1" size="6" weight="bold" className={styles.panelTitle}>
+          <FormattedMessage id="AppsScreen.title" />
+        </Heading>
+        <div className={styles.toolbar}>
+          <div className={styles.search}>
+            <TextField
+              size="3"
+              iconStart={TextFieldIcon.MagnifyingGlass}
+              placeholder={renderToString("AppsScreen.search.placeholder")}
+              value={searchKeyword}
+              onChange={onChangeSearchKeyword}
+            />
+          </div>
+          {!isAuthgearOnce ? (
+            <PrimaryButton
+              size="3"
+              onClick={onCreateClick}
+              text={<FormattedMessage id="AppsScreen.create-app" />}
+              disabled={createButtonDisabled}
+            />
+          ) : null}
+        </div>
+        {!isAuthgearOnce ? <ProjectQuotaMessageBar viewer={viewer} /> : null}
+        <section className={styles.list}>
+          {filteredAppRowsData.length > 0 ? (
+            filteredAppRowsData.map((appRowData) => {
+              return <AppRow key={appRowData.appID} {...appRowData} />;
+            })
+          ) : (
+            <Text as="p" size="2" color="gray" className={styles.emptyText}>
+              <FormattedMessage
+                id={
+                  searchKeyword.trim() === ""
+                    ? "AppsScreen.no-projects"
+                    : "AppsScreen.no-search-results"
+                }
+              />
+            </Text>
+          )}
+        </section>
+      </div>
+    </section>
+  );
+};
 
 interface AppListProps {
   apps: AppListItem[] | null;
@@ -96,15 +201,9 @@ interface AppListProps {
 
 const AppList: React.VFC<AppListProps> = function AppList(props: AppListProps) {
   const { apps: unfilteredApps, viewer } = props;
-  const { renderToString } = React.useContext(Context);
-  const projectQuotaReached = isProjectQuotaReached(viewer);
   const navigate = useNavigate();
   const systemConfig = useSystemConfig();
   const { authgearAppID, isAuthgearOnce } = systemConfig;
-
-  const [searchKeyword, setSearchKeyword] = useState("");
-
-  const createButtonDisabled = projectQuotaReached || isAuthgearOnce;
 
   const onCreateClick = useCallback(
     (e: React.MouseEvent<HTMLButtonElement>) => {
@@ -137,39 +236,6 @@ const AppList: React.VFC<AppListProps> = function AppList(props: AppListProps) {
     viewer,
   ]);
 
-  const appCardsData: AppCardData[] = useMemo(() => {
-    return apps.map((app) => {
-      const appID = app.appID;
-      const appOrigin = app.publicOrigin;
-      const typedID = toTypedID("App", appID);
-      const relPath = "/project/" + encodeURIComponent(typedID);
-      return {
-        appID,
-        appName: appOrigin,
-        url: relPath,
-      };
-    });
-  }, [apps]);
-
-  const filteredAppCardsData = useMemo(() => {
-    const keyword = searchKeyword.trim().toLowerCase();
-    if (keyword === "") {
-      return appCardsData;
-    }
-    return appCardsData.filter(
-      (a) =>
-        a.appID.toLowerCase().includes(keyword) ||
-        a.appName.toLowerCase().includes(keyword)
-    );
-  }, [appCardsData, searchKeyword]);
-
-  const onChangeSearchKeyword = useCallback(
-    (e: React.ChangeEvent<HTMLInputElement>) => {
-      setSearchKeyword(e.currentTarget.value);
-    },
-    []
-  );
-
   if (isAuthgearOnce && apps.length === 1) {
     return (
       <Navigate
@@ -182,50 +248,14 @@ const AppList: React.VFC<AppListProps> = function AppList(props: AppListProps) {
   return (
     <main className={styles.root}>
       <ScreenHeader showHamburger={false} />
-      <ScreenLayoutScrollView>
-        <section className={styles.body}>
-          <Heading as="h1" size="6" weight="bold">
-            <FormattedMessage id="AppsScreen.title" />
-          </Heading>
-          <div className={styles.toolbar}>
-            <div className={styles.search}>
-              <TextField
-                size="3"
-                iconStart={TextFieldIcon.MagnifyingGlass}
-                placeholder={renderToString("AppsScreen.search.placeholder")}
-                value={searchKeyword}
-                onChange={onChangeSearchKeyword}
-              />
-            </div>
-            {!isAuthgearOnce ? (
-              <PrimaryButton
-                size="3"
-                onClick={onCreateClick}
-                text={<FormattedMessage id="AppsScreen.create-app" />}
-                disabled={createButtonDisabled}
-              />
-            ) : null}
-          </div>
-          {!isAuthgearOnce ? <ProjectQuotaMessageBar viewer={viewer} /> : null}
-          <section className={styles.list}>
-            {filteredAppCardsData.length > 0 ? (
-              filteredAppCardsData.map((appCardData) => {
-                return <AppCard key={appCardData.appID} {...appCardData} />;
-              })
-            ) : (
-              <Text as="p" size="2" color="gray" className={styles.emptyText}>
-                <FormattedMessage
-                  id={
-                    searchKeyword.trim() === ""
-                      ? "AppsScreen.no-projects"
-                      : "AppsScreen.no-search-results"
-                  }
-                />
-              </Text>
-            )}
-          </section>
-        </section>
-      </ScreenLayoutScrollView>
+      <div className={styles.content}>
+        <AppListPanel
+          apps={apps}
+          viewer={viewer}
+          isAuthgearOnce={isAuthgearOnce}
+          onCreateClick={onCreateClick}
+        />
+      </div>
     </main>
   );
 };

--- a/portal/src/graphql/portal/AppsScreen.tsx
+++ b/portal/src/graphql/portal/AppsScreen.tsx
@@ -111,20 +111,17 @@ const AppListPanel: React.VFC<AppListPanelProps> = function AppListPanel(
   const [searchKeyword, setSearchKeyword] = useState("");
 
   const appRowsData: AppRowData[] = useMemo(() => {
-    // The API returns projects in no particular order; sort them A-Z by ID,
-    // which is the leading column of each row.
-    return [...apps]
-      .sort((a, b) => a.appID.localeCompare(b.appID))
-      .map((app) => {
-        const appID = app.appID;
-        const typedID = toTypedID("App", appID);
-        const relPath = "/project/" + encodeURIComponent(typedID);
-        return {
-          appID,
-          publicOrigin: app.publicOrigin,
-          url: relPath,
-        };
-      });
+    // The API returns the list sorted A-Z by app ID.
+    return apps.map((app) => {
+      const appID = app.appID;
+      const typedID = toTypedID("App", appID);
+      const relPath = "/project/" + encodeURIComponent(typedID);
+      return {
+        appID,
+        publicOrigin: app.publicOrigin,
+        url: relPath,
+      };
+    });
   }, [apps]);
 
   const filteredAppRowsData = useMemo(() => {

--- a/portal/src/graphql/portal/globalTypes.generated.ts
+++ b/portal/src/graphql/portal/globalTypes.generated.ts
@@ -632,7 +632,7 @@ export type Query = {
   __typename?: 'Query';
   /** Active users chart dataset */
   activeUserChart?: Maybe<Chart>;
-  /** The list of apps accessible to the current viewer */
+  /** The list of apps accessible to the current viewer, sorted by app ID in ascending order */
   appList?: Maybe<Array<AppListItem>>;
   /** Check whether the viewer can accept the collaboration invitation */
   checkCollaboratorInvitation?: Maybe<CheckCollaboratorInvitationPayload>;

--- a/portal/src/graphql/portal/schema.graphql
+++ b/portal/src/graphql/portal/schema.graphql
@@ -717,7 +717,9 @@ type Query {
     rangeTo: Date!
   ): Chart
 
-  """The list of apps accessible to the current viewer"""
+  """
+  The list of apps accessible to the current viewer, sorted by app ID in ascending order
+  """
   appList: [AppListItem!]
 
   """Check whether the viewer can accept the collaboration invitation"""


### PR DESCRIPTION
ref [DEV-3841](https://linear.app/authgear/issue/DEV-3841/project-listing-should-be-sorted-by-alphabetical-order)

## What

The project list in the portal was rendered in the order the API returned, which made projects hard to find.

- Sort the list on the server: `AppService.GetAppList` now returns projects in ascending app ID order for every client, whichever config source produced the IDs, and the `appList` field description documents the order. The client-side sorts in the projects page and in the header's project selector are removed.
- Present the list as one bordered panel: title, search box and Create button, then tight two-column rows with the project ID on the left and its public origin on the right, divided by hairlines like the other v2 list tables.
- Cap the panel to the viewport and scroll only the rows, so the title and toolbar stay visible however long the list is.
- On mobile, the panel fills the area under the screen header edge to edge. The screen uses its own fixed-height container instead of `ScreenLayoutScrollView`, whose mobile override lets the page scroll instead.
- Fix a pre-existing mobile header bug this exposed: on pages without a hamburger button the logo kept its own left padding on top of the header's, landing 16px too far right. Also affects the project wizard and accept-invitation screens.

## Notes

- No change to the GraphQL shape or i18n strings; only the `appList` description changes, with the schema and generated types regenerated. Search still matches on both the ID and the origin.
- The page root prefers `100dvh` over `100vh` where supported so the fixed-height panel does not hide behind the iOS Safari toolbar; older browsers keep `100vh`. This needs a stylelint disable because the browserslist still includes iOS 14.5.

## Testing

- New unit test for the server-side sort in `pkg/portal/service`. `go test ./pkg/portal/... ./cmd/portal/...`, golangci-lint, and goanalysis pass on the touched packages.
- Full portal CI sequence passes locally: typecheck, eslint, stylelint, prettier, tests, gentype, build.
- Verified visually on desktop and mobile widths with 0, 2, and 50 projects, including the quota-reached callout.

## Screenshots

2 projects: 
<img width="1089" height="751" alt="SCR-20260909-mqfc" src="https://github.com/user-attachments/assets/59bc32f9-931a-4f65-8d42-0e282ccc46b7" />

50 projects:
<img width="1091" height="750" alt="SCR-20260909-mqgv" src="https://github.com/user-attachments/assets/edaf82d7-be90-4fff-bc50-2864b2df228e" />

Quota exceeded:
<img width="956" height="661" alt="image" src="https://github.com/user-attachments/assets/bdddaca8-b1f7-47fd-b6a7-c90bf0b42078" />
