### PR TITLE
[Migration Needed] Fix users list sorting by the previous login instead of the last login

### DIFF
--- a/cmd/authgear/cmd/cmddatabase/migrations/authgear/20260911161002-add_index_auth_user_app_id_login_at.sql
+++ b/cmd/authgear/cmd/cmddatabase/migrations/authgear/20260911161002-add_index_auth_user_app_id_login_at.sql
@@ -1,0 +1,11 @@
+-- +migrate Up
+-- The Admin API sorts users by their most recent login, which _auth_user
+-- stores in login_at (last_login_at holds the login before that). Index the
+-- column actually sorted on, and drop the index on the column no longer used
+-- for sorting.
+CREATE INDEX _auth_user_app_id_login_at ON _auth_user (app_id, login_at DESC NULLS LAST);
+DROP INDEX _auth_user_app_id_last_login_at;
+
+-- +migrate Down
+CREATE INDEX _auth_user_app_id_last_login_at ON _auth_user (app_id, last_login_at DESC NULLS LAST);
+DROP INDEX _auth_user_app_id_login_at;

--- a/pkg/lib/authn/user/model.go
+++ b/pkg/lib/authn/user/model.go
@@ -56,19 +56,35 @@ func (o SortOption) GetSortDirection() model.SortDirection {
 	return model.SortDirectionDesc
 }
 
+// SortColumns maps a sort key to the column that holds it in a particular
+// table, for tables whose column names differ from the SortBy values.
+type SortColumns map[SortBy]string
+
+// Apply orders the query by the sort key, using the SortBy value as the column
+// name. Tables that store a sort key under another name use ApplyWithColumns.
 func (o SortOption) Apply(builder db.SelectBuilder, after string) db.SelectBuilder {
+	return o.ApplyWithColumns(builder, after, nil)
+}
+
+// ApplyWithColumns is Apply with the sort key resolved through columns. A key
+// missing from columns falls back to its SortBy value as the column name.
+func (o SortOption) ApplyWithColumns(builder db.SelectBuilder, after string, columns SortColumns) db.SelectBuilder {
 	sortBy := o.GetSortBy()
+	column := string(sortBy)
+	if c, ok := columns[sortBy]; ok {
+		column = c
+	}
 
 	sortDirection := o.GetSortDirection()
 
-	q := builder.OrderBy(fmt.Sprintf("%s %s NULLS LAST", sortBy, sortDirection))
+	q := builder.OrderBy(fmt.Sprintf("%s %s NULLS LAST", column, sortDirection))
 
 	if after != "" {
 		switch sortDirection {
 		case model.SortDirectionDesc:
-			q = q.Where(fmt.Sprintf("%s < ?", sortBy), after)
+			q = q.Where(fmt.Sprintf("%s < ?", column), after)
 		case model.SortDirectionAsc:
-			q = q.Where(fmt.Sprintf("%s > ?", sortBy), after)
+			q = q.Where(fmt.Sprintf("%s > ?", column), after)
 		}
 	}
 

--- a/pkg/lib/authn/user/model_test.go
+++ b/pkg/lib/authn/user/model_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/authgear/authgear-server/pkg/api/model"
 	"github.com/authgear/authgear-server/pkg/lib/authn/identity"
+	"github.com/authgear/authgear-server/pkg/lib/infra/db"
 )
 
 func TestComputeUserEndUserActionID(t *testing.T) {
@@ -115,5 +116,50 @@ func TestComputeUserEndUserActionID(t *testing.T) {
 				},
 			},
 		}), ShouldEqual, "uid=example-user")
