### PR TITLE
Add config to disable source map and add basic auth to source maps

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -80,6 +80,17 @@ CONFIG_SOURCE_DIRECTORY=./var
 # Portal frontend Sentry
 #PORTAL_FRONTEND_SENTRY_DSN=
 
+# Source map files (*.map) embed the application source code, so they are NOT served by default.
+# Set SOURCE_MAP_ENABLED=true to serve them.
+SOURCE_MAP_ENABLED=true
+# When SOURCE_MAP_SENTRY_TOKEN is non-empty, source map files are additionally protected by
+# HTTP basic authentication, with the token being the password. The username is ignored.
+# This is intended for Sentry, which fetches publicly hosted source maps with a configurable header.
+# In the Sentry project settings, set "Security Token Header" to Authorization,
+# and "Security Token" to "Basic <base64 of :the-token>".
+# See https://docs.sentry.io/platforms/javascript/sourcemaps/uploading/hosting-publicly/
+#SOURCE_MAP_SENTRY_TOKEN=
+
 SEARCH_ENABLED=true
 WEB3_ENABLED=true
 AUDIT_LOG_ENABLED=true

--- a/.vettedpositions
+++ b/.vettedpositions
@@ -352,7 +352,7 @@
 /pkg/util/httproute/httproute.go:150:38: requestcontext
 /pkg/util/httputil/csp.go:158:42: requestcontext
 /pkg/util/httputil/csp.go:164:42: requestcontext
-/pkg/util/httputil/file_server.go:116:11: requestcontext
+/pkg/util/httputil/file_server.go:167:11: requestcontext
 /pkg/util/httputil/json.go:96:9: requestcontext
 /pkg/util/httputil/result.go:29:11: requestcontext
 /pkg/util/jwkutil/contextbackground.go:11:52: contextbackground

--- a/.vettedpositions
+++ b/.vettedpositions
@@ -56,7 +56,7 @@
 /pkg/auth/handler/saml/logout.go:621:46: requestcontext
 /pkg/auth/handler/saml/logout.go:624:31: requestcontext
 /pkg/auth/handler/webapp/account_status.go:48:27: requestcontext
-/pkg/auth/handler/webapp/app_static_assets.go:39:33: requestcontext
+/pkg/auth/handler/webapp/app_static_assets.go:40:33: requestcontext
 /pkg/auth/handler/webapp/auth_entry_point_middleware.go:35:10: requestcontext
 /pkg/auth/handler/webapp/authflow_change_password.go:96:26: requestcontext
 /pkg/auth/handler/webapp/authflow_controller.go:1070:30: requestcontext

