### PR TITLE
Ensure cimd and dcr works in common ai agents

### DIFF
--- a/docs/specs/cimd.md
+++ b/docs/specs/cimd.md
@@ -271,7 +271,9 @@ Unlike DCR, it **controls nothing**. It is validated, persisted and reported thr
 
 ### `token_endpoint_auth_method` (optional)
 
-Must be `none` if present. Any other value — including `private_key_jwt` and any `client_secret_*` variant — is out of scope for this v1 proposal; see [Client Authentication](#client-authentication). Default when absent: `none`.
+**Ignored**, exactly as in [DCR](./dcr.md#token_endpoint_auth_method-optional). Every CIMD client is public — no `client_secret` is ever issued or accepted, and PKCE is required — so the declared value cannot change how the client authenticates, whatever it says. `private_key_jwt` and the `client_secret_*` variants are out of scope for this v1 proposal (see [Client Authentication](#client-authentication)) and declaring one is not an error; it simply has no effect.
+
+There is no need to reject in order to tell the client: `token_endpoint_auth_methods_supported` in this project's [discovery metadata](#oidc-discovery-metadata) already publishes which methods exist, and a client that reads it — as an MCP client selecting CIMD must, since it has to confirm `none` is offered before it can authenticate as a public client — learns Authgear's position without a per-document answer. Refusing the document taught its author nothing the metadata did not, while costing them every authorization.
 
 ### `logo_uri`, `client_uri`, `tos_uri`, `policy_uri` (all optional)
 
@@ -341,7 +343,7 @@ For the `authorization_code` grant specifically, the `redirect_uri` presented at
 
 ## Client Authentication
 
-CIMD clients in v1 are always **public**: `token_endpoint_auth_method` must be absent or `none`, PKCE is required exactly as it is for any other public client today, and no `client_secret` is ever issued or accepted. This keeps v1 scoped to the change that has no new cryptographic surface. Confidential CIMD clients via `private_key_jwt` + `jwks_uri` are out of scope for this proposal — the spec explicitly forbids shared-secret auth methods for CIMD clients regardless ([§4.1](https://www.ietf.org/archive/id/draft-ietf-oauth-client-id-metadata-document-02.html#section-4.1)), so any future addition would be key-based only, never `client_secret_post`/`client_secret_basic`.
+CIMD clients in v1 are always **public**: whatever `token_endpoint_auth_method` a document declares is [ignored](#token_endpoint_auth_method-optional), PKCE is required exactly as it is for any other public client today, and no `client_secret` is ever issued or accepted. This keeps v1 scoped to the change that has no new cryptographic surface. Confidential CIMD clients via `private_key_jwt` + `jwks_uri` are out of scope for this proposal — the spec explicitly forbids shared-secret auth methods for CIMD clients regardless ([§4.1](https://www.ietf.org/archive/id/draft-ietf-oauth-client-id-metadata-document-02.html#section-4.1)), so any future addition would be key-based only, never `client_secret_post`/`client_secret_basic`.
 
 ## Security Considerations
 

--- a/docs/specs/cimd.md
+++ b/docs/specs/cimd.md
@@ -219,6 +219,7 @@ See [SSRF Protection](#ssrf-protection) for why the size/timeout/redirect limits
 - The response MUST be `2xx` and MUST parse as a JSON object within the size limit described above.
 - Each field is checked against the rules in [Accepted Metadata Fields](#accepted-metadata-fields).
 - Unrecognized properties are ignored (the spec explicitly allows additional properties).
+- Unrecognized `grant_types` **values** are likewise ignored rather than fatal — see [`grant_types`](#grant_types-optional) for why, and for the one case that is still an error.
 
 A document that fails any MUST-level check is treated as if the fetch had failed (see [Error Handling](#error-handling)); it is never reused for a later request.
 
@@ -250,11 +251,17 @@ Human-readable name shown on the consent screen and in the portal. Default when 
 
 ### `grant_types` (optional)
 
-Must be a subset of `["authorization_code", "refresh_token"]`. Default when absent: `["authorization_code", "refresh_token"]`.
+Entries Authgear does not implement are **ignored**. A document that declared grant types and had every one of them ignored is rejected with `grant_type_unsupported`; otherwise what survives is subject only to the consistency rule below. Default when absent: `["authorization_code", "refresh_token"]`. Only the surviving entries are persisted and reported through `OAuthClient.grantTypes`, in the order the document listed them — so a document declaring a grant Authgear has no support for is valid, and that grant simply never becomes available to the client.
+
+**Ignoring rather than rejecting** is deliberate, and differs from [DCR's rule](./dcr.md#grant_types-optional). A CIMD document is a single self-published description of a client, used against every authorization server that client talks to, so it advertises every grant the client can perform *anywhere* rather than the subset any one server implements — the client cannot tailor it per server the way a DCR request is tailored to the server it is POSTed to. [Claude's document](https://claude.ai/oauth/mcp-oauth-client-metadata) declares `urn:ietf:params:oauth:grant-type:jwt-bearer`, for [MCP Enterprise Managed Authorization](https://modelcontextprotocol.io/extensions/auth/enterprise-managed-authorization)'s identity-assertion exchange ([RFC 7523](https://datatracker.ietf.org/doc/html/rfc7523)), alongside the `authorization_code` and `refresh_token` it uses everywhere else. Rejecting the whole document over that one entry left every Claude MCP connector unresolvable, and it protected nothing: a grant type absent from Authgear's `grant_types_supported` discovery metadata is never requested, and the token endpoint answers `unsupported_grant_type` to one that is requested anyway — the persisted `grant_types` are not what gates the token endpoint.
+
+This is a **pure relaxation**: every document that resolved before this rule existed still resolves, and no new rejection reason is introduced. An explicitly empty `grant_types` is not a Rule 5 failure — it declared nothing to lose, and the consistency rule decides it as it always has — which is why the "everything ignored" rejection is scoped to a list that had entries in the first place. There is deliberately no requirement that `authorization_code` survive: a client's persisted `grant_types` gate nothing at `/oauth2/authorize` or `/oauth2/token` (`authorization_code` is allowed for every client regardless), so such a requirement would reject documents that work today while protecting nothing.
 
 ### `response_types` (optional)
 
 Must be a subset of `["code"]`, and consistent with `grant_types` (same consistency rule as [DCR](./dcr.md#response_types-optional)). Default when absent: `["code"]`.
+
+Consistency is evaluated against the **surviving** grant types — the list after the rule above has ignored what Authgear does not implement, not the list as published.
 
 ### `application_type` (optional)
 
@@ -316,7 +323,7 @@ CIMD fields map onto `OAuthClient` (see [client.md](./client.md)) as follows:
 | `client_name` (default: `Client <clientID>` when omitted) | `name`, `clientName`                                                         |
 | `client_uri`, `logo_uri`, `tos_uri`, `policy_uri`         | `clientURI`, `logoURI`, `tosURI`, `policyURI`                                |
 | `redirect_uris`                                           | `redirectURIs`                                                               |
-| `grant_types`, `response_types`                           | `grantTypes`, `responseTypes`                                                |
+| `grant_types` (unimplemented entries dropped), `response_types` | `grantTypes`, `responseTypes`                                          |
 | —                                                         | `postLogoutRedirectURIs`: always `[]`                                        |
 | —                                                         | token lifetimes from `client_config`                                         |
 | —                                                         | `registeredAt`: always `null` — there is no registration event, only a fetch |

--- a/docs/specs/dcr.md
+++ b/docs/specs/dcr.md
@@ -409,7 +409,7 @@ Error responses follow [RFC 7591 §3.2.2](https://www.rfc-editor.org/rfc/rfc7591
 
 | `error` value | HTTP status | Meaning |
 |---|---|---|
-| `invalid_redirect_uri` | 400 | One or more `redirect_uris` are invalid (e.g. plain `http://` for non-localhost) |
+| `invalid_redirect_uri` | 400 | One or more `redirect_uris` are invalid (e.g. plain `http://` for a non-loopback host) |
 | `invalid_client_metadata` | 400 | Other metadata validation failure — see table below |
 | `invalid_initial_access_token` | 401 | IAT is missing, expired, or not recognized |
 | `access_denied` | 403 | Registration is not permitted (e.g. DCR is disabled, a first-party IAT is required but a third-party IAT or no IAT was presented, or the project's [client limit](#client-limit) has been reached) |
@@ -441,7 +441,7 @@ Array of redirect URIs the client will use in authorization code flows. Each URI
 - An `https://` URI, **or**
 - A custom URI scheme (e.g., `com.example.app://callback`) for native apps.
 
-Plain `http://` URIs are rejected except for `http://localhost` (loopback), which is allowed for native app development.
+Plain `http://` URIs are rejected except for a loopback address — `http://localhost`, `http://127.0.0.1` or `http://[::1]`, any port — which is allowed for native app development. Per [RFC 8252 §7.3](https://www.rfc-editor.org/rfc/rfc8252#section-7.3), both the `localhost` hostname and the IPv4/IPv6 loopback literals count as loopback; a client that binds its callback listener to `127.0.0.1` (as many native/CLI OAuth clients do, to avoid `localhost` DNS-resolution ambiguity) is accepted the same as one that uses `localhost`. Same set CIMD accepts — see [CIMD's `redirect_uris`](./cimd.md#redirect_uris-required).
 
 Each URI must be an absolute URI (per RFC 3986 §4.3) and must not contain a fragment component (`#`).
 
@@ -474,10 +474,10 @@ Controls the client's technical profile (redirect URI rules, PKCE requirements).
 
 | Value | IAT type required | Consent screen | `kind` | Redirect URI validation |
 |---|---|---|---|---|
-| `web` (default) | none or `iat_tp_` | Yes | `THIRD_PARTY` | Must use `https://`; `localhost` not allowed |
-| `native` | none or `iat_tp_` | Yes | `THIRD_PARTY` | Custom URI scheme or `http://localhost` |
-| `web` | `iat_fp_` | No | `FIRST_PARTY` | Must use `https://`; `localhost` not allowed |
-| `native` | `iat_fp_` | No | `FIRST_PARTY` | Custom URI scheme or `http://localhost` |
+| `web` (default) | none or `iat_tp_` | Yes | `THIRD_PARTY` | Must use `https://`; loopback not allowed |
+| `native` | none or `iat_tp_` | Yes | `THIRD_PARTY` | Custom URI scheme or loopback `http://` |
+| `web` | `iat_fp_` | No | `FIRST_PARTY` | Must use `https://`; loopback not allowed |
+| `native` | `iat_fp_` | No | `FIRST_PARTY` | Custom URI scheme or loopback `http://` |
 
 Default: `web`.
 

--- a/docs/specs/dcr.md
+++ b/docs/specs/dcr.md
@@ -102,7 +102,8 @@ Response:
   "redirect_uris": ["https://pr-123.preview.example.com/callback"],
   "grant_types": ["authorization_code", "refresh_token"],
   "response_types": ["code"],
-  "application_type": "web"
+  "application_type": "web",
+  "token_endpoint_auth_method": "none"
 }
 ```
 
@@ -189,7 +190,8 @@ Response:
   "redirect_uris": ["https://mcp-client.example.com/callback"],
   "grant_types": ["authorization_code", "refresh_token"],
   "response_types": ["code"],
-  "application_type": "web"
+  "application_type": "web",
+  "token_endpoint_auth_method": "none"
 }
 ```
 
@@ -387,7 +389,8 @@ See [Accepted Client Metadata](#accepted-client-metadata) for the full list of r
   "redirect_uris": ["https://pr-123.preview.example.com/callback"],
   "grant_types": ["authorization_code", "refresh_token"],
   "response_types": ["code"],
-  "application_type": "web"
+  "application_type": "web",
+  "token_endpoint_auth_method": "none"
 }
 ```
 
@@ -418,8 +421,7 @@ Error responses follow [RFC 7591 §3.2.2](https://www.rfc-editor.org/rfc/rfc7591
 |---|---|
 | `redirect_uris` is missing | omitted from request body |
 | `redirect_uris` contains a URI with a fragment component | `https://example.com/callback#section` |
-| `token_endpoint_auth_method` is provided and is not `none` | `token_endpoint_auth_method=client_secret_post` |
-| `grant_types` contains an unsupported value | `grant_types=["implicit"]` |
+| `grant_types` contains no value Authgear implements | `grant_types=["implicit"]` |
 | `response_types` contains an unsupported value | `response_types=["token"]` |
 | `response_types` is inconsistent with `grant_types` | `grant_types=["refresh_token"]` + `response_types=["code"]` without `authorization_code` |
 | `logo_uri`, `client_uri`, `tos_uri`, or `policy_uri` is not `https://` | `logo_uri=http://example.com/logo.png` |
@@ -456,6 +458,10 @@ Array of grant types the client is allowed to use. Accepted values:
 
 Default: `["authorization_code", "refresh_token"]`.
 
+Any other value is **dropped**, on the same [RFC 7591 §3.2.1](https://www.rfc-editor.org/rfc/rfc7591#section-3.2.1) substitution grounds as [`token_endpoint_auth_method`](#token_endpoint_auth_method-optional): only what survives is registered, and the response reports it, so a client that asked for a grant Authgear does not implement can see that it did not get it. A request that provided `grant_types` and lost *every* entry — `["implicit"]`, say — still returns `invalid_client_metadata`, because it asked for nothing Authgear can offer and there is no suitable value to substitute. An explicitly empty `grant_types` provided nothing to drop and is left to the [`response_types`](#response_types-optional) consistency rule, as before.
+
+Same rule as [CIMD's](./cimd.md#grant_types-optional), and for the same reason: an MCP client sends one registration body to every authorization server it meets, so it advertises what it can do anywhere rather than what any one server implements.
+
 ### `response_types` (optional)
 
 Array of response types. Must be consistent with `grant_types`. The only accepted value is `code`, which must be paired with the `authorization_code` grant type. Requesting `response_types=["code"]` without `authorization_code` in `grant_types`, or vice versa, returns `invalid_client_metadata`.
@@ -479,7 +485,13 @@ The IAT type — not `application_type` — determines whether the registered cl
 
 ### `token_endpoint_auth_method` (optional)
 
-The only accepted value is `none`. Every DCR-registered client is public and uses PKCE — Authgear never issues a `client_secret` via DCR — so `none` is simply a client explicitly stating what's already true, and is accepted. Any other value (e.g. `client_secret_post`, `client_secret_basic`) returns `invalid_client_metadata`, since Authgear has no client secret to authenticate with. Omitting the field entirely is equivalent to sending `none`.
+**Ignored.** Whatever the client asks for, the registered value is always `none`, and the response reports `"token_endpoint_auth_method": "none"` so the client learns what it got. Omitting the field is equivalent to sending anything else.
+
+Every DCR-registered client is public and uses PKCE — Authgear never issues a `client_secret` via DCR — so there is no value the client can ask for that would change how it authenticates. Substituting is [RFC 7591 §3.2.1](https://www.rfc-editor.org/rfc/rfc7591#section-3.2.1) behaviour ("The authorization server MAY reject **or replace** any of the client's requested metadata values submitted during the registration and substitute them with suitable values"), and the same section requires the response to carry all registered metadata, which is what makes the substitution visible rather than silent.
+
+Refusing the registration instead — as an earlier version of this spec did for every value other than `none` — taught the client nothing it could act on and blocked a real client for no benefit: Claude's MCP connector registration asks for `client_secret_post`, so every hosted Claude connector failed with `invalid_client_metadata` against a project with DCR enabled. Nothing was protected by that refusal, since no `client_secret` exists to be misused and the response never carried a secret either way.
+
+[CIMD](./cimd.md#token_endpoint_auth_method-optional) ignores the field the same way, for the same reason.
 
 ### `logo_uri` (optional)
 

--- a/docs/specs/event.md
+++ b/docs/specs/event.md
@@ -1301,9 +1301,18 @@ Payload, on first resolution:
       "kind": "THIRD_PARTY",
       "client_name": "Example MCP Client",
       "application_type": "web",
+      "token_endpoint_auth_method": "none",
       "redirect_uris": ["http://127.0.0.1:3000/callback"],
       "grant_types": ["authorization_code", "refresh_token"],
       "response_types": ["code"]
+    },
+    "document": {
+      "client_name": "Example MCP Client",
+      "redirect_uris": ["http://127.0.0.1:3000/callback"],
+      "grant_types": ["authorization_code", "refresh_token"],
+      "response_types": ["code"],
+      "application_type": "web",
+      "token_endpoint_auth_method": "none"
     },
     "created": true
   }
@@ -1339,7 +1348,8 @@ Payload, on a refetch that changed something:
 }
 ```
 
-- `client`: The client's state after the resolution — `client_id`, `source`, `kind`, `client_name`, `client_uri`, `logo_uri`, `tos_uri`, `policy_uri`, `application_type`, `redirect_uris`, `grant_types`, `response_types`, with `source` always `CIMD` and `kind` always `THIRD_PARTY`.
+- `client`: The client's state after the resolution — `client_id`, `source`, `kind`, `client_name`, `client_uri`, `logo_uri`, `tos_uri`, `policy_uri`, `application_type`, `token_endpoint_auth_method`, `redirect_uris`, `grant_types`, `response_types`, with `source` always `CIMD`, `kind` always `THIRD_PARTY`, and `token_endpoint_auth_method` always `none` — CIMD ignores whatever the document declares and always resolves the client as public with no secret. See `document.token_endpoint_auth_method` below for what the document actually declared.
+- `document`: The metadata document as fetched for this resolution — no defaults applied, nothing dropped. Same rationale as [`oauth.client.registered`'s `request`](#oauthclientregistered): `client.grant_types` can have fewer entries than `document.grant_types` when the document declares a grant type Authgear does not implement, and `client.token_endpoint_auth_method` is always `none` regardless of what `document.token_endpoint_auth_method` says — this is the only place either discrepancy is visible. Fields absent from the document are absent here too. Unlike `old_client`, there is no "old document" — only the document for this resolution is shown.
 - `created`: `true` on first resolution, `false` on a refetch that changed something.
 - `old_client`: The client's state immediately before this resolution, same shape as `client`. Absent when `created` is `true` (there is no "before"), and otherwise always present — this event is never emitted for a refetch that produced identical metadata, so a present `old_client` is guaranteed to differ from `client` in at least one field. Only fields derived from the document are ever compared to decide whether to emit this event at all — never `last_fetched_at`, which changes on every refetch by construction — and the three list fields are compared as sets, so reordering entries alone does not count as a change. `client` and `old_client` show full state rather than a computed list of changed fields, so the reader does the diffing.
 

--- a/docs/specs/event.md
+++ b/docs/specs/event.md
@@ -1197,10 +1197,21 @@ Payload:
       "source": "DCR",
       "kind": "THIRD_PARTY",
       "client_name": "PR #123 preview",
+      "client_uri": "https://pr-123.preview.example.com",
       "application_type": "web",
+      "token_endpoint_auth_method": "none",
       "redirect_uris": ["https://pr-123.preview.example.com/callback"],
       "grant_types": ["authorization_code", "refresh_token"],
       "response_types": ["code"]
+    },
+    "request": {
+      "client_name": "PR #123 preview",
+      "client_uri": "https://pr-123.preview.example.com",
+      "redirect_uris": ["https://pr-123.preview.example.com/callback"],
+      "grant_types": ["authorization_code", "refresh_token"],
+      "response_types": ["code"],
+      "application_type": "web",
+      "token_endpoint_auth_method": "none"
     },
     "initial_access_token": {
       "id": "60f4c2a1-9d3e-4a7b-8c15-2e6f0b9d4a83",
@@ -1215,9 +1226,11 @@ Payload:
 - `client.client_id`: The `client_id` assigned to the client. See [Client ID Format](./dcr.md#client-id-format).
 - `client.source`: How the client came to exist. `DCR` for a client created by the registration endpoint.
 - `client.kind`: `FIRST_PARTY` or `THIRD_PARTY`. Determined by the type of Initial Access Token used, not by `application_type`. See [Initial Access Token](./dcr.md#initial-access-token).
-- `client.client_name`: The registered client name. Absent if the client did not provide one.
+- `client.client_name`, `client.client_uri`, `client.logo_uri`, `client.tos_uri`, `client.policy_uri`: The registered values. Absent if the client did not provide one.
 - `client.application_type`: `web` or `native`.
-- `client.redirect_uris`, `client.grant_types`, `client.response_types`: The registered values, after defaults have been applied. See [Accepted Client Metadata](./dcr.md#accepted-client-metadata).
+- `client.token_endpoint_auth_method`: Always `none` — DCR ignores whatever the caller asked for and always registers a public client with no secret. See [`request.token_endpoint_auth_method`](#oauthclientregistered) below for what was actually requested.
+- `client.redirect_uris`, `client.grant_types`, `client.response_types`: The registered values, after defaults have been applied and any unimplemented entries dropped. See [Accepted Client Metadata](./dcr.md#accepted-client-metadata).
+- `request`: The client metadata the caller asked for, **as sent** — no defaults applied, no normalization, nothing dropped. Same shape and same rationale as [`oauth.client.registration.failed`'s `request`](#oauthclientregistrationfailed): `client.grant_types` can have fewer entries than `request.grant_types` when the caller asked for a grant type Authgear does not implement, and `client.token_endpoint_auth_method` is always `none` regardless of what `request.token_endpoint_auth_method` says — this is the only place either discrepancy is visible. Fields absent from the request are absent here too.
 - `initial_access_token`: The Initial Access Token that authorized the registration. **The field does not exist** when the project allows open registration (`initial_access_token_required: false`) and the client presented no token.
   - `initial_access_token.id`: The ID of the token, as returned by the `initialAccessTokens` Admin API query. The token value itself is never included, nor is a hash of it.
   - `initial_access_token.type`: `FIRST_PARTY` or `THIRD_PARTY`.
@@ -1264,7 +1277,7 @@ Payload:
 - `initial_access_token`: Present only when `message` is `expired` — the only case where a token row exists to describe. Same shape as in [oauth.client.registered](#oauthclientregistered). An unknown token has nothing to report, and none was presented in the `not_presented` case.
 - `request`: The client metadata the caller asked for, **as sent** — no defaults applied, no normalization, nothing dropped. `message` names the rule that failed but never the value that failed it, so this is what turns `grant_type_unsupported` into an actionable record: the registering client is a third party whose request body the admin cannot otherwise see. Fields absent from the request are absent here.
 
-  It includes `token_endpoint_auth_method` even though that field is [ignored](./dcr.md#token_endpoint_auth_method-optional) and can no longer fail a registration — it is recorded because it is invisible everywhere else, and "what did the client ask to authenticate with?" is a routine follow-up question when a registration fails for some other reason.
+  It includes `token_endpoint_auth_method` even though that field is [ignored](./dcr.md#token_endpoint_auth_method-optional) and can no longer fail a registration — the persisted client always registers as `none`, so "what did the client ask to authenticate with?" would otherwise be unanswerable, whether the registration failed or (see [`oauth.client.registered`'s own `request`](#oauthclientregistered)) succeeded.
 
   The key is **absent** when the request never got as far as a decoded body — `message` of `malformed_header`, `not_presented` or `malformed_json` — and present for every other failure, including `limit_exceeded` and an unknown or expired token, which are decided after the body is read. Absent is therefore "nothing was parsed", never "an empty request was sent".
 

--- a/docs/specs/event.md
+++ b/docs/specs/event.md
@@ -1242,6 +1242,14 @@ Payload:
       "type": "FIRST_PARTY",
       "created_at": "2026-07-20T09:14:02Z",
       "expires_at": "2026-08-20T09:14:02Z"
+    },
+    "request": {
+      "client_name": "Some MCP Client",
+      "redirect_uris": ["https://app.example.com/callback"],
+      "grant_types": ["authorization_code", "refresh_token"],
+      "response_types": ["code"],
+      "token_endpoint_auth_method": "client_secret_post",
+      "client_uri": "https://app.example.com"
     }
   }
 }
@@ -1251,9 +1259,16 @@ Payload:
   - `invalid_initial_access_token` — the `Authorization` header was malformed, a token was required and absent, or the token presented was unknown or expired.
   - `invalid_client_metadata` — the body was not a JSON object, or failed a rule in [Accepted Client Metadata](./dcr.md#accepted-client-metadata).
   - `limit_exceeded` — the project is at its [`oauth_client_dcr` quota](./dcr.md#client-limit).
-- `message`: The specific cause within `reason`. For `invalid_initial_access_token`: `malformed_header`, `not_presented`, `unknown` or `expired`. For `invalid_client_metadata`: the rule that failed, e.g. `malformed_json`, `redirect_uris_missing`, `redirect_uri_invalid`, `grant_type_unsupported`, `response_type_inconsistent`, `application_type_unsupported`, `token_endpoint_auth_method_not_accepted`, `uri_field_not_https`. Absent for `limit_exceeded`, which has no sub-cases.
+- `message`: The specific cause within `reason`. For `invalid_initial_access_token`: `malformed_header`, `not_presented`, `unknown` or `expired`. For `invalid_client_metadata`: the rule that failed, e.g. `malformed_json`, `redirect_uris_missing`, `redirect_uri_invalid`, `grant_type_unsupported`, `response_type_inconsistent`, `application_type_unsupported`, `uri_field_not_https`. `token_endpoint_auth_method_not_accepted` is no longer among them — the requested value is [ignored](./dcr.md#token_endpoint_auth_method-optional) rather than refused, so it can no longer fail a registration. Absent for `limit_exceeded`, which has no sub-cases.
 - `usage_name`, `quota`: Present only for `limit_exceeded`. The usage name (`oauth_client_dcr`) and the quota that was reached.
 - `initial_access_token`: Present only when `message` is `expired` — the only case where a token row exists to describe. Same shape as in [oauth.client.registered](#oauthclientregistered). An unknown token has nothing to report, and none was presented in the `not_presented` case.
+- `request`: The client metadata the caller asked for, **as sent** — no defaults applied, no normalization, nothing dropped. `message` names the rule that failed but never the value that failed it, so this is what turns `grant_type_unsupported` into an actionable record: the registering client is a third party whose request body the admin cannot otherwise see. Fields absent from the request are absent here.
+
+  It includes `token_endpoint_auth_method` even though that field is [ignored](./dcr.md#token_endpoint_auth_method-optional) and can no longer fail a registration — it is recorded because it is invisible everywhere else, and "what did the client ask to authenticate with?" is a routine follow-up question when a registration fails for some other reason.
+
+  The key is **absent** when the request never got as far as a decoded body — `message` of `malformed_header`, `not_presented` or `malformed_json` — and present for every other failure, including `limit_exceeded` and an unknown or expired token, which are decided after the body is read. Absent is therefore "nothing was parsed", never "an empty request was sent".
+
+  Every value is client-authored and unvalidated: reaching this record means the request was **rejected**, so read `request` as what the caller claimed, never as configuration Authgear accepted. It is bounded by the 1 MB request body limit and by the endpoint's per-IP and per-project [rate limits](./dcr.md#rate-limits), which are consumed before the body is parsed.
 
 Note that the HTTP response does **not** distinguish these messages: all four `invalid_initial_access_token` cases return the same error to the caller, so a caller guessing tokens learns nothing. The distinction exists only in the audit log, which only the project admin can read.
 
@@ -1338,7 +1353,7 @@ Payload:
   - `unavailable` — the document could not be retrieved. **Every** transport-level failure is this one value: DNS failure, blocked address, connection refused, TLS failure, timeout, non-2xx response, oversize body, unparseable body.
   - `invalid` — a JSON object was retrieved and failed a rule in [Accepted Metadata Fields](./cimd.md#accepted-metadata-fields).
   - `limit_exceeded` — the document resolved cleanly but the project is at its [`oauth_client_cimd` quota](./cimd.md#client-limit), so no record was created.
-- `message`: The rule that failed, for `invalid` only — e.g. `client_id_mismatch`, `redirect_uris_missing`, `redirect_uri_invalid`, `token_endpoint_auth_method_not_accepted`. **Never present for `unavailable`.**
+- `message`: The rule that failed, for `invalid` only — e.g. `client_id_mismatch`, `redirect_uris_missing`, `redirect_uri_invalid`, `grant_type_unsupported`. **Never present for `unavailable`.**
 - `usage_name`, `quota`: Present only for `limit_exceeded`.
 - `served_stale_record`: `true` when a persisted record already existed and was served despite this failure, so the client still works on its last-known metadata; `false` when the client was left unresolvable. Always `false` for `limit_exceeded`, which only arises when there was no record. See [Error Handling](./cimd.md#error-handling).
 

--- a/docs/specs/oidc.md
+++ b/docs/specs/oidc.md
@@ -81,6 +81,54 @@ response_types:
 
 Refresh token is not used.
 
+#### CLI application Client Metadata example
+
+```yaml
+redirect_uris:
+- "http://127.0.0.1/callback"
+grant_types:
+- authorization_code
+- refresh_token
+response_types:
+- code
+```
+
+Note that no port is registered. See [Redirect URI Matching](#redirect-uri-matching).
+
+### Redirect URI Matching
+
+The `redirect_uri` of an authorization request must match one of the client's
+`redirect_uris` exactly, with one exception.
+
+**Loopback exception.** When a registered entry has scheme `http` and host
+`127.0.0.1`, `[::1]` or `localhost`, its port is ignored on both sides of the
+comparison. Scheme, host, path and query must still match, and the three hosts
+stay distinct. This implements
+[RFC 8252 §7.3](https://datatracker.ietf.org/doc/html/rfc8252#section-7.3).
+
+With `http://127.0.0.1/callback` registered:
+
+| `redirect_uri` | Result |
+| -- | -- |
+| `http://127.0.0.1:53412/callback` | allowed |
+| `http://127.0.0.1/callback` | allowed |
+| `http://localhost:53412/callback` | rejected — different host |
+| `https://127.0.0.1:53412/callback` | rejected — scheme is not `http` |
+| `http://127.0.0.1:53412/other` | rejected — different path |
+
+Two things the exception does not cover:
+
+- **CORS.** `redirect_uris` also feed the CORS allowed-origin matcher
+  (`pkg/lib/infra/middleware/cors_matcher.go`), which compares ports exactly, so
+  `http://127.0.0.1/callback` allows the origin `http://127.0.0.1` only. The
+  loopback flow uses top-level navigations and needs no CORS, but a browser app
+  served from an ephemeral loopback port must register the origin it runs on.
+- **`post_logout_redirect_uris`**, which still require an exact match per
+  [OpenID Connect RP-Initiated Logout 1.0 §3](https://openid.net/specs/openid-connect-rpinitiated-1_0.html#RedirectionAfterLogout).
+  A client on an ephemeral port can log in but is not redirected back after
+  logout; it lands on the Settings page through the fallback described in
+  [RP-Initiated Logout](#rp-initiated-logout).
+
 ## Authentication Request
 
 ### scope

--- a/e2e/tests/cimd/audit_log.test.yaml
+++ b/e2e/tests/cimd/audit_log.test.yaml
@@ -186,3 +186,84 @@ steps:
             "served_stale_record": "false"
           }
         ]
+
+---
+
+# The document declares a grant type Authgear does not implement
+# (urn:ietf:params:oauth:grant-type:jwt-bearer, same as Claude's real CIMD
+# document -- see cimd/document_test.go) and a token_endpoint_auth_method,
+# both of which CIMD ignores. Resolution must still succeed (Rule 5 drops
+# the unsupported entry rather than refusing the whole document), and the
+# audit event's `client` must show only what survived while `document`
+# shows what was actually declared -- otherwise neither fact is visible
+# anywhere.
+name: oauth.client.resolved shows token_endpoint_auth_method and the document as fetched, including a dropped grant_type
+authgear.yaml:
+  override: |
+    oauth:
+      client_id_metadata_document:
+        enabled: true
+authgear.features.yaml:
+  override: |
+    oauth:
+      client_id_metadata_document:
+        insecure_http_allowed: true
+steps:
+  - name: configure_document
+    action: http_request
+    http_request_method: POST
+    http_request_url: http://localhost:2727/_control/set
+    http_request_body: |
+      {
+        "path": "audit-log-metadata.json",
+        "document": {
+          "client_id": "http://localhost:2727/audit-log-metadata.json",
+          "client_name": "Metadata Client",
+          "redirect_uris": ["http://127.0.0.1:3000/callback"],
+          "grant_types": ["authorization_code", "refresh_token", "urn:ietf:params:oauth:grant-type:jwt-bearer"],
+          "response_types": ["code"],
+          "token_endpoint_auth_method": "client_secret_post"
+        }
+      }
+    http_output:
+      http_status: 200
+
+  - name: authorize
+    action: http_request
+    http_request_method: GET
+    http_request_url: http://{{ .AppID }}.authgeare2e.localhost:4000/oauth2/authorize
+    http_request_query:
+      client_id: http://localhost:2727/audit-log-metadata.json
+      response_type: code
+      redirect_uri: http://127.0.0.1:3000/callback
+      scope: openid
+      code_challenge: E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM
+      code_challenge_method: S256
+    http_request_follow_redirects: false
+    http_output:
+      http_status: 302
+
+  - name: verify_audit_log
+    action: audit_query
+    audit_query: |
+      SELECT activity_type,
+             data->'payload'->'client'->>'token_endpoint_auth_method' AS client_auth_method,
+             data->'payload'->'client'->'grant_types' AS client_grant_types,
+             data->'payload'->'document'->>'token_endpoint_auth_method' AS document_auth_method,
+             data->'payload'->'document'->'grant_types' AS document_grant_types
+      FROM _audit_log
+      WHERE app_id = '{{ .AppID }}'
+        AND activity_type = 'oauth.client.resolved'
+        AND client_id = 'http://localhost:2727/audit-log-metadata.json'
+      ORDER BY created_at, id
+    audit_query_output:
+      rows: |
+        [
+          {
+            "activity_type": "oauth.client.resolved",
+            "client_auth_method": "none",
+            "client_grant_types": ["authorization_code", "refresh_token"],
+            "document_auth_method": "client_secret_post",
+            "document_grant_types": ["authorization_code", "refresh_token", "urn:ietf:params:oauth:grant-type:jwt-bearer"]
+          }
+        ]

--- a/e2e/tests/dcr/audit_log.test.yaml
+++ b/e2e/tests/dcr/audit_log.test.yaml
@@ -474,3 +474,77 @@ steps:
             "quota": "2"
           }
         ]
+
+---
+
+# Claude's registration body again (see register_validation.test.yaml's
+# "metadata Authgear does not implement" case for the HTTP response side of
+# this). Here we check the audit log: client_uri/logo_uri/tos_uri/policy_uri
+# and token_endpoint_auth_method must appear on `client` (previously
+# missing entirely), and `request` must show what Claude actually asked
+# for -- the jwt-bearer grant Rule 5 dropped and the client_secret_post
+# DCR always ignores -- neither of which is visible on `client` alone.
+name: oauth.client.registered records client_uri/logo_uri/tos_uri/policy_uri, token_endpoint_auth_method, and the original request
+authgear.yaml:
+  override: |
+    oauth:
+      dynamic_client_registration:
+        enabled: true
+        initial_access_token_required: false
+steps:
+  - name: register
+    action: http_request
+    http_request_method: POST
+    http_request_url: http://{{ .AppID }}.authgeare2e.localhost:4000/oauth2/register
+    http_request_headers:
+      Content-Type: application/json
+    http_request_body: |
+      {
+        "client_name": "Claude",
+        "client_uri": "https://claude.ai",
+        "logo_uri": "https://claude.ai/logo.png",
+        "tos_uri": "https://claude.ai/tos",
+        "policy_uri": "https://claude.ai/policy",
+        "redirect_uris": ["https://claude.ai/api/mcp/auth_callback"],
+        "grant_types": ["authorization_code", "refresh_token", "urn:ietf:params:oauth:grant-type:jwt-bearer"],
+        "response_types": ["code"],
+        "token_endpoint_auth_method": "client_secret_post"
+      }
+    http_output:
+      http_status: 201
+      json_body: |
+        {
+          "client_id": "[[string]]"
+        }
+  - name: verify_audit_log
+    action: audit_query
+    audit_query: |
+      SELECT activity_type,
+             data->'payload'->'client'->>'client_uri' AS client_uri,
+             data->'payload'->'client'->>'logo_uri' AS logo_uri,
+             data->'payload'->'client'->>'tos_uri' AS tos_uri,
+             data->'payload'->'client'->>'policy_uri' AS policy_uri,
+             data->'payload'->'client'->>'token_endpoint_auth_method' AS client_auth_method,
+             data->'payload'->'client'->'grant_types' AS client_grant_types,
+             data->'payload'->'request'->>'token_endpoint_auth_method' AS request_auth_method,
+             data->'payload'->'request'->'grant_types' AS request_grant_types
+      FROM _audit_log
+      WHERE app_id = '{{ .AppID }}'
+        AND activity_type = 'oauth.client.registered'
+        AND client_id = '{{ .steps.register.result.http_json_body.client_id }}'
+      ORDER BY created_at, id
+    audit_query_output:
+      rows: |
+        [
+          {
+            "activity_type": "oauth.client.registered",
+            "client_uri": "https://claude.ai",
+            "logo_uri": "https://claude.ai/logo.png",
+            "tos_uri": "https://claude.ai/tos",
+            "policy_uri": "https://claude.ai/policy",
+            "client_auth_method": "none",
+            "client_grant_types": ["authorization_code", "refresh_token"],
+            "request_auth_method": "client_secret_post",
+            "request_grant_types": ["authorization_code", "refresh_token", "urn:ietf:params:oauth:grant-type:jwt-bearer"]
+          }
+        ]

--- a/e2e/tests/dcr/register_validation.test.yaml
+++ b/e2e/tests/dcr/register_validation.test.yaml
@@ -166,6 +166,8 @@ steps:
 # invalid_client_metadata / "dcr: token_endpoint_auth_method is not
 # accepted" solely because Inspector explicitly sends
 # token_endpoint_auth_method=none, which every DCR client already is.
+# That value is now ignored rather than required, but keep sending it --
+# the point of this case is the captured body, unchanged.
 name: MCP Inspector's exact registration request succeeds
 authgear.yaml:
   override: |
@@ -201,12 +203,56 @@ steps:
           "grant_types": ["authorization_code", "refresh_token"],
           "response_types": ["code"],
           "application_type": "native",
+          "token_endpoint_auth_method": "none",
           "client_uri": "https://github.com/modelcontextprotocol/inspector"
         }
 
 ---
 
-name: token_endpoint_auth_method other than none returns invalid_client_metadata
+# Claude's hosted MCP connector body, which asks for client_secret_post
+# and the jwt-bearer grant. Authgear implements neither and used to refuse
+# the whole registration; both are now substituted and the response
+# reports what was registered.
+name: metadata Authgear does not implement is registered as what it can offer
+authgear.yaml:
+  override: |
+    oauth:
+      dynamic_client_registration:
+        enabled: true
+        initial_access_token_required: false
+steps:
+  - action: http_request
+    http_request_method: POST
+    http_request_url: http://{{ .AppID }}.authgeare2e.localhost:4000/oauth2/register
+    http_request_headers:
+      Content-Type: application/json
+    http_request_body: |
+      {
+        "client_name": "Claude",
+        "client_uri": "https://claude.ai",
+        "redirect_uris": ["https://claude.ai/api/mcp/auth_callback"],
+        "grant_types": ["authorization_code", "refresh_token", "urn:ietf:params:oauth:grant-type:jwt-bearer"],
+        "response_types": ["code"],
+        "token_endpoint_auth_method": "client_secret_post"
+      }
+    http_output:
+      http_status: 201
+      json_body: |
+        {
+          "client_id": "[[string]]",
+          "client_id_issued_at": "[[number]]",
+          "client_name": "Claude",
+          "redirect_uris": ["https://claude.ai/api/mcp/auth_callback"],
+          "grant_types": ["authorization_code", "refresh_token"],
+          "response_types": ["code"],
+          "application_type": "web",
+          "token_endpoint_auth_method": "none",
+          "client_uri": "https://claude.ai"
+        }
+
+---
+
+name: grant_types with no value Authgear implements returns invalid_client_metadata
 authgear.yaml:
   override: |
     oauth:
@@ -222,7 +268,7 @@ steps:
     http_request_body: |
       {
         "redirect_uris": ["https://example.com/callback"],
-        "token_endpoint_auth_method": "client_secret_post"
+        "grant_types": ["urn:ietf:params:oauth:grant-type:jwt-bearer"]
       }
     http_output:
       http_status: 400

--- a/e2e/tests/dcr/register_validation.test.yaml
+++ b/e2e/tests/dcr/register_validation.test.yaml
@@ -76,6 +76,96 @@ steps:
 
 ---
 
+# RFC 8252 §7.3 treats the loopback IP literals the same as the "localhost"
+# hostname -- a native/CLI client that binds its callback listener to
+# 127.0.0.1 (rather than resolving "localhost") must be accepted too.
+name: native application_type accepts http://127.0.0.1 redirect_uris
+authgear.yaml:
+  override: |
+    oauth:
+      dynamic_client_registration:
+        enabled: true
+        initial_access_token_required: false
+steps:
+  - action: http_request
+    http_request_method: POST
+    http_request_url: http://{{ .AppID }}.authgeare2e.localhost:4000/oauth2/register
+    http_request_headers:
+      Content-Type: application/json
+    http_request_body: |
+      {
+        "application_type": "native",
+        "redirect_uris": ["http://127.0.0.1:60327/callback/abc"]
+      }
+    http_output:
+      http_status: 201
+      json_body: |
+        {
+          "client_id": "[[string]]",
+          "application_type": "native",
+          "redirect_uris": ["http://127.0.0.1:60327/callback/abc"]
+        }
+
+---
+
+name: native application_type accepts http://[::1] redirect_uris
+authgear.yaml:
+  override: |
+    oauth:
+      dynamic_client_registration:
+        enabled: true
+        initial_access_token_required: false
+steps:
+  - action: http_request
+    http_request_method: POST
+    http_request_url: http://{{ .AppID }}.authgeare2e.localhost:4000/oauth2/register
+    http_request_headers:
+      Content-Type: application/json
+    http_request_body: |
+      {
+        "application_type": "native",
+        "redirect_uris": ["http://[::1]:3000/callback"]
+      }
+    http_output:
+      http_status: 201
+      json_body: |
+        {
+          "client_id": "[[string]]",
+          "application_type": "native",
+          "redirect_uris": ["http://[::1]:3000/callback"]
+        }
+
+---
+
+# Loopback is the only relaxation -- an ordinary non-loopback IP still needs
+# https:// (or a custom scheme) exactly like any other host would.
+name: native application_type rejects http:// on a non-loopback IP
+authgear.yaml:
+  override: |
+    oauth:
+      dynamic_client_registration:
+        enabled: true
+        initial_access_token_required: false
+steps:
+  - action: http_request
+    http_request_method: POST
+    http_request_url: http://{{ .AppID }}.authgeare2e.localhost:4000/oauth2/register
+    http_request_headers:
+      Content-Type: application/json
+    http_request_body: |
+      {
+        "application_type": "native",
+        "redirect_uris": ["http://127.0.0.2/callback"]
+      }
+    http_output:
+      http_status: 400
+      json_body: |
+        {
+          "error": "invalid_redirect_uri"
+        }
+
+---
+
 name: web application_type rejects http://localhost redirect_uris
 authgear.yaml:
   override: |

--- a/e2e/tests/oidc/loopback_redirect_uri.test.yaml
+++ b/e2e/tests/oidc/loopback_redirect_uri.test.yaml
@@ -1,0 +1,144 @@
+name: A loopback redirect URI is accepted on any port and delivers the code there
+# RFC 8252 §7.3: "The authorization server MUST allow any port to be specified
+# at the time of the request for loopback IP redirect URIs, to accommodate
+# clients that obtain an available ephemeral port from the operating system at
+# the time of the request."
+#
+# The client below registers http://127.0.0.1/callback with no port at all,
+# which is the registration shape a CLI or native app can actually commit to;
+# the port it ends up listening on is only known at runtime.
+authgear.yaml:
+  override: |
+    authentication:
+      identities:
+      - login_id
+      primary_authenticators:
+      - password
+    oauth:
+      clients:
+      - client_id: e2eloopback
+        name: CLI app
+        x_application_type: native
+        grant_types:
+        - authorization_code
+        - refresh_token
+        response_types:
+        - code
+        redirect_uris:
+        - http://127.0.0.1/callback
+before:
+  - type: user_import
+    user_import: users.json
+steps:
+  # 53412 is the "ephemeral port the OS handed us", and it appears nowhere in
+  # the client config.
+  - name: authorize
+    action: http_request
+    http_request_method: GET
+    http_request_url: http://{{.AppID}}.authgeare2e.localhost:4000/oauth2/authorize
+    http_request_follow_redirects: false
+    http_request_query:
+      client_id: e2eloopback
+      redirect_uri: http://127.0.0.1:53412/callback
+      response_type: code
+      code_challenge_method: S256
+      code_challenge: RqIZl4LIgn8KxW9QO-nTnv7pf0CnNrksx9fF-CXP2FE
+      scope: "openid https://authgear.com/scopes/full-access"
+      x_sso_enabled: "false"
+    http_output:
+      http_status: 302
+
+  - name: create_flow
+    action: create
+    input: |
+      {
+        "type": "login",
+        "name": "default",
+        "url_query": "{{ (urlParse .steps.authorize.result.http_response_headers.location).query }}"
+      }
+    output:
+      result: |
+        {
+          "action": {
+            "type": "identify"
+          }
+        }
+
+  - name: identify
+    action: input
+    input: |
+      {
+        "identification": "username",
+        "login_id": "e2e_userinfo_user"
+      }
+    output:
+      result: |
+        {
+          "action": {
+            "type": "authenticate"
+          }
+        }
+
+  - name: authenticate
+    action: input
+    input: |
+      {
+        "authentication": "primary_password",
+        "password": "password"
+      }
+    output:
+      result: |
+        {
+          "action": {
+            "type": "finished",
+            "data": {
+              "finish_redirect_uri": "[[string]]"
+            }
+          }
+        }
+
+  # The code must be delivered to the port the client asked for, not to the
+  # registered one.
+  - name: get_code
+    action: http_request
+    http_request_method: GET
+    http_request_url: "{{ .steps.authenticate.result.action.data.finish_redirect_uri }}"
+    http_request_follow_redirects: false
+    http_output:
+      http_status: 303
+      location_contains:
+        - "http://127.0.0.1:53412/callback?"
+        - "code="
+
+  # And the code exchange must accept the same ephemeral redirect_uri back.
+  - name: exchange_code
+    action: http_request
+    http_request_method: POST
+    http_request_url: http://{{.AppID}}.authgeare2e.localhost:4000/oauth2/token
+    http_request_form_urlencoded_body:
+      grant_type: authorization_code
+      client_id: e2eloopback
+      redirect_uri: http://127.0.0.1:53412/callback
+      code_verifier: abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQ
+      code: "{{ (urlParse .steps.get_code.result.http_response_headers.location).query | regexFind \"code=[^&]+\" | trimPrefix \"code=\" }}"
+    http_output:
+      http_status: 200
+      json_body: |
+        {
+          "access_token": "[[string]]",
+          "token_type": "Bearer"
+        }
+
+  # Confirm the issued access token actually works.
+  - name: userinfo
+    action: http_request
+    http_request_method: GET
+    http_request_url: http://{{.AppID}}.authgeare2e.localhost:4000/oauth2/userinfo
+    http_request_headers:
+      Authorization: "Bearer {{ .steps.exchange_code.result.http_json_body.access_token }}"
+    http_output:
+      http_status: 200
+      json_body: |
+        {
+          "sub": "[[string]]"
+        }

--- a/e2e/tests/oidc/loopback_redirect_uri_rejected.test.yaml
+++ b/e2e/tests/oidc/loopback_redirect_uri_rejected.test.yaml
@@ -1,0 +1,140 @@
+name: The loopback any-port exception is confined to the registered loopback URI
+# The RFC 8252 §7.3 exception ignores the port and nothing else. Everything
+# below differs from the registered URI in some other component, so every one
+# of them must still be refused.
+authgear.yaml:
+  override: |
+    authentication:
+      identities:
+      - login_id
+      primary_authenticators:
+      - password
+    oauth:
+      clients:
+      - client_id: e2eloopback
+        name: CLI app
+        x_application_type: native
+        grant_types:
+        - authorization_code
+        - refresh_token
+        response_types:
+        - code
+        redirect_uris:
+        - http://127.0.0.1/callback
+      - client_id: e2ewebapp
+        name: Web app
+        x_application_type: spa
+        grant_types:
+        - authorization_code
+        - refresh_token
+        response_types:
+        - code
+        redirect_uris:
+        - https://app.example.com/callback
+steps:
+  - name: reject_different_path
+    action: http_request
+    http_request_method: GET
+    http_request_url: http://{{.AppID}}.authgeare2e.localhost:4000/oauth2/authorize
+    http_request_follow_redirects: false
+    http_request_query:
+      client_id: e2eloopback
+      redirect_uri: http://127.0.0.1:53412/other
+      response_type: code
+      code_challenge_method: S256
+      code_challenge: RqIZl4LIgn8KxW9QO-nTnv7pf0CnNrksx9fF-CXP2FE
+      scope: "openid https://authgear.com/scopes/full-access"
+    http_output:
+      http_status: 400
+      html_text_contains:
+        - redirect URI is not allowed
+
+  - name: reject_different_query
+    action: http_request
+    http_request_method: GET
+    http_request_url: http://{{.AppID}}.authgeare2e.localhost:4000/oauth2/authorize
+    http_request_follow_redirects: false
+    http_request_query:
+      client_id: e2eloopback
+      redirect_uri: http://127.0.0.1:53412/callback?next=http://evil.example.com
+      response_type: code
+      code_challenge_method: S256
+      code_challenge: RqIZl4LIgn8KxW9QO-nTnv7pf0CnNrksx9fF-CXP2FE
+      scope: "openid https://authgear.com/scopes/full-access"
+    http_output:
+      http_status: 400
+      html_text_contains:
+        - redirect URI is not allowed
+
+  # https on the loopback is not a loopback redirect URI: the exception exists
+  # because http on the loopback never leaves the machine, and only for that.
+  - name: reject_https_scheme
+    action: http_request
+    http_request_method: GET
+    http_request_url: http://{{.AppID}}.authgeare2e.localhost:4000/oauth2/authorize
+    http_request_follow_redirects: false
+    http_request_query:
+      client_id: e2eloopback
+      redirect_uri: https://127.0.0.1:53412/callback
+      response_type: code
+      code_challenge_method: S256
+      code_challenge: RqIZl4LIgn8KxW9QO-nTnv7pf0CnNrksx9fF-CXP2FE
+      scope: "openid https://authgear.com/scopes/full-access"
+    http_output:
+      http_status: 400
+      html_text_contains:
+        - redirect URI is not allowed
+
+  # 127.0.0.1, localhost and [::1] stay distinct hosts. A client that wants
+  # more than one of them registers more than one of them.
+  - name: reject_other_loopback_host
+    action: http_request
+    http_request_method: GET
+    http_request_url: http://{{.AppID}}.authgeare2e.localhost:4000/oauth2/authorize
+    http_request_follow_redirects: false
+    http_request_query:
+      client_id: e2eloopback
+      redirect_uri: http://localhost:53412/callback
+      response_type: code
+      code_challenge_method: S256
+      code_challenge: RqIZl4LIgn8KxW9QO-nTnv7pf0CnNrksx9fF-CXP2FE
+      scope: "openid https://authgear.com/scopes/full-access"
+    http_output:
+      http_status: 400
+      html_text_contains:
+        - redirect URI is not allowed
+
+  - name: reject_host_that_only_looks_like_loopback
+    action: http_request
+    http_request_method: GET
+    http_request_url: http://{{.AppID}}.authgeare2e.localhost:4000/oauth2/authorize
+    http_request_follow_redirects: false
+    http_request_query:
+      client_id: e2eloopback
+      redirect_uri: http://127.0.0.1.evil.example.com:53412/callback
+      response_type: code
+      code_challenge_method: S256
+      code_challenge: RqIZl4LIgn8KxW9QO-nTnv7pf0CnNrksx9fF-CXP2FE
+      scope: "openid https://authgear.com/scopes/full-access"
+    http_output:
+      http_status: 400
+      html_text_contains:
+        - redirect URI is not allowed
+
+  # A non-loopback client keeps strict equality, port included.
+  - name: reject_port_substitution_on_non_loopback_client
+    action: http_request
+    http_request_method: GET
+    http_request_url: http://{{.AppID}}.authgeare2e.localhost:4000/oauth2/authorize
+    http_request_follow_redirects: false
+    http_request_query:
+      client_id: e2ewebapp
+      redirect_uri: https://app.example.com:9000/callback
+      response_type: code
+      code_challenge_method: S256
+      code_challenge: RqIZl4LIgn8KxW9QO-nTnv7pf0CnNrksx9fF-CXP2FE
+      scope: "openid https://authgear.com/scopes/full-access"
+    http_output:
+      http_status: 400
+      html_text_contains:
+        - redirect URI is not allowed

--- a/pkg/api/event/nonblocking/oauth_client_registered.go
+++ b/pkg/api/event/nonblocking/oauth_client_registered.go
@@ -9,19 +9,33 @@ const (
 	OAuthClientRegistered event.Type = "oauth.client.registered"
 )
 
+// OAuthClientRegisteredEventPayloadClient embeds
+// model.OAuthClientRegisteredMetadata rather than repeating its fields --
+// see that type's own comment for why: the same embed backs
+// handler.RegistrationResponse, so the two cannot drift apart the way they
+// once did (client_uri/logo_uri/tos_uri/policy_uri/
+// token_endpoint_auth_method were present in the HTTP response but missing
+// here).
 type OAuthClientRegisteredEventPayloadClient struct {
-	ClientID        string                  `json:"client_id"`
-	Source          model.OAuthClientSource `json:"source"`
-	Kind            model.OAuthClientKind   `json:"kind"`
-	ClientName      string                  `json:"client_name,omitempty"`
-	ApplicationType string                  `json:"application_type,omitempty"`
-	RedirectURIs    []string                `json:"redirect_uris"`
-	GrantTypes      []string                `json:"grant_types"`
-	ResponseTypes   []string                `json:"response_types"`
+	ClientID string                  `json:"client_id"`
+	Source   model.OAuthClientSource `json:"source"`
+	Kind     model.OAuthClientKind   `json:"kind"`
+	model.OAuthClientRegisteredMetadata
 }
 
 type OAuthClientRegisteredEventPayload struct {
 	Client OAuthClientRegisteredEventPayloadClient `json:"client"`
+
+	// Request is the client metadata the caller asked for, as sent -- no
+	// defaults applied, no normalization, nothing dropped. Client above is
+	// what was actually registered, which can differ: an unimplemented
+	// grant_type is silently dropped rather than refused, and
+	// token_endpoint_auth_method is always ignored, so Request is what
+	// makes either of those visible in the audit log at all. Shared type
+	// with oauth.client.registration.failed's own Request field, since it
+	// is the same record either way -- see
+	// model.OAuthClientRegistrationRequest's own doc comment.
+	Request model.OAuthClientRegistrationRequest `json:"request"`
 
 	// InitialAccessToken is nil under open registration
 	// (initial_access_token_required: false), and the `omitempty` drops the
@@ -32,10 +46,10 @@ type OAuthClientRegisteredEventPayload struct {
 	// because "no IAT" must be distinguishable from "an IAT with empty
 	// fields". docs/specs/event.md documents the key as absent, not null.
 	//
-	// EventPayloadInitialAccessToken, not a type of its own: it is shared
-	// with oauth.client.registration.failed's "expired" outcome, so a token
+	// model.EventPayloadInitialAccessToken is shared with
+	// oauth.client.registration.failed's "expired" outcome, so a token
 	// presents identically in both records.
-	InitialAccessToken *EventPayloadInitialAccessToken `json:"initial_access_token,omitempty"`
+	InitialAccessToken *model.EventPayloadInitialAccessToken `json:"initial_access_token,omitempty"`
 }
 
 func (e *OAuthClientRegisteredEventPayload) NonBlockingEventType() event.Type {

--- a/pkg/api/event/nonblocking/oauth_client_registration_failed.go
+++ b/pkg/api/event/nonblocking/oauth_client_registration_failed.go
@@ -30,6 +30,31 @@ const (
 	OAuthClientRegistrationReasonLimitExceeded OAuthClientRegistrationReason = "limit_exceeded"
 )
 
+// OAuthClientRegistrationFailedEventPayloadRequest is the client metadata
+// the caller asked for, recorded as sent: no defaults, no normalization.
+// Message names the rule that failed but never the value that failed it,
+// and the client is a third party whose request body the admin cannot
+// otherwise see.
+//
+// Every field is client-authored and was rejected, so read it as what the
+// caller claimed, never as configuration. Bounded by the 1MB root body
+// limit (middleware.MaxBodySize) and the endpoint's rate limits.
+type OAuthClientRegistrationFailedEventPayloadRequest struct {
+	ClientName      string   `json:"client_name,omitempty"`
+	RedirectURIs    []string `json:"redirect_uris,omitempty"`
+	GrantTypes      []string `json:"grant_types,omitempty"`
+	ResponseTypes   []string `json:"response_types,omitempty"`
+	ApplicationType string   `json:"application_type,omitempty"`
+	// TokenEndpointAuthMethod is recorded even though DCR ignores it, and
+	// so can never cause a failure: being ignored is what makes it
+	// invisible everywhere else.
+	TokenEndpointAuthMethod string `json:"token_endpoint_auth_method,omitempty"`
+	ClientURI               string `json:"client_uri,omitempty"`
+	LogoURI                 string `json:"logo_uri,omitempty"`
+	TOSURI                  string `json:"tos_uri,omitempty"`
+	PolicyURI               string `json:"policy_uri,omitempty"`
+}
+
 // OAuthClientRegistrationFailedEventPayload has no oracle constraint, unlike
 // its CIMD counterpart: POST /oauth2/register fetches nothing, so there is
 // no third party and no network reachability to leak, and it already
@@ -46,6 +71,11 @@ type OAuthClientRegistrationFailedEventPayload struct {
 	// UsageName and Quota are set only when Reason is "limit_exceeded".
 	UsageName model.UsageName `json:"usage_name,omitempty"`
 	Quota     int             `json:"quota,omitempty"`
+	// Request is what the caller asked for. Nil, and the key absent, only
+	// where no body was decoded: Message "malformed_header",
+	// "not_presented" or "malformed_json". A pointer so that case stays
+	// distinguishable from a body of `{}`, which records an empty object.
+	Request *OAuthClientRegistrationFailedEventPayloadRequest `json:"request,omitempty"`
 	// InitialAccessToken identifies the token that was rejected. Present
 	// only when Message is "expired" -- an unknown token has no row to
 	// describe, and none was presented in the "not_presented" case. Shared

--- a/pkg/api/event/nonblocking/oauth_client_registration_failed.go
+++ b/pkg/api/event/nonblocking/oauth_client_registration_failed.go
@@ -30,31 +30,6 @@ const (
 	OAuthClientRegistrationReasonLimitExceeded OAuthClientRegistrationReason = "limit_exceeded"
 )
 
-// OAuthClientRegistrationFailedEventPayloadRequest is the client metadata
-// the caller asked for, recorded as sent: no defaults, no normalization.
-// Message names the rule that failed but never the value that failed it,
-// and the client is a third party whose request body the admin cannot
-// otherwise see.
-//
-// Every field is client-authored and was rejected, so read it as what the
-// caller claimed, never as configuration. Bounded by the 1MB root body
-// limit (middleware.MaxBodySize) and the endpoint's rate limits.
-type OAuthClientRegistrationFailedEventPayloadRequest struct {
-	ClientName      string   `json:"client_name,omitempty"`
-	RedirectURIs    []string `json:"redirect_uris,omitempty"`
-	GrantTypes      []string `json:"grant_types,omitempty"`
-	ResponseTypes   []string `json:"response_types,omitempty"`
-	ApplicationType string   `json:"application_type,omitempty"`
-	// TokenEndpointAuthMethod is recorded even though DCR ignores it, and
-	// so can never cause a failure: being ignored is what makes it
-	// invisible everywhere else.
-	TokenEndpointAuthMethod string `json:"token_endpoint_auth_method,omitempty"`
-	ClientURI               string `json:"client_uri,omitempty"`
-	LogoURI                 string `json:"logo_uri,omitempty"`
-	TOSURI                  string `json:"tos_uri,omitempty"`
-	PolicyURI               string `json:"policy_uri,omitempty"`
-}
-
 // OAuthClientRegistrationFailedEventPayload has no oracle constraint, unlike
 // its CIMD counterpart: POST /oauth2/register fetches nothing, so there is
 // no third party and no network reachability to leak, and it already
@@ -75,13 +50,13 @@ type OAuthClientRegistrationFailedEventPayload struct {
 	// where no body was decoded: Message "malformed_header",
 	// "not_presented" or "malformed_json". A pointer so that case stays
 	// distinguishable from a body of `{}`, which records an empty object.
-	Request *OAuthClientRegistrationFailedEventPayloadRequest `json:"request,omitempty"`
+	Request *model.OAuthClientRegistrationRequest `json:"request,omitempty"`
 	// InitialAccessToken identifies the token that was rejected. Present
 	// only when Message is "expired" -- an unknown token has no row to
 	// describe, and none was presented in the "not_presented" case. Shared
 	// shape with oauth.client.registered, deliberately: see
-	// EventPayloadInitialAccessToken's own doc comment.
-	InitialAccessToken *EventPayloadInitialAccessToken `json:"initial_access_token,omitempty"`
+	// model.EventPayloadInitialAccessToken's own doc comment.
+	InitialAccessToken *model.EventPayloadInitialAccessToken `json:"initial_access_token,omitempty"`
 }
 
 func (e *OAuthClientRegistrationFailedEventPayload) NonBlockingEventType() event.Type {

--- a/pkg/api/event/nonblocking/oauth_client_registration_failed_test.go
+++ b/pkg/api/event/nonblocking/oauth_client_registration_failed_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/authgear/authgear-server/pkg/api/event"
 	"github.com/authgear/authgear-server/pkg/api/event/nonblocking"
+	"github.com/authgear/authgear-server/pkg/api/model"
 )
 
 func TestOAuthClientRegistrationFailedEventPayload(t *testing.T) {
@@ -36,14 +37,14 @@ func TestOAuthClientRegistrationFailedEventPayload(t *testing.T) {
 			So(err, ShouldBeNil)
 			So(string(b), ShouldNotContainSubstring, `"request"`)
 
-			payload.Request = &nonblocking.OAuthClientRegistrationFailedEventPayloadRequest{}
+			payload.Request = &model.OAuthClientRegistrationRequest{}
 			b, err = json.Marshal(payload)
 			So(err, ShouldBeNil)
 			So(string(b), ShouldContainSubstring, `"request":{}`)
 		})
 
 		Convey("the request is recorded as sent, including the ignored auth method", func() {
-			payload.Request = &nonblocking.OAuthClientRegistrationFailedEventPayloadRequest{
+			payload.Request = &model.OAuthClientRegistrationRequest{
 				GrantTypes:              []string{"client_credentials"},
 				TokenEndpointAuthMethod: "client_secret_post",
 			}

--- a/pkg/api/event/nonblocking/oauth_client_registration_failed_test.go
+++ b/pkg/api/event/nonblocking/oauth_client_registration_failed_test.go
@@ -1,6 +1,7 @@
 package nonblocking_test
 
 import (
+	"encoding/json"
 	"testing"
 
 	. "github.com/smartystreets/goconvey/convey"
@@ -26,6 +27,33 @@ func TestOAuthClientRegistrationFailedEventPayload(t *testing.T) {
 			ctx := &event.Context{}
 			payload.FillContext(ctx)
 			So(ctx.ClientID, ShouldEqual, "")
+		})
+
+		// event.md documents an absent key as "no body was parsed", which
+		// only holds if an empty request still serializes to a key.
+		Convey("an absent request is distinguishable from an empty one", func() {
+			b, err := json.Marshal(payload)
+			So(err, ShouldBeNil)
+			So(string(b), ShouldNotContainSubstring, `"request"`)
+
+			payload.Request = &nonblocking.OAuthClientRegistrationFailedEventPayloadRequest{}
+			b, err = json.Marshal(payload)
+			So(err, ShouldBeNil)
+			So(string(b), ShouldContainSubstring, `"request":{}`)
+		})
+
+		Convey("the request is recorded as sent, including the ignored auth method", func() {
+			payload.Request = &nonblocking.OAuthClientRegistrationFailedEventPayloadRequest{
+				GrantTypes:              []string{"client_credentials"},
+				TokenEndpointAuthMethod: "client_secret_post",
+			}
+			b, err := json.Marshal(payload)
+			So(err, ShouldBeNil)
+			So(string(b), ShouldContainSubstring, `"grant_types":["client_credentials"]`)
+			So(string(b), ShouldContainSubstring, `"token_endpoint_auth_method":"client_secret_post"`)
+			// Unset fields stay out rather than appear as empty values.
+			So(string(b), ShouldNotContainSubstring, `"redirect_uris"`)
+			So(string(b), ShouldNotContainSubstring, `"client_name"`)
 		})
 	})
 }

--- a/pkg/api/event/nonblocking/oauth_client_resolved.go
+++ b/pkg/api/event/nonblocking/oauth_client_resolved.go
@@ -24,9 +24,14 @@ type OAuthClientResolvedEventPayloadClient struct {
 	TOSURI          string                  `json:"tos_uri,omitempty"`
 	PolicyURI       string                  `json:"policy_uri,omitempty"`
 	ApplicationType string                  `json:"application_type,omitempty"`
-	RedirectURIs    []string                `json:"redirect_uris"`
-	GrantTypes      []string                `json:"grant_types"`
-	ResponseTypes   []string                `json:"response_types"`
+	// TokenEndpointAuthMethod is always "none": CIMD ignores whatever a
+	// document declares (see docs/specs/cimd.md's
+	// token_endpoint_auth_method section) and always resolves the client
+	// as public with no secret.
+	TokenEndpointAuthMethod string   `json:"token_endpoint_auth_method,omitempty"`
+	RedirectURIs            []string `json:"redirect_uris"`
+	GrantTypes              []string `json:"grant_types"`
+	ResponseTypes           []string `json:"response_types"`
 }
 
 type OAuthClientResolvedEventPayload struct {
@@ -34,6 +39,14 @@ type OAuthClientResolvedEventPayload struct {
 	// record is complete on its own and a changed record shows the
 	// resulting client alongside its previous state.
 	Client OAuthClientResolvedEventPayloadClient `json:"client"`
+	// Document is the metadata document as fetched for this resolution --
+	// no defaults applied, nothing dropped. Client above is what was
+	// actually persisted, which can differ: an unimplemented grant_type is
+	// silently dropped rather than refused, and token_endpoint_auth_method
+	// is always ignored, so Document is what makes either of those visible
+	// in the audit log at all. See model.OAuthClientResolutionDocument's
+	// own doc comment.
+	Document model.OAuthClientResolutionDocument `json:"document"`
 	// Created is true on first resolution, false on a refetch that changed
 	// something. An explicit discriminator: an auditor should not have to
 	// infer it from OldClient being absent.

--- a/pkg/api/event/resolve_tag_invariant_test.go
+++ b/pkg/api/event/resolve_tag_invariant_test.go
@@ -152,10 +152,11 @@ var payloadRegistry = []any{
 // countPayloadSourceFiles counts the *.go files in dir that define payload
 // types, i.e. every file except test files and the shared helper files that
 // carry no payload type of their own (util.go and project.go in
-// nonblocking's case; oauth_initial_access_token.go defines
-// EventPayloadInitialAccessToken, a sub-object shared by
-// oauth.client.registered and oauth.client.registration.failed, not a
-// payload in its own right).
+// nonblocking's case). Sub-objects shared across multiple event payloads
+// but referenced from outside the event system too --
+// EventPayloadInitialAccessToken, OAuthClientRegistrationRequest,
+// OAuthClientResolutionDocument -- live in pkg/api/model instead of here,
+// so this directory no longer needs an exception list for them.
 func countPayloadSourceFiles(t *testing.T, dir string) int {
 	entries, err := os.ReadDir(dir)
 	if err != nil {
@@ -167,7 +168,7 @@ func countPayloadSourceFiles(t *testing.T, dir string) int {
 		if entry.IsDir() {
 			continue
 		}
-		if name == "util.go" || name == "project.go" || name == "oauth_initial_access_token.go" {
+		if name == "util.go" || name == "project.go" {
 			continue
 		}
 		if !hasSuffix(name, ".go") || hasSuffix(name, "_test.go") {

--- a/pkg/api/model/oauth_client_registered_metadata.go
+++ b/pkg/api/model/oauth_client_registered_metadata.go
@@ -1,0 +1,60 @@
+package model
+
+// OAuthClientRegisteredMetadata is the OAuth client metadata a DCR
+// registration returns per RFC 7591 §3.2.1 -- the same metadata
+// oauth.client.registered's audit event shows for the client that was
+// created. There is exactly one type and one constructor
+// (NewOAuthClientRegisteredMetadata) for it, embedded by both
+// handler.RegistrationResponse and
+// nonblocking.OAuthClientRegisteredEventPayloadClient, so that a field
+// present in the HTTP response but missing from the audit event (or vice
+// versa) is structurally impossible rather than something a future change
+// has to remember to keep in sync by hand.
+//
+// Always construct this via NewOAuthClientRegisteredMetadata -- never
+// populate its fields individually at a call site. Doing so would defeat
+// the whole point: the guarantee holds only because every consumer gets
+// its values from the one function that knows how to read them off
+// *OAuthClient.
+type OAuthClientRegisteredMetadata struct {
+	ClientName      string   `json:"client_name,omitempty"`
+	RedirectURIs    []string `json:"redirect_uris"`
+	GrantTypes      []string `json:"grant_types"`
+	ResponseTypes   []string `json:"response_types"`
+	ApplicationType string   `json:"application_type"`
+	// TokenEndpointAuthMethod is always "none": DCR ignores whatever the
+	// caller asked for and always registers a public client with no
+	// secret. Never omitted -- see RegistrationResponse's own comment on
+	// why a client needs to see this even though it never varies.
+	TokenEndpointAuthMethod string `json:"token_endpoint_auth_method"`
+	ClientURI               string `json:"client_uri,omitempty"`
+	LogoURI                 string `json:"logo_uri,omitempty"`
+	TOSURI                  string `json:"tos_uri,omitempty"`
+	PolicyURI               string `json:"policy_uri,omitempty"`
+}
+
+// NewOAuthClientRegisteredMetadata reads the RFC 7591 response metadata off
+// a freshly created or resolved *OAuthClient. See
+// OAuthClientRegisteredMetadata's own comment for why every consumer must
+// go through this constructor rather than building the struct by hand.
+func NewOAuthClientRegisteredMetadata(c *OAuthClient) OAuthClientRegisteredMetadata {
+	return OAuthClientRegisteredMetadata{
+		ClientName:              c.Name,
+		RedirectURIs:            c.RedirectURIs,
+		GrantTypes:              c.GrantTypes,
+		ResponseTypes:           c.ResponseTypes,
+		ApplicationType:         derefStringOr(c.ApplicationType, ""),
+		TokenEndpointAuthMethod: "none",
+		ClientURI:               derefStringOr(c.ClientURI, ""),
+		LogoURI:                 derefStringOr(c.LogoURI, ""),
+		TOSURI:                  derefStringOr(c.TOSURI, ""),
+		PolicyURI:               derefStringOr(c.PolicyURI, ""),
+	}
+}
+
+func derefStringOr(s *string, fallback string) string {
+	if s == nil {
+		return fallback
+	}
+	return *s
+}

--- a/pkg/api/model/oauth_client_registration_request.go
+++ b/pkg/api/model/oauth_client_registration_request.go
@@ -1,0 +1,35 @@
+package model
+
+// OAuthClientRegistrationRequest is the client metadata a POST
+// /oauth2/register caller asked for, recorded as sent: no defaults, no
+// normalization, nothing dropped. Shared between nonblocking's
+// oauth.client.registered and oauth.client.registration.failed payloads
+// rather than given one type per event, because it is the same record
+// either way -- "what did the caller actually send" -- and a registration
+// that succeeds can still have silently dropped or ignored parts of it (an
+// unimplemented grant_type, the ignored token_endpoint_auth_method) that
+// the persisted client alone cannot show. Lives in this package rather
+// than nonblocking because it is plain data referenced from outside the
+// event system too (pkg/lib/oauth/handler builds one directly from the
+// decoded request body).
+//
+// Every field is client-authored and unvalidated: read it as what the
+// caller claimed, never as configuration Authgear accepted. Bounded by the
+// 1 MB root body limit (middleware.MaxBodySize) and the endpoint's rate
+// limits.
+type OAuthClientRegistrationRequest struct {
+	ClientName      string   `json:"client_name,omitempty"`
+	RedirectURIs    []string `json:"redirect_uris,omitempty"`
+	GrantTypes      []string `json:"grant_types,omitempty"`
+	ResponseTypes   []string `json:"response_types,omitempty"`
+	ApplicationType string   `json:"application_type,omitempty"`
+	// TokenEndpointAuthMethod is recorded even though DCR ignores it, and
+	// so can never cause a failure: being ignored is what makes it
+	// invisible everywhere else -- the persisted client always registers
+	// as "none" regardless of what was asked for.
+	TokenEndpointAuthMethod string `json:"token_endpoint_auth_method,omitempty"`
+	ClientURI               string `json:"client_uri,omitempty"`
+	LogoURI                 string `json:"logo_uri,omitempty"`
+	TOSURI                  string `json:"tos_uri,omitempty"`
+	PolicyURI               string `json:"policy_uri,omitempty"`
+}

--- a/pkg/api/model/oauth_client_resolution_document.go
+++ b/pkg/api/model/oauth_client_resolution_document.go
@@ -1,0 +1,36 @@
+package model
+
+// OAuthClientResolutionDocument is the CIMD client metadata document as
+// fetched: no defaults applied where the document omitted a field, and
+// nothing dropped -- GrantTypes in particular is the document's declared
+// list before Rule 5 filters out entries Authgear does not implement,
+// unlike the persisted client's own GrantTypes, which is what survived.
+// This is the CIMD counterpart of OAuthClientRegistrationRequest, and for
+// the same reason: a resolution that succeeds can still have silently
+// dropped or ignored parts of the document (an unimplemented grant_type,
+// the ignored token_endpoint_auth_method) that the persisted client alone
+// cannot show. Lives in this package rather than nonblocking because it is
+// plain data referenced from outside the event system too
+// (pkg/lib/cimd/service.go builds one directly from the parsed document).
+//
+// The document is the client's own published, publicly-fetched metadata --
+// never a secret (client_secret is dropped before it ever reaches Go code;
+// see cimd.rawDocument's own doc comment) -- so recording it in full
+// carries none of the SSRF/probing-oracle sensitivity that governs
+// oauth.client.resolution.failed's uniform "unavailable" reason.
+type OAuthClientResolutionDocument struct {
+	ClientName      string   `json:"client_name,omitempty"`
+	RedirectURIs    []string `json:"redirect_uris,omitempty"`
+	GrantTypes      []string `json:"grant_types,omitempty"`
+	ResponseTypes   []string `json:"response_types,omitempty"`
+	ApplicationType string   `json:"application_type,omitempty"`
+	// TokenEndpointAuthMethod is recorded even though CIMD ignores it, and
+	// so can never cause a failure: being ignored is what makes it
+	// invisible everywhere else -- the persisted client always resolves as
+	// "none" regardless of what the document declared.
+	TokenEndpointAuthMethod string `json:"token_endpoint_auth_method,omitempty"`
+	ClientURI               string `json:"client_uri,omitempty"`
+	LogoURI                 string `json:"logo_uri,omitempty"`
+	TOSURI                  string `json:"tos_uri,omitempty"`
+	PolicyURI               string `json:"policy_uri,omitempty"`
+}

--- a/pkg/api/model/oauth_initial_access_token_event_payload.go
+++ b/pkg/api/model/oauth_initial_access_token_event_payload.go
@@ -1,26 +1,25 @@
-package nonblocking
+package model
 
-import (
-	"time"
-
-	"github.com/authgear/authgear-server/pkg/api/model"
-)
+import "time"
 
 // EventPayloadInitialAccessToken describes an initial access token in an
-// audit event payload. Shared by oauth.client.registered and
+// audit event payload. Shared by nonblocking's oauth.client.registered and
 // oauth.client.registration.failed, deliberately -- unlike the per-event
 // Client payload structs, which are kept independent on purpose, this one
 // must never diverge: the point is that a token presents identically in
 // both records, so an auditor correlating "which clients did leaked token
 // X register, and when did it stop working" reads one shape throughout.
+// Lives in this package rather than nonblocking for the same reason as
+// OAuthClientRegistrationRequest and OAuthClientResolutionDocument: plain
+// data referenced from outside the event system too.
 //
 // Never carries the token value or a hash of it (a hash is still a
 // guessing oracle). ID is the row uuid the Admin API already exposes.
 type EventPayloadInitialAccessToken struct {
-	ID        string                            `json:"id"`
-	Type      model.OAuthInitialAccessTokenType `json:"type"`
-	CreatedAt time.Time                         `json:"created_at"`
-	ExpiresAt time.Time                         `json:"expires_at"`
+	ID        string                      `json:"id"`
+	Type      OAuthInitialAccessTokenType `json:"type"`
+	CreatedAt time.Time                   `json:"created_at"`
+	ExpiresAt time.Time                   `json:"expires_at"`
 }
 
 // NewEventPayloadInitialAccessToken maps nil to nil, which is what both
@@ -28,7 +27,7 @@ type EventPayloadInitialAccessToken struct {
 // absent one has no row to describe. Combined with `omitempty` on the
 // field, that drops the key entirely rather than emitting an object of
 // zero values.
-func NewEventPayloadInitialAccessToken(iat *model.OAuthInitialAccessToken) *EventPayloadInitialAccessToken {
+func NewEventPayloadInitialAccessToken(iat *OAuthInitialAccessToken) *EventPayloadInitialAccessToken {
 	if iat == nil {
 		return nil
 	}

--- a/pkg/api/model/oauth_initial_access_token_event_payload_test.go
+++ b/pkg/api/model/oauth_initial_access_token_event_payload_test.go
@@ -1,4 +1,4 @@
-package nonblocking_test
+package model_test
 
 import (
 	"testing"
@@ -6,14 +6,13 @@ import (
 
 	. "github.com/smartystreets/goconvey/convey"
 
-	"github.com/authgear/authgear-server/pkg/api/event/nonblocking"
 	"github.com/authgear/authgear-server/pkg/api/model"
 )
 
 func TestNewEventPayloadInitialAccessToken(t *testing.T) {
 	Convey("NewEventPayloadInitialAccessToken", t, func() {
 		Convey("nil maps to nil", func() {
-			So(nonblocking.NewEventPayloadInitialAccessToken(nil), ShouldBeNil)
+			So(model.NewEventPayloadInitialAccessToken(nil), ShouldBeNil)
 		})
 
 		Convey("a real token maps to its id, type, created_at and expires_at -- never the token value", func() {
@@ -27,7 +26,7 @@ func TestNewEventPayloadInitialAccessToken(t *testing.T) {
 				ExpiresAt: expiresAt,
 				Type:      model.OAuthInitialAccessTokenTypeThirdParty,
 			}
-			result := nonblocking.NewEventPayloadInitialAccessToken(iat)
+			result := model.NewEventPayloadInitialAccessToken(iat)
 			So(result, ShouldNotBeNil)
 			So(result.ID, ShouldEqual, "iat-id-123")
 			So(result.Type, ShouldEqual, model.OAuthInitialAccessTokenTypeThirdParty)

--- a/pkg/lib/cimd/document.go
+++ b/pkg/lib/cimd/document.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	"github.com/authgear/authgear-server/pkg/api/apierrors"
+	"github.com/authgear/authgear-server/pkg/util/httputil"
 )
 
 // CIMDDocumentInvalid is the one apierrors.Kind shared by every
@@ -220,7 +221,7 @@ func ParseAndValidate(requestURL string, body []byte, allowInsecureHTTP bool) (*
 //   - a custom (non-http, non-https) URI scheme
 //
 // Unlike dcr's redirect URI rule, application_type is NOT a parameter. DCR
-// gates http://localhost on application_type: native; CIMD cannot, because
+// gates loopback http:// on application_type: native; CIMD cannot, because
 // the MCP Authorization spec's own reference CIMD document uses
 // http://127.0.0.1:3000/callback and http://localhost:3000/callback while
 // omitting application_type entirely (so it defaults to "web"). Gating
@@ -241,15 +242,11 @@ func validateCIMDRedirectURI(raw string) error {
 		return nil
 	case "http":
 		// url.URL.Hostname() strips the brackets from "[::1]:3000", so this
-		// matches "http://[::1]:3000/callback" too. RFC 8252 §7.3 treats
-		// both IPv4 and IPv6 loopback as loopback, and an IPv6-only
-		// developer machine has no 127.0.0.1 to listen on.
-		switch u.Hostname() {
-		case "localhost", "127.0.0.1", "::1":
-			return nil
-		default:
+		// matches "http://[::1]:3000/callback" too.
+		if !httputil.IsLoopbackHost(u.Hostname()) {
 			return ErrDocumentRedirectURIInvalid
 		}
+		return nil
 	default:
 		// Any custom scheme (com.example.app:/callback, myapp://cb, ...).
 		return nil

--- a/pkg/lib/cimd/document.go
+++ b/pkg/lib/cimd/document.go
@@ -27,38 +27,37 @@ import (
 var CIMDDocumentInvalid = apierrors.Invalid.WithReason("CIMDDocumentInvalid")
 
 var (
-	ErrDocumentNotJSONObject                      = CIMDDocumentInvalid.NewWithCause("cimd: document is not a JSON object", apierrors.StringCause("NotJSONObject"))
-	ErrDocumentClientIDMismatch                   = CIMDDocumentInvalid.NewWithCause("cimd: client_id does not equal the request URL", apierrors.StringCause("ClientIDMismatch"))
-	ErrDocumentRedirectURIsMissing                = CIMDDocumentInvalid.NewWithCause("cimd: redirect_uris is required", apierrors.StringCause("RedirectURIsMissing"))
-	ErrDocumentRedirectURIInvalid                 = CIMDDocumentInvalid.NewWithCause("cimd: invalid redirect_uri", apierrors.StringCause("RedirectURIInvalid"))
-	ErrDocumentGrantTypeUnsupported               = CIMDDocumentInvalid.NewWithCause("cimd: no supported grant_type", apierrors.StringCause("GrantTypeUnsupported"))
-	ErrDocumentResponseTypeInconsistent           = CIMDDocumentInvalid.NewWithCause("cimd: response_types is inconsistent with grant_types", apierrors.StringCause("ResponseTypeInconsistent"))
-	ErrDocumentApplicationTypeUnsupported         = CIMDDocumentInvalid.NewWithCause("cimd: unsupported application_type", apierrors.StringCause("ApplicationTypeUnsupported"))
-	ErrDocumentTokenEndpointAuthMethodNotAccepted = CIMDDocumentInvalid.NewWithCause("cimd: token_endpoint_auth_method is not accepted", apierrors.StringCause("TokenEndpointAuthMethodNotAccepted"))
-	ErrDocumentURIFieldNotHTTPS                   = CIMDDocumentInvalid.NewWithCause("cimd: uri field must use https", apierrors.StringCause("URIFieldNotHTTPS"))
+	ErrDocumentNotJSONObject              = CIMDDocumentInvalid.NewWithCause("cimd: document is not a JSON object", apierrors.StringCause("NotJSONObject"))
+	ErrDocumentClientIDMismatch           = CIMDDocumentInvalid.NewWithCause("cimd: client_id does not equal the request URL", apierrors.StringCause("ClientIDMismatch"))
+	ErrDocumentRedirectURIsMissing        = CIMDDocumentInvalid.NewWithCause("cimd: redirect_uris is required", apierrors.StringCause("RedirectURIsMissing"))
+	ErrDocumentRedirectURIInvalid         = CIMDDocumentInvalid.NewWithCause("cimd: invalid redirect_uri", apierrors.StringCause("RedirectURIInvalid"))
+	ErrDocumentGrantTypeUnsupported       = CIMDDocumentInvalid.NewWithCause("cimd: no supported grant_type", apierrors.StringCause("GrantTypeUnsupported"))
+	ErrDocumentResponseTypeInconsistent   = CIMDDocumentInvalid.NewWithCause("cimd: response_types is inconsistent with grant_types", apierrors.StringCause("ResponseTypeInconsistent"))
+	ErrDocumentApplicationTypeUnsupported = CIMDDocumentInvalid.NewWithCause("cimd: unsupported application_type", apierrors.StringCause("ApplicationTypeUnsupported"))
+	ErrDocumentURIFieldNotHTTPS           = CIMDDocumentInvalid.NewWithCause("cimd: uri field must use https", apierrors.StringCause("URIFieldNotHTTPS"))
 )
 
 // rawDocument is the wire shape. Every field the spec says to reject or
 // ignore -- client_secret, client_secret_expires_at, jwks_uri,
-// software_statement, and any unknown property -- is simply absent from
-// this struct, so encoding/json drops it. There is no need to name them
-// and no DisallowUnknownFields: spec § Validation says "Unrecognized
-// properties are ignored (the spec explicitly allows additional
-// properties)", and spec §4.1 says credential material is "always ignored",
-// not "rejected". A document carrying a client_secret is therefore VALID
-// and its secret is discarded.
+// software_statement, token_endpoint_auth_method, and any unknown
+// property -- is simply absent from this struct, so encoding/json drops
+// it. There is no need to name them and no DisallowUnknownFields: spec
+// § Validation says "Unrecognized properties are ignored (the spec
+// explicitly allows additional properties)", and spec §4.1 says
+// credential material is "always ignored", not "rejected". A document
+// carrying a client_secret is therefore VALID and its secret is
+// discarded.
 type rawDocument struct {
-	ClientID                *string  `json:"client_id"`
-	ClientName              *string  `json:"client_name"`
-	RedirectURIs            []string `json:"redirect_uris"`
-	GrantTypes              []string `json:"grant_types"`
-	ResponseTypes           []string `json:"response_types"`
-	ApplicationType         *string  `json:"application_type"`
-	LogoURI                 *string  `json:"logo_uri"`
-	ClientURI               *string  `json:"client_uri"`
-	TOSURI                  *string  `json:"tos_uri"`
-	PolicyURI               *string  `json:"policy_uri"`
-	TokenEndpointAuthMethod *string  `json:"token_endpoint_auth_method"`
+	ClientID        *string  `json:"client_id"`
+	ClientName      *string  `json:"client_name"`
+	RedirectURIs    []string `json:"redirect_uris"`
+	GrantTypes      []string `json:"grant_types"`
+	ResponseTypes   []string `json:"response_types"`
+	ApplicationType *string  `json:"application_type"`
+	LogoURI         *string  `json:"logo_uri"`
+	ClientURI       *string  `json:"client_uri"`
+	TOSURI          *string  `json:"tos_uri"`
+	PolicyURI       *string  `json:"policy_uri"`
 }
 
 // Document is a rawDocument after defaults have been applied and every
@@ -69,9 +68,7 @@ type Document struct {
 	ClientName   *string
 	RedirectURIs []string
 	// GrantTypes holds only the grant types Authgear implements, in the
-	// order the document listed them -- anything else the document
-	// declared has been dropped by Rule 5, so this is what the client can
-	// actually do here, not a verbatim copy of what it published.
+	// document's order -- Rule 5 dropped the rest.
 	GrantTypes    []string
 	ResponseTypes []string
 	// ApplicationType is always "web" or "native" -- never nil, never
@@ -118,12 +115,9 @@ func ParseAndValidate(requestURL string, body []byte, allowInsecureHTTP bool) (*
 		return nil, errors.Join(ErrDocumentNotJSONObject, err)
 	}
 
-	// Rule 1: token_endpoint_auth_method, if present, MUST be "none".
-	// Checked first, mirroring dcr.ValidateAndNormalize. Rejects
-	// private_key_jwt and every client_secret_* variant.
-	if raw.TokenEndpointAuthMethod != nil && *raw.TokenEndpointAuthMethod != "none" {
-		return nil, ErrDocumentTokenEndpointAuthMethodNotAccepted
-	}
+	// Rule 1: token_endpoint_auth_method is ignored -- no check here and no
+	// field in rawDocument. Numbering below is kept as-is so the spec's
+	// rules still line up.
 
 	// Rule 2: client_id MUST be present and MUST equal requestURL
 	// byte-for-byte. No normalization, no case folding, no trailing-slash
@@ -154,33 +148,9 @@ func ParseAndValidate(requestURL string, body []byte, allowInsecureHTTP bool) (*
 		}
 	}
 
-	// Rule 5: grant_types entries Authgear does not implement are IGNORED.
-	// A document that declared grant types and had ALL of them dropped
-	// keeps the ErrDocumentGrantTypeUnsupported it has always returned;
-	// everything else is left to Rules 6 and 7, exactly as before.
-	//
-	// Ignoring rather than rejecting is the whole point: a CIMD document is
-	// ONE self-published description of a client, used against every
-	// authorization server that client talks to, so it advertises every
-	// grant the client can perform anywhere -- not the subset any single
-	// server implements, and unlike a DCR request it cannot be tailored to
-	// the server receiving it. Claude's document
-	// (https://claude.ai/oauth/mcp-oauth-client-metadata) declares
-	// urn:ietf:params:oauth:grant-type:jwt-bearer for MCP Enterprise
-	// Managed Auth's identity-assertion exchange (RFC 7523) alongside the
-	// authorization_code and refresh_token it uses everywhere else.
-	// Rejecting the whole document over that one entry made every Claude
-	// connector unresolvable, and it protected nothing: a grant Authgear
-	// omits from grant_types_supported is never requested, and if one were
-	// requested anyway the token endpoint answers unsupported_grant_type
-	// on its own (see handler_token.go's validateRequestWithoutTx) --
-	// the persisted grant_types are not what gates it.
-	//
-	// This is deliberately a pure relaxation: no document that resolved
-	// before this rule existed stops resolving because of it. In
-	// particular an explicitly empty grant_types is NOT an error here --
-	// it never was, and Rule 7 keeps deciding it -- so the emptiness check
-	// below is scoped to a list that had entries to lose.
+	// Rule 5: entries Authgear does not implement are dropped; erroring
+	// only if the document declared entries and lost them all. An
+	// explicitly empty list had nothing to lose, so Rule 7 decides it.
 	rawGrantTypes := raw.GrantTypes
 	if rawGrantTypes == nil {
 		rawGrantTypes = []string{"authorization_code", "refresh_token"}
@@ -207,12 +177,7 @@ func ParseAndValidate(requestURL string, body []byte, allowInsecureHTTP bool) (*
 	}
 
 	// Rule 7: response_types MUST be consistent with grant_types. Same rule
-	// as DCR (dcr/validate.go): contains(grantTypes, "authorization_code")
-	// == contains(responseTypes, "code"). Checked against the FILTERED
-	// grant types, so a document whose authorization_code was never
-	// declared -- or that declared only refresh_token next to grants
-	// Authgear does not implement -- is held to the same consistency it
-	// always was: it needs a response_types that omits "code" too.
+	// as DCR (dcr/validate.go), applied to the filtered grant types.
 	hasAuthorizationCode := slices.Contains(grantTypes, "authorization_code")
 	hasCode := slices.Contains(responseTypes, "code")
 	if hasAuthorizationCode != hasCode {

--- a/pkg/lib/cimd/document.go
+++ b/pkg/lib/cimd/document.go
@@ -38,27 +38,34 @@ var (
 	ErrDocumentURIFieldNotHTTPS           = CIMDDocumentInvalid.NewWithCause("cimd: uri field must use https", apierrors.StringCause("URIFieldNotHTTPS"))
 )
 
-// rawDocument is the wire shape. Every field the spec says to reject or
-// ignore -- client_secret, client_secret_expires_at, jwks_uri,
-// software_statement, token_endpoint_auth_method, and any unknown
-// property -- is simply absent from this struct, so encoding/json drops
-// it. There is no need to name them and no DisallowUnknownFields: spec
-// § Validation says "Unrecognized properties are ignored (the spec
-// explicitly allows additional properties)", and spec §4.1 says
-// credential material is "always ignored", not "rejected". A document
-// carrying a client_secret is therefore VALID and its secret is
+// rawDocument is the wire shape. Every field the spec says to reject --
+// client_secret, client_secret_expires_at, jwks_uri, software_statement,
+// and any unknown property -- is simply absent from this struct, so
+// encoding/json drops it. There is no need to name them and no
+// DisallowUnknownFields: spec § Validation says "Unrecognized properties
+// are ignored (the spec explicitly allows additional properties)", and
+// spec §4.1 says credential material is "always ignored", not "rejected".
+// A document carrying a client_secret is therefore VALID and its secret is
 // discarded.
+//
+// token_endpoint_auth_method IS named here, unlike the fields above,
+// despite being ignored exactly the same way: Rule 1 never validates or
+// acts on it, but Document.TokenEndpointAuthMethod carries it through
+// purely so oauth.client.resolved's audit record can show what a document
+// declared, the same way DCR's registrationRequestBody keeps it for
+// oauth.client.registered/oauth.client.registration.failed.
 type rawDocument struct {
-	ClientID        *string  `json:"client_id"`
-	ClientName      *string  `json:"client_name"`
-	RedirectURIs    []string `json:"redirect_uris"`
-	GrantTypes      []string `json:"grant_types"`
-	ResponseTypes   []string `json:"response_types"`
-	ApplicationType *string  `json:"application_type"`
-	LogoURI         *string  `json:"logo_uri"`
-	ClientURI       *string  `json:"client_uri"`
-	TOSURI          *string  `json:"tos_uri"`
-	PolicyURI       *string  `json:"policy_uri"`
+	ClientID                *string  `json:"client_id"`
+	ClientName              *string  `json:"client_name"`
+	RedirectURIs            []string `json:"redirect_uris"`
+	GrantTypes              []string `json:"grant_types"`
+	ResponseTypes           []string `json:"response_types"`
+	ApplicationType         *string  `json:"application_type"`
+	LogoURI                 *string  `json:"logo_uri"`
+	ClientURI               *string  `json:"client_uri"`
+	TOSURI                  *string  `json:"tos_uri"`
+	PolicyURI               *string  `json:"policy_uri"`
+	TokenEndpointAuthMethod *string  `json:"token_endpoint_auth_method"`
 }
 
 // Document is a rawDocument after defaults have been applied and every
@@ -70,15 +77,45 @@ type Document struct {
 	RedirectURIs []string
 	// GrantTypes holds only the grant types Authgear implements, in the
 	// document's order -- Rule 5 dropped the rest.
-	GrantTypes    []string
+	GrantTypes []string
+	// RawGrantTypes is the document's declared grant_types, before Rule 5
+	// filtering -- nil if the document omitted the field, same as
+	// rawDocument.GrantTypes. Not used for anything but the audit trail
+	// (oauth.client.resolved's Document.GrantTypes): the persisted client
+	// only ever gets GrantTypes above.
+	RawGrantTypes []string
 	ResponseTypes []string
+	// RawResponseTypes is the document's declared response_types, before
+	// Rule 6's default is applied -- nil if the document omitted the
+	// field. Same relationship to ResponseTypes as RawGrantTypes has to
+	// GrantTypes, though Rule 6 never filters entries the way Rule 5
+	// does -- an unsupported response_type rejects the whole document
+	// rather than being dropped, so this exists only for "no defaults
+	// applied" audit-trail consistency, not because entries can go
+	// missing silently.
+	RawResponseTypes []string
 	// ApplicationType is always "web" or "native" -- never nil, never
-	// anything else.
+	// anything else. Rule 3 never substitutes a value, unlike Rule 5's
+	// grant_types filtering: an invalid application_type rejects the whole
+	// document rather than falling back to a default, so this can never
+	// diverge from what the document declared the way GrantTypes can --
+	// RawApplicationType exists only for the same "no defaults applied"
+	// audit-trail consistency as RawGrantTypes, not because this one can
+	// hide anything.
 	ApplicationType string
-	LogoURI         *string
-	ClientURI       *string
-	TOSURI          *string
-	PolicyURI       *string
+	// RawApplicationType is the document's declared application_type, ""
+	// if absent -- same relationship to ApplicationType as
+	// RawGrantTypes has to GrantTypes.
+	RawApplicationType string
+	LogoURI            *string
+	ClientURI          *string
+	TOSURI             *string
+	PolicyURI          *string
+	// TokenEndpointAuthMethod is the document's declared value, "" if
+	// absent. Never validated, never acted on -- Rule 1 ignores it
+	// unconditionally -- kept only for the audit trail, same as
+	// RawGrantTypes.
+	TokenEndpointAuthMethod string
 }
 
 var cimdSupportedGrantTypes = map[string]bool{
@@ -116,9 +153,10 @@ func ParseAndValidate(requestURL string, body []byte, allowInsecureHTTP bool) (*
 		return nil, errors.Join(ErrDocumentNotJSONObject, err)
 	}
 
-	// Rule 1: token_endpoint_auth_method is ignored -- no check here and no
-	// field in rawDocument. Numbering below is kept as-is so the spec's
-	// rules still line up.
+	// Rule 1: token_endpoint_auth_method is ignored -- no check here, and
+	// the value below is kept only for the audit trail (Document's own
+	// comment), never validated or acted on. Numbering below is kept as-is
+	// so the spec's rules still line up.
 
 	// Rule 2: client_id MUST be present and MUST equal requestURL
 	// byte-for-byte. No normalization, no case folding, no trailing-slash
@@ -200,15 +238,19 @@ func ParseAndValidate(requestURL string, body []byte, allowInsecureHTTP bool) (*
 	// "Client <clientID>" fallback is NOT applied here; it is computed on
 	// read by oauthclient.Client.DisplayName().
 	return &Document{
-		ClientName:      raw.ClientName,
-		RedirectURIs:    raw.RedirectURIs,
-		GrantTypes:      grantTypes,
-		ResponseTypes:   responseTypes,
-		ApplicationType: applicationType,
-		LogoURI:         raw.LogoURI,
-		ClientURI:       raw.ClientURI,
-		TOSURI:          raw.TOSURI,
-		PolicyURI:       raw.PolicyURI,
+		ClientName:              raw.ClientName,
+		RedirectURIs:            raw.RedirectURIs,
+		GrantTypes:              grantTypes,
+		RawGrantTypes:           raw.GrantTypes,
+		ResponseTypes:           responseTypes,
+		RawResponseTypes:        raw.ResponseTypes,
+		ApplicationType:         applicationType,
+		RawApplicationType:      derefStringOr(raw.ApplicationType, ""),
+		TokenEndpointAuthMethod: derefStringOr(raw.TokenEndpointAuthMethod, ""),
+		LogoURI:                 raw.LogoURI,
+		ClientURI:               raw.ClientURI,
+		TOSURI:                  raw.TOSURI,
+		PolicyURI:               raw.PolicyURI,
 	}, nil
 }
 

--- a/pkg/lib/cimd/document.go
+++ b/pkg/lib/cimd/document.go
@@ -31,7 +31,7 @@ var (
 	ErrDocumentClientIDMismatch                   = CIMDDocumentInvalid.NewWithCause("cimd: client_id does not equal the request URL", apierrors.StringCause("ClientIDMismatch"))
 	ErrDocumentRedirectURIsMissing                = CIMDDocumentInvalid.NewWithCause("cimd: redirect_uris is required", apierrors.StringCause("RedirectURIsMissing"))
 	ErrDocumentRedirectURIInvalid                 = CIMDDocumentInvalid.NewWithCause("cimd: invalid redirect_uri", apierrors.StringCause("RedirectURIInvalid"))
-	ErrDocumentGrantTypeUnsupported               = CIMDDocumentInvalid.NewWithCause("cimd: unsupported grant_type", apierrors.StringCause("GrantTypeUnsupported"))
+	ErrDocumentGrantTypeUnsupported               = CIMDDocumentInvalid.NewWithCause("cimd: no supported grant_type", apierrors.StringCause("GrantTypeUnsupported"))
 	ErrDocumentResponseTypeInconsistent           = CIMDDocumentInvalid.NewWithCause("cimd: response_types is inconsistent with grant_types", apierrors.StringCause("ResponseTypeInconsistent"))
 	ErrDocumentApplicationTypeUnsupported         = CIMDDocumentInvalid.NewWithCause("cimd: unsupported application_type", apierrors.StringCause("ApplicationTypeUnsupported"))
 	ErrDocumentTokenEndpointAuthMethodNotAccepted = CIMDDocumentInvalid.NewWithCause("cimd: token_endpoint_auth_method is not accepted", apierrors.StringCause("TokenEndpointAuthMethodNotAccepted"))
@@ -66,8 +66,12 @@ type rawDocument struct {
 // of dcr.NormalizedRegistration, and for the same reason: the caller
 // (Part 3) copies it straight onto oauthclient.NewClientOptions.
 type Document struct {
-	ClientName    *string
-	RedirectURIs  []string
+	ClientName   *string
+	RedirectURIs []string
+	// GrantTypes holds only the grant types Authgear implements, in the
+	// order the document listed them -- anything else the document
+	// declared has been dropped by Rule 5, so this is what the client can
+	// actually do here, not a verbatim copy of what it published.
 	GrantTypes    []string
 	ResponseTypes []string
 	// ApplicationType is always "web" or "native" -- never nil, never
@@ -150,16 +154,45 @@ func ParseAndValidate(requestURL string, body []byte, allowInsecureHTTP bool) (*
 		}
 	}
 
-	// Rule 5: grant_types MUST be a subset of
-	// ["authorization_code", "refresh_token"].
-	grantTypes := raw.GrantTypes
-	if grantTypes == nil {
-		grantTypes = []string{"authorization_code", "refresh_token"}
+	// Rule 5: grant_types entries Authgear does not implement are IGNORED.
+	// A document that declared grant types and had ALL of them dropped
+	// keeps the ErrDocumentGrantTypeUnsupported it has always returned;
+	// everything else is left to Rules 6 and 7, exactly as before.
+	//
+	// Ignoring rather than rejecting is the whole point: a CIMD document is
+	// ONE self-published description of a client, used against every
+	// authorization server that client talks to, so it advertises every
+	// grant the client can perform anywhere -- not the subset any single
+	// server implements, and unlike a DCR request it cannot be tailored to
+	// the server receiving it. Claude's document
+	// (https://claude.ai/oauth/mcp-oauth-client-metadata) declares
+	// urn:ietf:params:oauth:grant-type:jwt-bearer for MCP Enterprise
+	// Managed Auth's identity-assertion exchange (RFC 7523) alongside the
+	// authorization_code and refresh_token it uses everywhere else.
+	// Rejecting the whole document over that one entry made every Claude
+	// connector unresolvable, and it protected nothing: a grant Authgear
+	// omits from grant_types_supported is never requested, and if one were
+	// requested anyway the token endpoint answers unsupported_grant_type
+	// on its own (see handler_token.go's validateRequestWithoutTx) --
+	// the persisted grant_types are not what gates it.
+	//
+	// This is deliberately a pure relaxation: no document that resolved
+	// before this rule existed stops resolving because of it. In
+	// particular an explicitly empty grant_types is NOT an error here --
+	// it never was, and Rule 7 keeps deciding it -- so the emptiness check
+	// below is scoped to a list that had entries to lose.
+	rawGrantTypes := raw.GrantTypes
+	if rawGrantTypes == nil {
+		rawGrantTypes = []string{"authorization_code", "refresh_token"}
 	}
-	for _, gt := range grantTypes {
-		if !cimdSupportedGrantTypes[gt] {
-			return nil, ErrDocumentGrantTypeUnsupported
+	grantTypes := make([]string, 0, len(rawGrantTypes))
+	for _, gt := range rawGrantTypes {
+		if cimdSupportedGrantTypes[gt] {
+			grantTypes = append(grantTypes, gt)
 		}
+	}
+	if len(grantTypes) == 0 && len(rawGrantTypes) > 0 {
+		return nil, ErrDocumentGrantTypeUnsupported
 	}
 
 	// Rule 6: response_types MUST be a subset of ["code"].
@@ -175,7 +208,11 @@ func ParseAndValidate(requestURL string, body []byte, allowInsecureHTTP bool) (*
 
 	// Rule 7: response_types MUST be consistent with grant_types. Same rule
 	// as DCR (dcr/validate.go): contains(grantTypes, "authorization_code")
-	// == contains(responseTypes, "code").
+	// == contains(responseTypes, "code"). Checked against the FILTERED
+	// grant types, so a document whose authorization_code was never
+	// declared -- or that declared only refresh_token next to grants
+	// Authgear does not implement -- is held to the same consistency it
+	// always was: it needs a response_types that omits "code" too.
 	hasAuthorizationCode := slices.Contains(grantTypes, "authorization_code")
 	hasCode := slices.Contains(responseTypes, "code")
 	if hasAuthorizationCode != hasCode {

--- a/pkg/lib/cimd/document_test.go
+++ b/pkg/lib/cimd/document_test.go
@@ -27,8 +27,25 @@ var mcpExampleDocument = []byte(`{
   "token_endpoint_auth_method": "none"
 }`)
 
+const claudeClientID = "https://claude.ai/oauth/mcp-oauth-client-metadata"
+
+// claudeDocument is what claude.ai serves for its hosted MCP connectors,
+// verbatim. Its jwt-bearer grant type (MCP Enterprise Managed Auth, which
+// Authgear does not implement) used to make the whole document invalid,
+// leaving every Claude connector unresolvable -- see Rule 5.
+var claudeDocument = []byte(`{"client_id":"https://claude.ai/oauth/mcp-oauth-client-metadata","client_name":"Claude","client_uri":"https://claude.ai","redirect_uris":["https://claude.ai/api/mcp/auth_callback"],"grant_types":["authorization_code","refresh_token","urn:ietf:params:oauth:grant-type:jwt-bearer"],"response_types":["code"],"token_endpoint_auth_method":"none"}`)
+
 func TestParseAndValidate(t *testing.T) {
 	Convey("ParseAndValidate", t, func() {
+		Convey("claude.ai's real document is valid, with jwt-bearer dropped", func() {
+			doc, err := cimd.ParseAndValidate(claudeClientID, claudeDocument, false)
+			So(err, ShouldBeNil)
+			So(doc.GrantTypes, ShouldResemble, []string{"authorization_code", "refresh_token"})
+			So(doc.ResponseTypes, ShouldResemble, []string{"code"})
+			So(doc.RedirectURIs, ShouldResemble, []string{"https://claude.ai/api/mcp/auth_callback"})
+			So(*doc.ClientName, ShouldEqual, "Claude")
+		})
+
 		Convey("the MCP spec's own example document is valid", func() {
 			doc, err := cimd.ParseAndValidate(mcpExampleClientID, mcpExampleDocument, false)
 			So(err, ShouldBeNil)
@@ -164,11 +181,71 @@ func TestParseAndValidate(t *testing.T) {
 		})
 
 		Convey("grant_types", func() {
+			Convey("absent defaults to authorization_code and refresh_token", func() {
+				doc := validDoc()
+				delete(doc, "grant_types")
+				parsed, err := parse(t, mcpExampleClientID, doc)
+				So(err, ShouldBeNil)
+				So(parsed.GrantTypes, ShouldResemble, []string{"authorization_code", "refresh_token"})
+			})
+
+			Convey("an unimplemented grant type is ignored, not fatal", func() {
+				doc := validDoc()
+				doc["grant_types"] = []string{"authorization_code", "refresh_token", "urn:ietf:params:oauth:grant-type:jwt-bearer"}
+				parsed, err := parse(t, mcpExampleClientID, doc)
+				So(err, ShouldBeNil)
+				So(parsed.GrantTypes, ShouldResemble, []string{"authorization_code", "refresh_token"})
+			})
+
+			Convey("ignoring preserves the document's order of what remains", func() {
+				doc := validDoc()
+				doc["grant_types"] = []string{"refresh_token", "client_credentials", "authorization_code"}
+				parsed, err := parse(t, mcpExampleClientID, doc)
+				So(err, ShouldBeNil)
+				So(parsed.GrantTypes, ShouldResemble, []string{"refresh_token", "authorization_code"})
+			})
+
 			Convey("client_credentials is rejected", func() {
 				doc := validDoc()
 				doc["grant_types"] = []string{"client_credentials"}
 				_, err := parse(t, mcpExampleClientID, doc)
 				So(err, ShouldEqual, cimd.ErrDocumentGrantTypeUnsupported)
+			})
+
+			Convey("jwt-bearer alone is rejected", func() {
+				doc := validDoc()
+				doc["grant_types"] = []string{"urn:ietf:params:oauth:grant-type:jwt-bearer"}
+				_, err := parse(t, mcpExampleClientID, doc)
+				So(err, ShouldEqual, cimd.ErrDocumentGrantTypeUnsupported)
+			})
+
+			// An explicitly empty array declared nothing to lose, so it is
+			// not a Rule 5 failure -- Rule 7 decides it, as it always has.
+			Convey("an empty array is left to the consistency rule", func() {
+				doc := validDoc()
+				doc["grant_types"] = []string{}
+				_, err := parse(t, mcpExampleClientID, doc)
+				So(err, ShouldEqual, cimd.ErrDocumentResponseTypeInconsistent)
+
+				doc["response_types"] = []string{}
+				parsed, err := parse(t, mcpExampleClientID, doc)
+				So(err, ShouldBeNil)
+				So(parsed.GrantTypes, ShouldBeEmpty)
+			})
+
+			// Same shape, reached by filtering rather than by declaration:
+			// what survives must still satisfy Rule 7, and nothing that
+			// resolved before the filter existed stops resolving now.
+			Convey("filtering down to refresh_token alone is left to the consistency rule", func() {
+				doc := validDoc()
+				doc["grant_types"] = []string{"refresh_token", "urn:ietf:params:oauth:grant-type:jwt-bearer"}
+				_, err := parse(t, mcpExampleClientID, doc)
+				So(err, ShouldEqual, cimd.ErrDocumentResponseTypeInconsistent)
+
+				doc["response_types"] = []string{}
+				parsed, err := parse(t, mcpExampleClientID, doc)
+				So(err, ShouldBeNil)
+				So(parsed.GrantTypes, ShouldResemble, []string{"refresh_token"})
 			})
 		})
 
@@ -184,6 +261,13 @@ func TestParseAndValidate(t *testing.T) {
 				doc := validDoc()
 				doc["grant_types"] = []string{"refresh_token"}
 				doc["response_types"] = []string{"code"}
+				_, err := parse(t, mcpExampleClientID, doc)
+				So(err, ShouldEqual, cimd.ErrDocumentResponseTypeInconsistent)
+			})
+
+			Convey("an empty response_types is rejected as inconsistent with authorization_code", func() {
+				doc := validDoc()
+				doc["response_types"] = []string{}
 				_, err := parse(t, mcpExampleClientID, doc)
 				So(err, ShouldEqual, cimd.ErrDocumentResponseTypeInconsistent)
 			})

--- a/pkg/lib/cimd/document_test.go
+++ b/pkg/lib/cimd/document_test.go
@@ -30,9 +30,8 @@ var mcpExampleDocument = []byte(`{
 const claudeClientID = "https://claude.ai/oauth/mcp-oauth-client-metadata"
 
 // claudeDocument is what claude.ai serves for its hosted MCP connectors,
-// verbatim. Its jwt-bearer grant type (MCP Enterprise Managed Auth, which
-// Authgear does not implement) used to make the whole document invalid,
-// leaving every Claude connector unresolvable -- see Rule 5.
+// verbatim. Its jwt-bearer grant type used to invalidate the whole
+// document, leaving every Claude connector unresolvable.
 var claudeDocument = []byte(`{"client_id":"https://claude.ai/oauth/mcp-oauth-client-metadata","client_name":"Claude","client_uri":"https://claude.ai","redirect_uris":["https://claude.ai/api/mcp/auth_callback"],"grant_types":["authorization_code","refresh_token","urn:ietf:params:oauth:grant-type:jwt-bearer"],"response_types":["code"],"token_endpoint_auth_method":"none"}`)
 
 func TestParseAndValidate(t *testing.T) {
@@ -102,18 +101,19 @@ func TestParseAndValidate(t *testing.T) {
 				So(err, ShouldBeNil)
 			})
 
-			Convey("client_secret_post is rejected", func() {
+			// Ignored, not honored: the client is public either way.
+			Convey("client_secret_post is ignored", func() {
 				doc := validDoc()
 				doc["token_endpoint_auth_method"] = "client_secret_post"
 				_, err := parse(t, mcpExampleClientID, doc)
-				So(err, ShouldEqual, cimd.ErrDocumentTokenEndpointAuthMethodNotAccepted)
+				So(err, ShouldBeNil)
 			})
 
-			Convey("private_key_jwt is rejected", func() {
+			Convey("private_key_jwt is ignored", func() {
 				doc := validDoc()
 				doc["token_endpoint_auth_method"] = "private_key_jwt"
 				_, err := parse(t, mcpExampleClientID, doc)
-				So(err, ShouldEqual, cimd.ErrDocumentTokenEndpointAuthMethodNotAccepted)
+				So(err, ShouldBeNil)
 			})
 		})
 
@@ -219,8 +219,7 @@ func TestParseAndValidate(t *testing.T) {
 				So(err, ShouldEqual, cimd.ErrDocumentGrantTypeUnsupported)
 			})
 
-			// An explicitly empty array declared nothing to lose, so it is
-			// not a Rule 5 failure -- Rule 7 decides it, as it always has.
+			// Nothing to lose, so Rule 7 decides it, as it always has.
 			Convey("an empty array is left to the consistency rule", func() {
 				doc := validDoc()
 				doc["grant_types"] = []string{}
@@ -233,9 +232,7 @@ func TestParseAndValidate(t *testing.T) {
 				So(parsed.GrantTypes, ShouldBeEmpty)
 			})
 
-			// Same shape, reached by filtering rather than by declaration:
-			// what survives must still satisfy Rule 7, and nothing that
-			// resolved before the filter existed stops resolving now.
+			// Same shape, reached by filtering rather than by declaration.
 			Convey("filtering down to refresh_token alone is left to the consistency rule", func() {
 				doc := validDoc()
 				doc["grant_types"] = []string{"refresh_token", "urn:ietf:params:oauth:grant-type:jwt-bearer"}

--- a/pkg/lib/cimd/service.go
+++ b/pkg/lib/cimd/service.go
@@ -479,8 +479,9 @@ func (s *Service) upsert(ctx context.Context, clientID string, doc *Document, ex
 	changed := !created && existing.MetadataChangedFrom(options)
 	if created || changed {
 		payload := &nonblocking.OAuthClientResolvedEventPayload{
-			Client:  oauthClientResolvedEventPayloadClient(client),
-			Created: created,
+			Client:   oauthClientResolvedEventPayloadClient(client),
+			Document: oauthClientResolutionDocumentEventPayload(doc),
+			Created:  created,
 		}
 		if changed {
 			old := oauthClientResolvedEventPayloadClient(existing)
@@ -505,9 +506,33 @@ func oauthClientResolvedEventPayloadClient(c *oauthclient.Client) nonblocking.OA
 		TOSURI:          derefStringOr(c.TOSURI, ""),
 		PolicyURI:       derefStringOr(c.PolicyURI, ""),
 		ApplicationType: c.ApplicationType,
-		RedirectURIs:    c.RedirectURIs,
-		GrantTypes:      c.GrantTypes,
-		ResponseTypes:   c.ResponseTypes,
+		// CIMD always resolves the client as a public client with no
+		// secret, whatever token_endpoint_auth_method the document
+		// declared -- see oauthClientResolutionDocumentEventPayload for
+		// that.
+		TokenEndpointAuthMethod: "none",
+		RedirectURIs:            c.RedirectURIs,
+		GrantTypes:              c.GrantTypes,
+		ResponseTypes:           c.ResponseTypes,
+	}
+}
+
+// oauthClientResolutionDocumentEventPayload describes doc as fetched, before
+// Rule 5 grant_types filtering -- see Document.RawGrantTypes and
+// Document.TokenEndpointAuthMethod's own comments, and
+// model.OAuthClientResolutionDocument's.
+func oauthClientResolutionDocumentEventPayload(doc *Document) model.OAuthClientResolutionDocument {
+	return model.OAuthClientResolutionDocument{
+		ClientName:              derefStringOr(doc.ClientName, ""),
+		RedirectURIs:            doc.RedirectURIs,
+		GrantTypes:              doc.RawGrantTypes,
+		ResponseTypes:           doc.RawResponseTypes,
+		ApplicationType:         doc.RawApplicationType,
+		TokenEndpointAuthMethod: doc.TokenEndpointAuthMethod,
+		ClientURI:               derefStringOr(doc.ClientURI, ""),
+		LogoURI:                 derefStringOr(doc.LogoURI, ""),
+		TOSURI:                  derefStringOr(doc.TOSURI, ""),
+		PolicyURI:               derefStringOr(doc.PolicyURI, ""),
 	}
 }
 

--- a/pkg/lib/cimd/service.go
+++ b/pkg/lib/cimd/service.go
@@ -303,8 +303,6 @@ func documentErrorMessage(err error) string {
 		return "response_type_inconsistent"
 	case errors.Is(err, ErrDocumentApplicationTypeUnsupported):
 		return "application_type_unsupported"
-	case errors.Is(err, ErrDocumentTokenEndpointAuthMethodNotAccepted):
-		return "token_endpoint_auth_method_not_accepted"
 	case errors.Is(err, ErrDocumentURIFieldNotHTTPS):
 		return "uri_field_not_https"
 	default:

--- a/pkg/lib/cimd/service_test.go
+++ b/pkg/lib/cimd/service_test.go
@@ -464,6 +464,59 @@ func TestServiceEnsureClientResolved(t *testing.T) {
 			So(payload.Client.ClientName, ShouldEqual, "New Client")
 		})
 
+		Convey("audit: resolved event's Document shows the document as fetched, dropped grant_type and ignored auth method included", func() {
+			var ds *documentServer
+			ds = newDocumentServer(func(w http.ResponseWriter, r *http.Request) {
+				doc := `{"client_id":"` + ds.URL + `/x","client_name":"New Client",` +
+					`"redirect_uris":["http://127.0.0.1:3000/callback"],` +
+					`"grant_types":["authorization_code","refresh_token","urn:ietf:params:oauth:grant-type:jwt-bearer"],` +
+					`"response_types":["code"],"token_endpoint_auth_method":"client_secret_post"}`
+				_, _ = w.Write([]byte(doc))
+			})
+			defer ds.Close()
+
+			commands := &stubCommands{upsertFn: func(o *oauthclient.UpsertCIMDClientOptions) (*oauthclient.Client, bool, error) {
+				return &oauthclient.Client{
+					ClientID:      o.ClientID,
+					Source:        model.OAuthClientSourceCIMD,
+					Kind:          model.OAuthClientKindThirdParty,
+					ClientName:    o.ClientName,
+					RedirectURIs:  o.RedirectURIs,
+					GrantTypes:    o.GrantTypes,
+					ResponseTypes: o.ResponseTypes,
+				}, true, nil
+			}}
+			events := &stubEventService{}
+			svc := &cimd.Service{
+				OAuthConfig:  enabledOAuthConfig(),
+				Fetcher:      fetcherFor(ds),
+				Commands:     commands,
+				Queries:      &stubQueries{},
+				Database:     &stubDatabase{},
+				RateLimiter:  &stubRateLimiter{},
+				UsageLimiter: &stubUsageLimiter{},
+				Events:       events,
+				SingleFlight: newWorkingSingleFlight(t),
+			}
+
+			clientID := ds.URL + "/x"
+			err := svc.EnsureClientResolved(ctx, clientID)
+			So(err, ShouldBeNil)
+			So(events.dispatched, ShouldHaveLength, 1)
+			payload, ok := events.dispatched[0].Payload.(*nonblocking.OAuthClientResolvedEventPayload)
+			So(ok, ShouldBeTrue)
+
+			// The persisted client only ever shows what survived Rule 5
+			// filtering, and always resolves as a public client.
+			So(payload.Client.GrantTypes, ShouldResemble, []string{"authorization_code", "refresh_token"})
+			So(payload.Client.TokenEndpointAuthMethod, ShouldEqual, "none")
+			// Document shows the document as fetched -- the dropped grant
+			// type and the ignored auth method included -- otherwise an
+			// auditor could never tell the two apart from this record.
+			So(payload.Document.GrantTypes, ShouldResemble, []string{"authorization_code", "refresh_token", "urn:ietf:params:oauth:grant-type:jwt-bearer"})
+			So(payload.Document.TokenEndpointAuthMethod, ShouldEqual, "client_secret_post")
+		})
+
 		Convey("audit: refetch, metadata identical: no event at all -- the routine hourly case", func() {
 			var ds *documentServer
 			ds = newDocumentServer(func(w http.ResponseWriter, r *http.Request) {

--- a/pkg/lib/dcr/validate.go
+++ b/pkg/lib/dcr/validate.go
@@ -4,6 +4,8 @@ import (
 	"errors"
 	"net/url"
 	"slices"
+
+	"github.com/authgear/authgear-server/pkg/util/httputil"
 )
 
 var (
@@ -143,8 +145,8 @@ func ValidateAndNormalize(req *RegistrationRequest) (*NormalizedRegistration, er
 
 // validateRedirectURI implements the per-application_type redirect URI
 // scheme rules from docs/specs/dcr.md's application_type table: web must
-// use https://, localhost not allowed; native must use a custom URI
-// scheme or http://localhost.
+// use https://, loopback not allowed; native must use a custom URI scheme
+// or a loopback http:// URI.
 func validateRedirectURI(raw string, applicationType string) error {
 	u, err := url.Parse(raw)
 	if err != nil || !u.IsAbs() {
@@ -162,7 +164,7 @@ func validateRedirectURI(raw string, applicationType string) error {
 	case "native":
 		switch u.Scheme {
 		case "http":
-			if u.Hostname() != "localhost" {
+			if !httputil.IsLoopbackHost(u.Hostname()) {
 				return ErrDCRRedirectURIInvalid
 			}
 		case "https":

--- a/pkg/lib/dcr/validate.go
+++ b/pkg/lib/dcr/validate.go
@@ -9,32 +9,29 @@ import (
 var (
 	ErrDCRRedirectURIsMissing = errors.New("dcr: redirect_uris is required")
 	ErrDCRRedirectURIInvalid  = errors.New("dcr: invalid redirect_uri")
-	// ErrDCRTokenEndpointAuthMethodNotAccepted is returned when
-	// token_endpoint_auth_method is present and is anything other than
-	// "none" -- every DCR-registered client is public and uses PKCE, so
-	// "none" is accepted (it's simply what every such client already is),
-	// but "client_secret_post"/"client_secret_basic" are rejected since
-	// Authgear never issues a client_secret via DCR.
-	ErrDCRTokenEndpointAuthMethodNotAccepted = errors.New("dcr: token_endpoint_auth_method is not accepted")
-	ErrDCRGrantTypeUnsupported               = errors.New("dcr: unsupported grant_type")
-	ErrDCRResponseTypeInconsistent           = errors.New("dcr: response_types is inconsistent with grant_types")
-	ErrDCRApplicationTypeUnsupported         = errors.New("dcr: unsupported application_type")
-	ErrDCRURIFieldNotHTTPS                   = errors.New("dcr: uri field must use https")
+	// ErrDCRGrantTypeUnsupported is returned only when grant_types was
+	// provided and no entry survived filtering.
+	ErrDCRGrantTypeUnsupported       = errors.New("dcr: no supported grant_type")
+	ErrDCRResponseTypeInconsistent   = errors.New("dcr: response_types is inconsistent with grant_types")
+	ErrDCRApplicationTypeUnsupported = errors.New("dcr: unsupported application_type")
+	ErrDCRURIFieldNotHTTPS           = errors.New("dcr: uri field must use https")
 )
 
 // RegistrationRequest is the parsed (but not yet validated/normalized)
 // POST /oauth2/register request body.
 type RegistrationRequest struct {
-	ClientName              *string
-	RedirectURIs            []string
-	GrantTypes              []string // nil means "not provided" (apply default)
-	ResponseTypes           []string // nil means "not provided" (apply default)
-	ApplicationType         *string
-	LogoURI                 *string
-	ClientURI               *string
-	TOSURI                  *string
-	PolicyURI               *string
-	TokenEndpointAuthMethod *string // only used for rejecting the request if present and not "none"
+	ClientName      *string
+	RedirectURIs    []string
+	GrantTypes      []string // nil means "not provided" (apply default)
+	ResponseTypes   []string // nil means "not provided" (apply default)
+	ApplicationType *string
+	LogoURI         *string
+	ClientURI       *string
+	TOSURI          *string
+	PolicyURI       *string
+	// token_endpoint_auth_method is deliberately absent: it is ignored, and
+	// the response reports the registered "none". See
+	// docs/specs/dcr.md#token_endpoint_auth_method-optional.
 }
 
 // NormalizedRegistration is a RegistrationRequest after defaults have been
@@ -68,11 +65,11 @@ var dcrSupportedResponseTypes = map[string]bool{
 // response_types, application_type) and returns one of the sentinel
 // errors above on the first rule violated — the HTTP handler layer maps
 // each to its exact RFC 7591 (error, status) pair.
+//
+// Metadata Authgear does not implement is dropped rather than refused,
+// per RFC 7591 §3.2.1's allowance to substitute suitable values, and the
+// response reports what was registered.
 func ValidateAndNormalize(req *RegistrationRequest) (*NormalizedRegistration, error) {
-	if req.TokenEndpointAuthMethod != nil && *req.TokenEndpointAuthMethod != "none" {
-		return nil, ErrDCRTokenEndpointAuthMethodNotAccepted
-	}
-
 	applicationType := "web"
 	if req.ApplicationType != nil {
 		applicationType = *req.ApplicationType
@@ -90,14 +87,21 @@ func ValidateAndNormalize(req *RegistrationRequest) (*NormalizedRegistration, er
 		}
 	}
 
-	grantTypes := req.GrantTypes
-	if grantTypes == nil {
-		grantTypes = []string{"authorization_code", "refresh_token"}
+	// Entries Authgear does not implement are dropped; erroring only if the
+	// request provided entries and lost them all. Same rule as CIMD's
+	// (cimd/document.go, Rule 5).
+	rawGrantTypes := req.GrantTypes
+	if rawGrantTypes == nil {
+		rawGrantTypes = []string{"authorization_code", "refresh_token"}
 	}
-	for _, gt := range grantTypes {
-		if !dcrSupportedGrantTypes[gt] {
-			return nil, ErrDCRGrantTypeUnsupported
+	grantTypes := make([]string, 0, len(rawGrantTypes))
+	for _, gt := range rawGrantTypes {
+		if dcrSupportedGrantTypes[gt] {
+			grantTypes = append(grantTypes, gt)
 		}
+	}
+	if len(grantTypes) == 0 && len(rawGrantTypes) > 0 {
+		return nil, ErrDCRGrantTypeUnsupported
 	}
 
 	responseTypes := req.ResponseTypes

--- a/pkg/lib/dcr/validate_test.go
+++ b/pkg/lib/dcr/validate_test.go
@@ -92,25 +92,40 @@ func TestValidateAndNormalize(t *testing.T) {
 			So(err, ShouldEqual, dcr.ErrDCRRedirectURIInvalid)
 		})
 
-		Convey("token_endpoint_auth_method other than none is rejected", func() {
-			req := validReq()
-			req.TokenEndpointAuthMethod = new("client_secret_post")
-			_, err := dcr.ValidateAndNormalize(req)
-			So(err, ShouldEqual, dcr.ErrDCRTokenEndpointAuthMethodNotAccepted)
-		})
-
-		Convey("token_endpoint_auth_method=none is accepted", func() {
-			req := validReq()
-			req.TokenEndpointAuthMethod = new("none")
-			_, err := dcr.ValidateAndNormalize(req)
-			So(err, ShouldBeNil)
-		})
-
-		Convey("unsupported grant_type", func() {
+		Convey("grant_types with no supported entry is rejected", func() {
 			req := validReq()
 			req.GrantTypes = []string{"implicit"}
 			_, err := dcr.ValidateAndNormalize(req)
 			So(err, ShouldEqual, dcr.ErrDCRGrantTypeUnsupported)
+		})
+
+		Convey("an unimplemented grant_type is dropped, not fatal", func() {
+			req := validReq()
+			req.GrantTypes = []string{"authorization_code", "refresh_token", "urn:ietf:params:oauth:grant-type:jwt-bearer"}
+			r, err := dcr.ValidateAndNormalize(req)
+			So(err, ShouldBeNil)
+			So(r.GrantTypes, ShouldResemble, []string{"authorization_code", "refresh_token"})
+		})
+
+		Convey("dropping preserves the order of what remains", func() {
+			req := validReq()
+			req.GrantTypes = []string{"refresh_token", "implicit", "authorization_code"}
+			r, err := dcr.ValidateAndNormalize(req)
+			So(err, ShouldBeNil)
+			So(r.GrantTypes, ShouldResemble, []string{"refresh_token", "authorization_code"})
+		})
+
+		// Nothing to drop, so the consistency rule decides it.
+		Convey("an empty grant_types is left to the consistency rule", func() {
+			req := validReq()
+			req.GrantTypes = []string{}
+			_, err := dcr.ValidateAndNormalize(req)
+			So(err, ShouldEqual, dcr.ErrDCRResponseTypeInconsistent)
+
+			req.ResponseTypes = []string{}
+			r, err := dcr.ValidateAndNormalize(req)
+			So(err, ShouldBeNil)
+			So(r.GrantTypes, ShouldBeEmpty)
 		})
 
 		Convey("unsupported response_type", func() {

--- a/pkg/lib/dcr/validate_test.go
+++ b/pkg/lib/dcr/validate_test.go
@@ -76,6 +76,30 @@ func TestValidateAndNormalize(t *testing.T) {
 			So(err, ShouldBeNil)
 		})
 
+		Convey("native application_type accepts http://127.0.0.1 loopback, any port", func() {
+			req := validReq()
+			req.ApplicationType = new("native")
+			req.RedirectURIs = []string{"http://127.0.0.1:60327/callback/abc"}
+			_, err := dcr.ValidateAndNormalize(req)
+			So(err, ShouldBeNil)
+		})
+
+		Convey("native application_type accepts http://[::1] loopback", func() {
+			req := validReq()
+			req.ApplicationType = new("native")
+			req.RedirectURIs = []string{"http://[::1]:3000/callback"}
+			_, err := dcr.ValidateAndNormalize(req)
+			So(err, ShouldBeNil)
+		})
+
+		Convey("native application_type rejects non-loopback IP", func() {
+			req := validReq()
+			req.ApplicationType = new("native")
+			req.RedirectURIs = []string{"http://127.0.0.2/callback"}
+			_, err := dcr.ValidateAndNormalize(req)
+			So(err, ShouldEqual, dcr.ErrDCRRedirectURIInvalid)
+		})
+
 		Convey("native application_type rejects https", func() {
 			req := validReq()
 			req.ApplicationType = new("native")

--- a/pkg/lib/oauth/handler/handler_register.go
+++ b/pkg/lib/oauth/handler/handler_register.go
@@ -68,22 +68,16 @@ type RegistrationHandler struct {
 // These fields are the registration as Authgear recorded it, not an echo
 // of the request -- §3.2.1 requires all registered metadata, which is
 // what makes substituting a requested value safe.
+// RegistrationResponse embeds model.OAuthClientRegisteredMetadata rather
+// than repeating its fields -- see that type's own comment for why: the
+// same embed backs oauth.client.registered's audit event, so the two
+// cannot drift apart the way they once did (client_uri/logo_uri/tos_uri/
+// policy_uri/token_endpoint_auth_method were present here but missing from
+// the event).
 type RegistrationResponse struct {
-	ClientID         string   `json:"client_id"`
-	ClientIDIssuedAt int64    `json:"client_id_issued_at"`
-	ClientName       string   `json:"client_name,omitempty"`
-	RedirectURIs     []string `json:"redirect_uris"`
-	GrantTypes       []string `json:"grant_types"`
-	ResponseTypes    []string `json:"response_types"`
-	ApplicationType  string   `json:"application_type"`
-	// TokenEndpointAuthMethod is always "none", and never omitted: the
-	// request's own value is ignored, so this is how a client that asked
-	// for client_secret_post learns it must use PKCE alone.
-	TokenEndpointAuthMethod string `json:"token_endpoint_auth_method"`
-	ClientURI               string `json:"client_uri,omitempty"`
-	LogoURI                 string `json:"logo_uri,omitempty"`
-	TOSURI                  string `json:"tos_uri,omitempty"`
-	PolicyURI               string `json:"policy_uri,omitempty"`
+	ClientID         string `json:"client_id"`
+	ClientIDIssuedAt int64  `json:"client_id_issued_at"`
+	model.OAuthClientRegisteredMetadata
 }
 
 // registrationRequestBody is the raw JSON shape of the POST /oauth2/register
@@ -105,8 +99,8 @@ type registrationRequestBody struct {
 
 // auditRequest describes this body for the failure event, as sent. Only
 // the failure paths with a decoded body call it; the rest pass nil.
-func (b *registrationRequestBody) auditRequest() *nonblocking.OAuthClientRegistrationFailedEventPayloadRequest {
-	return &nonblocking.OAuthClientRegistrationFailedEventPayloadRequest{
+func (b *registrationRequestBody) auditRequest() *model.OAuthClientRegistrationRequest {
+	return &model.OAuthClientRegistrationRequest{
 		ClientName:              derefStringOr(b.ClientName, ""),
 		RedirectURIs:            b.RedirectURIs,
 		GrantTypes:              b.GrantTypes,
@@ -206,7 +200,7 @@ func (h *RegistrationHandler) Handle(ctx context.Context, r *http.Request) (*Reg
 		}
 		client = c
 		countBeforeCreate = count
-		return h.Events.DispatchEventOnCommit(ctx, newOAuthClientRegisteredEventPayload(client, iat))
+		return h.Events.DispatchEventOnCommit(ctx, newOAuthClientRegisteredEventPayload(client, iat, body.auditRequest()))
 	})
 	if err != nil {
 		if errors.Is(err, dcr.ErrInitialAccessTokenNotFound) {
@@ -225,18 +219,9 @@ func (h *RegistrationHandler) Handle(ctx context.Context, r *http.Request) (*Reg
 	h.UsageLimiter.ReportStandingCreated(ctx, model.UsageNameOAuthClientDCR, countBeforeCreate)
 
 	return &RegistrationResponse{
-		ClientID:                client.ClientID,
-		ClientIDIssuedAt:        client.CreatedAt.Unix(),
-		ClientName:              client.Name,
-		RedirectURIs:            client.RedirectURIs,
-		GrantTypes:              client.GrantTypes,
-		ResponseTypes:           client.ResponseTypes,
-		ApplicationType:         derefStringOr(client.ApplicationType, ""),
-		TokenEndpointAuthMethod: "none",
-		ClientURI:               derefStringOr(client.ClientURI, ""),
-		LogoURI:                 derefStringOr(client.LogoURI, ""),
-		TOSURI:                  derefStringOr(client.TOSURI, ""),
-		PolicyURI:               derefStringOr(client.PolicyURI, ""),
+		ClientID:                      client.ClientID,
+		ClientIDIssuedAt:              client.CreatedAt.Unix(),
+		OAuthClientRegisteredMetadata: model.NewOAuthClientRegisteredMetadata(client),
 	}, nil
 }
 
@@ -255,7 +240,7 @@ func (h *RegistrationHandler) registerClientInTx(
 	ctx context.Context,
 	token string,
 	normalized *dcr.NormalizedRegistration,
-	auditRequest *nonblocking.OAuthClientRegistrationFailedEventPayloadRequest,
+	auditRequest *model.OAuthClientRegistrationRequest,
 ) (client *model.OAuthClient, iat *model.OAuthInitialAccessToken, countBeforeCreate int, err error) {
 	kind := model.OAuthClientKindThirdParty
 	if token != "" {
@@ -351,14 +336,14 @@ func (h *RegistrationHandler) dispatchRegistrationFailed(
 	usageName model.UsageName,
 	quota int,
 	iat *model.OAuthInitialAccessToken,
-	auditRequest *nonblocking.OAuthClientRegistrationFailedEventPayloadRequest,
+	auditRequest *model.OAuthClientRegistrationRequest,
 ) {
 	h.dispatchImmediately(ctx, &nonblocking.OAuthClientRegistrationFailedEventPayload{
 		Reason:             reason,
 		Message:            message,
 		UsageName:          usageName,
 		Quota:              quota,
-		InitialAccessToken: nonblocking.NewEventPayloadInitialAccessToken(iat),
+		InitialAccessToken: model.NewEventPayloadInitialAccessToken(iat),
 		Request:            auditRequest,
 	})
 }
@@ -399,20 +384,20 @@ func derefStringOr(s *string, fallback string) string {
 // successful registration. iat is nil under open registration
 // (initial_access_token_required: false), in which case the payload's
 // InitialAccessToken field is left nil too — see
-// nonblocking.OAuthClientRegisteredEventPayload.
-func newOAuthClientRegisteredEventPayload(client *model.OAuthClient, iat *model.OAuthInitialAccessToken) *nonblocking.OAuthClientRegisteredEventPayload {
+// nonblocking.OAuthClientRegisteredEventPayload. auditRequest is the
+// request body as sent, from registrationRequestBody.auditRequest() -- it
+// is what lets the event show a grant_type or token_endpoint_auth_method
+// the caller asked for that Client above silently dropped or ignored.
+func newOAuthClientRegisteredEventPayload(client *model.OAuthClient, iat *model.OAuthInitialAccessToken, auditRequest *model.OAuthClientRegistrationRequest) *nonblocking.OAuthClientRegisteredEventPayload {
 	payload := &nonblocking.OAuthClientRegisteredEventPayload{
 		Client: nonblocking.OAuthClientRegisteredEventPayloadClient{
-			ClientID:        client.ClientID,
-			Source:          client.Source,
-			Kind:            client.Kind,
-			ClientName:      client.Name,
-			ApplicationType: derefStringOr(client.ApplicationType, ""),
-			RedirectURIs:    client.RedirectURIs,
-			GrantTypes:      client.GrantTypes,
-			ResponseTypes:   client.ResponseTypes,
+			ClientID:                      client.ClientID,
+			Source:                        client.Source,
+			Kind:                          client.Kind,
+			OAuthClientRegisteredMetadata: model.NewOAuthClientRegisteredMetadata(client),
 		},
+		Request: *auditRequest,
 	}
-	payload.InitialAccessToken = nonblocking.NewEventPayloadInitialAccessToken(iat)
+	payload.InitialAccessToken = model.NewEventPayloadInitialAccessToken(iat)
 	return payload
 }

--- a/pkg/lib/oauth/handler/handler_register.go
+++ b/pkg/lib/oauth/handler/handler_register.go
@@ -64,6 +64,10 @@ type RegistrationHandler struct {
 // RegistrationResponse is the RFC 7591 §3.2.1 success response. There is
 // deliberately no client_secret / client_secret_expires_at field: DCR
 // clients are always public, per docs/specs/dcr.md.
+//
+// These fields are the registration as Authgear recorded it, not an echo
+// of the request -- §3.2.1 requires all registered metadata, which is
+// what makes substituting a requested value safe.
 type RegistrationResponse struct {
 	ClientID         string   `json:"client_id"`
 	ClientIDIssuedAt int64    `json:"client_id_issued_at"`
@@ -72,25 +76,48 @@ type RegistrationResponse struct {
 	GrantTypes       []string `json:"grant_types"`
 	ResponseTypes    []string `json:"response_types"`
 	ApplicationType  string   `json:"application_type"`
-	ClientURI        string   `json:"client_uri,omitempty"`
-	LogoURI          string   `json:"logo_uri,omitempty"`
-	TOSURI           string   `json:"tos_uri,omitempty"`
-	PolicyURI        string   `json:"policy_uri,omitempty"`
+	// TokenEndpointAuthMethod is always "none", and never omitted: the
+	// request's own value is ignored, so this is how a client that asked
+	// for client_secret_post learns it must use PKCE alone.
+	TokenEndpointAuthMethod string `json:"token_endpoint_auth_method"`
+	ClientURI               string `json:"client_uri,omitempty"`
+	LogoURI                 string `json:"logo_uri,omitempty"`
+	TOSURI                  string `json:"tos_uri,omitempty"`
+	PolicyURI               string `json:"policy_uri,omitempty"`
 }
 
 // registrationRequestBody is the raw JSON shape of the POST /oauth2/register
 // request body, decoded before being handed to dcr.ValidateAndNormalize.
 type registrationRequestBody struct {
-	ClientName              *string  `json:"client_name"`
-	RedirectURIs            []string `json:"redirect_uris"`
-	GrantTypes              []string `json:"grant_types"`
-	ResponseTypes           []string `json:"response_types"`
-	ApplicationType         *string  `json:"application_type"`
-	LogoURI                 *string  `json:"logo_uri"`
-	ClientURI               *string  `json:"client_uri"`
-	TOSURI                  *string  `json:"tos_uri"`
-	PolicyURI               *string  `json:"policy_uri"`
-	TokenEndpointAuthMethod *string  `json:"token_endpoint_auth_method"`
+	ClientName      *string  `json:"client_name"`
+	RedirectURIs    []string `json:"redirect_uris"`
+	GrantTypes      []string `json:"grant_types"`
+	ResponseTypes   []string `json:"response_types"`
+	ApplicationType *string  `json:"application_type"`
+	LogoURI         *string  `json:"logo_uri"`
+	ClientURI       *string  `json:"client_uri"`
+	TOSURI          *string  `json:"tos_uri"`
+	PolicyURI       *string  `json:"policy_uri"`
+	// TokenEndpointAuthMethod is decoded but never validated: it is kept
+	// only so a failed registration can record what was asked for.
+	TokenEndpointAuthMethod *string `json:"token_endpoint_auth_method"`
+}
+
+// auditRequest describes this body for the failure event, as sent. Only
+// the failure paths with a decoded body call it; the rest pass nil.
+func (b *registrationRequestBody) auditRequest() *nonblocking.OAuthClientRegistrationFailedEventPayloadRequest {
+	return &nonblocking.OAuthClientRegistrationFailedEventPayloadRequest{
+		ClientName:              derefStringOr(b.ClientName, ""),
+		RedirectURIs:            b.RedirectURIs,
+		GrantTypes:              b.GrantTypes,
+		ResponseTypes:           b.ResponseTypes,
+		ApplicationType:         derefStringOr(b.ApplicationType, ""),
+		TokenEndpointAuthMethod: derefStringOr(b.TokenEndpointAuthMethod, ""),
+		ClientURI:               derefStringOr(b.ClientURI, ""),
+		LogoURI:                 derefStringOr(b.LogoURI, ""),
+		TOSURI:                  derefStringOr(b.TOSURI, ""),
+		PolicyURI:               derefStringOr(b.PolicyURI, ""),
+	}
 }
 
 func (h *RegistrationHandler) checkRateLimit(ctx context.Context, spec ratelimit.BucketSpec) error {
@@ -131,38 +158,37 @@ func (h *RegistrationHandler) Handle(ctx context.Context, r *http.Request) (*Reg
 	if authHeader := r.Header.Get("Authorization"); authHeader != "" {
 		const prefix = "Bearer "
 		if !strings.HasPrefix(authHeader, prefix) {
-			h.dispatchRegistrationFailed(ctx, nonblocking.OAuthClientRegistrationReasonInvalidInitialAccessToken, "malformed_header", "", 0, nil)
+			h.dispatchRegistrationFailed(ctx, nonblocking.OAuthClientRegistrationReasonInvalidInitialAccessToken, "malformed_header", "", 0, nil, nil)
 			return nil, protocol.NewErrorStatusCode("invalid_initial_access_token", "invalid Authorization header", http.StatusUnauthorized)
 		}
 		token = strings.TrimPrefix(authHeader, prefix)
 	}
 
 	if token == "" && h.OAuthConfig.DynamicClientRegistration.IsInitialAccessTokenRequired() {
-		h.dispatchRegistrationFailed(ctx, nonblocking.OAuthClientRegistrationReasonInvalidInitialAccessToken, "not_presented", "", 0, nil)
+		h.dispatchRegistrationFailed(ctx, nonblocking.OAuthClientRegistrationReasonInvalidInitialAccessToken, "not_presented", "", 0, nil, nil)
 		return nil, protocol.NewErrorStatusCode("invalid_initial_access_token", "an initial access token is required", http.StatusUnauthorized)
 	}
 
 	var body registrationRequestBody
 	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
-		h.dispatchRegistrationFailed(ctx, nonblocking.OAuthClientRegistrationReasonInvalidClientMetadata, "malformed_json", "", 0, nil)
+		h.dispatchRegistrationFailed(ctx, nonblocking.OAuthClientRegistrationReasonInvalidClientMetadata, "malformed_json", "", 0, nil, nil)
 		return nil, protocol.NewErrorStatusCode("invalid_client_metadata", "malformed JSON body", http.StatusBadRequest)
 	}
 
 	normalized, err := dcr.ValidateAndNormalize(&dcr.RegistrationRequest{
-		ClientName:              body.ClientName,
-		RedirectURIs:            body.RedirectURIs,
-		GrantTypes:              body.GrantTypes,
-		ResponseTypes:           body.ResponseTypes,
-		ApplicationType:         body.ApplicationType,
-		LogoURI:                 body.LogoURI,
-		ClientURI:               body.ClientURI,
-		TOSURI:                  body.TOSURI,
-		PolicyURI:               body.PolicyURI,
-		TokenEndpointAuthMethod: body.TokenEndpointAuthMethod,
+		ClientName:      body.ClientName,
+		RedirectURIs:    body.RedirectURIs,
+		GrantTypes:      body.GrantTypes,
+		ResponseTypes:   body.ResponseTypes,
+		ApplicationType: body.ApplicationType,
+		LogoURI:         body.LogoURI,
+		ClientURI:       body.ClientURI,
+		TOSURI:          body.TOSURI,
+		PolicyURI:       body.PolicyURI,
 	})
 	if err != nil {
 		httpErr, message := mapDCRValidationError(err)
-		h.dispatchRegistrationFailed(ctx, nonblocking.OAuthClientRegistrationReasonInvalidClientMetadata, message, "", 0, nil)
+		h.dispatchRegistrationFailed(ctx, nonblocking.OAuthClientRegistrationReasonInvalidClientMetadata, message, "", 0, nil, body.auditRequest())
 		return nil, httpErr
 	}
 
@@ -173,7 +199,7 @@ func (h *RegistrationHandler) Handle(ctx context.Context, r *http.Request) (*Reg
 	var iat *model.OAuthInitialAccessToken
 	var countBeforeCreate int
 	err = h.Database.WithTx(ctx, func(ctx context.Context) error {
-		c, i, count, err := h.registerClientInTx(ctx, token, normalized)
+		c, i, count, err := h.registerClientInTx(ctx, token, normalized, body.auditRequest())
 		iat = i // set even on error: see registerClientInTx's own comment
 		if err != nil {
 			return err
@@ -184,11 +210,11 @@ func (h *RegistrationHandler) Handle(ctx context.Context, r *http.Request) (*Reg
 	})
 	if err != nil {
 		if errors.Is(err, dcr.ErrInitialAccessTokenNotFound) {
-			h.dispatchRegistrationFailed(ctx, nonblocking.OAuthClientRegistrationReasonInvalidInitialAccessToken, "unknown", "", 0, nil)
+			h.dispatchRegistrationFailed(ctx, nonblocking.OAuthClientRegistrationReasonInvalidInitialAccessToken, "unknown", "", 0, nil, body.auditRequest())
 			return nil, protocol.NewErrorStatusCode("invalid_initial_access_token", "invalid or expired initial access token", http.StatusUnauthorized)
 		}
 		if errors.Is(err, dcr.ErrInitialAccessTokenExpired) {
-			h.dispatchRegistrationFailed(ctx, nonblocking.OAuthClientRegistrationReasonInvalidInitialAccessToken, "expired", "", 0, iat)
+			h.dispatchRegistrationFailed(ctx, nonblocking.OAuthClientRegistrationReasonInvalidInitialAccessToken, "expired", "", 0, iat, body.auditRequest())
 			return nil, protocol.NewErrorStatusCode("invalid_initial_access_token", "invalid or expired initial access token", http.StatusUnauthorized)
 		}
 		// Any other error -- including the limit_exceeded access_denied
@@ -199,17 +225,18 @@ func (h *RegistrationHandler) Handle(ctx context.Context, r *http.Request) (*Reg
 	h.UsageLimiter.ReportStandingCreated(ctx, model.UsageNameOAuthClientDCR, countBeforeCreate)
 
 	return &RegistrationResponse{
-		ClientID:         client.ClientID,
-		ClientIDIssuedAt: client.CreatedAt.Unix(),
-		ClientName:       client.Name,
-		RedirectURIs:     client.RedirectURIs,
-		GrantTypes:       client.GrantTypes,
-		ResponseTypes:    client.ResponseTypes,
-		ApplicationType:  derefStringOr(client.ApplicationType, ""),
-		ClientURI:        derefStringOr(client.ClientURI, ""),
-		LogoURI:          derefStringOr(client.LogoURI, ""),
-		TOSURI:           derefStringOr(client.TOSURI, ""),
-		PolicyURI:        derefStringOr(client.PolicyURI, ""),
+		ClientID:                client.ClientID,
+		ClientIDIssuedAt:        client.CreatedAt.Unix(),
+		ClientName:              client.Name,
+		RedirectURIs:            client.RedirectURIs,
+		GrantTypes:              client.GrantTypes,
+		ResponseTypes:           client.ResponseTypes,
+		ApplicationType:         derefStringOr(client.ApplicationType, ""),
+		TokenEndpointAuthMethod: "none",
+		ClientURI:               derefStringOr(client.ClientURI, ""),
+		LogoURI:                 derefStringOr(client.LogoURI, ""),
+		TOSURI:                  derefStringOr(client.TOSURI, ""),
+		PolicyURI:               derefStringOr(client.PolicyURI, ""),
 	}, nil
 }
 
@@ -228,6 +255,7 @@ func (h *RegistrationHandler) registerClientInTx(
 	ctx context.Context,
 	token string,
 	normalized *dcr.NormalizedRegistration,
+	auditRequest *nonblocking.OAuthClientRegistrationFailedEventPayloadRequest,
 ) (client *model.OAuthClient, iat *model.OAuthInitialAccessToken, countBeforeCreate int, err error) {
 	kind := model.OAuthClientKindThirdParty
 	if token != "" {
@@ -261,7 +289,7 @@ func (h *RegistrationHandler) registerClientInTx(
 		// this transaction, so the record survives the rollback this
 		// triggers.
 		usageName, quota, _ := usage.StandingUsageLimitDetails(limitErr)
-		h.dispatchRegistrationFailed(ctx, nonblocking.OAuthClientRegistrationReasonLimitExceeded, "", usageName, quota, nil)
+		h.dispatchRegistrationFailed(ctx, nonblocking.OAuthClientRegistrationReasonLimitExceeded, "", usageName, quota, nil, auditRequest)
 		return nil, iat, 0, protocol.NewErrorStatusCode("access_denied", "the project has reached its dynamic client registration limit", http.StatusForbidden)
 	}
 
@@ -300,8 +328,6 @@ func mapDCRValidationError(err error) (httpErr error, message string) {
 		message = "response_type_inconsistent"
 	case errors.Is(err, dcr.ErrDCRApplicationTypeUnsupported):
 		message = "application_type_unsupported"
-	case errors.Is(err, dcr.ErrDCRTokenEndpointAuthMethodNotAccepted):
-		message = "token_endpoint_auth_method_not_accepted"
 	case errors.Is(err, dcr.ErrDCRURIFieldNotHTTPS):
 		message = "uri_field_not_https"
 	default:
@@ -315,7 +341,8 @@ func mapDCRValidationError(err error) (httpErr error, message string) {
 
 // dispatchRegistrationFailed builds and dispatches oauth.client.registration.failed.
 // usageName/quota are set only when reason is limit_exceeded; iat is set
-// only for the "expired" message, mirroring
+// only for the "expired" message; auditRequest is nil only where the
+// request body was never decoded -- all mirroring
 // OAuthClientRegistrationFailedEventPayload's own field comments.
 func (h *RegistrationHandler) dispatchRegistrationFailed(
 	ctx context.Context,
@@ -324,6 +351,7 @@ func (h *RegistrationHandler) dispatchRegistrationFailed(
 	usageName model.UsageName,
 	quota int,
 	iat *model.OAuthInitialAccessToken,
+	auditRequest *nonblocking.OAuthClientRegistrationFailedEventPayloadRequest,
 ) {
 	h.dispatchImmediately(ctx, &nonblocking.OAuthClientRegistrationFailedEventPayload{
 		Reason:             reason,
@@ -331,6 +359,7 @@ func (h *RegistrationHandler) dispatchRegistrationFailed(
 		UsageName:          usageName,
 		Quota:              quota,
 		InitialAccessToken: nonblocking.NewEventPayloadInitialAccessToken(iat),
+		Request:            auditRequest,
 	})
 }
 

--- a/pkg/lib/oauth/handler/handler_register_test.go
+++ b/pkg/lib/oauth/handler/handler_register_test.go
@@ -627,15 +627,15 @@ func TestRegistrationHandler(t *testing.T) {
 // still compile.
 func TestRegisteredClientMetadataCannotDrift(t *testing.T) {
 	Convey("RegistrationResponse and OAuthClientRegisteredEventPayloadClient embed the same metadata type", t, func() {
-		metadataType := reflect.TypeOf(model.OAuthClientRegisteredMetadata{})
+		metadataType := reflect.TypeFor[model.OAuthClientRegisteredMetadata]()
 
-		responseType := reflect.TypeOf(handler.RegistrationResponse{})
+		responseType := reflect.TypeFor[handler.RegistrationResponse]()
 		responseField, ok := responseType.FieldByName(metadataType.Name())
 		So(ok, ShouldBeTrue)
 		So(responseField.Anonymous, ShouldBeTrue)
 		So(responseField.Type, ShouldEqual, metadataType)
 
-		eventClientType := reflect.TypeOf(nonblocking.OAuthClientRegisteredEventPayloadClient{})
+		eventClientType := reflect.TypeFor[nonblocking.OAuthClientRegisteredEventPayloadClient]()
 		eventField, ok := eventClientType.FieldByName(metadataType.Name())
 		So(ok, ShouldBeTrue)
 		So(eventField.Anonymous, ShouldBeTrue)

--- a/pkg/lib/oauth/handler/handler_register_test.go
+++ b/pkg/lib/oauth/handler/handler_register_test.go
@@ -186,6 +186,39 @@ func TestRegistrationHandler(t *testing.T) {
 
 			So(captured.Reason, ShouldEqual, nonblocking.OAuthClientRegistrationReasonInvalidClientMetadata)
 			So(captured.Message, ShouldEqual, "malformed_json")
+			// Nothing decoded: omit the key rather than carry an empty
+			// object, which would read as an empty request.
+			So(captured.Request, ShouldBeNil)
+		})
+
+		Convey("a validation failure records the request as sent", func() {
+			b := false
+			oauthConfig.DynamicClientRegistration.InitialAccessTokenRequired = &b
+			var captured *nonblocking.OAuthClientRegistrationFailedEventPayload
+			events.EXPECT().DispatchEventImmediately(gomock.Any(), gomock.Any()).DoAndReturn(
+				func(ctx context.Context, payload apievent.NonBlockingPayload) error {
+					captured = payload.(*nonblocking.OAuthClientRegistrationFailedEventPayload)
+					return nil
+				},
+			)
+			body := `{"client_name":"Some MCP Client","redirect_uris":["https://app.example.com/cb"],` +
+				`"grant_types":["client_credentials"],"token_endpoint_auth_method":"client_secret_post",` +
+				`"client_uri":"https://app.example.com"}`
+			_, err := h.Handle(context.Background(), newRequest(body, ""))
+			So(err, ShouldNotBeNil)
+
+			So(captured.Message, ShouldEqual, "grant_type_unsupported")
+			So(captured.Request, ShouldNotBeNil)
+			So(captured.Request.ClientName, ShouldEqual, "Some MCP Client")
+			So(captured.Request.RedirectURIs, ShouldResemble, []string{"https://app.example.com/cb"})
+			// As sent: the offending value, and no default for the
+			// absent response_types.
+			So(captured.Request.GrantTypes, ShouldResemble, []string{"client_credentials"})
+			So(captured.Request.ResponseTypes, ShouldBeEmpty)
+			So(captured.Request.ApplicationType, ShouldBeEmpty)
+			So(captured.Request.ClientURI, ShouldEqual, "https://app.example.com")
+			// Recorded even though it can no longer fail a registration.
+			So(captured.Request.TokenEndpointAuthMethod, ShouldEqual, "client_secret_post")
 		})
 
 		Convey("every dcr.ErrDCR* validation sentinel gets a non-empty message", func() {
@@ -205,11 +238,6 @@ func TestRegistrationHandler(t *testing.T) {
 					"redirect_uri invalid (http for web)",
 					`{"redirect_uris":["http://app.example.com/cb"]}`,
 					"redirect_uri_invalid",
-				},
-				{
-					"token_endpoint_auth_method not accepted",
-					`{"redirect_uris":["https://app.example.com/cb"],"token_endpoint_auth_method":"client_secret_post"}`,
-					"token_endpoint_auth_method_not_accepted",
 				},
 				{
 					"grant_type unsupported",
@@ -433,6 +461,50 @@ func TestRegistrationHandler(t *testing.T) {
 			So(err, ShouldBeNil)
 			So(resp, ShouldNotBeNil)
 			So(registered.InitialAccessToken, ShouldBeNil)
+		})
+
+		// Claude's registration body, verbatim.
+		Convey("metadata Authgear does not implement is registered as what it can offer", func() {
+			body := `{"client_name":"Claude","redirect_uris":["https://claude.ai/api/mcp/auth_callback"],` +
+				`"grant_types":["authorization_code","refresh_token","urn:ietf:params:oauth:grant-type:jwt-bearer"],` +
+				`"response_types":["code"],"token_endpoint_auth_method":"client_secret_post"}`
+
+			b := false
+			oauthConfig.DynamicClientRegistration.InitialAccessTokenRequired = &b
+			dcrService.EXPECT().LockForClientCount(gomock.Any(), model.OAuthClientSourceDCR).Return(nil)
+			dcrService.EXPECT().CountClientsBySource(gomock.Any(), model.OAuthClientSourceDCR).Return(uint64(0), nil)
+			usageLimiter.EXPECT().CheckStanding(gomock.Any(), model.UsageNameOAuthClientDCR, 0).Return(nil)
+			usageLimiter.EXPECT().ReportStandingCreated(gomock.Any(), model.UsageNameOAuthClientDCR, 0)
+
+			appType := "web"
+			var registeredGrantTypes []string
+			dcrService.EXPECT().RegisterClient(gomock.Any(), gomock.Any()).DoAndReturn(
+				func(ctx context.Context, opts *dcr.RegisterClientOptions) (*model.OAuthClient, error) {
+					registeredGrantTypes = opts.Registration.GrantTypes
+					return &model.OAuthClient{
+						Meta:            model.Meta{ID: "client-record-id", CreatedAt: fixedTime},
+						ClientID:        "dcrc_claude",
+						Source:          model.OAuthClientSourceDCR,
+						Kind:            model.OAuthClientKindThirdParty,
+						ApplicationType: &appType,
+						RedirectURIs:    []string{"https://claude.ai/api/mcp/auth_callback"},
+						GrantTypes:      opts.Registration.GrantTypes,
+						ResponseTypes:   opts.Registration.ResponseTypes,
+					}, nil
+				},
+			)
+			events.EXPECT().DispatchEventOnCommit(gomock.Any(), gomock.Any()).Return(nil)
+			expectNoDispatch()
+
+			resp, err := h.Handle(context.Background(), newRequest(body, ""))
+			So(err, ShouldBeNil)
+			So(resp, ShouldNotBeNil)
+			// The jwt-bearer grant is dropped, not registered.
+			So(registeredGrantTypes, ShouldResemble, []string{"authorization_code", "refresh_token"})
+			So(resp.GrantTypes, ShouldResemble, []string{"authorization_code", "refresh_token"})
+			// The requested client_secret_post is not honored, and the
+			// response says so.
+			So(resp.TokenEndpointAuthMethod, ShouldEqual, "none")
 		})
 
 		Convey("successful registration emits only oauth.client.registered, never a failure event", func() {

--- a/pkg/lib/oauth/handler/handler_register_test.go
+++ b/pkg/lib/oauth/handler/handler_register_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"net/http"
 	"net/http/httptest"
+	"reflect"
 	"strings"
 	"testing"
 	"time"
@@ -420,10 +421,10 @@ func TestRegistrationHandler(t *testing.T) {
 			// Same fixture token: the shape the registered event just carried
 			// is byte-identical to what the failure event would have emitted
 			// had this same token instead been expired -- proving both
-			// events genuinely share nonblocking.EventPayloadInitialAccessToken
+			// events genuinely share model.EventPayloadInitialAccessToken
 			// rather than two independently-built lookalikes.
 			expiredVariant := &model.OAuthInitialAccessToken{Meta: token.Meta, Type: token.Type, ExpiresAt: token.ExpiresAt}
-			fromFailure := nonblocking.NewEventPayloadInitialAccessToken(expiredVariant)
+			fromFailure := model.NewEventPayloadInitialAccessToken(expiredVariant)
 			So(registered.InitialAccessToken, ShouldResemble, fromFailure)
 		})
 
@@ -493,7 +494,13 @@ func TestRegistrationHandler(t *testing.T) {
 					}, nil
 				},
 			)
-			events.EXPECT().DispatchEventOnCommit(gomock.Any(), gomock.Any()).Return(nil)
+			var registered *nonblocking.OAuthClientRegisteredEventPayload
+			events.EXPECT().DispatchEventOnCommit(gomock.Any(), gomock.Any()).DoAndReturn(
+				func(ctx context.Context, payload apievent.Payload) error {
+					registered = payload.(*nonblocking.OAuthClientRegisteredEventPayload)
+					return nil
+				},
+			)
 			expectNoDispatch()
 
 			resp, err := h.Handle(context.Background(), newRequest(body, ""))
@@ -505,6 +512,69 @@ func TestRegistrationHandler(t *testing.T) {
 			// The requested client_secret_post is not honored, and the
 			// response says so.
 			So(resp.TokenEndpointAuthMethod, ShouldEqual, "none")
+
+			// The persisted client only ever shows what survived...
+			So(registered.Client.GrantTypes, ShouldResemble, []string{"authorization_code", "refresh_token"})
+			So(registered.Client.TokenEndpointAuthMethod, ShouldEqual, "none")
+			// ...but Request shows what Claude actually asked for, dropped
+			// grant type and ignored auth method included -- otherwise an
+			// auditor could never tell the two apart from this record.
+			So(registered.Request.GrantTypes, ShouldResemble, []string{"authorization_code", "refresh_token", "urn:ietf:params:oauth:grant-type:jwt-bearer"})
+			So(registered.Request.TokenEndpointAuthMethod, ShouldEqual, "client_secret_post")
+		})
+
+		Convey("registered event carries client_uri/logo_uri/tos_uri/policy_uri on both Client and Request", func() {
+			body := `{"redirect_uris":["https://app.example.com/cb"],` +
+				`"client_uri":"https://app.example.com","logo_uri":"https://app.example.com/logo.png",` +
+				`"tos_uri":"https://app.example.com/tos","policy_uri":"https://app.example.com/policy"}`
+
+			b := false
+			oauthConfig.DynamicClientRegistration.InitialAccessTokenRequired = &b
+			dcrService.EXPECT().LockForClientCount(gomock.Any(), model.OAuthClientSourceDCR).Return(nil)
+			dcrService.EXPECT().CountClientsBySource(gomock.Any(), model.OAuthClientSourceDCR).Return(uint64(0), nil)
+			usageLimiter.EXPECT().CheckStanding(gomock.Any(), model.UsageNameOAuthClientDCR, 0).Return(nil)
+			usageLimiter.EXPECT().ReportStandingCreated(gomock.Any(), model.UsageNameOAuthClientDCR, 0)
+
+			appType := "web"
+			clientURI := "https://app.example.com"
+			logoURI := "https://app.example.com/logo.png"
+			tosURI := "https://app.example.com/tos"
+			policyURI := "https://app.example.com/policy"
+			dcrService.EXPECT().RegisterClient(gomock.Any(), gomock.Any()).Return(&model.OAuthClient{
+				Meta:            model.Meta{ID: "client-record-id", CreatedAt: fixedTime},
+				ClientID:        "dcrc_uris",
+				Source:          model.OAuthClientSourceDCR,
+				Kind:            model.OAuthClientKindThirdParty,
+				ApplicationType: &appType,
+				ClientURI:       &clientURI,
+				LogoURI:         &logoURI,
+				TOSURI:          &tosURI,
+				PolicyURI:       &policyURI,
+				RedirectURIs:    []string{"https://app.example.com/cb"},
+				GrantTypes:      []string{"authorization_code", "refresh_token"},
+				ResponseTypes:   []string{"code"},
+			}, nil)
+
+			var registered *nonblocking.OAuthClientRegisteredEventPayload
+			events.EXPECT().DispatchEventOnCommit(gomock.Any(), gomock.Any()).DoAndReturn(
+				func(ctx context.Context, payload apievent.Payload) error {
+					registered = payload.(*nonblocking.OAuthClientRegisteredEventPayload)
+					return nil
+				},
+			)
+			expectNoDispatch()
+
+			_, err := h.Handle(context.Background(), newRequest(body, ""))
+			So(err, ShouldBeNil)
+
+			So(registered.Client.ClientURI, ShouldEqual, "https://app.example.com")
+			So(registered.Client.LogoURI, ShouldEqual, "https://app.example.com/logo.png")
+			So(registered.Client.TOSURI, ShouldEqual, "https://app.example.com/tos")
+			So(registered.Client.PolicyURI, ShouldEqual, "https://app.example.com/policy")
+			So(registered.Request.ClientURI, ShouldEqual, "https://app.example.com")
+			So(registered.Request.LogoURI, ShouldEqual, "https://app.example.com/logo.png")
+			So(registered.Request.TOSURI, ShouldEqual, "https://app.example.com/tos")
+			So(registered.Request.PolicyURI, ShouldEqual, "https://app.example.com/policy")
 		})
 
 		Convey("successful registration emits only oauth.client.registered, never a failure event", func() {
@@ -543,5 +613,32 @@ func TestRegistrationHandler(t *testing.T) {
 			So(protoErr.StatusCode, ShouldEqual, http.StatusUnauthorized)
 			So(protoErr.Response["error"], ShouldEqual, "invalid_initial_access_token")
 		})
+	})
+}
+
+// TestRegisteredClientMetadataCannotDrift is a structural backstop for
+// model.OAuthClientRegisteredMetadata's own contract: RegistrationResponse
+// and oauth.client.registered's Client must embed that exact type, by that
+// exact name, as an anonymous field. This is what makes the previous bug --
+// client_uri/logo_uri/tos_uri/policy_uri/token_endpoint_auth_method present
+// in the HTTP response but missing from the audit event -- impossible to
+// reintroduce by a future edit that flattens either struct back to
+// individual fields: doing so would fail this test even though it would
+// still compile.
+func TestRegisteredClientMetadataCannotDrift(t *testing.T) {
+	Convey("RegistrationResponse and OAuthClientRegisteredEventPayloadClient embed the same metadata type", t, func() {
+		metadataType := reflect.TypeOf(model.OAuthClientRegisteredMetadata{})
+
+		responseType := reflect.TypeOf(handler.RegistrationResponse{})
+		responseField, ok := responseType.FieldByName(metadataType.Name())
+		So(ok, ShouldBeTrue)
+		So(responseField.Anonymous, ShouldBeTrue)
+		So(responseField.Type, ShouldEqual, metadataType)
+
+		eventClientType := reflect.TypeOf(nonblocking.OAuthClientRegisteredEventPayloadClient{})
+		eventField, ok := eventClientType.FieldByName(metadataType.Name())
+		So(ok, ShouldBeTrue)
+		So(eventField.Anonymous, ShouldBeTrue)
+		So(eventField.Type, ShouldEqual, metadataType)
 	})
 }

--- a/pkg/lib/oauth/handler/resolve.go
+++ b/pkg/lib/oauth/handler/resolve.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net/url"
 	"slices"
+	"strings"
 
 	"github.com/authgear/authgear-server/pkg/lib/config"
 	"github.com/authgear/authgear-server/pkg/lib/oauth/protocol"
@@ -58,6 +59,59 @@ func parseRedirectURI(
 	return redirectURI, nil
 }
 
+// loopbackRedirectURIHosts are the hosts RFC 8252 §7.3 treats as the loopback
+// interface. url.URL.Hostname() strips the brackets from "[::1]:53412", so
+// "::1" matches "http://[::1]:53412/callback" too. This mirrors the host set
+// accepted by pkg/lib/cimd and pkg/lib/dcr when validating registered URIs.
+var loopbackRedirectURIHosts = []string{"localhost", "127.0.0.1", "::1"}
+
+// isLoopbackRedirectURI reports whether u is a loopback redirect URI in the
+// sense of RFC 8252 §7.3, that is, the "http" scheme on a loopback host.
+// url.Parse already lowercases the scheme; the host is lowercased here since
+// RFC 3986 §3.2.2 makes it case-insensitive.
+func isLoopbackRedirectURI(u *url.URL) bool {
+	if u.Scheme != "http" {
+		return false
+	}
+	return slices.Contains(loopbackRedirectURIHosts, strings.ToLower(u.Hostname()))
+}
+
+// matchLoopbackRedirectURI implements RFC 8252 §7.3, which says the
+// authorization server "MUST allow any port to be specified at the time of the
+// request for loopback IP redirect URIs, to accommodate clients that obtain an
+// available ephemeral port from the operating system at the time of the
+// request". Native and CLI apps bind an OS-assigned ephemeral port, so the port
+// of their redirect URI is not known when the client is registered.
+//
+// The exception applies only when both the registered URI and the incoming URI
+// are loopback URIs. The port is then the only component allowed to differ:
+// scheme, host, path, query and fragment must still match. Everything else
+// keeps requiring strict equality, so a client that registers no loopback URI
+// sees no change in behaviour.
+//
+// Confining the exception to the "http" scheme on a loopback host keeps it
+// safe: such a redirect never leaves the end-user's machine, so an arbitrary
+// port cannot be turned into a cross-origin redirection to an attacker. PKCE
+// continues to protect the code against other local processes.
+func matchLoopbackRedirectURI(allowedURIString string, redirectURI *url.URL) bool {
+	allowedURI, err := url.Parse(allowedURIString)
+	if err != nil {
+		return false
+	}
+	if !isLoopbackRedirectURI(allowedURI) || !isLoopbackRedirectURI(redirectURI) {
+		return false
+	}
+	return redirectURIWithoutPort(allowedURI) == redirectURIWithoutPort(redirectURI)
+}
+
+// redirectURIWithoutPort serializes u with the port component removed, so that
+// two loopback URIs can be compared on every component except the port.
+func redirectURIWithoutPort(u *url.URL) string {
+	withoutPort := *u
+	withoutPort.Host = strings.ToLower(u.Hostname())
+	return withoutPort.String()
+}
+
 func validateRedirectURI(
 	client *config.OAuthClientConfig,
 	httpProto httputil.HTTPProto,
@@ -69,8 +123,15 @@ func validateRedirectURI(
 	allowed := false
 	redirectURIString := redirectURI.String()
 
-	if slices.Contains(client.RedirectURIs, redirectURIString) {
-		allowed = true
+	for _, allowedURIString := range client.RedirectURIs {
+		if allowedURIString == redirectURIString {
+			allowed = true
+			break
+		}
+		if matchLoopbackRedirectURI(allowedURIString, redirectURI) {
+			allowed = true
+			break
+		}
 	}
 
 	// Implicitly allow URIs at same origin as the AS.

--- a/pkg/lib/oauth/handler/resolve.go
+++ b/pkg/lib/oauth/handler/resolve.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"net/url"
-	"slices"
 	"strings"
 
 	"github.com/authgear/authgear-server/pkg/lib/config"
@@ -59,21 +58,17 @@ func parseRedirectURI(
 	return redirectURI, nil
 }
 
-// loopbackRedirectURIHosts are the hosts RFC 8252 §7.3 treats as the loopback
-// interface. url.URL.Hostname() strips the brackets from "[::1]:53412", so
-// "::1" matches "http://[::1]:53412/callback" too. This mirrors the host set
-// accepted by pkg/lib/cimd and pkg/lib/dcr when validating registered URIs.
-var loopbackRedirectURIHosts = []string{"localhost", "127.0.0.1", "::1"}
-
 // isLoopbackRedirectURI reports whether u is a loopback redirect URI in the
-// sense of RFC 8252 §7.3, that is, the "http" scheme on a loopback host.
-// url.Parse already lowercases the scheme; the host is lowercased here since
-// RFC 3986 §3.2.2 makes it case-insensitive.
+// sense of RFC 8252 §7.3, that is, the "http" scheme on a loopback host
+// (httputil.IsLoopbackHost -- the same set pkg/lib/cimd and pkg/lib/dcr
+// accept when validating registered URIs). url.Parse already lowercases the
+// scheme; the host is lowercased here since RFC 3986 §3.2.2 makes it
+// case-insensitive.
 func isLoopbackRedirectURI(u *url.URL) bool {
 	if u.Scheme != "http" {
 		return false
 	}
-	return slices.Contains(loopbackRedirectURIHosts, strings.ToLower(u.Hostname()))
+	return httputil.IsLoopbackHost(strings.ToLower(u.Hostname()))
 }
 
 // matchLoopbackRedirectURI implements RFC 8252 §7.3, which says the

--- a/pkg/lib/oauth/handler/resolve_test.go
+++ b/pkg/lib/oauth/handler/resolve_test.go
@@ -109,6 +109,128 @@ func TestParseRedirectURI(t *testing.T) {
 			So(err, ShouldResemble, protocol.NewErrorResponse("invalid_request", "redirect URI is not allowed"))
 		})
 
+		Convey("should allow any port for a registered loopback redirect uri", func() {
+			// RFC 8252 §7.3: the authorization server MUST allow any port to be
+			// specified at the time of the request for loopback redirect URIs.
+			loopbackClientConfig := &config.OAuthClientConfig{
+				RedirectURIs: []string{
+					"http://127.0.0.1/callback",
+					"http://[::1]/callback",
+					"http://localhost:1234/callback",
+					"https://app.example.com/callback",
+				},
+			}
+
+			Convey("should allow an ephemeral port on the IPv4 loopback", func() {
+				u, err := parseRedirectURI(loopbackClientConfig, httpProto, httpOrigin, []string{}, []string{}, &mockOAuthRequestImpl{
+					"http://127.0.0.1:53412/callback",
+				})
+
+				So(u.String(), ShouldResemble, "http://127.0.0.1:53412/callback")
+				So(err, ShouldBeNil)
+			})
+
+			Convey("should allow an ephemeral port on the IPv6 loopback", func() {
+				u, err := parseRedirectURI(loopbackClientConfig, httpProto, httpOrigin, []string{}, []string{}, &mockOAuthRequestImpl{
+					"http://[::1]:61023/callback",
+				})
+
+				So(u.String(), ShouldResemble, "http://[::1]:61023/callback")
+				So(err, ShouldBeNil)
+			})
+
+			Convey("should allow a different port than the registered one", func() {
+				u, err := parseRedirectURI(loopbackClientConfig, httpProto, httpOrigin, []string{}, []string{}, &mockOAuthRequestImpl{
+					"http://localhost:53412/callback",
+				})
+
+				So(u.String(), ShouldResemble, "http://localhost:53412/callback")
+				So(err, ShouldBeNil)
+			})
+
+			Convey("should still allow the registered loopback uri itself", func() {
+				u, err := parseRedirectURI(loopbackClientConfig, httpProto, httpOrigin, []string{}, []string{}, &mockOAuthRequestImpl{
+					"http://127.0.0.1/callback",
+				})
+
+				So(u.String(), ShouldResemble, "http://127.0.0.1/callback")
+				So(err, ShouldBeNil)
+			})
+
+			// This case has to use a config of its own. Every loopback entry in
+			// loopbackClientConfig is registered with the /callback path, so
+			// against that config no incoming URI can differ from all of them
+			// by host alone -- a rejection there would prove nothing about the
+			// host comparison, since the path would reject it anyway.
+			Convey("should reject a loopback host that is not registered, even on a registered path", func() {
+				_, err := parseRedirectURI(&config.OAuthClientConfig{
+					RedirectURIs: []string{"http://127.0.0.1/callback"},
+				}, httpProto, httpOrigin, []string{}, []string{}, &mockOAuthRequestImpl{
+					"http://localhost:8000/callback",
+				})
+
+				So(err, ShouldResemble, protocol.NewErrorResponse("invalid_request", "redirect URI is not allowed"))
+			})
+
+			Convey("should reject a registered loopback host on an unregistered path", func() {
+				_, err := parseRedirectURI(&config.OAuthClientConfig{
+					RedirectURIs: []string{"http://127.0.0.1/callback"},
+				}, httpProto, httpOrigin, []string{}, []string{}, &mockOAuthRequestImpl{
+					"http://127.0.0.1:53412/other",
+				})
+
+				So(err, ShouldResemble, protocol.NewErrorResponse("invalid_request", "redirect URI is not allowed"))
+			})
+
+			Convey("should reject a different path", func() {
+				_, err := parseRedirectURI(loopbackClientConfig, httpProto, httpOrigin, []string{}, []string{}, &mockOAuthRequestImpl{
+					"http://127.0.0.1:53412/other",
+				})
+
+				So(err, ShouldResemble, protocol.NewErrorResponse("invalid_request", "redirect URI is not allowed"))
+			})
+
+			Convey("should reject a different query", func() {
+				_, err := parseRedirectURI(loopbackClientConfig, httpProto, httpOrigin, []string{}, []string{}, &mockOAuthRequestImpl{
+					"http://127.0.0.1:53412/callback?evil=1",
+				})
+
+				So(err, ShouldResemble, protocol.NewErrorResponse("invalid_request", "redirect URI is not allowed"))
+			})
+
+			Convey("should reject the https scheme", func() {
+				_, err := parseRedirectURI(loopbackClientConfig, httpProto, httpOrigin, []string{}, []string{}, &mockOAuthRequestImpl{
+					"https://127.0.0.1:53412/callback",
+				})
+
+				So(err, ShouldResemble, protocol.NewErrorResponse("invalid_request", "redirect URI is not allowed"))
+			})
+
+			Convey("should reject a host that merely looks like the loopback", func() {
+				_, err := parseRedirectURI(loopbackClientConfig, httpProto, httpOrigin, []string{}, []string{}, &mockOAuthRequestImpl{
+					"http://127.0.0.1.evil.com:53412/callback",
+				})
+
+				So(err, ShouldResemble, protocol.NewErrorResponse("invalid_request", "redirect URI is not allowed"))
+			})
+
+			Convey("should not ignore the port of a non-loopback redirect uri", func() {
+				_, err := parseRedirectURI(loopbackClientConfig, httpProto, httpOrigin, []string{}, []string{}, &mockOAuthRequestImpl{
+					"https://app.example.com:9000/callback",
+				})
+
+				So(err, ShouldResemble, protocol.NewErrorResponse("invalid_request", "redirect URI is not allowed"))
+			})
+
+			Convey("should not ignore the port of a non-loopback redirect uri over http", func() {
+				_, err := parseRedirectURI(clientConfig, httpProto, httpOrigin, []string{}, []string{}, &mockOAuthRequestImpl{
+					"http://app.example.com:9000/handle_auth",
+				})
+
+				So(err, ShouldResemble, protocol.NewErrorResponse("invalid_request", "redirect URI is not allowed"))
+			})
+		})
+
 		Convey("should allow origins in allowlist", func() {
 			u, err := parseRedirectURI(clientConfig, httpProto, httpOrigin, []string{}, []string{
 				"http://anotheroriginexample.com",

--- a/pkg/util/httputil/loopback.go
+++ b/pkg/util/httputil/loopback.go
@@ -1,0 +1,20 @@
+package httputil
+
+// IsLoopbackHost reports whether host -- as returned by url.URL.Hostname(),
+// which strips the brackets from an IPv6 literal like "[::1]:3000" -- names
+// a loopback interface: "localhost", or the IPv4/IPv6 loopback literals
+// "127.0.0.1" and "::1". Per RFC 8252 §7.3, native/CLI OAuth clients use any
+// of these interchangeably for their redirect_uri callback listener.
+//
+// This checks the literal hostname string, not a resolved IP address: it is
+// for validating a redirect_uri that Authgear itself never connects to
+// (unlike the SSRF concern IsPubliclyRoutable addresses for URLs Authgear
+// fetches), so there is no DNS resolution step to filter.
+func IsLoopbackHost(host string) bool {
+	switch host {
+	case "localhost", "127.0.0.1", "::1":
+		return true
+	default:
+		return false
+	}
+}

--- a/pkg/util/httputil/loopback_test.go
+++ b/pkg/util/httputil/loopback_test.go
@@ -12,7 +12,6 @@ func TestIsLoopbackHost(t *testing.T) {
 	Convey("IsLoopbackHost", t, func() {
 		accepted := []string{"localhost", "127.0.0.1", "::1"}
 		for _, host := range accepted {
-			host := host
 			Convey("accepts "+host, func() {
 				So(httputil.IsLoopbackHost(host), ShouldBeTrue)
 			})
@@ -20,7 +19,6 @@ func TestIsLoopbackHost(t *testing.T) {
 
 		rejected := []string{"127.0.0.2", "0.0.0.0", "example.com", "", "localhost.example.com"}
 		for _, host := range rejected {
-			host := host
 			Convey("rejects "+host, func() {
 				So(httputil.IsLoopbackHost(host), ShouldBeFalse)
 			})

--- a/pkg/util/httputil/loopback_test.go
+++ b/pkg/util/httputil/loopback_test.go
@@ -1,0 +1,29 @@
+package httputil_test
+
+import (
+	"testing"
+
+	. "github.com/smartystreets/goconvey/convey"
+
+	"github.com/authgear/authgear-server/pkg/util/httputil"
+)
+
+func TestIsLoopbackHost(t *testing.T) {
+	Convey("IsLoopbackHost", t, func() {
+		accepted := []string{"localhost", "127.0.0.1", "::1"}
+		for _, host := range accepted {
+			host := host
+			Convey("accepts "+host, func() {
+				So(httputil.IsLoopbackHost(host), ShouldBeTrue)
+			})
+		}
+
+		rejected := []string{"127.0.0.2", "0.0.0.0", "example.com", "", "localhost.example.com"}
+		for _, host := range rejected {
+			host := host
+			Convey("rejects "+host, func() {
+				So(httputil.IsLoopbackHost(host), ShouldBeFalse)
+			})
+		}
+	})
+}

--- a/portal/src/locale-data/en.json
+++ b/portal/src/locale-data/en.json
@@ -975,7 +975,7 @@
   "EditOAuthClientForm.redirect-uris.label": "Authorized Redirect URIs",
   "EditOAuthClientForm.redirect-uris.description.spa": "After users login, users will be redirected to these URIs. Call the finishAuthentication() method in your code to complete the authentication.",
   "EditOAuthClientForm.redirect-uris.description.traditional-webapp": "After users login, users will be redirected to these URIs. Call the finishAuthentication() method in your code to complete the authentication.",
-  "EditOAuthClientForm.redirect-uris.description.native": "After users are authenticated, users will be redirected to these URIs. This should be a page in your application.",
+  "EditOAuthClientForm.redirect-uris.description.native": "After users are authenticated, users will be redirected to these URIs. This should be a page in your application. If your application receives the response on the loopback interface, register the URI without a port, such as http://127.0.0.1/callback. Any port is then accepted at login time, so the application can listen on a port assigned by the operating system.",
   "EditOAuthClientForm.redirect-uris.description.confidential": "After users are authenticated, users will be redirected to these URIs. This should be a page in your application.",
   "EditOAuthClientForm.redirect-uris.description.third-party-app": "After users are authenticated, users will be redirected to these URIs. This should be a page in your application.",
   "EditOAuthClientForm.redirect-uris.description.unspecified": "After users are authenticated, users will be redirected to these URIs. This should be a page in your application.",


### PR DESCRIPTION
ref DEV-3845
ref DEV-3843
ref DEV-3552

Tested with:
- claude code
- claude.ai web
- codex
- chatgpt web

All tested with both DCR and CIMD

Testing require serving your authgear in public domain, I used `cloudflared tunnel` in my testing.