+	})
+}
+
+func TestSortOptionApply(t *testing.T) {
+	Convey("SortOption.Apply", t, func() {
+		newQuery := func() db.SelectBuilder {
+			return db.NewSQLBuilderApp("public", "app-id").Select("id").From("t")
+		}
+		sortByLastLogin := SortOption{
+			SortBy:        SortByLastLoginAt,
+			SortDirection: model.SortDirectionDesc,
+		}
+
+		Convey("uses the sort key as the column name by default", func() {
+			sql, _, err := sortByLastLogin.Apply(newQuery(), "").ToSql()
+			So(err, ShouldBeNil)
+			So(sql, ShouldContainSubstring, "ORDER BY last_login_at desc NULLS LAST")
+		})
+
+		Convey("resolves the column through SortColumns", func() {
+			sql, _, err := sortByLastLogin.ApplyWithColumns(newQuery(), "", userSortColumns).ToSql()
+			So(err, ShouldBeNil)
+			So(sql, ShouldContainSubstring, "ORDER BY login_at desc NULLS LAST")
+			So(sql, ShouldNotContainSubstring, "last_login_at")
+		})
+
+		Convey("falls back to the sort key for keys missing from SortColumns", func() {
+			byCreatedAt := SortOption{
+				SortBy:        SortByCreatedAt,
+				SortDirection: model.SortDirectionAsc,
+			}
+			sql, _, err := byCreatedAt.ApplyWithColumns(newQuery(), "", SortColumns{
+				SortByLastLoginAt: "login_at",
+			}).ToSql()
+			So(err, ShouldBeNil)
+			So(sql, ShouldContainSubstring, "ORDER BY created_at asc NULLS LAST")
+		})
+
+		Convey("filters the cursor on the resolved column", func() {
+			sql, args, err := sortByLastLogin.ApplyWithColumns(newQuery(), "2026-09-10T00:00:00Z", userSortColumns).ToSql()
+			So(err, ShouldBeNil)
+			So(sql, ShouldContainSubstring, "login_at <")
+			So(sql, ShouldNotContainSubstring, "last_login_at <")
+			So(args, ShouldContain, "2026-09-10T00:00:00Z")
+		})
 	})
 }

--- a/pkg/lib/authn/user/store.go
+++ b/pkg/lib/authn/user/store.go
@@ -333,10 +333,21 @@ func (s *Store) Count(ctx context.Context) (uint64, error) {
 	return count, nil
 }
 
+// userSortColumns maps sort keys to _auth_user columns. SortByLastLoginAt means
+// the most recent login, which _auth_user stores in login_at; its last_login_at
+// column holds the login before that (see UpdateLoginTime). Sorting by
+// last_login_at ranked users by their previous login while the list displayed
+// their latest one. _search_user stores the latest login in last_login_at, so
+// the search path keeps the default column names.
+var userSortColumns = SortColumns{
+	SortByCreatedAt:   "created_at",
+	SortByLastLoginAt: "login_at",
+}
+
 func (s *Store) QueryPage(ctx context.Context, listOption ListOptions, pageArgs graphqlutil.PageArgs) ([]*User, uint64, error) {
 	query := s.selectQuery("u")
 
-	query = listOption.SortOption.Apply(query, "")
+	query = listOption.SortOption.ApplyWithColumns(query, "", userSortColumns)
 
 	query, offset, err := db.ApplyPageArgs(query, pageArgs)
 	if err != nil {


### PR DESCRIPTION
ref [DEV-3852](https://linear.app/authgear/issue/DEV-3852/portal-users-list-sorts-last-login-by-the-previous-login-not-the)

## Problem

In the portal's Users list, sorting by **Last Login** produced an order that did not match the displayed dates, and a user who had just logged in did not rise to the top.

`_auth_user` has two login columns. `login_at` is the most recent login and is what the Admin API exposes as `lastLoginAt`. `last_login_at` is the login **before** that: `UpdateLoginTime` copies `login_at` into `last_login_at` before writing the new time. The list without a search keyword or filter is served from `_auth_user`, and the sort helper used the `SortBy` value (`last_login_at`) verbatim as the ORDER BY column. So the list sorted by the previous login while showing the latest one.

The search-backed list (a keyword or a role/group filter set) reads `_search_user`, whose `last_login_at` holds the latest login, and was already correct. That is why typing a keyword made the order right.

## Fix

- `SortOption` gains `ApplyWithColumns`, which resolves the sort key through a per-table column map; `Apply` keeps its previous behaviour for the search store.
- The `_auth_user` store maps `SortByLastLoginAt` to `login_at`.
- Migration: index `(app_id, login_at DESC NULLS LAST)` to support the corrected sort, and drop `_auth_user_app_id_last_login_at`, which nothing sorts by any more.

No change to the GraphQL API: the `LAST_LOGIN_AT` enum and the `lastLoginAt` field are unchanged. Bug fix, so no breaking-changes entry.

## Notes for deployment

The migration creates one index and drops one on `_auth_user`, in the same style as the 2024 index migration. As with that migration, the index build holds a write lock on `_auth_user` for its duration on large tables.

## Testing

- New unit tests for the column resolution and the cursor filter in `pkg/lib/authn/user`.
- Migration verified with an up, down, up round trip on a database with the current schema; the planner uses the new index for the corrected sort.
- `go build ./pkg/... ./cmd/...`, `go test` for the user, search, admin, and elasticsearch packages, golangci-lint, goanalysis, and the goimports check all pass.