--- a/pkg/auth/handler/webapp/app_static_assets.go
+++ b/pkg/auth/handler/webapp/app_static_assets.go
@@ -32,6 +32,7 @@ type ResourceManager interface {
 
 type AppStaticAssetsHandler struct {
 	Resources ResourceManager
+	SourceMap httputil.SourceMapConfig
 }
 
 func (h *AppStaticAssetsHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
@@ -39,6 +40,7 @@ func (h *AppStaticAssetsHandler) ServeHTTP(w http.ResponseWriter, r *http.Reques
 		FileSystem:          h.makeFs(r.Context()),
 		AssetsDir:           web.AppAssetsURLDirname,
 		FallbackToIndexHTML: false,
+		SourceMap:           h.SourceMap,
 	}
 	fileServer.ServeHTTP(w, r)
 }

--- a/pkg/auth/handler/webapp/generated_static_assets.go
+++ b/pkg/auth/handler/webapp/generated_static_assets.go
@@ -20,6 +20,7 @@ type GlobalEmbeddedResourceManager interface {
 
 type GeneratedStaticAssetsHandler struct {
 	EmbeddedResources GlobalEmbeddedResourceManager
+	SourceMap         httputil.SourceMapConfig
 }
 
 func (h *GeneratedStaticAssetsHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
@@ -27,6 +28,7 @@ func (h *GeneratedStaticAssetsHandler) ServeHTTP(w http.ResponseWriter, r *http.
 		FileSystem:          h.EmbeddedResources,
 		AssetsDir:           web.GeneratedAssetsURLDirname,
 		FallbackToIndexHTML: false,
+		SourceMap:           h.SourceMap,
 	}
 	fileServer.ServeHTTP(w, r)
 }

--- a/pkg/auth/wire_gen.go
+++ b/pkg/auth/wire_gen.go
@@ -144,8 +144,11 @@ func newHealthzHandler(p *deps.RootProvider, w http.ResponseWriter, r *http.Requ
 
 func newWebAppGeneratedStaticAssetsHandler(p *deps.RootProvider, w http.ResponseWriter, r *http.Request, ctx context.Context) http.Handler {
 	globalEmbeddedResourceManager := p.EmbeddedResources
+	environmentConfig := p.EnvironmentConfig
+	sourceMapConfig := deps.ProvideSourceMapConfig(environmentConfig)
 	generatedStaticAssetsHandler := &webapp.GeneratedStaticAssetsHandler{
 		EmbeddedResources: globalEmbeddedResourceManager,
+		SourceMap:         sourceMapConfig,
 	}
 	return generatedStaticAssetsHandler
 }
@@ -41301,8 +41304,12 @@ func newWebAppAppStaticAssetsHandler(p *deps.RequestProvider) http.Handler {
 	appProvider := p.AppProvider
 	appContext := appProvider.AppContext
 	manager := appContext.Resources
+	rootProvider := appProvider.RootProvider
+	environmentConfig := rootProvider.EnvironmentConfig
+	sourceMapConfig := deps.ProvideSourceMapConfig(environmentConfig)
 	appStaticAssetsHandler := &webapp.AppStaticAssetsHandler{
 		Resources: manager,
+		SourceMap: sourceMapConfig,
 	}
 	return appStaticAssetsHandler
 }

--- a/pkg/lib/config/environment.go
+++ b/pkg/lib/config/environment.go
@@ -138,4 +138,7 @@ type EnvironmentConfig struct {
 
 	// Analytic configures analytics forwarding (e.g. PostHog) from the server runtime.
 	Analytic AnalyticConfig `envconfig:"ANALYTIC"`
+
+	// SourceMap configures how source map files (*.map) are served.
+	SourceMap SourceMapEnvironmentConfig `envconfig:"SOURCE_MAP"`
 }

--- a/pkg/lib/config/source_map_env.go
+++ b/pkg/lib/config/source_map_env.go
@@ -1,0 +1,12 @@
+package config
+
+type SourceMapEnvironmentConfig struct {
+	// Enabled sets whether source map files (*.map) are served.
+	// It is false by default so that the application source code is not disclosed.
+	Enabled bool `envconfig:"ENABLED" default:"false"`
+	// SentryToken sets the token Sentry sends when it fetches a publicly hosted source map file.
+	// When it is non-empty, source map files are protected by HTTP basic authentication,
+	// with the token being the password.
+	// See https://docs.sentry.io/platforms/javascript/sourcemaps/uploading/hosting-publicly/
+	SentryToken string `envconfig:"SENTRY_TOKEN"`
+}

--- a/pkg/lib/deps/deps_provider.go
+++ b/pkg/lib/deps/deps_provider.go
@@ -50,6 +50,7 @@ var EnvConfigDeps = wire.NewSet(
 		"SMSGatewayConfig",
 		"SharedAuthgearEndpoint",
 	),
+	ProvideSourceMapConfig,
 	wire.FieldsOf(new(*config.SMSGatewayEnvironmentConfig),
 		"Default",
 		"Twilio",
@@ -116,6 +117,13 @@ var RootDependencySet = wire.NewSet(
 		"BaseResources",
 	),
 )
+
+func ProvideSourceMapConfig(cfg *config.EnvironmentConfig) httputil.SourceMapConfig {
+	return httputil.SourceMapConfig{
+		Enabled:     cfg.SourceMap.Enabled,
+		SentryToken: cfg.SourceMap.SentryToken,
+	}
+}
 
 func ProvideRemoteIP(r *http.Request, trustProxy config.TrustProxy) httputil.RemoteIP {
 	return httputil.RemoteIP(httputil.GetIP(r, bool(trustProxy)))

--- a/pkg/portal/deps/deps.go
+++ b/pkg/portal/deps/deps.go
@@ -37,6 +37,13 @@ func ProvideConfigSource(ctrl *configsource.Controller) *configsource.ConfigSour
 	return ctrl.GetConfigSource()
 }
 
+func ProvideSourceMapConfig(cfg *config.EnvironmentConfig) httputil.SourceMapConfig {
+	return httputil.SourceMapConfig{
+		Enabled:     cfg.SourceMap.Enabled,
+		SentryToken: cfg.SourceMap.SentryToken,
+	}
+}
+
 func ProvideAuditDatabaseCredentials(cfg *config.EnvironmentConfig) *config.AuditDatabaseCredentials {
 	if cfg.AuditDatabase.DatabaseURL != "" && cfg.AuditDatabase.DatabaseSchema != "" {
 		return &config.AuditDatabaseCredentials{
@@ -100,6 +107,7 @@ var DependencySet = wire.NewSet(
 	ProvideConfigSource,
 	ProvideAppBaseResources,
 	ProvideAuditDatabaseCredentials,
+	ProvideSourceMapConfig,
 	wire.Bind(new(template.ResourceManager), new(*resource.Manager)),
 	wire.Value(template.DefaultLanguageTag(intl.BuiltinBaseLanguage)),
 	wire.Value(template.SupportedLanguageTags([]string{intl.BuiltinBaseLanguage})),

--- a/pkg/portal/transport/static_assets_handler.go
+++ b/pkg/portal/transport/static_assets_handler.go
@@ -15,6 +15,7 @@ type ResourceManager interface {
 
 type StaticAssetsHandler struct {
 	Resources ResourceManager
+	SourceMap httputil.SourceMapConfig
 }
 
 func (h *StaticAssetsHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
@@ -22,6 +23,7 @@ func (h *StaticAssetsHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) 
 		FileSystem:          h,
 		AssetsDir:           "shared-assets",
 		FallbackToIndexHTML: true,
+		SourceMap:           h.SourceMap,
 	}
 	server.ServeHTTP(w, r)
 }

--- a/pkg/portal/wire_gen.go
+++ b/pkg/portal/wire_gen.go
@@ -553,8 +553,11 @@ func newAdminAPIHandler(p *deps.RequestProvider) http.Handler {
 func newStaticAssetsHandler(p *deps.RequestProvider) http.Handler {
 	rootProvider := p.RootProvider
 	manager := rootProvider.Resources
+	environmentConfig := rootProvider.EnvironmentConfig
+	sourceMapConfig := deps.ProvideSourceMapConfig(environmentConfig)
 	staticAssetsHandler := &transport.StaticAssetsHandler{
 		Resources: manager,
+		SourceMap: sourceMapConfig,
 	}
 	return staticAssetsHandler
 }

--- a/pkg/util/filepathutil/hashed_path.go
+++ b/pkg/util/filepathutil/hashed_path.go
@@ -6,8 +6,10 @@ import (
 	"strings"
 )
 
+// IsSourceMapPath is case-insensitive so that it stays correct
+// when it guards a file system that is case-insensitive.
 func IsSourceMapPath(filePath string) bool {
-	return path.Ext(filePath) == ".map"
+	return strings.EqualFold(path.Ext(filePath), ".map")
 }
 
 func Ext(filePath string) string {

--- a/pkg/util/filepathutil/hashed_path_test.go
+++ b/pkg/util/filepathutil/hashed_path_test.go
@@ -66,5 +66,14 @@ func TestIsSourceMapPath(t *testing.T) {
 
 		result = IsSourceMapPath("style.css")
 		So(result, ShouldEqual, false)
+
+		result = IsSourceMapPath("script.hash.js.MAP")
+		So(result, ShouldEqual, true)
+
+		result = IsSourceMapPath("script.hash.js.Map")
+		So(result, ShouldEqual, true)
+
+		result = IsSourceMapPath("script.hash.js.map.")
+		So(result, ShouldEqual, false)
 	})
 }

--- a/pkg/util/httputil/file_server.go
+++ b/pkg/util/httputil/file_server.go
@@ -2,7 +2,9 @@ package httputil
 
 import (
 	"bytes"
+	"crypto/subtle"
 	"errors"
+	"fmt"
 	htmltemplate "html/template"
 	"io"
 	"io/fs"
@@ -10,7 +12,38 @@ import (
 	"path"
 	"strings"
 	"time"
+
+	"github.com/authgear/authgear-server/pkg/util/filepathutil"
 )
+
+const sourceMapBasicAuthRealm = "source map"
+
+// SourceMapConfig configures how FileServer serves source map (*.map) files.
+type SourceMapConfig struct {
+	// Enabled sets whether source map files are served at all.
+	// When it is false, source map files are served as if they did not exist.
+	Enabled bool
+	// SentryToken, when non-empty, protects source map files with HTTP basic authentication.
+	// The token is the password, and the username is ignored.
+	// Sentry fetches a publicly hosted source map with a configurable header,
+	// so it can be configured to send `Authorization: Basic <base64 of ":<token>">`.
+	// See https://docs.sentry.io/platforms/javascript/sourcemaps/uploading/hosting-publicly/
+	SentryToken string
+}
+
+// IsAuthorized tells whether r is allowed to fetch a source map file.
+func (c SourceMapConfig) IsAuthorized(r *http.Request) bool {
+	if c.SentryToken == "" {
+		return true
+	}
+
+	_, password, ok := r.BasicAuth()
+	if !ok {
+		return false
+	}
+
+	return subtle.ConstantTimeCompare([]byte(password), []byte(c.SentryToken)) == 1
+}
 
 type FileServerIndexHTMLTemplateDataKeyType struct{}
 
@@ -25,6 +58,9 @@ type FileServer struct {
 	FileSystem          http.FileSystem
 	AssetsDir           string
 	FallbackToIndexHTML bool
+	// SourceMap configures how source map (*.map) files are served.
+	// The zero value serves no source map file.
+	SourceMap SourceMapConfig
 }
 
 func (s *FileServer) writeError(w http.ResponseWriter, err error) {
@@ -42,6 +78,15 @@ func (s *FileServer) writeError(w http.ResponseWriter, err error) {
 	}
 	w.WriteHeader(http.StatusInternalServerError)
 	return
+}
+
+func (s *FileServer) writeUnauthorized(w http.ResponseWriter) {
+	// http.Error is NOT used intentionally to avoid returning a text/plain response.
+	// The desired response is WITHOUT content-type, and with content-length: 0
+	w.Header().Del("Content-Type")
+	w.Header().Set("Content-Length", "0")
+	w.Header().Set("WWW-Authenticate", fmt.Sprintf("Basic realm=%q", sourceMapBasicAuthRealm))
+	w.WriteHeader(http.StatusUnauthorized)
 }
 
 func (s *FileServer) open(name string) (http.File, fs.FileInfo, error) {
@@ -62,7 +107,7 @@ func (s *FileServer) open(name string) (http.File, fs.FileInfo, error) {
 	return file, stat, nil
 }
 
-func (s *FileServer) serveAsset(w http.ResponseWriter, r *http.Request) {
+func (s *FileServer) serveAsset(w http.ResponseWriter, r *http.Request, isSourceMap bool) {
 	file, stat, err := s.open(r.URL.Path)
 	if err != nil {
 		s.writeError(w, err)
@@ -70,7 +115,13 @@ func (s *FileServer) serveAsset(w http.ResponseWriter, r *http.Request) {
 	}
 	defer file.Close()
 
-	w.Header().Set("Cache-Control", "public, max-age=604800")
+	if isSourceMap {
+		// A source map response can be protected by credentials,
+		// so it must never be stored by a shared cache.
+		w.Header().Set("Cache-Control", "no-store")
+	} else {
+		w.Header().Set("Cache-Control", "public, max-age=604800")
+	}
 	http.ServeContent(w, r, stat.Name(), stat.ModTime(), file)
 }
 
@@ -141,6 +192,22 @@ func (s *FileServer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	// We always normalize the path before we pass it to FileSystem.
 	r.URL.Path = path.Clean("/" + r.URL.Path)
 
+	// Source map files embed the application source code, so they are not served
+	// unless they are explicitly enabled, and they can additionally be protected
+	// by HTTP basic authentication.
+	isSourceMap := filepathutil.IsSourceMapPath(r.URL.Path)
+	if isSourceMap {
+		if !s.SourceMap.Enabled {
+			// Behave as if the source map file did not exist.
+			s.writeError(w, fs.ErrNotExist)
+			return
+		}
+		if !s.SourceMap.IsAuthorized(r) {
+			s.writeUnauthorized(w)
+			return
+		}
+	}
+
 	// First of all we need to identity whether the path
 	// seems like fetching a name-hashed file.
 	//
@@ -150,7 +217,7 @@ func (s *FileServer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	// If the request fetches a non-name-hashed file,
 	// we fallback to index.html for not found.
 	if strings.HasPrefix(r.URL.Path, "/"+s.AssetsDir) {
-		s.serveAsset(w, r)
+		s.serveAsset(w, r, isSourceMap)
 	} else {
 		s.serveOther(w, r)
 	}

--- a/pkg/util/httputil/file_server_test.go
+++ b/pkg/util/httputil/file_server_test.go
@@ -88,5 +88,175 @@ func TestFileServer(t *testing.T) {
 			So(w.Result().Header.Get("content-type"), ShouldEqual, "text/html; charset=utf-8")
 			So(w.Result().Header.Get("cache-control"), ShouldEqual, "no-cache")
 		})
+
+		Convey("source map is not served by default", func() {
+			dir := http.Dir("testdata/noindex")
+
+			h := &FileServer{
+				FileSystem:          dir,
+				FallbackToIndexHTML: false,
+			}
+
+			r, _ := http.NewRequest("GET", "/a-deadbeef.js.map", nil)
+			w := httptest.NewRecorder()
+			h.ServeHTTP(w, r)
+			So(w.Code, ShouldEqual, 404)
+			So(w.Result().Header.Get("cache-control"), ShouldEqual, "no-cache")
+			So(w.Result().Header.Get("content-type"), ShouldEqual, "")
+			So(w.Result().Header.Get("content-length"), ShouldEqual, "0")
+
+			// The extension is matched case-insensitively, so that the check
+			// stays correct on a case-insensitive file system.
+			r, _ = http.NewRequest("GET", "/a-deadbeef.js.MAP", nil)
+			w = httptest.NewRecorder()
+			h.ServeHTTP(w, r)
+			So(w.Code, ShouldEqual, 404)
+			So(w.Result().Header.Get("content-length"), ShouldEqual, "0")
+
+			// A trailing slash is normalized away before the check.
+			r, _ = http.NewRequest("GET", "/a-deadbeef.js.map/", nil)
+			w = httptest.NewRecorder()
+			h.ServeHTTP(w, r)
+			So(w.Code, ShouldEqual, 404)
+			So(w.Result().Header.Get("content-length"), ShouldEqual, "0")
+		})
+
+		Convey("source map is not served by default, even when index.html is the fallback", func() {
+			dir := http.Dir("testdata/index")
+
+			h := &FileServer{
+				FileSystem:          dir,
+				AssetsDir:           "shared-assets",
+				FallbackToIndexHTML: true,
+			}
+
+			// A source map that exists.
+			r, _ := http.NewRequest("GET", "/shared-assets/a-deadbeef.js.map", nil)
+			w := httptest.NewRecorder()
+			h.ServeHTTP(w, r)
+			So(w.Code, ShouldEqual, 404)
+			So(w.Result().Header.Get("content-length"), ShouldEqual, "0")
+
+			// A source map that does not exist MUST NOT fall back to index.html.
+			r, _ = http.NewRequest("GET", "/no-such-file.js.map", nil)
+			w = httptest.NewRecorder()
+			h.ServeHTTP(w, r)
+			So(w.Code, ShouldEqual, 404)
+			So(w.Result().Header.Get("content-length"), ShouldEqual, "0")
+		})
+
+		Convey("source map is served when it is enabled", func() {
+			dir := http.Dir("testdata/noindex")
+
+			h := &FileServer{
+				FileSystem:          dir,
+				FallbackToIndexHTML: false,
+				SourceMap: SourceMapConfig{
+					Enabled: true,
+				},
+			}
+
+			r, _ := http.NewRequest("GET", "/a-deadbeef.js.map", nil)
+			w := httptest.NewRecorder()
+			h.ServeHTTP(w, r)
+			So(w.Code, ShouldEqual, 200)
+			So(w.Body.String(), ShouldContainSubstring, "sourcesContent")
+
+			// Non source map files are unaffected.
+			r, _ = http.NewRequest("GET", "/a-deadbeef.js", nil)
+			w = httptest.NewRecorder()
+			h.ServeHTTP(w, r)
+			So(w.Code, ShouldEqual, 200)
+		})
+
+		Convey("source map served from the assets dir is never publicly cacheable", func() {
+			dir := http.Dir("testdata/index")
+
+			h := &FileServer{
+				FileSystem:          dir,
+				AssetsDir:           "shared-assets",
+				FallbackToIndexHTML: true,
+				SourceMap: SourceMapConfig{
+					Enabled: true,
+				},
+			}
+
+			// A source map can be protected by credentials,
+			// so it must not be stored by a shared cache.
+			r, _ := http.NewRequest("GET", "/shared-assets/a-deadbeef.js.map", nil)
+			w := httptest.NewRecorder()
+			h.ServeHTTP(w, r)
+			So(w.Code, ShouldEqual, 200)
+			So(w.Result().Header.Get("cache-control"), ShouldEqual, "no-store")
+
+			// Other name-hashed assets keep the long-lived public cache.
+			r, _ = http.NewRequest("GET", "/shared-assets/a-deadbeef.js", nil)
+			w = httptest.NewRecorder()
+			h.ServeHTTP(w, r)
+			So(w.Code, ShouldEqual, 200)
+			So(w.Result().Header.Get("cache-control"), ShouldEqual, "public, max-age=604800")
+		})
+
+		Convey("source map is protected by basic auth when a sentry token is set", func() {
+			dir := http.Dir("testdata/noindex")
+
+			h := &FileServer{
+				FileSystem:          dir,
+				FallbackToIndexHTML: false,
+				SourceMap: SourceMapConfig{
+					Enabled:     true,
+					SentryToken: "s3cret",
+				},
+			}
+
+			// No credentials.
+			r, _ := http.NewRequest("GET", "/a-deadbeef.js.map", nil)
+			w := httptest.NewRecorder()
+			h.ServeHTTP(w, r)
+			So(w.Code, ShouldEqual, 401)
+			So(w.Result().Header.Get("www-authenticate"), ShouldEqual, `Basic realm="source map"`)
+			So(w.Result().Header.Get("content-type"), ShouldEqual, "")
+			So(w.Result().Header.Get("content-length"), ShouldEqual, "0")
+
+			// Wrong password.
+			r, _ = http.NewRequest("GET", "/a-deadbeef.js.map", nil)
+			r.SetBasicAuth("sentry", "wrong")
+			w = httptest.NewRecorder()
+			h.ServeHTTP(w, r)
+			So(w.Code, ShouldEqual, 401)
+
+			// Correct password. The username is ignored.
+			r, _ = http.NewRequest("GET", "/a-deadbeef.js.map", nil)
+			r.SetBasicAuth("", "s3cret")
+			w = httptest.NewRecorder()
+			h.ServeHTTP(w, r)
+			So(w.Code, ShouldEqual, 200)
+			So(w.Body.String(), ShouldContainSubstring, "sourcesContent")
+
+			// Non source map files are NOT protected.
+			r, _ = http.NewRequest("GET", "/a-deadbeef.js", nil)
+			w = httptest.NewRecorder()
+			h.ServeHTTP(w, r)
+			So(w.Code, ShouldEqual, 200)
+		})
+
+		Convey("the sentry token does not enable source map serving on its own", func() {
+			dir := http.Dir("testdata/noindex")
+
+			h := &FileServer{
+				FileSystem:          dir,
+				FallbackToIndexHTML: false,
+				SourceMap: SourceMapConfig{
+					Enabled:     false,
+					SentryToken: "s3cret",
+				},
+			}
+
+			r, _ := http.NewRequest("GET", "/a-deadbeef.js.map", nil)
+			r.SetBasicAuth("", "s3cret")
+			w := httptest.NewRecorder()
+			h.ServeHTTP(w, r)
+			So(w.Code, ShouldEqual, 404)
+		})
 	})
 }

--- a/pkg/util/httputil/testdata/index/shared-assets/a-deadbeef.js.map
+++ b/pkg/util/httputil/testdata/index/shared-assets/a-deadbeef.js.map
@@ -1,0 +1,1 @@
+{"version":3,"file":"a-deadbeef.js","sources":["a.ts"],"sourcesContent":["export const a = 1;\n"],"mappings":""}

--- a/pkg/util/httputil/testdata/noindex/a-deadbeef.js.map
+++ b/pkg/util/httputil/testdata/noindex/a-deadbeef.js.map
@@ -1,0 +1,1 @@
+{"version":3,"file":"a-deadbeef.js","sources":["a.ts"],"sourcesContent":["export const a = 1;\n"],"mappings":""}


### PR DESCRIPTION
ref DEV-3677

How to test:

1. Ensure all assets are built: `make authui && make portal`.
  You can find the source map files in You can find the source map files in resources/portal/static/shared-assets and resources/authgear/generated/shared-assets.
2. By default source maps are disabled. The source map files will return 404.
  Try http://localhost:3100/shared-assets/NAME.js.map or http://localhost:8010/shared-assets/NAME.js.map
4. Set `SOURCE_MAP_ENABLED=true`, now you should be able to get the source map files.
5. Set `SOURCE_MAP_SENTRY_TOKEN=yourtoken`, now when you open chrome inspector in localhost:3100 or localhost:8010, you will see it prompt for username password. Type `yourtoken` in password then you can load the sourcemap.